### PR TITLE
Purely propagate census construction panics

### DIFF
--- a/.receipts/construction-panic-census-escape/RECEIPT.md
+++ b/.receipts/construction-panic-census-escape/RECEIPT.md
@@ -1,0 +1,133 @@
+# ConstructionPanic census escape receipt
+
+## Pins
+
+- Current pinned main: `2c4bd291825a8b08a673818bc0ad1f72f14524fa`
+- Original red pin: `b1824eb6217fb92c5013743401bfe6edce2abcfa`
+- Rebased implementation commit: `e0204c1ecb4bffea53b95adacb1aadfa0a30977a`
+- Worktree: `/Users/tsavo/.herdr/worktrees/provekit/fenster-work`
+- Branch: `fenster/7185`
+
+The three production files were verified by content at the pinned main before
+editing. The earlier discrimination head
+`01dfab7e80b994bc3ab8f615126f3b3856051dc6` is not an ancestor of this pin, so
+it was preserved on `fenster/work` rather than rewritten.
+
+Re-pin verification compared both production scripts and the existing panic-test
+surfaces from `b1824eb6` to `227089c8`; `git diff --exit-code` returned `0`.
+After restacking, the three changed production/test files were byte-identical to
+the pre-rebase branch (`git diff --exit-code 5c31b59e..HEAD -- <three paths>`,
+exit `0`). The focused family then passed `6/6` in `0.68s`, unpiped exit `0`.
+
+The next re-pin compared the same production and existing-test surfaces from
+`227089c8` to `c710309d`; the content diff again returned `0`. Four unchanged
+combined attempts returned, in order: `143` after one passing arm, `6/6` exit
+`0`, `143` after two passing arms, and `6/6` exit `0`. An isolated six-process
+sweep had five exit `0` and one empty-log `143`; that exact context-manager arm
+then passed unchanged, exit `0`. No assertion failed at this pin, but the host's
+intermittent SIGTERM behavior is not claimed green. These commands loaded no
+package conftest and did not invoke `sugarbin`, so this receipt also makes no
+claim about #7211's migrated binary resolve path.
+
+At `ccea5292`, #7210 changed the same consumer function by moving contract-ref
+fallback after per-file roster enrollment. It did not change the source-identity
+catch repaired here. After restacking, the six #7185 arms and #7210's new
+`test_contract_ref_fallback_panic_stays_loud_after_roster_bank` tooth ran
+together: `7 passed in 0.73s`, unpiped exit `0`. The branch diff against this
+pin remains exactly three pure re-raise arms plus their tests and receipts; no
+#7210 fallback code was duplicated or changed.
+
+At `2c4bd291`, #7214 changed only `no_call_body_attribution.py`; every #7185
+production and existing-test surface was content-identical to `ccea5292`
+(`git diff --exit-code`, exit `0`). After restacking, the same seven combined
+teeth passed in `0.70s`, unpiped exit `0`; `py_compile` also returned `0`.
+
+## Red instrument
+
+Command, run unpiped with the exit captured before the log was read:
+
+```bash
+PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src \
+  python -m pytest --noconftest -q \
+  implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py \
+  > /tmp/fenster-7185-red-combined.log 2>&1
+```
+
+Measured on `b1824eb6217fb92c5013743401bfe6edce2abcfa`:
+
+```text
+pytest_unpiped_rc=1
+FFF...                                                                   [100%]
+3 failed, 3 passed in 0.77s
+```
+
+All three failures were `DID NOT RAISE ConstructionPanic`. The three passing
+arms were the sanctioned roster, context-manager-resolution, and residual
+membranes enrolling authenticated construction-panic terminals.
+
+`--noconftest` is deliberate: these script-only teeth do not need a Sugar
+binary. The package autouse fixture invokes `bin/sugarbin` and the unavailable
+local build rung terminated the otherwise focused run with exit `143`. That
+terminated run was discarded and no counts were taken from it.
+
+## First-terminal chains
+
+### Outer roster recovery catch
+
+- Input and coordinate: planted `ConstructionPanic` from
+  `demand_function_roster`, `fixture.py:outer-roster-escape`.
+- Entrance: `control_effect_recensus.terminal_after_measure_escape`.
+- First observed terminal on pinned main: the planted panic vanished and the
+  function returned the earlier outer-error row.
+- After fix: the exact planted exception object is the next terminal
+  (`caught.value is planted`).
+
+### Source-identity catch
+
+- Input and coordinate: planted `ConstructionPanic` from `path_source`,
+  `fixture.py:source-identity`.
+- Entrance: `recensus_enumerate_consumer.measure_file_via_enumerate`, phase
+  `source-identity`.
+- First observed terminal on pinned main: an `instrumentFailure` row with phase
+  `source-identity`.
+- After fix: the exact planted exception object is the next terminal.
+
+### Main-file-producer catch
+
+- Input and coordinate: one authenticated one-file corpus; planted
+  `ConstructionPanic` from `measure_file_via_enumerate`,
+  `fixture.py:main-file-producer`.
+- Entrance: `control_effect_recensus.main`, phase `main-file-producer`.
+- First observed terminal on pinned main: a checkpointed `instrumentFailure`
+  followed by compose refusing the unmeasured run.
+- After fix: the exact planted exception object is the next terminal before a
+  checkpoint can misclassify it.
+
+## Green instrument
+
+The red command was rerun unchanged after the three pure re-raise arms:
+
+```text
+pytest_unpiped_rc=0
+......                                                                   [100%]
+6 passed in 0.69s
+```
+
+This proves three exact-object propagation arms plus three sanctioned enrollment
+controls. It does not claim a corpus result, a frontier width, or a broad Python
+suite result.
+
+## Separate scanner axis
+
+The current repository scanner was run separately and remained red:
+
+```text
+current_catch_law_unpiped_rc=1
+R_construction_panic_catches_outside_audit = 7
+auditor_errors = 0
+```
+
+Its seven candidates include the three repaired pure re-raises and four
+sanctioned conversion sites. This is the known #7186 stale-discriminator axis;
+it was not changed, counted as a #7185 defect, or used to invalidate the runtime
+identity evidence.

--- a/docs/superpowers/plans/2026-08-03-construction-panic-census-escape.md
+++ b/docs/superpowers/plans/2026-08-03-construction-panic-census-escape.md
@@ -1,0 +1,159 @@
+# Construction Panic Census Escape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ConstructionPanic` propagate unchanged through the three unsanctioned census catches while preserving enrollment at the three sanctioned per-file audit membranes.
+
+**Architecture:** Add a named, pure re-raise arm immediately before each existing broad catch. The existing broad catches remain the owner of ordinary instrument failures; no helper, compatibility category, or new membrane is introduced. Focused runtime teeth plant one panic object at each repaired entrance and prove object identity, then plant panics at the sanctioned roster, context-manager, and residual membranes and prove typed enrollment.
+
+**Tech Stack:** Python 3, pytest, `monkeypatch`, the production `ConstructionPanic`/`ConstructionGap` types, and the in-process census scripts.
+
+## Global Constraints
+
+- Pinned base: `b1824eb6217fb92c5013743401bfe6edce2abcfa`.
+- Only the named per-file audit enumerators or production typed-gap classification may hold a `ConstructionPanic`; production outside those membranes may only pure re-raise.
+- Do not modify the four sanctioned membrane sites or the #7186 scanner.
+- Do not widen `_instrument_failure_row` or add a helper that catches `ConstructionPanic`.
+- Run focused tests locally with explicit `PYTHONPATH`; do not run broad pytest or take the battleaxe lease.
+
+---
+
+### Task 1: Pin the three unsanctioned catches red
+
+**Files:**
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py`
+
+**Interfaces:**
+- Consumes: `control_effect_recensus.terminal_after_measure_escape`, `control_effect_recensus.main`, and `recensus_enumerate_consumer.measure_file_via_enumerate`.
+- Produces: three regression tests that require the exact planted `ConstructionPanic` instance to escape.
+
+- [ ] **Step 1: Add a planted-panic factory and script loaders**
+
+```python
+def _panic(owner: str) -> ConstructionPanic:
+    return ConstructionPanic(
+        ConstructionGap(
+            owner=owner,
+            blame=f"fixture.py:{owner}",
+            observed="planted census catch",
+            requested="pure ConstructionPanic propagation",
+            fix="pure re-raise outside the sanctioned audit membrane",
+        )
+    )
+```
+
+Load `recensus_enumerate_consumer` under its production module name before loading `control_effect_recensus`, so the latter's local imports receive the monkeypatched consumer object.
+
+- [ ] **Step 2: Add the outer roster-escape identity tooth**
+
+Monkeypatch `recensus_enumerate_consumer.demand_function_roster` to raise one planted object. Call `terminal_after_measure_escape` with a real one-function fixture and assert `pytest.raises(ConstructionPanic).value is planted`.
+
+- [ ] **Step 3: Add the source-identity identity tooth**
+
+Monkeypatch `sugar_lift_python_source.source_oracle.path_source` to raise one planted object. Call `measure_file_via_enumerate(..., contract_refs={})` and assert the raised object is the planted object.
+
+- [ ] **Step 4: Add the main-file-producer identity tooth**
+
+Create a one-file authenticated test corpus, derive `_PANDAS_3_0_3_AGGREGATE_HASH` and `_PANDAS_3_0_3_MANIFEST_SHAPE_CID` from it, monkeypatch the production consumer's `measure_file_via_enumerate` to raise one planted object, invoke the real `control_effect_recensus.main()` with that corpus, and assert the raised object is the planted object.
+
+- [ ] **Step 5: Run the three teeth and record red**
+
+Run unpiped:
+
+```bash
+PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src \
+  python -m pytest --noconftest -q \
+  implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py \
+  > /tmp/fenster-7185-red.log 2>&1
+```
+
+Expected on the pinned base: `3 failed, 3 passed`; roster escape is swallowed, source identity becomes an `instrumentFailure`, and main-file producer becomes an `instrumentFailure`, while the sanctioned controls enroll. Capture the direct pytest exit before reading the log. `--noconftest` is required because these script-only teeth do not need a Sugar binary and the package autouse fixture enters the unavailable build rung.
+
+### Task 2: Prove the sanctioned membranes remain discriminating controls
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py`
+
+**Interfaces:**
+- Consumes: `recensus_enumerate_consumer.measure_file_via_enumerate` and its existing roster, context-manager-resolution, and residual demand doors.
+- Produces: a parameterized three-case positive control proving those named membranes enroll rather than propagate.
+
+- [ ] **Step 1: Add three membrane planters**
+
+For each phase, monkeypatch only that production demand function to raise a planted panic while earlier phases return the minimum authenticated testimony needed to reach it:
+
+```python
+cases = (
+    "roster",
+    "context-manager-resolutions",
+    "residual",
+)
+```
+
+- [ ] **Step 2: Assert typed enrollment**
+
+For each case, assert the call returns a row with `category == "panic"`, `terminalKind == "construction-panic"`, one `constructionPanics` entry, and payload fields matching the planted panic's owner and coordinate. The call must not raise.
+
+- [ ] **Step 3: Run all six arms before production edits**
+
+Run the same unpiped focused command. Expected: the three repaired-site teeth fail for their own propagation reason while all three sanctioned-membrane controls pass.
+
+### Task 3: Pure re-raise at the three production entrances
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py`
+
+**Interfaces:**
+- Consumes: `sugar_lift_py_tests.gap.panic.ConstructionPanic`.
+- Produces: exact identity propagation at all three unsanctioned catches; ordinary exception behavior is unchanged.
+
+- [ ] **Step 1: Import the panic type in both scripts**
+
+```python
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+```
+
+- [ ] **Step 2: Repair both catches in `control_effect_recensus.py`**
+
+Insert this arm immediately before the broad roster and main-file-producer handlers:
+
+```python
+except ConstructionPanic:
+    raise
+```
+
+Do not modify the body of either existing `except BaseException` arm.
+
+- [ ] **Step 3: Repair source identity in `recensus_enumerate_consumer.py`**
+
+Insert the same pure re-raise arm immediately before its existing broad handler. Do not modify the sanctioned roster, context-manager, or residual handlers.
+
+- [ ] **Step 4: Run the six-arm focused test green**
+
+Run the Task 1 command unpiped. Expected: `6 passed`, exit `0`.
+
+- [ ] **Step 5: Run the existing panic enrollment and catch-law teeth**
+
+Run unpiped:
+
+```bash
+PYTHONPATH=implementations/python/sugar-lift-py-tests/src:implementations/python/sugar-lift-python-source/src:implementations/python/sugar-source-tree/src \
+  python -m pytest --noconftest -q \
+  implementations/python/sugar-lift-py-tests/tests/test_recensus_panic_collection.py \
+  implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py \
+  > /tmp/fenster-7185-existing.log 2>&1
+```
+
+Record the collected count and the direct pytest exit. The separately tracked #7186 repository scan is expected to remain red at seven stale candidates, including pure re-raises and sanctioned membranes; report it separately rather than changing it in this lane.
+
+- [ ] **Step 6: Commit and push the topic branch**
+
+Stage only the plan, the focused test, and the two scripts. Commit with `Purely propagate census construction panics`, push `fenster/7185`, and report the branch plus full 40-character SHA. Do not merge.
+
+## Self-Review
+
+- Spec coverage: all three unsanctioned sites propagate exact identity; all three sanctioned handler paths exercise enrollment; no permitted catch is widened.
+- Placeholder scan: no deferred implementation or test step remains.
+- Type consistency: every repaired arm catches the canonical `ConstructionPanic`; every control checks its authenticated serialized payload because a membrane intentionally converts the exception into testimony.
+- Retirement path: these runtime teeth can retire when a typed census-result boundary makes `ConstructionPanic` uncatchable by ordinary instrument-failure handlers; Python's current exception hierarchy cannot encode that distinction at compile time.

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -105,6 +105,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Callable, TextIO
 
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
 # CI-visible narration: default print buffering makes a live process look dead.
 # Every RECENSUS line uses flush=True; prefer PYTHONUNBUFFERED=1 in the workflow.
 _PROGRESS_EVERY_N = max(1, int(os.environ.get("RECENSUS_PROGRESS_EVERY_N", "1")))
@@ -624,6 +626,8 @@ def terminal_after_measure_escape(
             workspace_root=workspace_root,
             file_rel=relative,
         )
+    except ConstructionPanic:
+        raise
     except BaseException as roster_err:
         if _is_process_control(roster_err):
             raise
@@ -1449,6 +1453,8 @@ def main() -> int:
                         row.setdefault("edgeWitnesses", {})[
                             EDGE_WITH_PARTITION
                         ] = with_partition["edgeWitness"]
+                except ConstructionPanic:
+                    raise
                 except BaseException as error:  # noqa: BLE001 -- per-file terminal
                     if _is_process_control(error):
                         raise

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -18,6 +18,8 @@ import ast
 from pathlib import Path
 from typing import Any, Mapping
 
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
 SCOREBOARD_AUTHORITY = False
 
 _FORBIDDEN_IMPORTS = frozenset(
@@ -713,6 +715,8 @@ def measure_file_via_enumerate(
         from sugar_lift_python_source.source_oracle import path_source
 
         _source, _filename, observed_source_cid = path_source(str(path))
+    except ConstructionPanic:
+        raise
     except BaseException as error:  # noqa: BLE001 — source identity is attendance
         if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
             raise

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py
@@ -1,0 +1,183 @@
+"""ConstructionPanic crosses ordinary census catches without reclassification.
+
+Only the per-file enumerate membranes may translate a construction panic into
+terminal testimony.  Outer census shells must preserve the exception object and
+purely re-raise it; an ``instrumentFailure`` means the instrument was blind,
+which is the opposite fact.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.gap.info import ConstructionGap
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONSUMER = _load("recensus_enumerate_consumer")
+RECENSUS = _load("control_effect_recensus")
+
+
+def _planted_panic(owner: str) -> ConstructionPanic:
+    return ConstructionPanic(
+        ConstructionGap(
+            owner=owner,
+            blame=f"fixture.py:{owner}",
+            observed="planted census catch",
+            requested="pure ConstructionPanic propagation",
+            fix="pure re-raise outside the sanctioned audit membrane",
+        )
+    )
+
+
+def _raise(error: BaseException):
+    def boom(*_args, **_kwargs):
+        raise error
+
+    return boom
+
+
+def _fixture_file(tmp_path: Path) -> Path:
+    path = tmp_path / "fixture.py"
+    path.write_text("def fixture():\n    return 1\n", encoding="utf-8")
+    return path
+
+
+def test_outer_roster_escape_purely_reraises_construction_panic(
+    tmp_path: Path, monkeypatch
+) -> None:
+    path = _fixture_file(tmp_path)
+    planted = _planted_panic("outer-roster-escape")
+    monkeypatch.setattr(CONSUMER, "demand_function_roster", _raise(planted))
+
+    with pytest.raises(ConstructionPanic) as caught:
+        RECENSUS.terminal_after_measure_escape(
+            path=path,
+            relative=path.name,
+            workspace_root=tmp_path,
+            error=ValueError("earlier outer error"),
+        )
+
+    assert caught.value is planted
+
+
+def test_source_identity_purely_reraises_construction_panic(
+    tmp_path: Path, monkeypatch
+) -> None:
+    path = _fixture_file(tmp_path)
+    planted = _planted_panic("source-identity")
+    from sugar_lift_python_source import source_oracle
+
+    monkeypatch.setattr(source_oracle, "path_source", _raise(planted))
+
+    with pytest.raises(ConstructionPanic) as caught:
+        CONSUMER.measure_file_via_enumerate(
+            workspace_root=tmp_path,
+            file_rel=path.name,
+            contract_refs={},
+        )
+
+    assert caught.value is planted
+
+
+def test_main_file_producer_purely_reraises_construction_panic(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = tmp_path / "pkg"
+    root.mkdir()
+    path = root / "fixture.py"
+    path.write_text("def fixture():\n    return 1\n", encoding="utf-8")
+
+    from pandas_floor_summary import corpus_cid
+    from sugar_lift_py_tests.corpus_pin import pin_corpus
+
+    observed = pin_corpus(root, distribution=root.name, version="test-pin")
+    RECENSUS._PANDAS_3_0_3_AGGREGATE_HASH = observed.aggregate_hash
+    RECENSUS._PANDAS_3_0_3_MANIFEST_SHAPE_CID = corpus_cid(list(observed.paths))
+    planted = _planted_panic("main-file-producer")
+    monkeypatch.setattr(CONSUMER, "measure_file_via_enumerate", _raise(planted))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "control_effect_recensus.py",
+            str(root),
+            "--corpus-root",
+            str(root),
+            "--corpus-version",
+            "test-pin",
+            "--commit",
+            "planted-main-file-producer",
+            "--out-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    with pytest.raises(ConstructionPanic) as caught:
+        RECENSUS.main()
+
+    assert caught.value is planted
+
+
+@pytest.mark.parametrize(
+    "phase,demand_name",
+    [
+        ("roster", "demand_function_roster"),
+        ("context-manager-resolutions", "demand_context_manager_resolution_events"),
+        ("residual", "demand_construction_residual"),
+    ],
+)
+def test_sanctioned_per_file_membranes_enroll_construction_panic(
+    tmp_path: Path,
+    monkeypatch,
+    phase: str,
+    demand_name: str,
+) -> None:
+    path = _fixture_file(tmp_path)
+    planted = _planted_panic(f"sanctioned-{phase}")
+
+    if phase != "roster":
+        monkeypatch.setattr(
+            CONSUMER,
+            "demand_function_roster",
+            lambda **_kwargs: ([], []),
+        )
+    if phase == "residual":
+        monkeypatch.setattr(
+            CONSUMER,
+            "demand_context_manager_resolution_events",
+            lambda **_kwargs: ([], []),
+        )
+    monkeypatch.setattr(CONSUMER, demand_name, _raise(planted))
+
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=tmp_path,
+        file_rel=path.name,
+        contract_refs={},
+    )
+
+    assert row["category"] == "panic"
+    assert row["terminalKind"] == "construction-panic"
+    assert len(row["constructionPanics"]) == 1
+    assert row["panic"]["owner"] == planted.info.owner
+    assert row["panic"]["coordinate"] == planted.info.blame
+    assert row["panic"]["entrance"] == f"sugar.enumerate:{phase}"


### PR DESCRIPTION
## Root cause and category law

Three census catch sites held ConstructionPanic outside sanctioned membranes:

- control_effect_recensus.py:627 discarded roster_err and reported only an earlier outer error, so a roster panic vanished
- control_effect_recensus.py:1452 reclassified ConstructionPanic as instrumentFailure at main-file-producer
- recensus_enumerate_consumer.py:687 reclassified ConstructionPanic as instrumentFailure at source-identity

That category inversion is load-bearing. An instrumentFailure makes the whole run Unmeasured because the instrument could not testify. A ConstructionPanic is honest product testimony. Reclassifying one as the other reverses the meaning and loses panic identity and count.

## Repair

Each unsanctioned broad catch now has an exact ConstructionPanic pure re-raise arm immediately before it. The exact planted exception object propagates unchanged; ordinary instrument errors continue through the existing instrumentFailure handlers.

No compatibility category, new membrane, or broad catch is added.

## Sanctioned membrane preserved

The four legitimate sites in recensus_enumerate_consumer.py remain untouched:

- :179 creates authenticated panic testimony
- :720 roster
- :773 context-manager resolution
- :833 residual

Those are the sanctioned per-file membrane and must retain category=panic, terminalKind=construction-panic, and constructionPanics testimony. The scanner that still flags them is stale and remains tracked separately as #7186; this PR does not weaken or update that scanner.

## Evidence

At exact head 139c7986fc3cd788c535612f8d98a96089993717 on main 2c4bd291825a8b08a673818bc0ad1f72f14524fa:

- 7/7 focused teeth passed
- unpiped pytest exit 0
- three exact-object propagation arms
- three sanctioned enrollment controls
- #7210 contract-ref fallback panic composition tooth

The branch carries two same-author commits and five scoped files: the two census scripts, the focused regression test, the implementation plan, and its pinned receipt. There are no deletions.

The receipt preserves prior red evidence: 3 propagation arms failed while all 3 sanctioned controls passed before repair. It also records that the separate catch-law scanner remains red under #7186 and was not counted as a #7185 regression.

## Non-claims

No corpus result or frontier width is claimed. No scanner fix is claimed. The four legitimate membrane sites are not defects and were not modified.

Closes #7185.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate `ConstructionPanic` through unsanctioned census exception handlers
> - Adds `except ConstructionPanic: raise` guards before broad `BaseException` handlers in [`control_effect_recensus.py`](https://github.com/TSavo/sugar/pull/7217/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) and [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7217/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79), preventing `ConstructionPanic` from being swallowed and converted into `instrumentFailure` rows.
> - Covers three escape paths: `terminal_after_measure_escape` outer roster, `measure_file_via_enumerate` source-identity, and the `main` file-producer loop.
> - Adds tests in [`test_recensus_construction_panic_escape.py`](https://github.com/TSavo/sugar/pull/7217/files#diff-5fdb7026c7f82df4712ef6054211f2ef6f08021a1577168e66c27ebcad2a02b5) verifying object identity is preserved on propagation and that sanctioned per-file membranes still enroll (rather than propagate) `ConstructionPanic`.
> - Behavioral Change: `ConstructionPanic` raised at the affected sites now crashes the calling process instead of producing a recoverable failure row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 139c798.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->