### PR TITLE
Write and diagnose artifact manifests atomically

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -505,11 +505,115 @@ sugar_bx_docker_bind_source() {
   printf '%s\n' "$resolved"
 }
 
+sugar_bx_quarantine_required_artifacts() {
+  local artifacts_dir="$1" quarantine_dir="$2" cap="${3:-64}"
+  python3 - "$artifacts_dir/required-artifacts.json" "$quarantine_dir" "$cap" <<'PY'
+import hashlib
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+manifest_path = pathlib.Path(sys.argv[1])
+quarantine_dir = pathlib.Path(sys.argv[2])
+cap = int(sys.argv[3])
+if not manifest_path.is_file():
+    raise SystemExit(0)
+
+raw = manifest_path.read_bytes()
+try:
+    json.loads(raw)
+except (json.JSONDecodeError, UnicodeDecodeError):
+    pass
+else:
+    raise SystemExit(0)
+
+digest = hashlib.sha256(raw).hexdigest()
+quarantine_dir.mkdir(parents=True, exist_ok=True)
+destination = quarantine_dir / f"required-artifacts.sha256-{digest}.json"
+if not destination.exists():
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".required-artifacts-quarantine.", dir=quarantine_dir
+    )
+    temporary = pathlib.Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(raw)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+entries = sorted(
+    quarantine_dir.glob("required-artifacts.sha256-*.json"),
+    key=lambda path: (path.stat().st_mtime_ns, path.name),
+)
+current_count = len(entries)
+if current_count > cap:
+    evicted = current_count - cap
+    print(
+        "sugarbin: crime=artifact-manifest-quarantine-cap-exceeded "
+        f"path={quarantine_dir} currentCount={current_count} cap={cap} "
+        f"evicted={evicted} remaining={cap} policy=oldest-first",
+        file=sys.stderr,
+    )
+    for path in entries[:evicted]:
+        path.unlink()
+PY
+}
+
+sugar_bx_artifact_build_script() {
+  local needs="$1" profile="$2"
+  local workspace="${3:-/workspace/sugar}" out="${4:-/out}"
+  {
+    printf 'workspace=%q; out=%q; needs=%q; profile=%q; ' \
+      "$workspace" "$out" "$needs" "$profile"
+    cat <<'SCRIPT'
+set -euo pipefail;
+cd "$workspace";
+manifest="$out/required-artifacts.json";
+manifest_tmp="$(mktemp "$out/.required-artifacts.json.XXXXXX")";
+cleanup_manifest_tmp() { [[ -z "${manifest_tmp:-}" ]] || rm -f -- "$manifest_tmp"; };
+trap cleanup_manifest_tmp EXIT;
+trap 'exit 129' HUP;
+trap 'exit 130' INT;
+trap 'exit 143' TERM;
+printf '{"artifacts":[' >"$manifest_tmp";
+first=1;
+IFS=,;
+for b in $needs; do
+  [[ -n "$b" ]] || continue;
+  r="$(env -u SUGAR_BIN -u SUGAR_BINARY_DIR bin/sugarbin --profile "$profile" --platform linux-x86_64 --bin "$b")";
+  cp "$r" "$out/$b";
+  cp "$r.sugarbin.json" "$out/$b.sugarbin.json";
+  sum="$(sha256sum "$out/$b" | cut -d' ' -f1)";
+  [[ "$first" == 1 ]] || printf ',' >>"$manifest_tmp";
+  first=0;
+  printf '{"name":"%s","sha256":"%s"}' "$b" "$sum" >>"$manifest_tmp";
+done;
+printf ']}' >>"$manifest_tmp";
+mv -f -- "$manifest_tmp" "$manifest";
+manifest_tmp="";
+trap - EXIT HUP INT TERM;
+SCRIPT
+  } | tr '\n' ' '
+  printf '\n'
+}
+
 sugar_bx_build_artifacts_docker() {
   local image="$1" needs="$2" profile="$3" provision_artifacts="${4:-0}"
   local image_digest="${image##*@sha256:}"
   local managed_target="${BCARGO_REMOTE_MANAGED_TARGET:-/home/tsavo/.cache/sugar/managed-targets/$image_digest}"
-  sugar_bx_ssh "rm -rf $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") && mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_BX_BINARY_CACHE") $(sugar_bx_quote "$SUGAR_BX_BINARY_SHELF") $(sugar_bx_quote "$managed_target")" || return $?
+  local quarantine_def reset_command
+  quarantine_def="$(declare -f sugar_bx_quarantine_required_artifacts)"
+  reset_command="set -euo pipefail
+$quarantine_def
+sugar_bx_quarantine_required_artifacts $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_BX_ROOT/artifact-manifest-quarantine") 64
+rm -rf $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts")
+mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_BX_BINARY_CACHE") $(sugar_bx_quote "$SUGAR_BX_BINARY_SHELF") $(sugar_bx_quote "$managed_target")"
+  sugar_bx_ssh "$reset_command" || return $?
   local workspace_source artifacts_source cache_source shelf_source target_source
   workspace_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_REPO")" || return $?
   artifacts_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_ROOT/artifacts")" || return $?
@@ -517,7 +621,7 @@ sugar_bx_build_artifacts_docker() {
   shelf_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_BINARY_SHELF")" || return $?
   target_source="$(sugar_bx_docker_bind_source "$managed_target")" || return $?
   local build_script
-  build_script="set -euo pipefail; cd /workspace/sugar; printf '{\"artifacts\":[' >/out/required-artifacts.json; first=1; needs=$(sugar_bx_quote "$needs"); IFS=,; for b in \$needs; do [ -n \"\$b\" ] || continue; r=\$(env -u SUGAR_BIN -u SUGAR_BINARY_DIR bin/sugarbin --profile $(sugar_bx_quote "$profile") --platform linux-x86_64 --bin \"\$b\"); cp \"\$r\" /out/\"\$b\"; cp \"\$r.sugarbin.json\" /out/\"\$b.sugarbin.json\"; sum=\$(sha256sum /out/\"\$b\" | cut -d' ' -f1); [ \$first = 1 ] || printf ',' >>/out/required-artifacts.json; first=0; printf '{\"name\":\"%s\",\"sha256\":\"%s\"}' \"\$b\" \"\$sum\" >>/out/required-artifacts.json; done; printf ']}' >>/out/required-artifacts.json"
+  build_script="$(sugar_bx_artifact_build_script "$needs" "$profile")"
   local shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2,readonly"
   local name
   if [[ "$provision_artifacts" == 1 ]]; then

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -189,4 +189,225 @@ line="$(tail -1 "$tmp/docker.log")"
 examples="$(run explain --host bx --task examples-gate)"
 [[ "$examples" == *"network=required"* ]] || fail "examples-gate network requirement not explicit"
 
+# Artifact-manifest refusal belongs to the managed entrypoint, after the
+# toolchain has authenticated. Exercise that real shell boundary with /opt
+# relocated into this test's private root; only absolute fixture paths change.
+entrypoint_root="$tmp/entrypoint-root"
+entrypoint_under_test="$tmp/entrypoint-under-test.sh"
+entrypoint_bin="$tmp/entrypoint-bin"
+mkdir -p "$entrypoint_root/opt/sugar/bin" \
+  "$entrypoint_root/opt/pyright/nodeenv/bin" "$entrypoint_bin"
+python3 - "$repo/tools/sugar-build/entrypoint.sh" \
+  "$entrypoint_under_test" "$entrypoint_root" <<'PY'
+from pathlib import Path
+import sys
+
+source, target, root = map(Path, sys.argv[1:])
+target.write_text(source.read_text().replace("/opt/", f"{root}/opt/"))
+PY
+cat >"$entrypoint_bin/rustc" <<'SH'
+#!/usr/bin/env bash
+printf 'rustc 1.96.0\n'
+SH
+cat >"$entrypoint_bin/cargo" <<'SH'
+#!/usr/bin/env bash
+printf 'cargo 1.96.0\n'
+SH
+cat >"$entrypoint_bin/black" <<'SH'
+#!/usr/bin/env bash
+printf 'black 26.5.1\n'
+SH
+cat >"$entrypoint_bin/b3sum" <<'SH'
+#!/usr/bin/env bash
+printf 'b3sum 1.8.1\n'
+SH
+cat >"$entrypoint_bin/python" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) printf 'Python 3.12.13\n' ;;
+  -m) printf 'pyright 1.1.411\n' ;;
+  -c) printf 'node 26.5.0\n' ;;
+  -) exec "$REAL_PYTHON" "$@" ;;
+  *) exec "$REAL_PYTHON" "$@" ;;
+esac
+SH
+printf '#!/usr/bin/env bash\nexit 0\n' \
+  >"$entrypoint_root/opt/pyright/nodeenv/bin/node"
+printf 'node 26.5.0\n' >"$entrypoint_root/opt/pyright/node-version"
+chmod +x "$entrypoint_under_test" "$entrypoint_bin"/* \
+  "$entrypoint_root/opt/pyright/nodeenv/bin/node"
+
+manifest="$entrypoint_root/opt/sugar/required-artifacts.json"
+printf '{"artifacts":[]}{}\n' >"$manifest"
+status=0
+PATH="$entrypoint_bin:$PATH" REAL_PYTHON="$(command -v python3)" \
+  "$entrypoint_under_test" true >"$tmp/manifest-parse.out" \
+  2>"$tmp/manifest-parse.err" || status=$?
+[[ "$status" == 70 ]] || fail "malformed artifact manifest status=$status, want 70"
+grep -Fq 'crime=artifact-manifest-parse-failed' "$tmp/manifest-parse.err" \
+  || fail "malformed artifact manifest did not name parse failure"
+grep -Fq "$manifest" "$tmp/manifest-parse.err" \
+  || fail "malformed artifact manifest did not name its file"
+grep -Fq 'Extra data' "$tmp/manifest-parse.err" \
+  || fail "malformed artifact manifest did not retain the parse error"
+! grep -Fq 'artifact checksum mismatch' "$tmp/manifest-parse.err" \
+  || fail "malformed JSON was misreported as a checksum mismatch"
+
+artifact="$entrypoint_root/opt/sugar/bin/sugar"
+printf 'artifact payload\n' >"$artifact"
+chmod +x "$artifact"
+expected="$(printf '%064d' 0)"
+observed="$(python3 - "$artifact" <<'PY'
+import hashlib, pathlib, sys
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+printf '{"artifacts":[{"name":"sugar","sha256":"%s"}]}\n' \
+  "$expected" >"$manifest"
+status=0
+PATH="$entrypoint_bin:$PATH" REAL_PYTHON="$(command -v python3)" \
+  "$entrypoint_under_test" true >"$tmp/manifest-checksum.out" \
+  2>"$tmp/manifest-checksum.err" || status=$?
+[[ "$status" == 70 ]] || fail "artifact checksum mismatch status=$status, want 70"
+grep -Fq 'crime=artifact-checksum-mismatch' "$tmp/manifest-checksum.err" \
+  || fail "checksum mismatch did not name its cause"
+grep -Fq "manifest=$manifest" "$tmp/manifest-checksum.err" \
+  || fail "checksum mismatch did not name its manifest"
+grep -Fq "artifact=$artifact" "$tmp/manifest-checksum.err" \
+  || fail "checksum mismatch did not name its artifact"
+grep -Fq "expected=$expected" "$tmp/manifest-checksum.err" \
+  || fail "checksum mismatch did not report its expected digest"
+grep -Fq "observed=$observed" "$tmp/manifest-checksum.err" \
+  || fail "checksum mismatch did not report its observed digest"
+! grep -Fq 'crime=artifact-manifest-parse-failed' "$tmp/manifest-checksum.err" \
+  || fail "checksum mismatch was misreported as a parse failure"
+
+# Exercise the exact writer script used by the Docker artifact builder. A
+# signal after the first artifact has been appended must leave the prior final
+# manifest byte-identical; existence alone would admit a truncated replacement.
+source "$repo/bin/lib/sugar-bx.sh"
+writer_workspace="$tmp/writer-workspace"
+writer_out="$tmp/writer-out"
+mkdir -p "$writer_workspace/bin" "$writer_out" "$tmp/writer-payloads"
+cat >"$writer_workspace/bin/sugarbin" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+binary=""
+while (($#)); do
+  if [[ "$1" == --bin ]]; then binary="$2"; shift 2; else shift; fi
+done
+[[ -n "$binary" ]]
+if [[ "$binary" == second && -n "${WRITER_BLOCK_MARKER:-}" ]]; then
+  : >"$WRITER_BLOCK_MARKER"
+  kill -TERM "$PPID"
+  exit 143
+fi
+printf '%s/%s\n' "$WRITER_PAYLOAD_ROOT" "$binary"
+SH
+chmod +x "$writer_workspace/bin/sugarbin"
+for binary in first second; do
+  printf '%s payload\n' "$binary" >"$tmp/writer-payloads/$binary"
+  printf '{}\n' >"$tmp/writer-payloads/$binary.sugarbin.json"
+done
+
+prior_manifest="$tmp/prior-required-artifacts.json"
+printf '{"prior":"evidence"}\n' >"$writer_out/required-artifacts.json"
+cp "$writer_out/required-artifacts.json" "$prior_manifest"
+writer_script="$(sugar_bx_artifact_build_script \
+  first,second release "$writer_workspace" "$writer_out")"
+status=0
+WRITER_PAYLOAD_ROOT="$tmp/writer-payloads" \
+WRITER_BLOCK_MARKER="$tmp/writer-blocked" \
+  bash -c "$writer_script" || status=$?
+[[ -e "$tmp/writer-blocked" ]] || fail "writer never reached the mid-write kill point"
+[[ "$status" != 0 ]] || fail "killed manifest writer returned success"
+cmp -s "$prior_manifest" "$writer_out/required-artifacts.json" \
+  || fail "killed writer replaced the prior final manifest"
+if find "$writer_out" -maxdepth 1 -name '.required-artifacts.json.*' -print -quit | grep -q .; then
+  fail "killed writer left staging residue"
+fi
+
+unset WRITER_BLOCK_MARKER
+rm -f "$writer_out/required-artifacts.json"
+writer_script="$(sugar_bx_artifact_build_script \
+  first release "$writer_workspace" "$writer_out")"
+WRITER_PAYLOAD_ROOT="$tmp/writer-payloads" bash -c "$writer_script"
+python3 - "$writer_out" <<'PY'
+import hashlib, json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+manifest = json.loads((root / "required-artifacts.json").read_text())
+assert len(manifest["artifacts"]) == 1, manifest
+item = manifest["artifacts"][0]
+assert item["name"] == "first", item
+assert item["sha256"] == hashlib.sha256((root / "first").read_bytes()).hexdigest(), item
+assert not list(root.glob(".required-artifacts.json.*"))
+PY
+
+# Malformed prior manifests are evidence. Quarantine them by content before the
+# full artifact reset, collapse repeats, and make bounded eviction loud.
+quarantine_artifacts="$tmp/quarantine-artifacts"
+quarantine="$tmp/quarantine"
+mkdir -p "$quarantine_artifacts" "$quarantine"
+printf '{"artifacts":[' >"$quarantine_artifacts/required-artifacts.json"
+corrupt_digest="$(python3 - "$quarantine_artifacts/required-artifacts.json" <<'PY'
+import hashlib, pathlib, sys
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+sugar_bx_quarantine_required_artifacts \
+  "$quarantine_artifacts" "$quarantine" 64 2>"$tmp/quarantine.err"
+quarantined="$quarantine/required-artifacts.sha256-$corrupt_digest.json"
+cmp -s "$quarantine_artifacts/required-artifacts.json" "$quarantined" \
+  || fail "quarantine did not preserve malformed bytes"
+sugar_bx_quarantine_required_artifacts \
+  "$quarantine_artifacts" "$quarantine" 64 2>>"$tmp/quarantine.err"
+[[ "$(find "$quarantine" -type f | wc -l | tr -d ' ')" == 1 ]] \
+  || fail "identical corruption did not collapse by content"
+
+cap_quarantine="$tmp/cap-quarantine"
+mkdir -p "$cap_quarantine"
+python3 - "$cap_quarantine" <<'PY'
+import os, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+for index in range(64):
+    path = root / f"required-artifacts.sha256-{index:064x}.json"
+    path.write_text(f"old-{index}\n")
+    stamp = 1_700_000_000 + index
+    os.utime(path, (stamp, stamp))
+PY
+sugar_bx_quarantine_required_artifacts \
+  "$quarantine_artifacts" "$cap_quarantine" 64 2>"$tmp/quarantine-cap.err"
+[[ "$(find "$cap_quarantine" -type f | wc -l | tr -d ' ')" == 64 ]] \
+  || fail "quarantine cap did not conserve 64 entries"
+[[ ! -e "$cap_quarantine/required-artifacts.sha256-$(printf '%064x' 0).json" ]] \
+  || fail "quarantine did not evict the oldest entry first"
+[[ -e "$cap_quarantine/required-artifacts.sha256-$corrupt_digest.json" ]] \
+  || fail "quarantine evicted the newly observed corruption"
+grep -Fq 'crime=artifact-manifest-quarantine-cap-exceeded' \
+  "$tmp/quarantine-cap.err" || fail "quarantine eviction was silent"
+grep -Fq 'currentCount=65' "$tmp/quarantine-cap.err" \
+  || fail "quarantine eviction did not report its current count"
+
+valid_artifacts="$tmp/valid-artifacts"
+valid_quarantine="$tmp/valid-quarantine"
+mkdir -p "$valid_artifacts" "$valid_quarantine"
+printf '{"artifacts":[]}\n' >"$valid_artifacts/required-artifacts.json"
+sugar_bx_quarantine_required_artifacts \
+  "$valid_artifacts" "$valid_quarantine" 64
+[[ "$(find "$valid_quarantine" -type f | wc -l | tr -d ' ')" == 0 ]] \
+  || fail "valid manifest was quarantined"
+
+python3 - "$repo/bin/lib/sugar-bx.sh" <<'PY'
+import pathlib, sys
+source = pathlib.Path(sys.argv[1]).read_text()
+body = source.split("sugar_bx_build_artifacts_docker() {", 1)[1]
+body = body.split("\n}", 1)[0]
+quarantine = body.index(
+    'sugar_bx_quarantine_required_artifacts '
+    '$(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts")'
+)
+reset = body.index('rm -rf $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts")')
+assert quarantine < reset, "malformed-manifest evidence is destroyed before quarantine"
+PY
+
 echo "PASS: sugarbin Docker execution contract"

--- a/tools/sugar-build/entrypoint.sh
+++ b/tools/sugar-build/entrypoint.sh
@@ -33,18 +33,38 @@ contract_mismatch() {
 [[ "$(b3sum --version | awk '{print $2}')" == 1.8.1 ]] || contract_mismatch b3sum
 
 if [[ -f /opt/sugar/required-artifacts.json ]]; then
-  artifact_count="$(python - /opt/sugar/required-artifacts.json <<'PY' || {
+  artifact_count="$(python - /opt/sugar/required-artifacts.json /opt/sugar/bin <<'PY' || exit $?
 import hashlib, json, pathlib, sys
-manifest = json.loads(pathlib.Path(sys.argv[1]).read_text())
+manifest_path = pathlib.Path(sys.argv[1])
+artifact_root = pathlib.Path(sys.argv[2])
+try:
+    manifest = json.loads(manifest_path.read_text())
+except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    print(
+        "sugarbin: crime=artifact-manifest-parse-failed "
+        f"path={manifest_path} error={type(error).__name__}: {error}",
+        file=sys.stderr,
+    )
+    raise SystemExit(70)
 for item in manifest["artifacts"]:
-    path = pathlib.Path("/opt/sugar/bin") / item["name"]
-    if not path.is_file() or hashlib.sha256(path.read_bytes()).hexdigest() != item["sha256"]:
-        raise SystemExit(1)
+    path = artifact_root / item["name"]
+    expected = item["sha256"]
+    observed = (
+        hashlib.sha256(path.read_bytes()).hexdigest()
+        if path.is_file()
+        else "<missing>"
+    )
+    if observed != expected:
+        print(
+            "sugarbin: crime=artifact-checksum-mismatch "
+            f"manifest={manifest_path} artifact={path} "
+            f"expected={expected} observed={observed}",
+            file=sys.stderr,
+        )
+        raise SystemExit(70)
 print(len(manifest["artifacts"]))
 PY
-    echo "artifact checksum mismatch" >&2
-    exit 70
-  })"
+  )"
   if [[ "$artifact_count" -gt 0 ]]; then
     export SUGAR_BINARY_DIR=/opt/sugar/bin
     if [[ -x /opt/sugar/bin/sugar ]]; then


### PR DESCRIPTION
## Load-bearing contract

The artifact manifest writer now creates its temporary file with `mktemp` inside `/out`, installs trap cleanup, and deposits it with a same-filesystem rename only after the complete JSON document exists. A killed invocation therefore leaves the prior manifest byte-identical and leaves zero staging residue instead of exposing partial JSON.

The reader now preserves two distinct refusal arms:

- `crime=artifact-manifest-parse-failed` names the manifest path and the parse error.
- `crime=artifact-checksum-mismatch` names the manifest, artifact, expected digest, and observed digest.

Previously both failures shared one shell arm, so a JSON parse failure emitted “artifact checksum mismatch” two layers from the real defect and required a PTY run to diagnose.

## Evidence preservation before reset

Malformed manifests are quarantined before the artifact directory is reset. The full reset remains authoritative so stale, unrequested binaries cannot leak through `PATH`.

Quarantine names each file by SHA-256 of its malformed bytes. Repeated identical corruption collapses to the same content-addressed file. The oldest-first cap is loud: the 65-to-64 arm reports `currentCount=65`, the cap, eviction count, and policy rather than silently discarding evidence.

## Measured teeth

The enrolled sugarbin Docker contract passed 1/1 and covers:

- distinct parse/checksum refusal twins
- mid-write prior-manifest byte identity with zero staging residue
- content-addressed duplicate collapse
- loud oldest-first cap from 65 to 64
- valid-manifest acceptance
- quarantine-before-reset ordering

Adjacent evidence:

- `sugarbin_bx_exec`: 1/1 passed
- mount proof: 1/1 passed
- `bash -n`: passed
- diff check: passed

## Honest causation boundary

This does not claim that historical overlapping writers caused the original concatenation. One writer cannot produce two complete JSON documents: it truncates before writing. Concurrent same-worktree invocations share a deterministic `/out` root and could interleave, but no process evidence survives to establish that as the cause.

The original corruption therefore remains unexplained. This change removes the writer and diagnostic mechanisms that could expose partial or misleading state, and preserves malformed evidence if it recurs.

The adjacent `sugarbin_artifact_manifest.sh` tooth remains red and is intentionally untouched. Its measured cause is the separately recorded stale `--platform` argument-order literal in #7163.

Closes #7212
Closes #7213

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write and diagnose artifact manifests atomically with quarantine for malformed files
> - The artifact build script in [`sugar-bx.sh`](https://github.com/TSavo/sugar/pull/7219/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) now writes `required-artifacts.json` via a temp file and atomic rename, preventing partial files on signal or failure.
> - Before clearing the artifacts directory, `sugar_bx_build_artifacts_docker` quarantines malformed `required-artifacts.json` files into a bounded, deduplicated `artifact-manifest-quarantine` directory (cap 64, evicts oldest first).
> - The entrypoint in [`entrypoint.sh`](https://github.com/TSavo/sugar/pull/7219/files#diff-a9d742f38b5e10924edca17d0a5298b10a7fa3d5c704c534da28c5ef0a9a0dc9) now exits with status 70 and emits structured stderr lines (`crime=artifact-manifest-parse-failed` or `crime=artifact-checksum-mismatch`) on manifest parse errors or checksum mismatches.
> - Tests in [`tests/sugarbin_docker_exec.sh`](https://github.com/TSavo/sugar/pull/7219/files#diff-dd07889f0744ddb1e6ea24d617d74078943ffb624914227169d92a4b12d3165c) cover atomicity, signal safety, quarantine deduplication, cap eviction, and entrypoint error reporting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b41ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact manifest validation with clearer diagnostics for malformed manifests and missing or modified files.
  * Standardized validation failures with consistent error reporting and exit status.
  * Preserved malformed manifests safely before artifact directory resets.

* **Reliability**
  * Added atomic artifact-manifest updates to prevent incomplete or corrupted files.
  * Added quarantine deduplication and automatic cleanup when storage reaches capacity.
  * Improved handling of interrupted artifact builds and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->