### PR TITLE
Repair stale sugarbin tier contracts

### DIFF
--- a/tests/sugarbin_artifact_manifest.sh
+++ b/tests/sugarbin_artifact_manifest.sh
@@ -244,7 +244,20 @@ chmod +x "$tmp/bin/ssh" "$tmp/bin/rsync"
   BCARGO_SSH="$tmp/bin/ssh" BCARGO_RSYNC="$tmp/bin/rsync" \
   BCARGO_REMOTE_ROOT=/home/tsavo/remote/sugarbin-artifact-manifest-test \
   "$repo/bin/sugarbin" run --host bx --needs sugar,sugar-ir-smt-lib -- true)
-grep -Fq 'bin/sugarbin --platform' "$tmp/ssh.log"
+python3 - "$tmp/ssh.log" <<'PY'
+import pathlib, sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+calls = text.split("bin/sugarbin ")[1:]
+assert len(calls) == 2, f"managed resolver call count={len(calls)}, want 2"
+for call in calls:
+    profile = call.index("--profile")
+    release = call.index("release", profile)
+    platform = call.index("--platform", release)
+    linux = call.index("linux-x86_64", platform)
+    binary = call.index("--bin", linux)
+    assert profile < release < platform < linux < binary, call
+PY
 grep -Fq -- '--bin "$b"' "$tmp/ssh.log"
 grep -Fq 'SUGAR_BINARY_DIR=' "$tmp/ssh.log"
 grep -Fq 'sugar-ir-smt-lib' "$tmp/ssh.log"

--- a/tests/sugarbin_build_identity_target.sh
+++ b/tests/sugarbin_build_identity_target.sh
@@ -117,9 +117,33 @@ resolved_again="$("$repo/bin/sugarbin" --bin sugar)"
 export SUGAR_BINARY_NO_SHELF=0 SUGAR_BINARY_PUBLISH=1
 export SUGAR_BINARY_SHELF_ROOT="$tmp/shelf"
 "$repo/bin/sugarbin" --bin sugar >/dev/null
-# Cell layout: shelf/<platform>/<profile>/<sourceStamp>/<artifactName>/*.gz
-ls "$tmp/shelf"/*/*/*/*/*.gz >/dev/null 2>&1 \
-  || { echo 'shelf cell missing after publish' >&2; ls -laR "$tmp/shelf" >&2; exit 1; }
+# Current binary shelf identity has two independent parts: the mutable
+# sourceStamp lookup ref and the immutable h(payload) CAS cell it names.
+# Authenticate both rather than pinning the retired stamp-keyed cell layout.
+python3 - "$tmp/shelf" "$SUGAR_BINARY_SOURCE_STAMP" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+shelf = pathlib.Path(sys.argv[1])
+source_stamp = sys.argv[2]
+refs = list(shelf.glob(f"*/release/by-stamp/{source_stamp}/sugar.ref"))
+assert len(refs) == 1, f"sourceStamp ref count={len(refs)}, want 1: {refs}"
+content_key = refs[0].read_text(encoding="utf-8").strip()
+assert re.fullmatch(r"blake3-512_[0-9a-f]{128}", content_key), content_key
+cell = shelf / "cas" / content_key / "sugar"
+expected = {
+    cell / "sugar.gz",
+    cell / "sugar.metadata.json",
+    cell / "sugar.sugarbin.json",
+}
+assert expected == {path for path in cell.iterdir() if path.is_file()}, cell
+metadata = json.loads((cell / "sugar.metadata.json").read_text(encoding="utf-8"))
+assert metadata["buildStamp"] == source_stamp, metadata
+assert metadata["contentKey"] == content_key, metadata
+assert metadata["transport"] == "filesystem-cas-v3", metadata
+PY
 rm "$tmp/target/release/sugar" "$tmp/target/release/sugar.sugarbin.json"
 export SUGAR_BINARY_ALLOW_BUILD=0
 resolved_from_shelf="$("$repo/bin/sugarbin" --bin sugar)"

--- a/tests/sugarbin_python_demand_table_fixture.sh
+++ b/tests/sugarbin_python_demand_table_fixture.sh
@@ -5,6 +5,11 @@ repo="${1:?usage: sugarbin_python_demand_table_fixture.sh REPO_ROOT}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# This fixture exercises the publisher itself. Its caller may have disabled
+# publication while testing a different resolver face; that ambient setting
+# cannot turn this fixture into a no-op that later looks like a missing cell.
+export SUGAR_BINARY_PUBLISH=1
+
 mkdir -p \
   "$tmp/corpus/pkg" \
   "$tmp/seed-shelf" \


### PR DESCRIPTION
## Two stale contracts, both valid at introduction

This repairs the two remaining #7163 tier reds by correcting test expectations against deliberate interface migrations. Production is unchanged: exactly three test files change and no product code is touched.

### Artifact manifest contract

The managed-argument tooth was valid when introduced at `8cb62b63`. Deliberate managed-bx commit `b1fe5556` changed the live interface to `--profile release --platform linux-x86_64` and left the literal behind. The tooth was not red from birth.

Once that stale argv assertion was corrected, a second masked defect became visible: caller environment could disable the nested demand-table publisher, producing zero cells. That leak entered at `964dbf95` and is now closed by fixture-owned publication. One red was masking another.

The repaired wrapper contract passes, including the nested demand-table race fixture.

### Build-identity contract

The stamp-keyed shelf-layout tooth was valid at `a42524ee`. Deliberate CAS commit `e0598d3a` replaced that layout and left the old assertion behind. This tooth also was not wrong at introduction.

The replacement authenticates:

- exactly one by-stamp reference
- the referenced `h(payload)` CAS cell
- all three cell files
- the source-stamp, content-key, and transport metadata identities
- build-disabled resolution from the shelf

That is stronger testimony than the retired layout glob and independently verifies the shelf migration landed by #7211.

## Measured evidence

Fresh verification at `982dfe56ab2d35ec5eefd54ee366c057e90d1ed3`:

- `bash -n`: exit 0
- `git diff --check`: exit 0
- artifact-manifest wrapper contract: PASS, including nested demand-table race fixture
- build-identity target contract: PASS, including the exact by-stamp-to-CAS identity and build-disabled shelf pull

These are the fourth and fifth examples today of a correct deliberate migration leaving a consumer behind—the same class as the wrapper-compat contract and the retired `_measure_file` door.

## Enrollment boundary

- The Rust tier has **0 current workflow execution edges and is NOT CI-enrolled**.
- Hockney does **not claim it was never run manually**.
- **#7153 enrollment is NOT fixed by this**.

The tests are now correct and still unobserved by current workflows. Fixing them improves the record, not the CI signal.

Closes #7163

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Repair stale sugarbin tier contracts by updating test assertions for CAS-based publishing
> - [sugarbin_artifact_manifest.sh](https://github.com/TSavo/sugar/pull/7220/files#diff-62ad08986dd81ce10fd2fa4dbf7cd2b129f5ddeeb3eb82a0c86231bb833225d3) replaces a simple `grep` with a Python assertion that verifies exactly two `bin/sugarbin` invocations occur in `ssh.log` with arguments in the required order: `--profile`, `release`, `--platform`, `linux-x86_64`, `--bin`.
> - [sugarbin_build_identity_target.sh](https://github.com/TSavo/sugar/pull/7220/files#diff-f723da7bd4ea671ebfa49bd0db49229a5d488c823f137e942daa0725f1a9775d) replaces a stamp-keyed shelf cell check with a Python validation that confirms publication via a by-stamp ref pointing to a CAS cell, verifying required files (`sugar.gz`, `sugar.metadata.json`, `sugar.sugarbin.json`) and metadata fields including `transport: filesystem-cas-v3`.
> - [sugarbin_python_demand_table_fixture.sh](https://github.com/TSavo/sugar/pull/7220/files#diff-76ba603dc23ed95c407e7fa2a240428ad1222cbfdbd03cbe8937c85f3d58fbbb) adds `export SUGAR_BINARY_PUBLISH=1` to ensure publishing is always exercised regardless of caller environment settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 982dfe5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->