### PR TITLE
Make CI dispatchable for merge-group candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@
 name: CI
 
 on:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main

--- a/docs/superpowers/plans/2026-08-03-merge-group-trigger.md
+++ b/docs/superpowers/plans/2026-08-03-merge-group-trigger.md
@@ -1,0 +1,110 @@
+# Merge-Group Trigger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CI dispatchable for future merge-group candidates without enabling a merge queue or requiring the red acid context.
+
+**Architecture:** Extend the independently enrolled workflow-dispatchability test with a small indentation-aware event parser and exact truthful/lying twins. Then add only the top-level `merge_group: types: [checks_requested]` trigger to `ci.yml`.
+
+**Tech Stack:** GitHub Actions YAML, Python 3 standard-library `unittest`, Ruby YAML parser.
+
+## Global Constraints
+
+- Queue activation and required status contexts remain out of scope.
+- Main protection stays with zero required contexts.
+- Do not add a `pull_request` trigger.
+- Do not change acid jobs, fan-out, batching, or concurrency.
+- Write the dispatchability tooth before editing the workflow.
+
+---
+
+### Task 1: Pin merge-group dispatchability independently
+
+**Files:**
+
+- Modify: `tests/test_workflow_context_availability.py`
+- Test: `tests/test_workflow_context_availability.py`
+
+- [ ] **Step 1: Add the exact discriminator and its twins**
+
+Add an indentation-aware helper that inspects the top-level `on` mapping and returns the configured activity types for a named event. Add fixtures proving that the discriminator:
+
+- accepts top-level `merge_group` with exactly `checks_requested`;
+- rejects a missing event;
+- rejects `merge_group` nested beneath `push`;
+- rejects any activity type other than `checks_requested`.
+
+Add a test applying the same law to `.github/workflows/ci.yml`.
+
+- [ ] **Step 2: Run the tooth before changing `ci.yml` and prove RED**
+
+Run:
+
+```bash
+python3 tests/test_workflow_context_availability.py
+```
+
+Expected: the fixture discrimination passes and the real-workflow test fails because `ci.yml` has no top-level `merge_group` trigger.
+
+- [ ] **Step 3: Commit the red instrument if a review boundary is useful**
+
+The red evidence may remain in the final implementation commit; the required artifact is the captured failing terminal before the workflow edit.
+
+### Task 2: Add the smallest lawful workflow trigger
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+- Test: `tests/test_workflow_context_availability.py`
+
+- [ ] **Step 1: Add only the top-level event**
+
+Add this sibling beside `push` without changing the existing push branches or path filters:
+
+```yaml
+merge_group:
+  types: [checks_requested]
+```
+
+- [ ] **Step 2: Prove the dispatchability tooth GREEN**
+
+Run:
+
+```bash
+python3 tests/test_workflow_context_availability.py
+```
+
+Expected: all workflow-context tests pass.
+
+- [ ] **Step 3: Keep syntax and dispatchability as separate evidence**
+
+Run:
+
+```bash
+ruby -e 'require "yaml"; paths=Dir[".github/workflows/*.{yml,yaml}"]; paths.each { |p| YAML.load_file(p) }; puts "yaml-ok #{paths.length}"'
+python3 -m py_compile tests/test_workflow_context_availability.py
+git diff --check
+```
+
+Expected: all workflow YAML documents parse, Python compiles, and the diff is clean.
+
+### Task 3: Publish the trigger-only change
+
+**Files:**
+
+- Verify: `.github/workflows/ci.yml`
+- Verify: `tests/test_workflow_context_availability.py`
+- Verify: `docs/superpowers/specs/2026-08-03-merge-group-trigger-design.md`
+- Verify: `docs/superpowers/plans/2026-08-03-merge-group-trigger.md`
+
+- [ ] **Step 1: Commit and preflight the complete branch**
+
+Enumerate every commit and changed file against `origin/main`; confirm there are no deletions, foreign commits, runner-capacity changes, or new category/kind/label/taxonomy/residual vocabulary.
+
+- [ ] **Step 2: Push and open a ready PR**
+
+The PR must state that the trigger makes the acid vector producible for merge-group candidates but does not enable a queue, require a context, or claim the currently red acid test is green.
+
+- [ ] **Step 3: Leave policy unchanged**
+
+Verify branch protection still has zero required status contexts and that no ruleset or merge queue was created.

--- a/docs/superpowers/specs/2026-08-03-merge-group-trigger-design.md
+++ b/docs/superpowers/specs/2026-08-03-merge-group-trigger-design.md
@@ -1,0 +1,41 @@
+# Merge-Group Trigger Design
+
+## Goal
+
+Make the existing `CI` workflow capable of producing `acid test (make ci)` for a future GitHub merge queue without enabling that queue or requiring the currently red acid check.
+
+## Scope
+
+The workflow gains one top-level `merge_group` event restricted to the `checks_requested` activity. The existing `push` trigger, path filter, jobs, acid vector, and main-branch protection remain unchanged.
+
+The independently enrolled `recensus-path-smoke` workflow already runs `tests/test_workflow_context_availability.py`. That test module will also validate merge-group dispatchability so `ci.yml` does not attempt to certify its own ability to dispatch.
+
+## Dispatchability Law
+
+`ci.yml` is merge-queue-dispatchable only when its top-level `on` mapping contains:
+
+```yaml
+merge_group:
+  types: [checks_requested]
+```
+
+The discriminator must reject all of these independently:
+
+- no `merge_group` event;
+- `merge_group` nested beneath another event;
+- a top-level `merge_group` with any activity type other than `checks_requested`.
+
+It must accept the exact lawful top-level event. YAML parsing remains a separate check because parseable and dispatchable are different properties.
+
+## Failure Semantics
+
+A malformed or missing event is a pre-dispatch refusal: GitHub creates no usable merge-group run, so `ci.yml` cannot report its own absence. The independent path-smoke tooth is therefore the owner of this law.
+
+## Explicit Non-Goals
+
+- Do not enable a merge queue.
+- Do not add any required status context.
+- Do not add a `pull_request` trigger.
+- Do not change acid-test jobs, fan-out, batching, or concurrency.
+- Do not claim that `acid test (make ci)` is green; twelve measured main runs are red.
+- Defer queue versus plain per-PR execution until the acid vector is green on main.

--- a/tests/test_workflow_context_availability.py
+++ b/tests/test_workflow_context_availability.py
@@ -30,6 +30,60 @@ def _pre_dispatch_runner_context_violations(text: str) -> list[int]:
     return violations
 
 
+def _top_level_event_types(text: str, event: str) -> tuple[str, ...] | None:
+    """Return an event's inline activity types from the top-level ``on`` map."""
+
+    lines = text.splitlines()
+    on_index: int | None = None
+    for index, line in enumerate(lines):
+        if re.fullmatch(r"on:\s*", line):
+            on_index = index
+            break
+    if on_index is None:
+        return None
+
+    event_indent = 2
+    event_pattern = re.compile(rf"{re.escape(event)}:\s*(.*)")
+    for index in range(on_index + 1, len(lines)):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent == 0:
+            break
+        if indent != event_indent:
+            continue
+        match = event_pattern.fullmatch(line.strip())
+        if match is None:
+            continue
+        if match.group(1):
+            return ()
+        for child in lines[index + 1 :]:
+            if not child.strip() or child.lstrip().startswith("#"):
+                continue
+            child_indent = len(child) - len(child.lstrip(" "))
+            if child_indent <= event_indent:
+                return ()
+            if child_indent != event_indent + 2:
+                continue
+            types_match = re.fullmatch(r"types:\s*\[([^]]*)\]\s*", child.strip())
+            if types_match is None:
+                continue
+            return tuple(
+                activity.strip()
+                for activity in types_match.group(1).split(",")
+                if activity.strip()
+            )
+        return ()
+    return None
+
+
+def _has_exact_merge_group_trigger(text: str) -> bool:
+    """Return whether GitHub can dispatch the intended merge-group activity."""
+
+    return _top_level_event_types(text, "merge_group") == ("checks_requested",)
+
+
 class WorkflowContextAvailabilityTest(unittest.TestCase):
     def test_runner_context_availability_discriminator(self) -> None:
         workflow = """\
@@ -58,6 +112,46 @@ jobs:
             {},
             "runner context is unavailable in workflow/job env before dispatch; "
             "move each use to step env",
+        )
+
+    def test_merge_group_dispatchability_discriminator(self) -> None:
+        lawful = """\
+on:
+  push:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+jobs: {}
+"""
+        nested_under_push = """\
+on:
+  push:
+    merge_group:
+      types: [checks_requested]
+jobs: {}
+"""
+        wrong_activity = """\
+on:
+  merge_group:
+    types: [closed]
+jobs: {}
+"""
+        missing = """\
+on:
+  push:
+jobs: {}
+"""
+
+        self.assertTrue(_has_exact_merge_group_trigger(lawful))
+        self.assertFalse(_has_exact_merge_group_trigger(nested_under_push))
+        self.assertFalse(_has_exact_merge_group_trigger(wrong_activity))
+        self.assertFalse(_has_exact_merge_group_trigger(missing))
+
+    def test_ci_dispatches_exact_merge_group_checks_requested_event(self) -> None:
+        self.assertTrue(
+            _has_exact_merge_group_trigger((WORKFLOWS / "ci.yml").read_text()),
+            "ci.yml must expose the exact top-level merge_group checks_requested "
+            "event; YAML parsing alone does not prove GitHub can dispatch it",
         )
 
 


### PR DESCRIPTION
## Finding

The acid vector runs on pushes to `main`, but it has no `merge_group` entrance. A future merge queue therefore could not produce the very signal it would require. This PR adds only the production entrance:

```yaml
merge_group:
  types: [checks_requested]
```

It does **not** enable a merge queue or add a required status context. The acid test is currently producible and red on main (12 measured runs, 12 failures); requiring it now would freeze every merge and recreate the gate just removed.

## Dispatchability law

Parseable and dispatchable are distinct properties. A workflow rejected before dispatch cannot report its own non-execution, so `ci.yml` does not certify itself. The independently enrolled `recensus-path-smoke` module now owns an indentation-aware discriminator that:

- accepts the exact top-level `merge_group` / `checks_requested` event;
- rejects a missing event;
- rejects `merge_group` nested beneath `push`;
- rejects a different activity type.

Before the workflow edit, the real-workflow arm was RED with `None != ('checks_requested',)` while the fixture discriminator passed. At head `c412c240b2aa5092ba6aca892b2753f4586a8553`, all four workflow-context tests pass.

## Evidence

- `python3 tests/test_workflow_context_availability.py`: 4/4 passed
- Python compile: passed
- all 15 workflow YAML documents parse
- `git diff --check`: passed
- branch preflight: merge-base `dfdd436b2c5d5c757a48019c62f06df04372c6ed`, 0 behind / 3 ahead, no deletions or foreign commits
- branch protection remains `strict=true` with zero required contexts/checks; repository rulesets remain empty

## Exact scope

All changed files are named:

- `.github/workflows/ci.yml`: two-line trigger only
- `tests/test_workflow_context_availability.py`: independent truthful/lying dispatchability teeth
- `docs/superpowers/specs/2026-08-03-merge-group-trigger-design.md`: boundary and non-goals
- `docs/superpowers/plans/2026-08-03-merge-group-trigger.md`: executable implementation record

No jobs, acid fan-out, batching, concurrency, runner autoscaling/capacity, category, kind, label, taxonomy, or residual bucket changed.

## Explicit non-claims

- No merge queue is enabled.
- No required context is added.
- No `pull_request` trigger is added.
- This does not claim the acid vector is green.
- Queue versus plain per-PR execution remains open until the acid vector is green on main.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `merge_group` trigger to CI workflow for merge-group candidates
> - Adds a top-level `merge_group: types: [checks_requested]` trigger to [ci.yml](https://github.com/TSavo/sugar/pull/7224/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) so CI runs for GitHub merge queue entries.
> - Adds tests in [test_workflow_context_availability.py](https://github.com/TSavo/sugar/pull/7224/files#diff-5307df7d3a1fd27633eae81b3257a33b9d4dfeedafa3ce19737f94678789e1ac) that enforce the exact trigger shape, including a discriminator test covering four cases (correct trigger, nested trigger, wrong activity type, missing event).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c412c24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->