### PR TITLE
Seal authenticated Python runtime identity in census receipts

### DIFF
--- a/docs/superpowers/plans/2026-08-02-runtime-identity-v1.md
+++ b/docs/superpowers/plans/2026-08-02-runtime-identity-v1.md
@@ -1,0 +1,130 @@
+# Runtime Identity V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every measured control-effect recensus body cryptographically bind the exact authenticated CPython runtime that produced it.
+
+**Architecture:** `sugar_lift_py_tests.authenticated_pytest` remains the runtime authority and projects one `runtimeIdentity/v1` wire value plus a path-independent runtime CID. Recensus workers authenticate before touching the corpus, partials carry the identity, and compose recomputes and agrees the identity before including it in the body CID seal domain. Every failure stays instrument-level Unmeasured.
+
+**Tech Stack:** Python 3.12.13, stdlib `sys`/`sysconfig`/`platform`/`hashlib`, existing BLAKE3-512 canonicalizer, pytest, battleaxe `bin/bpytest`.
+
+## Global Constraints
+
+- Required runtime is derived only from `sugar-build.toml` and equals `cpython-3.12.13` on this pin.
+- Host executable paths remain testimony but are excluded from `runtimeCid`.
+- The resolved base executable bytes are SHA-256 hashed.
+- Runtime authentication precedes corpus selection, demand work, checkpoints, and stages.
+- `runtimeIdentity` and `runtimeCid` remain inside `bodyCid`; `sourceStamp` is insufficient.
+- Identity failure or disagreement emits only Unmeasured and never `frontierWidth`.
+- Never import `no_call_body_attribution.AUTHENTICATED_RUNTIME`.
+- Do not run a corpus width measurement until this and the With entrance repair have landed.
+
+---
+
+### Task 1: Runtime identity authority
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_runtime_identity_v1.py`
+
+**Interfaces:**
+- Produces: `RuntimeIdentityV1.to_wire()`, `observe_runtime_identity_v1()`, `runtime_cid_for_identity()`, `authenticate_runtime_identity_v1()`.
+- Consumes: existing `interpreter_identity()`, `declared_interpreter_runtime()`, and `authenticate_interpreter_runtime()`.
+
+- [ ] **Step 1: Write moved-identical and changed-byte red twins**
+
+  Create two temporary base executable files with identical bytes and distinct paths; assert equal executable hashes and `runtimeCid` while path testimony differs. Change only one file's bytes and assert both hashes differ.
+
+- [ ] **Step 2: Write schema and failure teeth**
+
+  Assert the complete observed wire fields, required runtime, path exclusion, missing executable refusal, and mismatch preservation of the fully observed identity.
+
+- [ ] **Step 3: Run the new test file red on battleaxe**
+
+  Run `./bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_runtime_identity_v1.py -q`. Expected: collection/import failure because the v1 authority does not exist.
+
+- [ ] **Step 4: Implement the authority**
+
+  Add a frozen identity value, chunked SHA-256 hashing, canonical path-free CID preimage, structural wire validation, and authentication through the existing interpreter door. Replace `authenticate_environment()`'s basic runtime check with this full authenticated observation so plan-time corpus resolution hashes the runtime first.
+
+- [ ] **Step 5: Run Task 1 tests green and commit**
+
+  Run the new file plus `test_measured_corpus_is_authenticated.py` and `test_repo_root_door.py` on battleaxe; commit only authority and tests.
+
+### Task 2: Partial and compose refusal contract
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py`
+
+**Interfaces:**
+- Consumes: authenticated runtime attestation from Task 1.
+- Produces: runtime-bound shard partials, unmeasured envelopes, and sealed boards.
+
+- [ ] **Step 1: Add consumer-first red teeth**
+
+  Add tests proving a missing partial identity, a non-recomputable `runtimeCid`, two individually valid but disagreeing shard identities, and absent compose identity all refuse without width. Add a truthful test proving identity is present and changing a semantic identity field changes the sealed `bodyCid`; changing only path testimony preserves `runtimeCid`.
+
+- [ ] **Step 2: Run compose tests red on battleaxe**
+
+  Run `test_frontier_attestation_seal.py` and `test_board_number_meanings.py`. Expected: new tests fail because partials and compose do not yet validate runtime identity.
+
+- [ ] **Step 3: Bind partials and unmeasured envelopes**
+
+  Extend `mint_partial` so runtime testimony is required for measured status and participates in `partialCid`. Extend `unmeasured_envelope` to carry resolved identity or a separate `runtimeIdentityFailure`, never an unavailable marker.
+
+- [ ] **Step 4: Bind compose and board seals**
+
+  Require the compose process identity, validate and agree every partial CID, propagate identity through every refusal, place identity fields in the measured body before conservation minting, and leave them in the `bodyCid` preimage.
+
+- [ ] **Step 5: Run compose tests green and commit**
+
+  Run both focused files on battleaxe, inspect the full output and exit, then commit the compose contract.
+
+### Task 3: Early recensus and compose CLI authentication
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py`
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py`
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_identity_gate.py`
+
+**Interfaces:**
+- Consumes: Task 1 authority and Task 2 envelope/compose arguments.
+- Produces: early mismatch/failure artifacts and authenticated k=1/shard execution.
+
+- [ ] **Step 1: Write ordering and lying twins red**
+
+  Assert a wrong runtime returns Unmeasured before an absent corpus is inspected or any checkpoint/stage path is created; assert a hash-resolution failure emits `runtimeIdentityFailure`; assert ordinary later refusal retains resolved runtime testimony. Add a compose CLI test proving runtime refusal happens before plan/partial reads.
+
+- [ ] **Step 2: Run the gate file red on battleaxe**
+
+  Run the new test file. Expected: failure because runtime authentication occurs after corpus path handling or does not produce the required envelope.
+
+- [ ] **Step 3: Implement the preflight**
+
+  Resolve required and observed identities immediately after parsing. On mismatch or resolution failure, write only the diagnostic unmeasured envelope to the requested result path and return the unmeasured exit. Pass authenticated testimony into shard mint and k=1 compose. Authenticate compose CLI before reading input artifacts.
+
+- [ ] **Step 4: Run gate and integration tests green and commit**
+
+  Run Task 3 tests and the complete Task 1/2 set on battleaxe; commit the entry wiring.
+
+### Task 4: Exact branch verification and handoff
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+**Interfaces:**
+- Produces: a pushed runtime v1 branch ready for Kujan; no corpus number.
+
+- [ ] **Step 1: Verify branch structure and floors**
+
+  Confirm the branch is based on exact main, contains no With repair duplication, imports no floor-only runtime constant, deletes no tests/files, and adds no skips/xfails.
+
+- [ ] **Step 2: Run the full focused runtime/compose set on battleaxe**
+
+  Capture the unpiped exit and collected/pass counts. Do not infer a corpus result.
+
+- [ ] **Step 3: Push and report**
+
+  Push `keaton/runtime-identity-v1`; report the exact SHA, commands, counts, observed runtime field reproduction, and explicit nonclaim that no `frontierWidth` exists before both prerequisite branches land.

--- a/docs/superpowers/specs/2026-08-02-runtime-identity-v1-design.md
+++ b/docs/superpowers/specs/2026-08-02-runtime-identity-v1-design.md
@@ -1,0 +1,135 @@
+# Runtime Identity V1 Design
+
+## Goal
+
+No control-effect recensus body may claim a measured `frontierWidth` unless it
+is bound to the exact authenticated Python interpreter that produced it. The
+runtime is producer identity, parallel to loaded stage source CIDs, and belongs
+inside the sealed body rather than in the host-noise `sourceStamp` excluded
+from `bodyCid`.
+
+The diagnostic artifact produced at commit `8c117c65` remains an honest
+unmeasured refusal because it omitted `frontierWidth`. It was observed
+externally under CPython 3.12.12 and lacks this runtime identity, so it is not a
+fully self-supporting v1 receipt.
+
+## Authority and ownership
+
+`sugar_lift_py_tests.authenticated_pytest` remains the sole Python runtime
+authority. It already owns `interpreter_identity()`, reads `[tools].python`
+from `sugar-build.toml`, and refuses an implementation/version mismatch.
+Runtime identity v1 extends that door; census scripts consume its result and do
+not reproduce interpreter inspection or hashing.
+
+The floor-only `no_call_body_attribution.AUTHENTICATED_RUNTIME` constant is a
+different domain and must never be imported by the census.
+
+## Runtime identity schema
+
+`runtimeIdentity` has schema `runtimeIdentity/v1` and carries:
+
+- `implementation`: `sys.implementation.name`;
+- `version`: `major.minor.micro`;
+- `sysVersion`: the complete `sys.version` string;
+- `cacheTag`: `sys.implementation.cache_tag`;
+- `SOABI`: `sysconfig.get_config_var("SOABI")`;
+- `hexVersion`: `hex(sys.hexversion)`;
+- `platformTag`: `platform.platform()`;
+- `invokedExecutable`: absolute `sys.executable` testimony;
+- `resolvedBaseExecutable`: resolved `sys._base_executable` when available,
+  otherwise resolved `sys.executable`;
+- `executableSha256`: SHA-256 over the resolved base executable bytes.
+
+`requiredRuntime` is derived exclusively from `sugar-build.toml` and is
+`cpython-3.12.13` on this pin.
+
+`runtimeCid` is the canonical BLAKE3-512 CID of the schema, implementation,
+version, complete `sys.version`, cache tag, SOABI, hex version, platform
+tag, and executable SHA-256. Both executable path fields are deliberately
+excluded. Moving byte-identical interpreter content preserves `runtimeCid`;
+changing interpreter bytes changes it even when every version string remains
+the same.
+
+Identity resolution is total or it fails. Missing fields, a missing base
+executable, an unreadable executable, or hashing failure produce a typed
+runtime identity resolution failure. No `unavailable` marker may appear inside
+`runtimeIdentity`.
+
+## Data flow and refusal order
+
+1. After command-line parsing, the recensus resolves the full observed
+   identity and authenticates it against `requiredRuntime` before checking or
+   selecting corpus paths, deriving or loading demand tables, creating output
+   directories, opening checkpoints, or executing stages.
+2. A successfully resolved but wrong runtime writes only the existing
+   unmeasured envelope. It carries `requiredRuntime`, the fully observed
+   `runtimeIdentity`, `runtimeCid`, and the mismatch reason. It emits no width.
+3. An identity-resolution or hashing failure writes only the unmeasured
+   envelope with `requiredRuntime` when available and a separate
+   `runtimeIdentityFailure`. It carries neither `runtimeIdentity` nor
+   `runtimeCid` and emits no width.
+4. Every shard partial carries `requiredRuntime`, `runtimeIdentity`, and
+   `runtimeCid`. The fields participate in `partialCid`.
+5. Compose authenticates its own runtime before reading plan or partial
+   artifacts. It validates every partial's runtime schema and recomputed CID,
+   requires all partial CIDs to agree with its own, and requires each observed
+   implementation/version to equal `requiredRuntime`.
+6. Any absent, malformed, mismatched, or disagreeing runtime witness produces
+   the existing unmeasured envelope and omits `frontierWidth`.
+7. A measured board embeds `requiredRuntime`, `runtimeIdentity`, and
+   `runtimeCid` before the common conservation mint and before `bodyCid` is
+   computed. These fields remain in the `bodyCid` seal domain. They are not
+   placed only in `sourceStamp`.
+8. An ordinary instrument refusal after successful runtime resolution carries
+   the same runtime fields in its unmeasured envelope because those diagnostics
+   are runtime-dependent.
+
+## Constructors and validation boundary
+
+The runtime authority exposes observation, authentication, canonical CID
+recomputation, and wire validation from one module. Producers cannot mint a
+measured partial without supplying authenticated runtime testimony. Consumers
+validate raw JSON again; a producer-owned object alone cannot authenticate an
+artifact loaded from disk.
+
+No third product category is introduced. Runtime mismatch or identity failure
+is instrument/environment failure and therefore unmeasured, never a
+`construction-panic` terminal.
+
+## Discrimination teeth
+
+Focused tests must prove:
+
+- two different paths containing identical interpreter bytes mint the same
+  `runtimeCid` while retaining distinct path testimony;
+- changing only executable bytes changes `executableSha256` and `runtimeCid`;
+- a wrong implementation/version refuses before any corpus selection or
+  output/checkpoint creation and carries the complete observed identity;
+- identity/hash failure produces `runtimeIdentityFailure` and never an
+  unavailable marker or width;
+- a partial cannot be measured without runtime testimony;
+- a partial with a non-recomputable CID refuses;
+- equal-count shards with different valid runtime CIDs refuse at compose;
+- a truthful set of agreeing partials seals and embeds runtime identity;
+- mutating any sealed semantic identity field changes the recomputed
+  `runtimeCid` and invalidates/recomputes `bodyCid`;
+- changing only host path testimony leaves `runtimeCid` unchanged while the
+  sealed body still records the path testimony.
+
+The existing With entrance repair remains an independent prerequisite. No
+corpus width run is admissible until both it and runtime identity v1 have
+landed.
+
+## Deferred scope
+
+V1 does not add a full standard-library hash, loaded `libpython` hash,
+installed-distribution lock, cryptographic signature, cross-host equivalence
+tooling, performance telemetry, or generalized provenance framework.
+
+## Enforcement rung and retirement
+
+This is a constructor/consumer refusal contract backed by focused tests. Python
+cannot make a raw JSON artifact's fields statically unforgeable, so compose must
+recompute and refuse at the boundary. The focused tests may retire only if a
+future typed receipt decoder makes missing or inconsistent runtime testimony
+unconstructable before compose.

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -53,6 +53,7 @@ _TERMINAL_CONVENTION = {
     "blocking_terminal_count": "number of terminals that blocked construction",
     "final_terminal": "last observed terminal, separate from both counts",
 }
+_RUNTIME_AUTO = object()
 
 _PANDAS_3_0_3_AGGREGATE_HASH = (
     "bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c"
@@ -93,6 +94,111 @@ def canonical_cid(obj: Mapping[str, Any]) -> str:
     """Content id of a JSON-stable object (sort_keys, no host noise)."""
     rendered = json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
     return _blake3_512(rendered.encode("utf-8"))
+
+
+def _runtime_attestation_fields(
+    runtime_attestation: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Validate one closed runtime witness without trusting its claimed CID."""
+    from sugar_lift_py_tests.authenticated_pytest import runtime_cid_for_identity
+
+    required_fields = {"requiredRuntime", "runtimeIdentity", "runtimeCid"}
+    if not required_fields.issubset(runtime_attestation):
+        return None, (
+            "runtimeIdentity/v1 absent: "
+            f"missing={sorted(required_fields - set(runtime_attestation))}"
+        )
+    required = runtime_attestation.get("requiredRuntime")
+    identity = runtime_attestation.get("runtimeIdentity")
+    claimed_cid = runtime_attestation.get("runtimeCid")
+    if not isinstance(required, str) or not required:
+        return None, "requiredRuntime absent from runtimeIdentity/v1 testimony"
+    if not isinstance(identity, Mapping):
+        return None, "runtimeIdentity/v1 absent"
+    try:
+        recomputed_cid = runtime_cid_for_identity(identity)
+    except Exception as error:  # closed runtime schema names its own defect
+        return None, f"runtimeIdentity/v1 malformed: {type(error).__name__}: {error}"
+    if claimed_cid != recomputed_cid:
+        return None, "runtimeCid is not recomputable from runtimeIdentity/v1"
+    observed_required = (
+        f"{identity.get('implementation')}-{identity.get('version')}"
+    )
+    if required != observed_required:
+        return None, (
+            "requiredRuntime mismatches its runtimeIdentity/v1: "
+            f"required={required} observed={observed_required}"
+        )
+    return {
+        "requiredRuntime": required,
+        "runtimeIdentity": dict(identity),
+        "runtimeCid": recomputed_cid,
+    }, None
+
+
+def resolve_executing_runtime_attestation() -> tuple[
+    dict[str, Any] | None, dict[str, Any]
+]:
+    """Authenticate the executing interpreter before any producer input opens."""
+    from sugar_lift_py_tests import authenticated_pytest as runtime_authority
+
+    try:
+        required = runtime_authority.declared_interpreter_runtime()
+    except Exception as error:
+        return None, {
+            "runtimeIdentityFailure": (
+                f"requiredRuntime resolution failed: {type(error).__name__}: {error}"
+            )
+        }
+    try:
+        identity = runtime_authority.observe_runtime_identity_v1()
+    except Exception as error:
+        return None, {
+            "requiredRuntime": required,
+            "runtimeIdentityFailure": str(error),
+        }
+
+    identity_wire = identity.to_wire()
+    try:
+        runtime_cid = runtime_authority.runtime_cid_for_identity(identity)
+    except Exception as error:
+        return None, {
+            "requiredRuntime": required,
+            "runtimeIdentityFailure": str(error),
+        }
+    observed = {
+        "requiredRuntime": required,
+        "runtimeIdentity": identity_wire,
+        "runtimeCid": runtime_cid,
+    }
+    try:
+        runtime_authority.authenticate_runtime_identity_v1(identity)
+    except runtime_authority.ExecutionEnvironmentMismatch as error:
+        return None, {**observed, "runtimeIdentityMismatch": str(error)}
+    except Exception as error:
+        return None, {
+            **observed,
+            "runtimeIdentityFailure": f"{type(error).__name__}: {error}",
+        }
+    validated, reason = _runtime_attestation_fields(observed)
+    if validated is None:
+        return None, {**observed, "runtimeIdentityFailure": str(reason)}
+    return validated, {}
+
+
+def _resolve_runtime_argument(
+    runtime_attestation: Mapping[str, Any] | None | object,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    if runtime_attestation is _RUNTIME_AUTO:
+        return resolve_executing_runtime_attestation()
+    if runtime_attestation is None:
+        return None, {"runtimeIdentityFailure": "runtimeIdentity/v1 absent"}
+    if not isinstance(runtime_attestation, Mapping):
+        return None, {"runtimeIdentityFailure": "runtimeIdentity/v1 malformed"}
+    validated, reason = _runtime_attestation_fields(runtime_attestation)
+    if validated is None:
+        return None, {"runtimeIdentityFailure": str(reason)}
+    return validated, {}
 
 
 def shard_file_set_cid(files: Sequence[str]) -> str:
@@ -712,8 +818,10 @@ def mint_partial(
     measured_commit: str | None = None,
     status: str = "completed",
     unmeasured_reason: str | None = None,
+    runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> dict[str, Any]:
     """Mint a shard partial. Never includes R_construction_panics top-level."""
+    runtime, runtime_failure = _resolve_runtime_argument(runtime_attestation)
     shard_count = int(plan["shardCount"])
     if shard_index < 0 or shard_index >= shard_count:
         raise ValueError(f"shard_index {shard_index} out of range for k={shard_count}")
@@ -778,6 +886,13 @@ def mint_partial(
                 else {"file": file, "type": cat, "message": cat}
             )
 
+    if runtime is None:
+        status = "unmeasured"
+        unmeasured_reason = str(
+            runtime_failure.get("runtimeIdentityFailure")
+            or runtime_failure.get("runtimeIdentityMismatch")
+            or "runtimeIdentity/v1 refused"
+        )
     measured = status == "completed" and files_complete and unmeasured_reason is None
     if not measured and unmeasured_reason is None:
         unmeasured_reason = (
@@ -839,6 +954,10 @@ def mint_partial(
         "measured": measured,
         "unmeasuredReason": unmeasured_reason,
     }
+    if runtime is not None:
+        body.update(runtime)
+    else:
+        body.update(runtime_failure)
     # Forbidden fields must never appear:
     assert "R_construction_panics" not in body
     body["partialCid"] = canonical_cid(
@@ -1104,8 +1223,24 @@ def seal_board_from_aggregate(
     source_stamp: Mapping[str, Any] | None = None,
     with_census: Mapping[str, Any] | None = None,
     frontier_attestation: Mapping[str, Any] | None = None,
+    runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> dict[str, Any]:
     """Mint the sealed authoritative board body. Sole mint of the class."""
+    runtime, runtime_failure = _resolve_runtime_argument(runtime_attestation)
+    if runtime is None:
+        return unmeasured_envelope(
+            plan=plan,
+            missing_shards=["runtime"],
+            unmeasured_reasons={
+                "runtime": str(
+                    runtime_failure.get("runtimeIdentityFailure")
+                    or runtime_failure.get("runtimeIdentityMismatch")
+                    or "runtimeIdentity/v1 refused"
+                )
+            },
+            measured_commit=measured_commit,
+            runtime_failure=runtime_failure,
+        )
     file_names = list(agg["enrolled_files"])
     families = Counter(agg["families"])
     backend_defects = Counter(agg["backend_defects"])
@@ -1274,6 +1409,7 @@ def seal_board_from_aggregate(
         "planCid": (plan or {}).get("planCid"),
         "perShardCids": dict(sorted((per_shard_cids or {}).items())),
         "composeSchema": COMPOSE_SCHEMA,
+        **runtime,
     }
     if frontier_attestation is not None:
         body["frontierAttestation"] = dict(frontier_attestation)
@@ -1305,7 +1441,9 @@ def seal_board_from_aggregate(
         ),
     )
     if isinstance(outcome, ConservationFailure):
-        return outcome.to_wire()
+        failure_body = outcome.to_wire()
+        failure_body.update(runtime)
+        return failure_body
     body = outcome.to_wire()
 
     # Both seals are required: schema-local function facts and the universal
@@ -1329,6 +1467,8 @@ def unmeasured_envelope(
     measured_commit: str | None = None,
     instrument_failures: Sequence[Mapping[str, Any]] = (),
     d3_residency_exposure: Mapping[str, Any] | None = None,
+    runtime_attestation: Mapping[str, Any] | None = None,
+    runtime_failure: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Attendance testimony only. NEVER measurementClass=control-effect-recensus."""
     env: dict[str, Any] = {
@@ -1347,6 +1487,10 @@ def unmeasured_envelope(
     }
     if d3_residency_exposure is not None:
         env["d3ResidencyExposure"] = dict(d3_residency_exposure)
+    if runtime_attestation is not None:
+        env.update(dict(runtime_attestation))
+    if runtime_failure is not None:
+        env.update(dict(runtime_failure))
     assert "measurementClass" not in env
     assert "R_construction_panics" not in env
     assert "frontierWidth" not in env
@@ -1365,8 +1509,24 @@ def compose_from_partials(
     elapsed_seconds: float | None = None,
     source_stamp: Mapping[str, Any] | None = None,
     with_census_fn=None,
+    runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> tuple[str, dict[str, Any]]:
     """Sole compose door. Returns (\"sealed\"|\"unmeasured\", body)."""
+    runtime, runtime_failure = _resolve_runtime_argument(runtime_attestation)
+    if runtime is None:
+        return "unmeasured", unmeasured_envelope(
+            plan=plan,
+            missing_shards=["runtime"],
+            unmeasured_reasons={
+                "runtime": str(
+                    runtime_failure.get("runtimeIdentityFailure")
+                    or runtime_failure.get("runtimeIdentityMismatch")
+                    or "runtimeIdentity/v1 refused"
+                )
+            },
+            measured_commit=str(plan.get("measuredCommit") or ""),
+            runtime_failure=runtime_failure,
+        )
     k = int(plan["shardCount"])
     by_index: dict[int, Mapping[str, Any]] = {}
     missing: list[str] = []
@@ -1379,6 +1539,7 @@ def compose_from_partials(
             continue
         by_index[idx] = p
 
+    first_partial_runtime_cid: str | None = None
     for i in range(k):
         seat = f"s{i:02d}"
         p = by_index.get(i)
@@ -1417,6 +1578,39 @@ def compose_from_partials(
             missing.append(seat)
             reasons[seat] = "partial carries forbidden top-level R_construction_panics"
             continue
+        partial_runtime, partial_runtime_reason = _runtime_attestation_fields(p)
+        if partial_runtime is None:
+            missing.append(seat)
+            reasons[seat] = str(partial_runtime_reason)
+            continue
+        if partial_runtime["requiredRuntime"] != runtime["requiredRuntime"]:
+            missing.append(seat)
+            reasons[seat] = (
+                "requiredRuntime mismatches authenticated compose requirement: "
+                f"partial={partial_runtime['requiredRuntime']} "
+                f"compose={runtime['requiredRuntime']}"
+            )
+            continue
+        partial_runtime_cid = str(partial_runtime["runtimeCid"])
+        if (
+            first_partial_runtime_cid is not None
+            and partial_runtime_cid != first_partial_runtime_cid
+        ):
+            missing.append(seat)
+            reasons[seat] = (
+                "runtimeCid disagrees across shard partials: "
+                f"first={first_partial_runtime_cid} current={partial_runtime_cid}"
+            )
+            continue
+        if partial_runtime_cid != runtime["runtimeCid"]:
+            missing.append(seat)
+            reasons[seat] = (
+                "runtimeCid mismatches authenticated compose runtime: "
+                f"partial={partial_runtime_cid} compose={runtime['runtimeCid']}"
+            )
+            continue
+        if first_partial_runtime_cid is None:
+            first_partial_runtime_cid = partial_runtime_cid
 
     if missing:
         return "unmeasured", unmeasured_envelope(
@@ -1424,6 +1618,7 @@ def compose_from_partials(
             missing_shards=missing,
             unmeasured_reasons=reasons,
             measured_commit=str(plan.get("measuredCommit") or ""),
+            runtime_attestation=runtime,
         )
 
     # Concat terminals in enrolled order for determinism.
@@ -1457,6 +1652,7 @@ def compose_from_partials(
             measured_commit=str(plan.get("measuredCommit") or ""),
             instrument_failures=instrument_failures,
             d3_residency_exposure=d3_residency_exposure,
+            runtime_attestation=runtime,
         )
     agg = aggregate_terminal_rows(
         measured_rows,
@@ -1475,6 +1671,7 @@ def compose_from_partials(
             },
             measured_commit=str(plan.get("measuredCommit") or ""),
             d3_residency_exposure=d3_residency_exposure,
+            runtime_attestation=runtime,
         )
 
     partial_cids_sorted = sorted(per_shard_cids.values())
@@ -1510,6 +1707,7 @@ def compose_from_partials(
         source_stamp=source_stamp,
         with_census=with_census,
         frontier_attestation=frontier_attestation,
+        runtime_attestation=runtime,
     )
     if board.get("measurement") != "measured":
         failure = board.get("conservationFailure")
@@ -1524,6 +1722,7 @@ def compose_from_partials(
             if isinstance(failure, Mapping)
             else [{"reason": "common conservation mint refused without diagnostic"}],
             d3_residency_exposure=d3_residency_exposure,
+            runtime_attestation=runtime,
         )
     return "sealed", board
 
@@ -1543,8 +1742,24 @@ def compose_k1_from_rows(
     source_stamp: Mapping[str, Any] | None = None,
     with_census_fn=None,
     manifest_cid: str | None = None,
+    runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> tuple[str, dict[str, Any]]:
     """k=1 path: one full-bin partial + compose (serial observation, one seal door)."""
+    runtime, runtime_failure = _resolve_runtime_argument(runtime_attestation)
+    if runtime is None:
+        return "unmeasured", unmeasured_envelope(
+            plan=None,
+            missing_shards=["runtime"],
+            unmeasured_reasons={
+                "runtime": str(
+                    runtime_failure.get("runtimeIdentityFailure")
+                    or runtime_failure.get("runtimeIdentityMismatch")
+                    or "runtimeIdentity/v1 refused"
+                )
+            },
+            measured_commit=measured_commit,
+            runtime_failure=runtime_failure,
+        )
     enrolled = sorted(enrolled_files)
     plan = build_plan(
         enrolled_files=enrolled,
@@ -1563,6 +1778,7 @@ def compose_k1_from_rows(
         shard_index=0,
         terminal_rows=list(measured_rows),
         measured_commit=measured_commit,
+        runtime_attestation=runtime,
     )
     return compose_from_partials(
         plan,
@@ -1574,6 +1790,7 @@ def compose_k1_from_rows(
         elapsed_seconds=elapsed_seconds,
         source_stamp=source_stamp,
         with_census_fn=with_census_fn,
+        runtime_attestation=runtime,
     )
 
 
@@ -1598,6 +1815,25 @@ def main(argv: list[str] | None = None) -> int:
         help="sealed board or unmeasured envelope path",
     )
     args = parser.parse_args(argv)
+    runtime, runtime_failure = resolve_executing_runtime_attestation()
+    if runtime is None:
+        body = unmeasured_envelope(
+            plan=None,
+            missing_shards=["runtime"],
+            unmeasured_reasons={
+                "runtime": str(
+                    runtime_failure.get("runtimeIdentityFailure")
+                    or runtime_failure.get("runtimeIdentityMismatch")
+                    or "runtimeIdentity/v1 refused"
+                )
+            },
+            runtime_failure=runtime_failure,
+        )
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return 1
     plan = json.loads(args.plan.read_text(encoding="utf-8"))
     partials: list[dict[str, Any]] = []
     for path in sorted(args.partials_dir.glob("*.json")):
@@ -1607,7 +1843,9 @@ def main(argv: list[str] | None = None) -> int:
             continue
         if isinstance(data, dict) and data.get("kind") == KIND_PARTIAL:
             partials.append(data)
-    status, body = compose_from_partials(plan, partials)
+    status, body = compose_from_partials(
+        plan, partials, runtime_attestation=runtime
+    )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -893,6 +893,36 @@ def main() -> int:
     if args.plan_json is not None and args.shard_index is None:
         parser.error("--plan-json requires --shard-index for worker mode")
 
+    # Runtime identity is producer identity. Authenticate it before corpus
+    # selection, demand derivation, checkpoints, or any construction stage.
+    from compose_control_effect_board import (
+        resolve_executing_runtime_attestation,
+        unmeasured_envelope,
+    )
+
+    runtime_attestation, runtime_failure = resolve_executing_runtime_attestation()
+    if runtime_attestation is None:
+        result_path = args.json or (args.out_dir / "recensus.json")
+        result = unmeasured_envelope(
+            plan=None,
+            missing_shards=["runtime"],
+            unmeasured_reasons={
+                "runtime": str(
+                    runtime_failure.get("runtimeIdentityFailure")
+                    or runtime_failure.get("runtimeIdentityMismatch")
+                    or "runtimeIdentity/v1 refused"
+                )
+            },
+            measured_commit=args.commit,
+            runtime_failure=runtime_failure,
+        )
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return 2
+
     if not args.corpus.exists():
         parser.error(f"corpus not found: {args.corpus}")
 
@@ -1807,6 +1837,7 @@ def main() -> int:
             shard_index=args.shard_index,
             terminal_rows=measured_rows,
             measured_commit=tip_commit,
+            runtime_attestation=runtime_attestation,
         )
         partial_path = args.partial_out or (
             out / f"partial-s{args.shard_index:02d}.json"
@@ -1854,6 +1885,7 @@ def main() -> int:
         },
         with_census_fn=_with_census_partition,
         manifest_cid=checkpoint.manifest_cid,
+        runtime_attestation=runtime_attestation,
     )
     if seal_status != "sealed":
         _narrate(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import platform
+import re
 import sys
 import sysconfig
 import tomllib
@@ -10,7 +14,7 @@ from functools import lru_cache
 from importlib import import_module, metadata
 from pathlib import Path
 from types import ModuleType
-from typing import Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from sugar_lift_py_tests.demand_table_identity import corpus_manifest_cid
 from sugar_lift_py_tests.repo_root import (
@@ -22,6 +26,10 @@ from sugar_lift_py_tests.repo_root import (
 
 class ExecutionEnvironmentMismatch(RuntimeError):
     """The interpreter cannot truthfully name the corpus it would measure."""
+
+
+class RuntimeIdentityResolutionFailure(RuntimeError):
+    """The producing interpreter could not be content-addressed."""
 
 
 @dataclass(frozen=True)
@@ -36,6 +44,37 @@ class InterpreterIdentity:
     implementation: str
     version: str
     executable: Path
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeIdentityV1:
+    """Exact producing interpreter identity; host paths remain testimony only."""
+
+    implementation: str
+    version: str
+    sys_version: str
+    cache_tag: str
+    soabi: str
+    hex_version: str
+    platform_tag: str
+    invoked_executable: str
+    resolved_base_executable: str
+    executable_sha256: str
+
+    def to_wire(self) -> dict[str, Any]:
+        return {
+            "schema": "runtimeIdentity/v1",
+            "implementation": self.implementation,
+            "version": self.version,
+            "sysVersion": self.sys_version,
+            "cacheTag": self.cache_tag,
+            "SOABI": self.soabi,
+            "hexVersion": self.hex_version,
+            "platformTag": self.platform_tag,
+            "invokedExecutable": self.invoked_executable,
+            "resolvedBaseExecutable": self.resolved_base_executable,
+            "executableSha256": self.executable_sha256,
+        }
 
 
 @dataclass(frozen=True)
@@ -97,6 +136,150 @@ def interpreter_identity() -> InterpreterIdentity:
         version=f"{version.major}.{version.minor}.{version.micro}",
         executable=Path(sys.executable).absolute(),
     )
+
+
+_RUNTIME_IDENTITY_FIELDS = frozenset(
+    {
+        "schema",
+        "implementation",
+        "version",
+        "sysVersion",
+        "cacheTag",
+        "SOABI",
+        "hexVersion",
+        "platformTag",
+        "invokedExecutable",
+        "resolvedBaseExecutable",
+        "executableSha256",
+    }
+)
+_RUNTIME_SEMANTIC_FIELDS = (
+    "schema",
+    "implementation",
+    "version",
+    "sysVersion",
+    "cacheTag",
+    "SOABI",
+    "hexVersion",
+    "platformTag",
+    "executableSha256",
+)
+
+
+def _runtime_identity_wire(
+    identity: RuntimeIdentityV1 | Mapping[str, Any],
+) -> dict[str, Any]:
+    wire = identity.to_wire() if isinstance(identity, RuntimeIdentityV1) else dict(identity)
+    if set(wire) != _RUNTIME_IDENTITY_FIELDS:
+        raise RuntimeIdentityResolutionFailure(
+            "runtimeIdentity/v1 fields differ from the closed schema: "
+            f"missing={sorted(_RUNTIME_IDENTITY_FIELDS - set(wire))} "
+            f"extra={sorted(set(wire) - _RUNTIME_IDENTITY_FIELDS)}"
+        )
+    for field in _RUNTIME_IDENTITY_FIELDS - {"executableSha256"}:
+        if not isinstance(wire[field], str) or not wire[field]:
+            raise RuntimeIdentityResolutionFailure(
+                f"runtimeIdentity/v1 {field} must be a non-empty string"
+            )
+    if wire["schema"] != "runtimeIdentity/v1":
+        raise RuntimeIdentityResolutionFailure(
+            f"runtime identity schema is not runtimeIdentity/v1: {wire['schema']!r}"
+        )
+    if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", wire["version"]) is None:
+        raise RuntimeIdentityResolutionFailure(
+            f"runtime identity version is not major.minor.micro: {wire['version']!r}"
+        )
+    if re.fullmatch(r"0x[0-9a-f]+", wire["hexVersion"]) is None:
+        raise RuntimeIdentityResolutionFailure(
+            f"runtime identity hexVersion is not canonical hex: {wire['hexVersion']!r}"
+        )
+    sha256 = wire["executableSha256"]
+    if not isinstance(sha256, str) or re.fullmatch(r"[0-9a-f]{64}", sha256) is None:
+        raise RuntimeIdentityResolutionFailure(
+            "runtimeIdentity/v1 executableSha256 must be 64 lowercase hex digits"
+        )
+    for field in ("invokedExecutable", "resolvedBaseExecutable"):
+        if not Path(wire[field]).is_absolute():
+            raise RuntimeIdentityResolutionFailure(
+                f"runtimeIdentity/v1 {field} must be absolute: {wire[field]!r}"
+            )
+    return wire
+
+
+def runtime_cid_for_identity(
+    identity: RuntimeIdentityV1 | Mapping[str, Any],
+) -> str:
+    """Content-address semantic runtime fields; deliberately exclude host paths."""
+    from sugar_lift_py_tests.canonicalizer import blake3_512_of
+
+    wire = _runtime_identity_wire(identity)
+    semantic = {field: wire[field] for field in _RUNTIME_SEMANTIC_FIELDS}
+    payload = json.dumps(
+        semantic, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return blake3_512_of(payload)
+
+
+def observe_runtime_identity_v1() -> RuntimeIdentityV1:
+    """Resolve and hash the current interpreter before it can produce testimony."""
+    interpreter = interpreter_identity()
+    invoked = interpreter.executable.absolute()
+    base_value = getattr(sys, "_base_executable", None) or sys.executable
+    if not isinstance(base_value, str) or not base_value:
+        raise RuntimeIdentityResolutionFailure(
+            "runtimeIdentity/v1 cannot resolve sys._base_executable or sys.executable"
+        )
+    try:
+        resolved_base = Path(base_value).resolve(strict=True)
+        digest = hashlib.sha256()
+        with resolved_base.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        raise RuntimeIdentityResolutionFailure(
+            "runtimeIdentity/v1 could not hash resolved base executable "
+            f"{base_value!r}: {type(error).__name__}: {error}"
+        ) from error
+    cache_tag = getattr(sys.implementation, "cache_tag", None)
+    soabi = sysconfig.get_config_var("SOABI")
+    identity = RuntimeIdentityV1(
+        implementation=interpreter.implementation,
+        version=interpreter.version,
+        sys_version=sys.version,
+        cache_tag=str(cache_tag) if cache_tag is not None else "",
+        soabi=str(soabi) if soabi is not None else "",
+        hex_version=hex(sys.hexversion),
+        platform_tag=platform.platform(),
+        invoked_executable=str(invoked),
+        resolved_base_executable=str(resolved_base),
+        executable_sha256=digest.hexdigest(),
+    )
+    runtime_cid_for_identity(identity)
+    return identity
+
+
+def authenticate_runtime_identity_v1(identity: RuntimeIdentityV1) -> RuntimeIdentityV1:
+    """Authenticate a fully observed runtime through the existing version door."""
+    authenticate_interpreter_runtime(
+        InterpreterIdentity(
+            identity.implementation,
+            identity.version,
+            Path(identity.invoked_executable),
+        )
+    )
+    runtime_cid_for_identity(identity)
+    return identity
+
+
+def authenticated_runtime_attestation_v1() -> dict[str, Any]:
+    """Resolve once and return the closed runtime testimony consumed by receipts."""
+    identity = observe_runtime_identity_v1()
+    authenticate_runtime_identity_v1(identity)
+    return {
+        "requiredRuntime": declared_interpreter_runtime(),
+        "runtimeIdentity": identity.to_wire(),
+        "runtimeCid": runtime_cid_for_identity(identity),
+    }
 
 
 def declared_interpreter_runtime() -> str:
@@ -265,7 +448,7 @@ def _declared_corpus(package_root: Path) -> tuple[dict[str, str], str]:
 def authenticate_environment() -> (
     tuple[ImportIdentity, ImportIdentity, ImportIdentity, str]
 ):
-    authenticate_interpreter_runtime(interpreter_identity())
+    authenticate_runtime_identity_v1(observe_runtime_identity_v1())
     try:
         repo_root = resolve_repo_root()
         package_root = sugar_lift_py_tests_package_root(repo_root)

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -7,7 +7,10 @@ two teaches the producers the witness schema.
 
 from __future__ import annotations
 
+import copy
 import importlib.util
+import inspect
+import json
 import sys
 from pathlib import Path
 
@@ -68,13 +71,72 @@ def _row(module, *, key=None, with_inputs=(), with_outputs=()):
     }
 
 
-def _compose(module, row):
+def _runtime_attestation(
+    *,
+    suffix: str = "a",
+    invoked: str = "/venv/bin/python",
+    version: str = "3.12.13",
+    required_runtime: str | None = None,
+):
+    from sugar_lift_py_tests.authenticated_pytest import runtime_cid_for_identity
+
+    identity = {
+        "schema": "runtimeIdentity/v1",
+        "implementation": "cpython",
+        "version": version,
+        "sysVersion": f"{version} test-build-{suffix}",
+        "cacheTag": "cpython-312",
+        "SOABI": "cpython-312-x86_64-linux-gnu",
+        "hexVersion": "0x30c0df0",
+        "platformTag": "Linux-test-x86_64-with-glibc2.39",
+        "invokedExecutable": invoked,
+        "resolvedBaseExecutable": "/runtime/bin/python3.12",
+        "executableSha256": suffix * 64,
+    }
+    return {
+        "requiredRuntime": required_runtime or f"cpython-{version}",
+        "runtimeIdentity": identity,
+        "runtimeCid": runtime_cid_for_identity(identity),
+    }
+
+
+def _runtime_identity_object(*, suffix: str = "a"):
+    from sugar_lift_py_tests.authenticated_pytest import RuntimeIdentityV1
+
+    wire = _runtime_attestation(suffix=suffix)["runtimeIdentity"]
+    return RuntimeIdentityV1(
+        implementation=wire["implementation"],
+        version=wire["version"],
+        sys_version=wire["sysVersion"],
+        cache_tag=wire["cacheTag"],
+        soabi=wire["SOABI"],
+        hex_version=wire["hexVersion"],
+        platform_tag=wire["platformTag"],
+        invoked_executable=wire["invokedExecutable"],
+        resolved_base_executable=wire["resolvedBaseExecutable"],
+        executable_sha256=wire["executableSha256"],
+    )
+
+
+def _require_runtime_parameter(module) -> None:
+    assert "runtime_attestation" in inspect.signature(
+        module.compose_k1_from_rows
+    ).parameters, "compose can still mint a width without runtimeIdentity/v1"
+
+
+def _compose(module, row, *, runtime_attestation=None):
+    _require_runtime_parameter(module)
     return module.compose_k1_from_rows(
         [("pandas/a.py", row)],
         enrolled_files=["pandas/a.py"],
         measured_commit="4accd543",
         aggregate_hash="agg",
         manifest_shape_cid="manifest",
+        runtime_attestation=(
+            _runtime_attestation()
+            if runtime_attestation is None
+            else runtime_attestation
+        ),
     )
 
 
@@ -84,6 +146,288 @@ def _assert_only_unmeasured(body):
     assert "frontierWidth" not in body
     assert "R_construction_panics" not in body
     assert "measurementClass" not in body
+
+
+def test_compose_without_runtime_identity_refuses_before_width() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    status, body = module.compose_k1_from_rows(
+        [("pandas/a.py", _row(module))],
+        enrolled_files=["pandas/a.py"],
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        runtime_attestation=None,
+    )
+    assert status == "unmeasured"
+    _assert_only_unmeasured(body)
+    assert body["runtimeIdentityFailure"] == "runtimeIdentity/v1 absent"
+
+
+def test_compose_cli_wrong_runtime_refuses_before_reading_plan(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load()
+    import sugar_lift_py_tests.authenticated_pytest as runtime_authority
+
+    observed = _runtime_identity_object(suffix="b")
+    monkeypatch.setattr(
+        runtime_authority, "observe_runtime_identity_v1", lambda: observed
+    )
+
+    def refuse(_identity):
+        raise runtime_authority.ExecutionEnvironmentMismatch(
+            "Python runtime authority mismatch: required cpython-3.12.13; "
+            "observed locally patched cpython-3.12.13"
+        )
+
+    monkeypatch.setattr(runtime_authority, "authenticate_runtime_identity_v1", refuse)
+    monkeypatch.setattr(
+        runtime_authority,
+        "declared_interpreter_runtime",
+        lambda: "cpython-3.12.13",
+    )
+    out = tmp_path / "compose-unmeasured.json"
+
+    exit_code = module.main(
+        [
+            "--plan",
+            str(tmp_path / "missing-plan.json"),
+            "--partials-dir",
+            str(tmp_path / "missing-partials"),
+            "--out",
+            str(out),
+        ]
+    )
+
+    assert exit_code == 1
+    body = json.loads(out.read_text(encoding="utf-8"))
+    assert body["status"] == "unmeasured"
+    assert body["requiredRuntime"] == "cpython-3.12.13"
+    assert body["runtimeIdentity"] == observed.to_wire()
+    assert body["runtimeCid"] == runtime_authority.runtime_cid_for_identity(observed)
+    assert "locally patched" in body["runtimeIdentityMismatch"]
+    assert "frontierWidth" not in body
+
+
+def test_partial_without_runtime_identity_refuses_at_compose() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    attestation = _runtime_attestation()
+    plan = module.build_plan(
+        enrolled_files=["pandas/a.py"],
+        shard_count=1,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[["pandas/a.py"]],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=1,
+        estimated_loads=[0.0],
+    )
+    partial = module.mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=[("pandas/a.py", _row(module))],
+        runtime_attestation=attestation,
+    )
+    for field in ("requiredRuntime", "runtimeIdentity", "runtimeCid"):
+        partial.pop(field)
+    partial["partialCid"] = module.canonical_cid(
+        {key: value for key, value in partial.items() if key != "partialCid"}
+    )
+
+    status, body = module.compose_from_partials(
+        plan, [partial], runtime_attestation=attestation
+    )
+    assert status == "unmeasured"
+    _assert_only_unmeasured(body)
+    assert "runtimeIdentity/v1 absent" in body["unmeasuredReasons"]["s00"]
+
+
+def test_non_recomputable_partial_runtime_cid_refuses() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    attestation = _runtime_attestation()
+    plan = module.build_plan(
+        enrolled_files=["pandas/a.py"],
+        shard_count=1,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[["pandas/a.py"]],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=1,
+        estimated_loads=[0.0],
+    )
+    partial = module.mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=[("pandas/a.py", _row(module))],
+        runtime_attestation=attestation,
+    )
+    partial["runtimeCid"] = "blake3-512:" + ("0" * 128)
+    partial["partialCid"] = module.canonical_cid(
+        {key: value for key, value in partial.items() if key != "partialCid"}
+    )
+
+    status, body = module.compose_from_partials(
+        plan, [partial], runtime_attestation=attestation
+    )
+    assert status == "unmeasured"
+    _assert_only_unmeasured(body)
+    assert "runtimeCid is not recomputable" in body["unmeasuredReasons"]["s00"]
+
+
+def test_valid_but_disagreeing_shard_runtime_cids_refuse() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    left = _runtime_attestation(suffix="a")
+    right = _runtime_attestation(suffix="b")
+    plan = module.build_plan(
+        enrolled_files=["pandas/a.py", "pandas/b.py"],
+        shard_count=2,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[["pandas/a.py"], ["pandas/b.py"]],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=2,
+        estimated_loads=[0.0, 0.0],
+    )
+    partials = [
+        module.mint_partial(
+            plan=plan,
+            shard_index=0,
+            terminal_rows=[("pandas/a.py", _row(module))],
+            runtime_attestation=left,
+        ),
+        module.mint_partial(
+            plan=plan,
+            shard_index=1,
+            terminal_rows=[
+                ("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))
+            ],
+            runtime_attestation=right,
+        ),
+    ]
+
+    status, body = module.compose_from_partials(
+        plan, partials, runtime_attestation=left
+    )
+    assert status == "unmeasured"
+    _assert_only_unmeasured(body)
+    assert "runtimeCid disagrees" in body["unmeasuredReasons"]["s01"]
+
+
+def test_well_formed_shard_runtime_wrong_for_compose_authority_refuses() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    executing = _runtime_attestation(suffix="a")
+    forged = _runtime_attestation(suffix="b")
+    plan = module.build_plan(
+        enrolled_files=["pandas/a.py"],
+        shard_count=1,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[["pandas/a.py"]],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=1,
+        estimated_loads=[0.0],
+    )
+    partial = module.mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=[("pandas/a.py", _row(module))],
+        runtime_attestation=forged,
+    )
+
+    status, body = module.compose_from_partials(
+        plan, [partial], runtime_attestation=executing
+    )
+    assert status == "unmeasured"
+    _assert_only_unmeasured(body)
+    assert "runtimeCid mismatches authenticated compose runtime" in body[
+        "unmeasuredReasons"
+    ]["s00"]
+
+
+def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    executing = _runtime_attestation(suffix="a")
+    mutually_agreeing_wrong_runtime = _runtime_attestation(
+        suffix="b",
+        version="3.12.14",
+        required_runtime="cpython-3.12.14",
+    )
+    plan = module.build_plan(
+        enrolled_files=["pandas/a.py", "pandas/b.py"],
+        shard_count=2,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[["pandas/a.py"], ["pandas/b.py"]],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=2,
+        estimated_loads=[0.0, 0.0],
+    )
+    partials = [
+        module.mint_partial(
+            plan=plan,
+            shard_index=0,
+            terminal_rows=[("pandas/a.py", _row(module))],
+            runtime_attestation=mutually_agreeing_wrong_runtime,
+        ),
+        module.mint_partial(
+            plan=plan,
+            shard_index=1,
+            terminal_rows=[
+                ("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))
+            ],
+            runtime_attestation=mutually_agreeing_wrong_runtime,
+        ),
+    ]
+
+    status, body = module.compose_from_partials(
+        plan, partials, runtime_attestation=executing
+    )
+    assert status == "unmeasured"
+    _assert_only_unmeasured(body)
+    assert all(
+        "requiredRuntime mismatches authenticated compose requirement"
+        in body["unmeasuredReasons"][seat]
+        for seat in ("s00", "s01")
+    )
+
+
+def test_runtime_identity_is_inside_body_cid_but_paths_are_outside_runtime_cid() -> None:
+    module = _load()
+    _require_runtime_parameter(module)
+    first = _runtime_attestation(invoked="/venv-a/bin/python")
+    moved = copy.deepcopy(first)
+    moved["runtimeIdentity"]["invokedExecutable"] = "/venv-b/bin/python"
+    assert moved["runtimeCid"] == first["runtimeCid"]
+
+    left_status, left = _compose(
+        module, _row(module), runtime_attestation=first
+    )
+    right_status, right = _compose(
+        module, _row(module), runtime_attestation=moved
+    )
+
+    assert left_status == right_status == "sealed"
+    assert left["runtimeCid"] == right["runtimeCid"]
+    assert left["runtimeIdentity"]["invokedExecutable"] != right["runtimeIdentity"][
+        "invokedExecutable"
+    ]
+    assert left["bodyCid"] != right["bodyCid"]
 
 
 def test_truthful_current_main_with_collapse_refuses() -> None:
@@ -298,6 +642,35 @@ def test_truthful_attested_row_seals_and_carries_recomputable_manifests() -> Non
     }
 
 
+def test_direct_board_seal_cannot_bypass_runtime_identity() -> None:
+    module = _load()
+    row = _row(module)
+    aggregate = module.aggregate_terminal_rows(
+        [("pandas/a.py", row)],
+        enrolled_files=["pandas/a.py"],
+    )
+    attestation, failures = module.attest_frontier_rows([("pandas/a.py", row)])
+    assert failures == []
+
+    body = module.seal_board_from_aggregate(
+        aggregate,
+        plan=None,
+        per_shard_cids=None,
+        compose_cid=None,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        frontier_attestation=attestation,
+        runtime_attestation=None,
+    )
+
+    assert body["status"] == "unmeasured"
+    assert body["runtimeIdentityFailure"] == "runtimeIdentity/v1 absent"
+    assert "frontierWidth" not in body
+    assert "measurementClass" not in body
+    assert "bodyCid" not in body
+
+
 def test_aggregate_panic_magnitude_cannot_disagree_with_attested_keys() -> None:
     module = _load()
     row = _row(module)
@@ -321,6 +694,7 @@ def test_aggregate_panic_magnitude_cannot_disagree_with_attested_keys() -> None:
         aggregate_hash="agg",
         manifest_shape_cid="manifest",
         frontier_attestation=attestation,
+        runtime_attestation=_runtime_attestation(),
     )
     assert body["measurement"] == "unmeasured"
     assert "frontierWidth" not in body

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_preflight.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_preflight.py
@@ -1,0 +1,124 @@
+"""The recensus authenticates its producer before it can select corpus work."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+import sugar_lift_py_tests.authenticated_pytest as runtime_authority
+
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPT = _SCRIPTS / "control_effect_recensus.py"
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location("control_effect_recensus", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _identity(*, version: str = "3.12.12"):
+    return runtime_authority.RuntimeIdentityV1(
+        implementation="cpython",
+        version=version,
+        sys_version=f"{version} test build",
+        cache_tag="cpython-312",
+        soabi="cpython-312-x86_64-linux-gnu",
+        hex_version="0x30c0cf0",
+        platform_tag="Linux-test-x86_64-with-glibc2.39",
+        invoked_executable="/test/venv/bin/python",
+        resolved_base_executable="/test/runtime/bin/python3.12",
+        executable_sha256="a" * 64,
+    )
+
+
+def _invoke(module, *, corpus: Path, receipt: Path) -> int:
+    saved = sys.argv
+    sys.argv = [
+        "control_effect_recensus.py",
+        str(corpus),
+        "--json",
+        str(receipt),
+        "--out-dir",
+        str(receipt.parent / "run"),
+    ]
+    try:
+        return int(module.main())
+    finally:
+        sys.argv = saved
+
+
+def test_wrong_runtime_refuses_before_even_missing_corpus_selection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load()
+    observed = _identity()
+    monkeypatch.setattr(
+        runtime_authority, "observe_runtime_identity_v1", lambda: observed
+    )
+
+    def refuse(_identity):
+        raise runtime_authority.ExecutionEnvironmentMismatch(
+            "Python runtime authority mismatch: required cpython-3.12.13; "
+            "observed cpython-3.12.12 at /test/venv/bin/python"
+        )
+
+    monkeypatch.setattr(runtime_authority, "authenticate_runtime_identity_v1", refuse)
+    monkeypatch.setattr(
+        runtime_authority,
+        "declared_interpreter_runtime",
+        lambda: "cpython-3.12.13",
+    )
+    receipt = tmp_path / "wrong-runtime.json"
+
+    assert _invoke(module, corpus=tmp_path / "corpus-does-not-exist", receipt=receipt) == 2
+    body = json.loads(receipt.read_text(encoding="utf-8"))
+    assert body["kind"] == "control-effect-recensus-unmeasured/v1"
+    assert body["status"] == "unmeasured"
+    assert body["measured"] is False
+    assert body["requiredRuntime"] == "cpython-3.12.13"
+    assert body["runtimeIdentity"] == observed.to_wire()
+    assert body["runtimeCid"] == runtime_authority.runtime_cid_for_identity(observed)
+    assert "observed cpython-3.12.12" in body["runtimeIdentityMismatch"]
+    assert "frontierWidth" not in body
+    assert "measurementClass" not in body
+
+
+def test_runtime_hash_failure_is_separate_and_never_fabricates_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _load()
+
+    def fail_resolution():
+        raise runtime_authority.RuntimeIdentityResolutionFailure(
+            "runtimeIdentity/v1 could not hash resolved base executable"
+        )
+
+    monkeypatch.setattr(
+        runtime_authority, "observe_runtime_identity_v1", fail_resolution
+    )
+    monkeypatch.setattr(
+        runtime_authority,
+        "declared_interpreter_runtime",
+        lambda: "cpython-3.12.13",
+    )
+    receipt = tmp_path / "identity-failure.json"
+
+    assert _invoke(module, corpus=tmp_path / "corpus-does-not-exist", receipt=receipt) == 2
+    body = json.loads(receipt.read_text(encoding="utf-8"))
+    assert body["status"] == "unmeasured"
+    assert body["requiredRuntime"] == "cpython-3.12.13"
+    assert "could not hash" in body["runtimeIdentityFailure"]
+    assert "runtimeIdentity" not in body
+    assert "runtimeCid" not in body
+    assert "frontierWidth" not in body
+    assert "measurementClass" not in body

--- a/implementations/python/sugar-lift-py-tests/tests/test_runtime_identity_v1.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_runtime_identity_v1.py
@@ -1,0 +1,141 @@
+"""The recensus runtime is producer identity, not host-noise metadata."""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import re
+import sys
+
+import pytest
+
+import sugar_lift_py_tests.authenticated_pytest as authority
+
+
+def _require_v1_api() -> None:
+    assert hasattr(authority, "RuntimeIdentityV1"), (
+        "runtimeIdentity/v1 is not implemented at the authenticated interpreter door"
+    )
+    assert hasattr(authority, "observe_runtime_identity_v1")
+    assert hasattr(authority, "runtime_cid_for_identity")
+    assert hasattr(authority, "authenticate_runtime_identity_v1")
+
+
+def _observe_with_base(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    invoked: pathlib.Path,
+    base: pathlib.Path,
+):
+    _require_v1_api()
+    monkeypatch.setattr(sys, "executable", str(invoked))
+    monkeypatch.setattr(sys, "_base_executable", str(base), raising=False)
+    return authority.observe_runtime_identity_v1()
+
+
+def test_identical_runtime_bytes_moved_to_another_path_keep_runtime_cid(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = tmp_path / "first" / "python3.12"
+    second = tmp_path / "second" / "python3.12"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_bytes(b"same interpreter bytes")
+    second.write_bytes(first.read_bytes())
+
+    left = _observe_with_base(
+        monkeypatch,
+        invoked=tmp_path / "venv-a" / "bin" / "python",
+        base=first,
+    )
+    left_cid = authority.runtime_cid_for_identity(left)
+    right = _observe_with_base(
+        monkeypatch,
+        invoked=tmp_path / "venv-b" / "bin" / "python",
+        base=second,
+    )
+    right_cid = authority.runtime_cid_for_identity(right)
+
+    assert left.resolved_base_executable != right.resolved_base_executable
+    assert left.invoked_executable != right.invoked_executable
+    assert left.executable_sha256 == right.executable_sha256
+    assert left_cid == right_cid
+
+
+def test_changed_runtime_bytes_change_hash_and_runtime_cid(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = tmp_path / "python-a"
+    second = tmp_path / "python-b"
+    first.write_bytes(b"interpreter build A")
+    second.write_bytes(b"interpreter build B")
+
+    left = _observe_with_base(monkeypatch, invoked=first, base=first)
+    right = _observe_with_base(monkeypatch, invoked=second, base=second)
+
+    assert left.executable_sha256 != right.executable_sha256
+    assert authority.runtime_cid_for_identity(left) != authority.runtime_cid_for_identity(
+        right
+    )
+
+
+def test_runtime_identity_wire_matches_observed_v1_shape(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    executable = tmp_path / "python3.12"
+    executable.write_bytes(b"identity fixture")
+    identity = _observe_with_base(
+        monkeypatch,
+        invoked=tmp_path / "venv" / "bin" / "python",
+        base=executable,
+    )
+    wire = identity.to_wire()
+
+    assert wire == {
+        "schema": "runtimeIdentity/v1",
+        "implementation": sys.implementation.name,
+        "version": (
+            f"{sys.version_info.major}.{sys.version_info.minor}."
+            f"{sys.version_info.micro}"
+        ),
+        "sysVersion": sys.version,
+        "cacheTag": sys.implementation.cache_tag,
+        "SOABI": identity.soabi,
+        "hexVersion": hex(sys.hexversion),
+        "platformTag": identity.platform_tag,
+        "invokedExecutable": str((tmp_path / "venv" / "bin" / "python").absolute()),
+        "resolvedBaseExecutable": str(executable.resolve()),
+        "executableSha256": identity.executable_sha256,
+    }
+    assert re.fullmatch(r"[0-9a-f]{64}", identity.executable_sha256)
+    assert authority.runtime_cid_for_identity(wire).startswith("blake3-512:")
+
+
+def test_wrong_version_refuses_after_preserving_full_observed_identity(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    executable = tmp_path / "python3.12"
+    executable.write_bytes(b"runtime")
+    observed = _observe_with_base(monkeypatch, invoked=executable, base=executable)
+    wrong = dataclasses.replace(observed, version="3.14.4")
+
+    with pytest.raises(
+        authority.ExecutionEnvironmentMismatch,
+        match=r"required cpython-3\.12\.13; observed cpython-3\.14\.4",
+    ):
+        authority.authenticate_runtime_identity_v1(wrong)
+
+    assert wrong.to_wire()["executableSha256"] == observed.executable_sha256
+    assert "invokedExecutable" in wrong.to_wire()
+
+
+def test_missing_base_executable_is_identity_failure_not_unavailable_marker(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _require_v1_api()
+    missing = tmp_path / "missing-python"
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "invoked"))
+    monkeypatch.setattr(sys, "_base_executable", str(missing), raising=False)
+
+    with pytest.raises(authority.RuntimeIdentityResolutionFailure):
+        authority.observe_runtime_identity_v1()


### PR DESCRIPTION
## What this seals

Runtime identity is producer identity. This series authenticates `runtimeIdentity/v1` before corpus selection, demand-table work, checkpoints, or stage execution; carries `runtimeCid` on every shard partial; and requires every partial runtime CID to agree with the composing runtime.

The load-bearing integrity property is structural: `runtimeIdentity` and `runtimeCid` are embedded directly in the sealed body before `bodyCid` is calculated. They are not parked in `sourceStamp`, which compose deliberately excludes from the `bodyCid` domain.

Host paths remain testimony in `invokedExecutable` and `resolvedBaseExecutable`, but both are excluded from `runtimeCid`. The CID covers the semantic runtime fields plus `executableSha256`, so moving identical interpreter bytes to a different host path does not mint a different runtime.

## runtimeIdentity/v1

The authenticated identity carries:

- `requiredRuntime` from `sugar-build.toml`
- implementation and exact major/minor/micro plus full `sys.version`
- `cacheTag`, `SOABI`, `hexVersion`, and `platformTag`
- absolute `invokedExecutable`
- resolved `resolvedBaseExecutable`
- SHA-256 of the resolved base executable bytes
- semantic `runtimeCid`

Identity-resolution or executable-hashing failure emits `Unmeasured` with a separate `runtimeIdentityFailure`. A runtime mismatch emits `Unmeasured` with `requiredRuntime`, the observed identity, and the mismatch reason. Neither path may emit `frontierWidth`.

## Correct new refusal

A census executed under CPython 3.12.12 must now refuse. The battleaxe census venv used overnight is 3.12.12, so existing invocations will begin emitting honest `Unmeasured` receipts rather than widths. That is correct authentication behavior, not a regression.

The runnable authenticated path is:

- venv: `/tmp/mcmanus-census-a02-31213`
- implementation/version: CPython 3.12.13
- cache tag: `cpython-312`
- SOABI: `cpython-312-x86_64-linux-gnu`
- hex version: `0x30c0df0`
- resolved base: `/home/tsavo/.local/python-3.12.13/bin/python3.12`
- executable SHA-256: `aaaff2d985580740699b4996f886d0a49ce97b59c511366dabb04184e58b6fd1`

## Evidence

Measured on authenticated battleaxe CPython 3.12.13 and pandas 3.0.3:

- requested runtime-identity teeth: 21/21 passed in 0.79s
- runtime-authority plus existing corpus/root integration: 28/28 passed in 1.12s
- range-diff: 4/4 commits identical to the original series
- no files or tests deleted
- no skips or xfails added
- zero imports of the floor-only `no_call_body_attribution.AUTHENTICATED_RUNTIME`

## Scope and consequence

This claims no corpus census, no `frontierWidth`, and no measured result under CPython 3.12.12.

With the conservation causes at zero corpus-wide, the denominator consumer corrected, panic escape and enrollment restored, and the three catch sites repaired, this is the last named prerequisite for a first attested width. After it lands, the next census under authenticated CPython 3.12.13 is the first run eligible to speak; it still must be executed and measured.

Closes #7162

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seal authenticated Python runtime identity in census receipts
> - Adds `RuntimeIdentityV1` observation and hashing in [authenticated_pytest.py](https://github.com/TSavo/sugar/pull/7218/files#diff-6f32158e9034cf4948d264c100017b0e2fa8902654ebd9c5cae4496a4d9a1120): inspects the executing interpreter, SHA-256 hashes the resolved base executable, and computes a BLAKE3-512 `runtimeCid` over semantic fields only.
> - Extends `mint_partial`, `compose_from_partials`, `seal_board_from_aggregate`, and `compose_k1_from_rows` in [compose_control_effect_board.py](https://github.com/TSavo/sugar/pull/7218/files#diff-74e790a1f60d3814877eedd08ed5ab4d88fa6c54e5d483d8fec41180cd0f0915) to require a valid `runtime_attestation`; missing or invalid attestations force outputs to unmeasured with a typed `unmeasuredReason`.
> - Updates [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7218/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to authenticate the runtime immediately after argument parsing, emitting an unmeasured receipt and exiting with code 2 before touching any corpus or checkpoint paths on failure.
> - Cross-shard compose now enforces that all partials carry recomputable `runtimeCid`, agree on the same `runtimeCid`, and match the compose `requiredRuntime`.
> - Risk: all existing callers of `mint_partial`, `compose_from_partials`, and `seal_board_from_aggregate` that omit `runtime_attestation` now auto-resolve the executing runtime; mismatches or hashing failures that previously passed will now produce unmeasured outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1762e5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->