### PR TITLE
Make the sugarbin shell tier dispatchable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,8 +548,6 @@ jobs:
     name: sugarbin shell contracts (9/9 attendance)
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
-    env:
-      SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
     steps:
       - uses: actions/checkout@v6
 
@@ -558,6 +556,9 @@ jobs:
       # smaller denominator.
       - name: Initialize exact nine-contract attendance ledger
         shell: bash
+        env:
+          # runner.* does not exist until dispatch; never move this to job env.
+          SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
         run: |
           set -euo pipefail
           python3 tools/sugarbin_shell_tier.py init \
@@ -575,6 +576,8 @@ jobs:
       - name: Run batch 1/3 — execution routes
         if: always() && !cancelled()
         shell: bash
+        env:
+          SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
         run: |
           python3 -u tools/sugarbin_shell_tier.py run-batch execution \
             --repo "$GITHUB_WORKSPACE" \
@@ -584,6 +587,8 @@ jobs:
       - name: Run batch 2/3 — guards and wrappers
         if: always() && !cancelled()
         shell: bash
+        env:
+          SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
         run: |
           python3 -u tools/sugarbin_shell_tier.py run-batch guards \
             --repo "$GITHUB_WORKSPACE" \
@@ -593,6 +598,8 @@ jobs:
       - name: Run batch 3/3 — artifacts and identities
         if: always() && !cancelled()
         shell: bash
+        env:
+          SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
         run: |
           python3 -u tools/sugarbin_shell_tier.py run-batch artifacts \
             --repo "$GITHUB_WORKSPACE" \
@@ -602,6 +609,8 @@ jobs:
       - name: Audit exact 9/9 attendance and results
         if: always() && !cancelled()
         shell: bash
+        env:
+          SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
         run: |
           set -uo pipefail
           set +e

--- a/.github/workflows/recensus-path-smoke.yml
+++ b/.github/workflows/recensus-path-smoke.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # This must run in a workflow independent of ci.yml: a workflow rejected
+      # before dispatch cannot execute its own context-availability tooth.
+      - name: Check workflow contexts available before dispatch
+        run: python3 tests/test_workflow_context_availability.py
+
       - name: Prepare immutable Python test environment
         uses: ./.github/actions/python-test-environment
 

--- a/tests/test_workflow_context_availability.py
+++ b/tests/test_workflow_context_availability.py
@@ -1,0 +1,65 @@
+"""Static teeth for GitHub context availability before runner dispatch."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _pre_dispatch_runner_context_violations(text: str) -> list[int]:
+    """Return runner-context uses in workflow/job env, before a runner exists."""
+
+    violations: list[int] = []
+    env_indent: int | None = None
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if env_indent is not None and indent <= env_indent:
+            env_indent = None
+        if re.fullmatch(r"env:\s*", line.strip()) and indent in (0, 4):
+            env_indent = indent
+            continue
+        if env_indent is not None and "${{ runner." in line:
+            violations.append(line_number)
+    return violations
+
+
+class WorkflowContextAvailabilityTest(unittest.TestCase):
+    def test_runner_context_availability_discriminator(self) -> None:
+        workflow = """\
+env:
+  GLOBAL_ROOT: ${{ runner.temp }}/global
+jobs:
+  example:
+    env:
+      JOB_ROOT: ${{ runner.temp }}/job
+    steps:
+      - name: allowed after dispatch
+        env:
+          STEP_ROOT: ${{ runner.temp }}/step
+        run: echo ok
+"""
+        self.assertEqual(_pre_dispatch_runner_context_violations(workflow), [2, 6])
+
+    def test_workflows_do_not_use_runner_context_before_dispatch(self) -> None:
+        violations = {
+            path.relative_to(ROOT).as_posix(): lines
+            for path in sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")))
+            if (lines := _pre_dispatch_runner_context_violations(path.read_text()))
+        }
+        self.assertEqual(
+            violations,
+            {},
+            "runner context is unavailable in workflow/job env before dispatch; "
+            "move each use to step env",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What happened

This is the fix-forward for #7221 first firing. Run `30837462728` on merged main failed at workflow creation: `jobs=0`, `check-runs=0`, no logs, no attendance ledger, and creation/start/update timestamps all at `2026-08-03T17:35:46Z`.

The cause was `jobs.<job_id>.env` in `ci.yml` using `${{ runner.temp }}`. GitHub makes the `runner` context available only after a runner exists, including at step `env`; using it at job scope rejected the workflow before dispatch.

Predicted effect: the single pre-dispatch runner-context violation moves from 1 to 0. This changes no runner capacity, matrix width, or shell-tier denominator.

## Repair

The shell-tier root remains exactly the same value, but is now seated at the five consuming step environments. The job, three batches, nine-contract roster, always-run audit, always-uploaded receipt, and acid-vector enrollment are otherwise unchanged.

An independent static tooth is enrolled through `recensus-path-smoke`, not through `ci.yml`. It rejects `runner.*` in workflow and job environment scopes while accepting it at step scope.

## Structural finding

An attendance ledger cannot testify to its own non-execution. The ledger initializes nine named absences precisely so a contract that never starts remains visible, but a workflow rejected at creation has no job and therefore cannot initialize the ledger. The dispatchability tooth must execute from a different workflow; placing it inside `ci.yml` would reproduce the same silence it is meant to detect.

This also distinguishes two operationally different `0/9` states:

- workflow not dispatched: `jobs=0`, no ledger, no reason rows
- workflow dispatched with attended zero: ledger exists and names all nine absences

Parseable and dispatchable are also distinct properties. All workflow YAML parsed before #7221 merged, yet GitHub rejected the workflow at creation. YAML validation had proven a weaker property than the one the execution claim required.

## Evidence

At base `99d17711e96aedceaaf95fe209a941041b19d804`, the combined focused population was RED 5/6 and named `ci.yml:552` as a pre-dispatch runner-context violation.

At exact head `a484119996dff43f7e5d7537c7011f86dcb6a8c9`:

- workflow-context discrimination: 2/2 passed
- shell-tier attendance discrimination: 4/4 passed
- all 15 workflow YAML documents parsed
- diff-check passed

The discriminator independently rejects workflow-level and job-level `runner` context while accepting step-level use, so it is not pinned to the repaired line.

## Non-claims

This does not claim Linux 9/9 attendance or Linux duration. Only a fresh merged firing can measure either.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the sugarbin shell tier dispatchable by preventing runner context use in env blocks
> - Moves `SUGARBIN_SHELL_TIER_ROOT` from job-level `env` to step-level `env` in [ci.yml](https://github.com/TSavo/sugar/pull/7222/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f), as `runner.*` context is unavailable at job-level env evaluation before dispatch.
> - Adds [test_workflow_context_availability.py](https://github.com/TSavo/sugar/pull/7222/files#diff-5307df7d3a1fd27633eae81b3257a33b9d4dfeedafa3ce19737f94678789e1ac), a unittest that scans all workflows in `.github/workflows` and fails if any use `runner.*` context inside workflow- or job-level `env` blocks.
> - Adds a pre-dispatch step in [recensus-path-smoke.yml](https://github.com/TSavo/sugar/pull/7222/files#diff-2a88259228967a6b7e859fad9905325fb0cbae94c94c10bfa0296a50978b5751) that runs the new context-availability test before any other steps execute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a484119.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->