### PR TITLE
Refuse the shell tier before missing-tool execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,12 +569,39 @@ jobs:
         if: always() && !cancelled()
         run: python3 tests/test_sugarbin_shell_tier.py
 
-      - name: Install shell-contract dependency
+      - name: Provision Rust and pinned b3sum through the authoritative entrance
+        id: shell_contract_rust
         if: always() && !cancelled()
-        run: tools/ci-apt-install.sh b3sum
+        uses: ./.github/actions/setup-rust-cache
+
+      - name: Provision rsync through the authoritative package entrance
+        id: shell_contract_rsync
+        if: always() && !cancelled()
+        run: tools/ci-apt-install.sh rsync
+
+      # Provisioning failure is one setup refusal, not nine mysterious test
+      # failures. This step runs after either provisioner fails so it can name
+      # every absent tool; the batches run only when this exact precondition is
+      # green.
+      - name: Require the complete shell-contract toolset
+        id: shell_contract_preconditions
+        if: always() && !cancelled()
+        shell: bash
+        env:
+          SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
+          RUST_SETUP_OUTCOME: ${{ steps.shell_contract_rust.outcome }}
+          RSYNC_SETUP_OUTCOME: ${{ steps.shell_contract_rsync.outcome }}
+        run: |
+          python3 tools/sugarbin_shell_tier.py preflight \
+            --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
+            --commit "$GITHUB_SHA" \
+            --require-tool b3sum \
+            --require-tool rsync \
+            --setup-outcome "rust=$RUST_SETUP_OUTCOME" \
+            --setup-outcome "rsync=$RSYNC_SETUP_OUTCOME"
 
       - name: Run batch 1/3 — execution routes
-        if: always() && !cancelled()
+        if: ${{ always() && !cancelled() && steps.shell_contract_preconditions.outcome == 'success' }}
         shell: bash
         env:
           SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
@@ -585,7 +612,7 @@ jobs:
             --commit "$GITHUB_SHA"
 
       - name: Run batch 2/3 — guards and wrappers
-        if: always() && !cancelled()
+        if: ${{ always() && !cancelled() && steps.shell_contract_preconditions.outcome == 'success' }}
         shell: bash
         env:
           SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier
@@ -596,7 +623,7 @@ jobs:
             --commit "$GITHUB_SHA"
 
       - name: Run batch 3/3 — artifacts and identities
-        if: always() && !cancelled()
+        if: ${{ always() && !cancelled() && steps.shell_contract_preconditions.outcome == 'success' }}
         shell: bash
         env:
           SUGARBIN_SHELL_TIER_ROOT: ${{ runner.temp }}/sugarbin-shell-tier

--- a/tests/test_sugarbin_shell_tier.py
+++ b/tests/test_sugarbin_shell_tier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -12,6 +13,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 TOOL = ROOT / "tools" / "sugarbin_shell_tier.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 EXPECTED_BATCHES = {
     "execution": [
         "tests/sugarbin_local_exec.sh",
@@ -35,13 +37,16 @@ EXPECTED_ROSTER = [
 
 
 class SugarbinShellTierTest(unittest.TestCase):
-    def run_tool(self, *args: str) -> subprocess.CompletedProcess[str]:
+    def run_tool(
+        self, *args: str, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [sys.executable, str(TOOL), *args],
             cwd=ROOT,
             text=True,
             capture_output=True,
             check=False,
+            env=env,
         )
 
     def test_roster_is_exactly_three_batches_of_three(self) -> None:
@@ -56,13 +61,139 @@ class SugarbinShellTierTest(unittest.TestCase):
                 "init", "--reports-dir", str(reports), "--commit", "abc123"
             )
             self.assertEqual(result.returncode, 0, result.stderr)
-            bodies = sorted(reports.glob("*.json"))
+            bodies = sorted(reports.glob("sugarbin_*.json"))
             self.assertEqual(len(bodies), 9)
             payloads = [json.loads(path.read_text(encoding="utf-8")) for path in bodies]
             self.assertEqual({body["contract"] for body in payloads}, set(EXPECTED_ROSTER))
             self.assertEqual({body["status"] for body in payloads}, {"unmeasured"})
             self.assertEqual({body["reason"] for body in payloads}, {"batch-not-started"})
             self.assertEqual({body["measuredCommit"] for body in payloads}, {"abc123"})
+            setup = json.loads((reports / "setup.json").read_text(encoding="utf-8"))
+            self.assertEqual(setup["status"], "unmeasured")
+            self.assertEqual(setup["reason"], "preflight-not-run")
+
+    def test_setup_preflight_refuses_all_missing_tools_as_one_terminal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            reports = temp / "reports"
+            initialized = self.run_tool(
+                "init", "--reports-dir", str(reports), "--commit", "abc123"
+            )
+            self.assertEqual(initialized.returncode, 0, initialized.stderr)
+
+            env = os.environ.copy()
+            env["PATH"] = str(temp / "empty-bin")
+            refused = self.run_tool(
+                "preflight",
+                "--reports-dir",
+                str(reports),
+                "--commit",
+                "abc123",
+                "--require-tool",
+                "b3sum",
+                "--require-tool",
+                "rsync",
+                "--setup-outcome",
+                "rust=failure",
+                "--setup-outcome",
+                "rsync=success",
+                env=env,
+            )
+
+            self.assertNotEqual(refused.returncode, 0)
+            self.assertIn("missing required tools: b3sum, rsync", refused.stderr)
+            self.assertIn("failed provisioning steps: rust", refused.stderr)
+            setup = json.loads((reports / "setup.json").read_text(encoding="utf-8"))
+            self.assertEqual(setup["status"], "refused")
+            self.assertEqual(setup["reason"], "setup-refused")
+            self.assertEqual(setup["missingTools"], ["b3sum", "rsync"])
+            self.assertEqual(setup["failedSteps"], ["rust"])
+
+            bodies = [
+                json.loads(path.read_text(encoding="utf-8"))
+                for path in reports.glob("sugarbin_*.json")
+            ]
+            self.assertEqual(len(bodies), 9)
+            self.assertEqual({body["status"] for body in bodies}, {"unmeasured"})
+            self.assertEqual({body["reason"] for body in bodies}, {"batch-not-started"})
+
+            receipt = temp / "receipt.json"
+            audited = self.run_tool(
+                "audit",
+                "--reports-dir",
+                str(reports),
+                "--receipt",
+                str(receipt),
+                "--require-commit",
+                "abc123",
+            )
+            self.assertNotEqual(audited.returncode, 0)
+            self.assertIn("setup: `refused`", audited.stdout)
+            summary = json.loads(receipt.read_text(encoding="utf-8"))
+            self.assertEqual(summary["setupStatus"], "refused")
+            self.assertEqual(summary["setupMissingTools"], ["b3sum", "rsync"])
+
+    def test_setup_preflight_accepts_tools_after_successful_provisioning(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            temp = Path(directory)
+            reports = temp / "reports"
+            fake_bin = temp / "bin"
+            fake_bin.mkdir()
+            for tool in ("b3sum", "rsync"):
+                path = fake_bin / tool
+                path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+                path.chmod(0o755)
+            initialized = self.run_tool(
+                "init", "--reports-dir", str(reports), "--commit", "abc123"
+            )
+            self.assertEqual(initialized.returncode, 0, initialized.stderr)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            accepted = self.run_tool(
+                "preflight",
+                "--reports-dir",
+                str(reports),
+                "--commit",
+                "abc123",
+                "--require-tool",
+                "b3sum",
+                "--require-tool",
+                "rsync",
+                "--setup-outcome",
+                "rust=success",
+                "--setup-outcome",
+                "rsync=success",
+                env=env,
+            )
+
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            self.assertIn("setup ready: b3sum, rsync", accepted.stdout)
+            setup = json.loads((reports / "setup.json").read_text(encoding="utf-8"))
+            self.assertEqual(setup["status"], "ready")
+            self.assertEqual(setup["missingTools"], [])
+            self.assertEqual(setup["failedSteps"], [])
+
+    def test_workflow_provisions_once_and_runs_batches_only_after_preflight(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        job = workflow.split("  sugarbin-shell-contracts:\n", 1)[1].split(
+            "\n  acid-test:", 1
+        )[0]
+
+        rust_setup = job.index("uses: ./.github/actions/setup-rust-cache")
+        rsync_setup = job.index("tools/ci-apt-install.sh rsync")
+        preflight = job.index("id: shell_contract_preconditions")
+        first_batch = job.index("name: Run batch 1/3")
+        self.assertLess(rust_setup, preflight)
+        self.assertLess(rsync_setup, preflight)
+        self.assertLess(preflight, first_batch)
+        self.assertNotIn("tools/ci-apt-install.sh b3sum", job)
+        self.assertIn("--require-tool b3sum", job)
+        self.assertIn("--require-tool rsync", job)
+        self.assertEqual(
+            job.count("steps.shell_contract_preconditions.outcome == 'success'"),
+            3,
+        )
 
     def test_batch_records_pass_failure_and_missing_script_without_stopping(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -132,6 +263,32 @@ class SugarbinShellTierTest(unittest.TestCase):
             self.assertNotEqual(absent.returncode, 0)
             self.assertIn("R_sugarbin_shell_attendance = 9", absent.stdout)
             self.assertEqual(json.loads(receipt.read_text())["passed"], 0)
+
+            fake_bin = Path(directory) / "bin"
+            fake_bin.mkdir()
+            for tool in ("b3sum", "rsync"):
+                path = fake_bin / tool
+                path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+                path.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            preflight = self.run_tool(
+                "preflight",
+                "--reports-dir",
+                str(reports),
+                "--commit",
+                "abc123",
+                "--require-tool",
+                "b3sum",
+                "--require-tool",
+                "rsync",
+                "--setup-outcome",
+                "rust=success",
+                "--setup-outcome",
+                "rsync=success",
+                env=env,
+            )
+            self.assertEqual(preflight.returncode, 0, preflight.stderr)
 
             for contract in EXPECTED_ROSTER:
                 path = reports / f"{Path(contract).stem}.json"

--- a/tools/sugarbin_shell_tier.py
+++ b/tools/sugarbin_shell_tier.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -35,6 +36,10 @@ ROSTER = [contract for batch in BATCHES.values() for contract in batch]
 
 def _body_path(reports_dir: Path, contract: str) -> Path:
     return reports_dir / f"{Path(contract).stem}.json"
+
+
+def _setup_path(reports_dir: Path) -> Path:
+    return reports_dir / "setup.json"
 
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
@@ -80,6 +85,20 @@ def _body(
 
 
 def initialize(reports_dir: Path, *, commit: str) -> int:
+    _write_json(
+        _setup_path(reports_dir),
+        {
+            "schemaVersion": 1,
+            "measurementClass": "sugarbin-shell-tier-setup",
+            "measuredCommit": commit,
+            "status": "unmeasured",
+            "reason": "preflight-not-run",
+            "requiredTools": [],
+            "missingTools": [],
+            "setupSteps": {},
+            "failedSteps": [],
+        },
+    )
     for contract in ROSTER:
         _write_json(
             _body_path(reports_dir, contract),
@@ -91,6 +110,58 @@ def initialize(reports_dir: Path, *, commit: str) -> int:
             ),
         )
     print(f"sugarbin-shell init roster={len(ROSTER)} absent={len(ROSTER)}")
+    return 0
+
+
+def preflight(
+    reports_dir: Path,
+    *,
+    commit: str,
+    required_tools: list[str],
+    setup_outcomes: list[str],
+) -> int:
+    tools = list(dict.fromkeys(required_tools))
+    outcomes: dict[str, str] = {}
+    for item in setup_outcomes:
+        name, separator, outcome = item.partition("=")
+        if not separator or not name or not outcome:
+            print(
+                f"::error::invalid setup outcome {item!r}; expected NAME=OUTCOME",
+                file=sys.stderr,
+            )
+            return 2
+        outcomes[name] = outcome
+
+    missing_tools = [tool for tool in tools if shutil.which(tool) is None]
+    failed_steps = [name for name, outcome in outcomes.items() if outcome != "success"]
+    refused = bool(missing_tools or failed_steps)
+    _write_json(
+        _setup_path(reports_dir),
+        {
+            "schemaVersion": 1,
+            "measurementClass": "sugarbin-shell-tier-setup",
+            "measuredCommit": commit,
+            "status": "refused" if refused else "ready",
+            "reason": "setup-refused" if refused else "setup-ready",
+            "requiredTools": tools,
+            "missingTools": missing_tools,
+            "setupSteps": outcomes,
+            "failedSteps": failed_steps,
+        },
+    )
+    if refused:
+        details: list[str] = []
+        if missing_tools:
+            details.append(f"missing required tools: {', '.join(missing_tools)}")
+        if failed_steps:
+            details.append(f"failed provisioning steps: {', '.join(failed_steps)}")
+        print(
+            f"::error::sugarbin shell tier setup refused: {'; '.join(details)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"sugarbin shell tier setup ready: {', '.join(tools)}")
     return 0
 
 
@@ -196,6 +267,31 @@ def audit(
     failed = 0
     test_elapsed_seconds = 0.0
 
+    setup, setup_read_error = _read_body(_setup_path(reports_dir))
+    setup_status = "unmeasured"
+    setup_reason = setup_read_error or "setup-report-invalid"
+    setup_missing_tools: list[str] = []
+    setup_failed_steps: list[str] = []
+    if setup_read_error is None:
+        assert setup is not None
+        if setup.get("measurementClass") != "sugarbin-shell-tier-setup":
+            setup_reason = "setup-measurement-class-mismatch"
+        elif require_commit and setup.get("measuredCommit") != require_commit:
+            setup_reason = "setup-commit-mismatch"
+        else:
+            setup_status = str(setup.get("status", "unmeasured"))
+            setup_reason = str(setup.get("reason", "setup-reason-missing"))
+            missing = setup.get("missingTools")
+            failed_setup = setup.get("failedSteps")
+            if isinstance(missing, list) and all(
+                isinstance(item, str) for item in missing
+            ):
+                setup_missing_tools = missing
+            if isinstance(failed_setup, list) and all(
+                isinstance(item, str) for item in failed_setup
+            ):
+                setup_failed_steps = failed_setup
+
     for contract in ROSTER:
         payload, read_error = _read_body(_body_path(reports_dir, contract))
         if read_error is not None:
@@ -252,7 +348,15 @@ def audit(
         "schemaVersion": 1,
         "measurementClass": "sugarbin-shell-tier-attendance",
         "measuredCommit": require_commit,
-        "status": "complete" if attended == len(ROSTER) else "unmeasured",
+        "status": (
+            "complete"
+            if setup_status == "ready" and attended == len(ROSTER)
+            else "unmeasured"
+        ),
+        "setupStatus": setup_status,
+        "setupReason": setup_reason,
+        "setupMissingTools": setup_missing_tools,
+        "setupFailedSteps": setup_failed_steps,
         "roster": len(ROSTER),
         "attended": attended,
         "passed": passed,
@@ -265,6 +369,11 @@ def audit(
 
     print("### sugarbin shell tier attendance")
     print()
+    print(f"- setup: `{setup_status}` ({setup_reason})")
+    if setup_missing_tools:
+        print(f"- missing tools: `{', '.join(setup_missing_tools)}`")
+    if setup_failed_steps:
+        print(f"- failed setup steps: `{', '.join(setup_failed_steps)}`")
     print(f"- roster: `{len(ROSTER)}`")
     print(f"- attended: `{attended}`")
     print(f"- passed: `{passed}`")
@@ -283,7 +392,13 @@ def audit(
     print(f"**R_sugarbin_shell_attendance = {absent}**")
     for crime in crimes:
         print(f"::error::{crime}", file=sys.stderr)
-    return 0 if attended == len(ROSTER) and passed == len(ROSTER) else 1
+    return (
+        0
+        if setup_status == "ready"
+        and attended == len(ROSTER)
+        and passed == len(ROSTER)
+        else 1
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -296,6 +411,12 @@ def main(argv: list[str] | None = None) -> int:
     init_parser = subparsers.add_parser("init")
     init_parser.add_argument("--reports-dir", type=Path, required=True)
     init_parser.add_argument("--commit", required=True)
+
+    preflight_parser = subparsers.add_parser("preflight")
+    preflight_parser.add_argument("--reports-dir", type=Path, required=True)
+    preflight_parser.add_argument("--commit", required=True)
+    preflight_parser.add_argument("--require-tool", action="append", default=[])
+    preflight_parser.add_argument("--setup-outcome", action="append", default=[])
 
     batch_parser = subparsers.add_parser("run-batch")
     batch_parser.add_argument("batch", choices=BATCHES)
@@ -319,6 +440,13 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == "init":
         return initialize(args.reports_dir, commit=args.commit)
+    if args.command == "preflight":
+        return preflight(
+            args.reports_dir,
+            commit=args.commit,
+            required_tools=args.require_tool,
+            setup_outcomes=args.setup_outcome,
+        )
     if args.command == "run-batch":
         return run_batch(
             args.batch,


### PR DESCRIPTION
## What happened

The first Linux firing of the enrolled shell tier, run `30838933583` / job `91770931764`, produced four red contracts without reaching a single product assertion.

Setup reported that pinned `b3sum` could not be acquired, but the job continued into all three batches. Three artifact contracts then terminated with `crime=missing-blake3-tool`. `sugarbin_bx_exec.sh` emitted zero bytes between its attendance start and completion rows and exited 1 because `rsync` was also absent.

Two provisioning gaps therefore produced four apparent test reds. Observers who reported the missing-BLAKE3 terminal and the silent `bx_exec` terminal were both correct at different layers; the job log resolves the disagreement rather than averaging it into one product hypothesis.

Predicted effect: the two missing setup preconditions become one explicit setup verdict before any contract body can run. No runner capacity or test denominator changes.

## Repair and ordering

1. Initialize the exact nine-row attendance ledger and setup row.
2. Provision Rust and pinned `b3sum` through `setup-rust-cache`, the authoritative entrance established by #6351 / `a3a75a22`.
3. Provision `rsync` through `tools/ci-apt-install.sh`.
4. Run one always-run preflight that names every missing tool and every failed setup step in a single terminal.
5. Run the three batches only when that preflight is green.
6. Always audit and upload the receipt.

There is no second acquisition path for either tool.

A failed setup step must not permit downstream execution: proceeding without a precondition asserts that the precondition was optional. The ledger now records `setupStatus=refused` separately from both absent and attended contract rows. Nine contracts that never ran because setup refused are one setup refusal, not nine failures.

## Evidence

At exact head `f550408c777e2c3ecd2648faf8a5400d1c8a88da`:

- shell-tier teeth: 7/7 passed
- workflow-context teeth: 2/2 passed
- all 15 workflow YAML documents parsed
- Python compilation passed
- diff-check passed

The refusal twin names both absent tools and failed provisioners together, preserves all nine contracts as not started, and makes the audit unmeasured with `setupStatus=refused`. The truthful twin accepts the fully provisioned toolset before any batch begins.

## Non-claims

This does not claim Linux 9/9 attendance; only the merged firing can measure that.

The prior four reds carry no product-law verdict. Every red terminated in setup before its assertions, so none is evidence of a shelf, manifest, atomic-write, or other product regression.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse shell-tier batch execution before missing-tool preflight passes
> - Adds a `preflight` command to [sugarbin_shell_tier.py](https://github.com/TSavo/sugar/pull/7223/files#diff-a3b9ba5bac9fd2a8594dd21c7331f80202b80fa674e45a0f4e899e4498648503) that checks required tools (`b3sum`, `rsync`) are on PATH and that all provisioning steps succeeded, writing a `setup.json` with status `ready` or `refused`.
> - Updates `initialize` to write `setup.json` upfront with status `unmeasured` and reason `preflight-not-run`, so audit can detect skipped preflight.
> - Updates `audit` to fail unless `setup.json` shows `ready`, surfacing missing tools and failed steps even when all nine contracts attended.
> - Updates [ci.yml](https://github.com/TSavo/sugar/pull/7223/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to provision Rust+b3sum via `setup-rust-cache` and rsync via apt, run preflight as a gate step, and condition all three batch steps on `steps.shell_contract_preconditions.outcome == 'success'`.
> - Behavioral Change: batches no longer run when preflight is refused; `audit` now returns non-zero if preflight was skipped or refused, even if all contract bodies are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f550408.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->