### PR TITLE
Enroll nine sugarbin shell contracts directly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,6 +541,87 @@ jobs:
             --require-commit "$GITHUB_SHA" \
             | tee -a "$GITHUB_STEP_SUMMARY"
 
+  # Nine sugarbin shell contracts used to be reachable only through
+  # test-rust, which is deliberately outside per-tip CI. Run the exact shell
+  # population directly: one job, three batches, and one attendance receipt.
+  sugarbin-shell-contracts:
+    name: sugarbin shell contracts (9/9 attendance)
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 15
+    env:
+      SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
+    steps:
+      - uses: actions/checkout@v6
+
+      # Initialize every expected row before setup. If setup or a later batch
+      # cannot run, the final audit retains a named absence rather than a
+      # smaller denominator.
+      - name: Initialize exact nine-contract attendance ledger
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/sugarbin_shell_tier.py init \
+            --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
+            --commit "$GITHUB_SHA"
+
+      - name: Verify attendance instrument discrimination twins
+        if: always() && !cancelled()
+        run: python3 tests/test_sugarbin_shell_tier.py
+
+      - name: Install shell-contract dependency
+        if: always() && !cancelled()
+        run: tools/ci-apt-install.sh b3sum
+
+      - name: Run batch 1/3 — execution routes
+        if: always() && !cancelled()
+        shell: bash
+        run: |
+          python3 -u tools/sugarbin_shell_tier.py run-batch execution \
+            --repo "$GITHUB_WORKSPACE" \
+            --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
+            --commit "$GITHUB_SHA"
+
+      - name: Run batch 2/3 — guards and wrappers
+        if: always() && !cancelled()
+        shell: bash
+        run: |
+          python3 -u tools/sugarbin_shell_tier.py run-batch guards \
+            --repo "$GITHUB_WORKSPACE" \
+            --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
+            --commit "$GITHUB_SHA"
+
+      - name: Run batch 3/3 — artifacts and identities
+        if: always() && !cancelled()
+        shell: bash
+        run: |
+          python3 -u tools/sugarbin_shell_tier.py run-batch artifacts \
+            --repo "$GITHUB_WORKSPACE" \
+            --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
+            --commit "$GITHUB_SHA"
+
+      - name: Audit exact 9/9 attendance and results
+        if: always() && !cancelled()
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          python3 tools/sugarbin_shell_tier.py audit \
+            --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
+            --receipt "$SUGARBIN_SHELL_TIER_ROOT/receipt.json" \
+            --require-commit "$GITHUB_SHA" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          audit_status="${PIPESTATUS[0]}"
+          set -e
+          exit "$audit_status"
+
+      - name: Upload sugarbin shell attendance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sugarbin-shell-tier-${{ github.sha }}
+          path: ${{ runner.temp }}/sugarbin-shell-tier/
+          if-no-files-found: error
+
   acid-test:
     name: acid test (make ci)
     # Aggregate genuine success/failure results, but do not manufacture a red
@@ -553,6 +634,7 @@ jobs:
       - claim-mass-attendance
       - python-format-attendance
       - showcase-attendance
+      - sugarbin-shell-contracts
     runs-on: ubuntu-latest
     steps:
       - name: Report the complete acid-test vector
@@ -563,11 +645,13 @@ jobs:
           CLAIM_MASS_RESULT: ${{ needs.claim-mass-attendance.result }}
           FORMAT_RESULT: ${{ needs.python-format-attendance.result }}
           SHOWCASE_RESULT: ${{ needs.showcase-attendance.result }}
+          SUGARBIN_SHELL_RESULT: ${{ needs.sugarbin-shell-contracts.result }}
         run: |
-          echo "apt=$APT_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT claim-mass=$CLAIM_MASS_RESULT format=$FORMAT_RESULT showcases=$SHOWCASE_RESULT"
+          echo "apt=$APT_RESULT core=$CORE_RESULT core-shelf=$CORE_SHELF_RESULT claim-mass=$CLAIM_MASS_RESULT format=$FORMAT_RESULT showcases=$SHOWCASE_RESULT sugarbin-shell=$SUGARBIN_SHELL_RESULT"
           test "$APT_RESULT" = success
           test "$CORE_RESULT" = success
           test "$CORE_SHELF_RESULT" = success
           test "$CLAIM_MASS_RESULT" = success
           test "$FORMAT_RESULT" = success
           test "$SHOWCASE_RESULT" = success
+          test "$SUGARBIN_SHELL_RESULT" = success

--- a/tests/test_sugarbin_shell_tier.py
+++ b/tests/test_sugarbin_shell_tier.py
@@ -1,0 +1,174 @@
+"""Executable teeth for the nine-contract sugarbin shell tier."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "sugarbin_shell_tier.py"
+EXPECTED_BATCHES = {
+    "execution": [
+        "tests/sugarbin_local_exec.sh",
+        "tests/sugarbin_bx_exec.sh",
+        "tests/sugarbin_docker_exec.sh",
+    ],
+    "guards": [
+        "tests/sugarbin_mount_proof_guard.sh",
+        "tests/sugarbin_docker_daemon_guard.sh",
+        "tests/sugarbin_wrapper_compat.sh",
+    ],
+    "artifacts": [
+        "tests/sugarbin_artifact_manifest.sh",
+        "tests/sugarbin_build_identity_target.sh",
+        "tests/sugarbin_build_root_identity.sh",
+    ],
+}
+EXPECTED_ROSTER = [
+    contract for batch in EXPECTED_BATCHES.values() for contract in batch
+]
+
+
+class SugarbinShellTierTest(unittest.TestCase):
+    def run_tool(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(TOOL), *args],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_roster_is_exactly_three_batches_of_three(self) -> None:
+        result = self.run_tool("list", "--json")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), EXPECTED_BATCHES)
+
+    def test_init_names_every_absence_before_any_batch_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            reports = Path(directory)
+            result = self.run_tool(
+                "init", "--reports-dir", str(reports), "--commit", "abc123"
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            bodies = sorted(reports.glob("*.json"))
+            self.assertEqual(len(bodies), 9)
+            payloads = [json.loads(path.read_text(encoding="utf-8")) for path in bodies]
+            self.assertEqual({body["contract"] for body in payloads}, set(EXPECTED_ROSTER))
+            self.assertEqual({body["status"] for body in payloads}, {"unmeasured"})
+            self.assertEqual({body["reason"] for body in payloads}, {"batch-not-started"})
+            self.assertEqual({body["measuredCommit"] for body in payloads}, {"abc123"})
+
+    def test_batch_records_pass_failure_and_missing_script_without_stopping(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            repo = temp / "repo"
+            reports = temp / "reports"
+            tests = repo / "tests"
+            tests.mkdir(parents=True)
+            (tests / "sugarbin_local_exec.sh").write_text(
+                "#!/usr/bin/env bash\nexit 0\n", encoding="utf-8"
+            )
+            (tests / "sugarbin_bx_exec.sh").write_text(
+                "#!/usr/bin/env bash\nexit 7\n", encoding="utf-8"
+            )
+            initialized = self.run_tool(
+                "init", "--reports-dir", str(reports), "--commit", "abc123"
+            )
+            self.assertEqual(initialized.returncode, 0, initialized.stderr)
+
+            result = self.run_tool(
+                "run-batch",
+                "execution",
+                "--repo",
+                str(repo),
+                "--reports-dir",
+                str(reports),
+                "--commit",
+                "abc123",
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout.count("ATTEND phase=start"), 3)
+
+            local = json.loads(
+                (reports / "sugarbin_local_exec.json").read_text(encoding="utf-8")
+            )
+            bx = json.loads(
+                (reports / "sugarbin_bx_exec.json").read_text(encoding="utf-8")
+            )
+            docker = json.loads(
+                (reports / "sugarbin_docker_exec.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual((local["status"], local["exitCode"]), ("completed", 0))
+            self.assertEqual((bx["status"], bx["exitCode"]), ("completed", 7))
+            self.assertEqual(
+                (docker["status"], docker["reason"]),
+                ("unmeasured", "script-missing"),
+            )
+
+    def test_audit_refuses_absence_and_accepts_exact_nine_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            reports = Path(directory) / "reports"
+            receipt = Path(directory) / "receipt.json"
+            initialized = self.run_tool(
+                "init", "--reports-dir", str(reports), "--commit", "abc123"
+            )
+            self.assertEqual(initialized.returncode, 0, initialized.stderr)
+
+            absent = self.run_tool(
+                "audit",
+                "--reports-dir",
+                str(reports),
+                "--receipt",
+                str(receipt),
+                "--require-commit",
+                "abc123",
+            )
+            self.assertNotEqual(absent.returncode, 0)
+            self.assertIn("R_sugarbin_shell_attendance = 9", absent.stdout)
+            self.assertEqual(json.loads(receipt.read_text())["passed"], 0)
+
+            for contract in EXPECTED_ROSTER:
+                path = reports / f"{Path(contract).stem}.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schemaVersion": 1,
+                            "measurementClass": "sugarbin-shell-contract",
+                            "contract": contract,
+                            "measuredCommit": "abc123",
+                            "status": "completed",
+                            "exitCode": 0,
+                            "reason": "exit-0",
+                        }
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+
+            complete = self.run_tool(
+                "audit",
+                "--reports-dir",
+                str(reports),
+                "--receipt",
+                str(receipt),
+                "--require-commit",
+                "abc123",
+            )
+            self.assertEqual(complete.returncode, 0, complete.stderr)
+            self.assertIn("R_sugarbin_shell_attendance = 0", complete.stdout)
+            summary = json.loads(receipt.read_text())
+            self.assertEqual(
+                (summary["roster"], summary["attended"], summary["passed"]),
+                (9, 9, 9),
+            )
+            self.assertEqual(summary.get("testElapsedSeconds"), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sugarbin_shell_tier.py
+++ b/tools/sugarbin_shell_tier.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Run and audit the nine sugarbin shell contracts enrolled in per-tip CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+BATCHES = {
+    "execution": [
+        "tests/sugarbin_local_exec.sh",
+        "tests/sugarbin_bx_exec.sh",
+        "tests/sugarbin_docker_exec.sh",
+    ],
+    "guards": [
+        "tests/sugarbin_mount_proof_guard.sh",
+        "tests/sugarbin_docker_daemon_guard.sh",
+        "tests/sugarbin_wrapper_compat.sh",
+    ],
+    "artifacts": [
+        "tests/sugarbin_artifact_manifest.sh",
+        "tests/sugarbin_build_identity_target.sh",
+        "tests/sugarbin_build_root_identity.sh",
+    ],
+}
+ROSTER = [contract for batch in BATCHES.values() for contract in batch]
+
+
+def _body_path(reports_dir: Path, contract: str) -> Path:
+    return reports_dir / f"{Path(contract).stem}.json"
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _body(
+    contract: str,
+    *,
+    commit: str,
+    status: str,
+    reason: str,
+    exit_code: int | None = None,
+    elapsed_seconds: float | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schemaVersion": 1,
+        "measurementClass": "sugarbin-shell-contract",
+        "contract": contract,
+        "batch": next(name for name, rows in BATCHES.items() if contract in rows),
+        "measuredCommit": commit,
+        "status": status,
+        "reason": reason,
+        "exitCode": exit_code,
+    }
+    if elapsed_seconds is not None:
+        payload["elapsedSeconds"] = round(elapsed_seconds, 3)
+    return payload
+
+
+def initialize(reports_dir: Path, *, commit: str) -> int:
+    for contract in ROSTER:
+        _write_json(
+            _body_path(reports_dir, contract),
+            _body(
+                contract,
+                commit=commit,
+                status="unmeasured",
+                reason="batch-not-started",
+            ),
+        )
+    print(f"sugarbin-shell init roster={len(ROSTER)} absent={len(ROSTER)}")
+    return 0
+
+
+def run_batch(batch: str, *, repo: Path, reports_dir: Path, commit: str) -> int:
+    failures = 0
+    for contract in BATCHES[batch]:
+        path = repo / contract
+        body_path = _body_path(reports_dir, contract)
+        print(f"ATTEND phase=start batch={batch} contract={contract}", flush=True)
+        if not path.is_file():
+            _write_json(
+                body_path,
+                _body(
+                    contract,
+                    commit=commit,
+                    status="unmeasured",
+                    reason="script-missing",
+                ),
+            )
+            print(
+                f"ATTEND phase=done batch={batch} contract={contract} "
+                "status=unmeasured reason=script-missing",
+                flush=True,
+            )
+            failures += 1
+            continue
+
+        _write_json(
+            body_path,
+            _body(
+                contract,
+                commit=commit,
+                status="running",
+                reason="command-started",
+            ),
+        )
+        started = time.monotonic()
+        try:
+            completed = subprocess.run(
+                ["bash", str(path), str(repo)], cwd=repo, check=False
+            )
+        except OSError as error:
+            elapsed = time.monotonic() - started
+            _write_json(
+                body_path,
+                _body(
+                    contract,
+                    commit=commit,
+                    status="unmeasured",
+                    reason=f"launch-failed:{error}",
+                    elapsed_seconds=elapsed,
+                ),
+            )
+            print(
+                f"ATTEND phase=done batch={batch} contract={contract} "
+                f"status=unmeasured reason=launch-failed elapsed_s={elapsed:.3f}",
+                flush=True,
+            )
+            failures += 1
+            continue
+
+        elapsed = time.monotonic() - started
+        _write_json(
+            body_path,
+            _body(
+                contract,
+                commit=commit,
+                status="completed",
+                reason=f"exit-{completed.returncode}",
+                exit_code=completed.returncode,
+                elapsed_seconds=elapsed,
+            ),
+        )
+        print(
+            f"ATTEND phase=done batch={batch} contract={contract} "
+            f"status=completed exit={completed.returncode} elapsed_s={elapsed:.3f}",
+            flush=True,
+        )
+        if completed.returncode != 0:
+            failures += 1
+    return 1 if failures else 0
+
+
+def _read_body(path: Path) -> tuple[dict[str, object] | None, str | None]:
+    if not path.is_file():
+        return None, "report-missing"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        return None, f"report-invalid:{error}"
+    if not isinstance(payload, dict):
+        return None, "report-root-not-object"
+    return payload, None
+
+
+def audit(
+    reports_dir: Path, *, receipt: Path, require_commit: str | None = None
+) -> int:
+    rows: list[dict[str, object]] = []
+    crimes: list[str] = []
+    attended = 0
+    passed = 0
+    failed = 0
+    test_elapsed_seconds = 0.0
+
+    for contract in ROSTER:
+        payload, read_error = _read_body(_body_path(reports_dir, contract))
+        if read_error is not None:
+            row = {
+                "contract": contract,
+                "batch": next(
+                    name for name, contracts in BATCHES.items() if contract in contracts
+                ),
+                "status": "unmeasured",
+                "reason": read_error,
+                "exitCode": None,
+                "elapsedSeconds": None,
+            }
+            crimes.append(f"{contract}: {read_error}")
+            rows.append(row)
+            continue
+
+        assert payload is not None
+        reason: str | None = None
+        if payload.get("measurementClass") != "sugarbin-shell-contract":
+            reason = "measurement-class-mismatch"
+        elif payload.get("contract") != contract:
+            reason = "contract-mismatch"
+        elif require_commit and payload.get("measuredCommit") != require_commit:
+            reason = "commit-mismatch"
+
+        status = payload.get("status")
+        exit_code = payload.get("exitCode")
+        elapsed_seconds = payload.get("elapsedSeconds")
+        if isinstance(elapsed_seconds, (int, float)):
+            test_elapsed_seconds += float(elapsed_seconds)
+        if reason is not None:
+            crimes.append(f"{contract}: {reason}")
+            status = "unmeasured"
+        elif status in ("running", "completed"):
+            attended += 1
+        if status == "completed" and exit_code == 0:
+            passed += 1
+        elif status == "completed":
+            failed += 1
+
+        row = {
+            "contract": contract,
+            "batch": payload.get("batch"),
+            "status": status,
+            "reason": reason or payload.get("reason"),
+            "exitCode": exit_code,
+            "elapsedSeconds": elapsed_seconds,
+        }
+        rows.append(row)
+
+    absent = len(ROSTER) - attended
+    summary = {
+        "schemaVersion": 1,
+        "measurementClass": "sugarbin-shell-tier-attendance",
+        "measuredCommit": require_commit,
+        "status": "complete" if attended == len(ROSTER) else "unmeasured",
+        "roster": len(ROSTER),
+        "attended": attended,
+        "passed": passed,
+        "failed": failed,
+        "absent": absent,
+        "testElapsedSeconds": round(test_elapsed_seconds, 3),
+        "rows": rows,
+    }
+    _write_json(receipt, summary)
+
+    print("### sugarbin shell tier attendance")
+    print()
+    print(f"- roster: `{len(ROSTER)}`")
+    print(f"- attended: `{attended}`")
+    print(f"- passed: `{passed}`")
+    print(f"- failed: `{failed}`")
+    print(f"- absent: `{absent}`")
+    print(f"- measured test time: `{test_elapsed_seconds:.3f}s`")
+    print()
+    print("| batch | contract | status | reason |")
+    print("| --- | --- | --- | --- |")
+    for row in rows:
+        print(
+            f"| `{row['batch']}` | `{row['contract']}` | `{row['status']}` | "
+            f"`{row['reason']}` |"
+        )
+    print()
+    print(f"**R_sugarbin_shell_attendance = {absent}**")
+    for crime in crimes:
+        print(f"::error::{crime}", file=sys.stderr)
+    return 0 if attended == len(ROSTER) and passed == len(ROSTER) else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list")
+    list_parser.add_argument("--json", action="store_true")
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--reports-dir", type=Path, required=True)
+    init_parser.add_argument("--commit", required=True)
+
+    batch_parser = subparsers.add_parser("run-batch")
+    batch_parser.add_argument("batch", choices=BATCHES)
+    batch_parser.add_argument("--repo", type=Path, required=True)
+    batch_parser.add_argument("--reports-dir", type=Path, required=True)
+    batch_parser.add_argument("--commit", required=True)
+
+    audit_parser = subparsers.add_parser("audit")
+    audit_parser.add_argument("--reports-dir", type=Path, required=True)
+    audit_parser.add_argument("--receipt", type=Path, required=True)
+    audit_parser.add_argument("--require-commit")
+
+    args = parser.parse_args(argv)
+    if args.command == "list":
+        if args.json:
+            print(json.dumps(BATCHES, indent=2))
+        else:
+            for batch, contracts in BATCHES.items():
+                for contract in contracts:
+                    print(f"{batch}\t{contract}")
+        return 0
+    if args.command == "init":
+        return initialize(args.reports_dir, commit=args.commit)
+    if args.command == "run-batch":
+        return run_batch(
+            args.batch,
+            repo=args.repo.resolve(),
+            reports_dir=args.reports_dir,
+            commit=args.commit,
+        )
+    if args.command == "audit":
+        return audit(
+            args.reports_dir,
+            receipt=args.receipt,
+            require_commit=args.require_commit,
+        )
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

This closes #7153 by directly enrolling the exact nine sugarbin shell-contract paths that previously had zero workflow execution edges. They were referenced only through `implementations/rust/sugar-cli/tests/sugarbin_execution_contract.rs`, while `ci.yml` deliberately excludes both `test-rust` and `test-all`; one of the nine had therefore remained red since its introducing commit without an enrolled signal.

Predicted effect: `R_sugarbin_shell_unenrolled` moves from 9 to 0 once the merged workflow fires. The execution floor remains exact: all nine named paths must attend and pass.

## Why direct shell enrollment

Enrolling `test-rust` would pull in a Python venv, six package installs, a 29-package workspace build, and roughly 7,100 test attributes across 530 Rust files, including intentionally red frontier work. That would import a permanently red signal merely to reach nine independently runnable shell paths. This PR instead runs those exact nine paths directly.

The workflow adds one job with no matrix fan-out. It initializes all nine ledger rows as absent, each with a reason, before setup starts; then it runs three always-run batches of three. A failed contract remains attended and red, a batch continues past a failure, and a batch that never starts remains explicitly unmeasured rather than disappearing from the denominator. The final always-run audit requires exactly 9/9 attendance and 9/9 passes.

The receipt is always uploaded, including after red batches, and the job is enrolled in the acid-test vector so this tier contributes to the same aggregate signal as the rest of CI.

## Evidence

Local execution at exact base `00e1e3ce67a662fb2a5a00591805e3f3cee06b73`, using the same commands now enrolled:

- batch 1: 3/3 passed in 22.223s
- batch 2: 3/3 passed in 3.357s
- batch 3: 3/3 passed in 111.548s
- final receipt: roster=9, attended=9, passed=9, failed=0, absent=0
- measured test time: 137.128s
- receipt: 2,106 bytes, sha256 `bc6bb02b66951de2e4741dfbef6232a9c93f469068c787fb3a526f8251fa507f`

Four discrimination teeth pass in 0.803s at the pushed head:

- a missing batch remains unmeasured with a named reason
- a failed test is attended and red
- a batch continues after failure
- exactly nine passes are required

The nine enrolled paths match the Rust wrapper roster exactly. YAML parsing and diff-check also pass.

## Non-claims

This does not claim Linux CI execution, attendance, duration, or cost before the merged workflow actually fires. The 137.128s figure is local execution of the same commands, not a Linux CI measurement.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enroll nine sugarbin shell contracts directly in CI with audit and artifact upload
> - Adds [tools/sugarbin_shell_tier.py](https://github.com/TSavo/sugar/pull/7221/files#diff-a3b9ba5bac9fd2a8594dd21c7331f80202b80fa674e45a0f4e899e4498648503), a new CLI tool that initializes attendance records, runs contracts in three batches (execution, guards, artifacts), and audits results, exiting non-zero if any contract is missing or fails.
> - Adds a new `sugarbin-shell-contracts` CI job in [ci.yml](https://github.com/TSavo/sugar/pull/7221/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that runs the tool on self-hosted Linux runners and uploads JSON attendance artifacts.
> - The existing `acid test (make ci)` job now depends on `sugarbin-shell-contracts` and asserts its success before passing.
> - Adds [tests/test_sugarbin_shell_tier.py](https://github.com/TSavo/sugar/pull/7221/files#diff-afaaf3e4cb65c55985be1ed1cee211069cd4c2593e060a51a7b15f94676b575f) with four unit tests covering batch listing, init, run-batch, and audit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e25ac60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to list, initialize, run, and audit nine shell contracts across three batches.
  * Added JSON status reports with contract outcomes, timing, commit details, and attendance receipts.
  * Added Markdown audit summaries and CI error reporting.
  * CI now requires all nine contracts to pass before reporting success.

* **Tests**
  * Added coverage for contract batches, failures, missing scripts, report initialization, and audit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->