### PR TITLE
Format sugar-lift-python-source with Black 26.5.1

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -111,9 +111,7 @@ def _fingerprint_disk_cache_path(seat_key: str, fingerprint: str) -> Path:
     return _cache_root() / "dependency-artifact-fingerprints" / f"{digest}.json"
 
 
-def _load_artifact_cid_for_fingerprint(
-    seat_key: str, fingerprint: str
-) -> str | None:
+def _load_artifact_cid_for_fingerprint(seat_key: str, fingerprint: str) -> str | None:
     path = _fingerprint_disk_cache_path(seat_key, fingerprint)
     if not path.is_file():
         return None

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -109,9 +109,7 @@ def resolve_export(
     _bind()
     session = session_or_new(session)
     if (module_name, exported_name) in seen:
-        return _gap(
-            "reexport-cycle", binding_cid, graph, module_name, exported_name
-        )
+        return _gap("reexport-cycle", binding_cid, graph, module_name, exported_name)
     cache_key = (
         graph.distribution_artifact_cid,
         module_name,
@@ -131,9 +129,7 @@ def resolve_export(
         # Reexport hop / path context: share definition identity only.
         terminal = session.export_terminal_hit(cache_key)
         if terminal is not None:
-            return _restamp_export_result(
-                terminal, binding_cid, warrants=warrants
-            )
+            return _restamp_export_result(terminal, binding_cid, warrants=warrants)
 
     result = _resolve_export_uncached(
         graph,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/leaf_assertions.py
@@ -201,7 +201,12 @@ class _TranslatedTerm:
         object.__setattr__(
             self,
             "_seal",
-            (preimage, preimage.unit.source_cid, term_cid, tuple(call._seal for call in calls)),
+            (
+                preimage,
+                preimage.unit.source_cid,
+                term_cid,
+                tuple(call._seal for call in calls),
+            ),
         )
         return self
 
@@ -281,9 +286,7 @@ def harvest_source(source: str, source_path: str) -> HarvestResult:
     return result
 
 
-def _lift_assert(
-    stmt: Assert, *, source_contract: FunctionDef
-) -> _LiftedAssertion:
+def _lift_assert(stmt: Assert, *, source_contract: FunctionDef) -> _LiftedAssertion:
     test = stmt.test
     if not isinstance(test, Compare):
         raise _Unsupported("assert is not a comparison")
@@ -322,23 +325,35 @@ def _translate_term(node: Expression) -> _TranslatedTerm:
     if isinstance(node, Constant):
         value = node.value
         if isinstance(value, bool):
-            return _TranslatedTerm._mint(term={
-                "kind": "const",
-                "value": value,
-                "sort": {"kind": "primitive", "name": "Bool"},
-            }, calls=(), preimage=node)
+            return _TranslatedTerm._mint(
+                term={
+                    "kind": "const",
+                    "value": value,
+                    "sort": {"kind": "primitive", "name": "Bool"},
+                },
+                calls=(),
+                preimage=node,
+            )
         if isinstance(value, int):
-            return _TranslatedTerm._mint(term={
-                "kind": "const",
-                "value": value,
-                "sort": {"kind": "primitive", "name": "Int"},
-            }, calls=(), preimage=node)
+            return _TranslatedTerm._mint(
+                term={
+                    "kind": "const",
+                    "value": value,
+                    "sort": {"kind": "primitive", "name": "Int"},
+                },
+                calls=(),
+                preimage=node,
+            )
         if isinstance(value, str):
-            return _TranslatedTerm._mint(term={
-                "kind": "const",
-                "value": value,
-                "sort": {"kind": "primitive", "name": "String"},
-            }, calls=(), preimage=node)
+            return _TranslatedTerm._mint(
+                term={
+                    "kind": "const",
+                    "value": value,
+                    "sort": {"kind": "primitive", "name": "String"},
+                },
+                calls=(),
+                preimage=node,
+            )
         if value is None:
             return _TranslatedTerm._mint(
                 term={"kind": "ctor", "name": "None", "args": []},
@@ -353,11 +368,15 @@ def _translate_term(node: Expression) -> _TranslatedTerm:
             and isinstance(operand.value, int)
             and not isinstance(operand.value, bool)
         ):
-            return _TranslatedTerm._mint(term={
-                "kind": "const",
-                "value": -operand.value,
-                "sort": {"kind": "primitive", "name": "Int"},
-            }, calls=(), preimage=node)
+            return _TranslatedTerm._mint(
+                term={
+                    "kind": "const",
+                    "value": -operand.value,
+                    "sort": {"kind": "primitive", "name": "Int"},
+                },
+                calls=(),
+                preimage=node,
+            )
         raise _Unsupported("unary minus only on int literals")
     if isinstance(node, Call):
         # Single-arg bare call f(arg) -> ctor("f", [<arg>]); the ctor name is
@@ -370,7 +389,11 @@ def _translate_term(node: Expression) -> _TranslatedTerm:
         projected_args = [arg.project() for arg in args]
         occurrence = _CallOccurrence._mint(node)
         return _TranslatedTerm._mint(
-            term={"kind": "ctor", "name": node.func.id, "args": [arg.term for arg in args]},
+            term={
+                "kind": "ctor",
+                "name": node.func.id,
+                "args": [arg.term for arg in args],
+            },
             calls=(occurrence,)
             + tuple(call for _, calls in projected_args for call in calls),
             preimage=node,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -161,11 +161,11 @@ def _project_metaclass_final_class(value: FloorValue, *, blame) -> FloorValue:
 
         shape = (
             (
-            "BlockValue["
-            + ",".join(describe(statement) for statement in final_class.statements)
-            + "]"
-            + f"; canFallThrough={final_class.can_fall_through}"
-            + f"; fallThroughGuards={len(final_class.fall_through)}"
+                "BlockValue["
+                + ",".join(describe(statement) for statement in final_class.statements)
+                + "]"
+                + f"; canFallThrough={final_class.can_fall_through}"
+                + f"; fallThroughGuards={len(final_class.fall_through)}"
             )
             if isinstance(final_class, BlockValue)
             else type(final_class).__name__
@@ -972,32 +972,32 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
             if isinstance(statement, (FunctionDef, AsyncFunctionDef))
             else (
                 _ModuleClassDefinitionBindingSugar(
-                statement, source_file.construction_event_receipt_cid
-            )
-            if isinstance(statement, ClassDef)
+                    statement, source_file.construction_event_receipt_cid
+                )
+                if isinstance(statement, ClassDef)
                 else (
                     _ModuleNameAssignmentBindingSugar(
                         statement, tuple(statement.targets)
                     )
-            if (
-                isinstance(statement, Assign)
+                    if (
+                        isinstance(statement, Assign)
                         and statement.targets
                         and all(
                             isinstance(target, Name) for target in statement.targets
-            )
+                        )
                     )
                     else (
                         _ModuleSubscriptDeleteBindingSugar(
-                statement, statement.targets[0].value
-            )
-            if (
-                isinstance(statement, Delete)
-                and len(statement.targets) == 1
-                and isinstance(statement.targets[0], Subscript)
-                and isinstance(statement.targets[0].value, Name)
-            )
-            else statement.sugar()
-        )
+                            statement, statement.targets[0].value
+                        )
+                        if (
+                            isinstance(statement, Delete)
+                            and len(statement.targets) == 1
+                            and isinstance(statement.targets[0], Subscript)
+                            and isinstance(statement.targets[0].value, Name)
+                        )
+                        else statement.sugar()
+                    )
                 )
             )
         )
@@ -2076,9 +2076,7 @@ def resolve_source_visible_frame(
     # success must cite, never rebuild.  Placed AFTER artifact identity checks
     # and BEFORE any SourceFile / MaterializeModule.  Failure already cites via
     # _install_opaque_call_obligation; success must take the same door.
-    off_pop = _off_population_materialize_gap(
-        resolved, graph=graph, session=session
-    )
+    off_pop = _off_population_materialize_gap(resolved, graph=graph, session=session)
     if off_pop is not None:
         return off_pop
     definition = resolved.definition
@@ -2172,9 +2170,7 @@ def _resolve_source_visible_frame_uncached(
     )
     from sugar_source_tree.reporter import NULL_REPORTER
 
-    dependency_graphs = _bind_dependency_graphs(
-        session, dict(dependency_graphs or {})
-    )
+    dependency_graphs = _bind_dependency_graphs(session, dict(dependency_graphs or {}))
     top = resolved.module_name.split(".", 1)[0]
     dependency_graphs[top] = graph
     if session.enabled:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py
@@ -561,9 +561,7 @@ def enter_generator_resource_outcome(protocol, *, ctx: object = None):
     return enter_bound_generator_resource_outcome(protocol, machine, ctx=ctx)
 
 
-def enter_bound_generator_resource_outcome(
-    protocol, machine, *, ctx: object = None
-):
+def enter_bound_generator_resource_outcome(protocol, machine, *, ctx: object = None):
     """Resume the exact authenticated generator construction at manager enter."""
     del ctx
     from sugar_lift_py_tests.generator_construction import (
@@ -611,6 +609,7 @@ def _project_generator_enter_result(protocol, machine, result):
             lambda value: _project_generator_enter_result(protocol, machine, value)
         )
     if isinstance(result, GuardedValue):
+
         def project_arm(arm):
             if type(arm) is GeneratorConstructionV1:
                 if arm.frame_coordinate != protocol.generator_frame_cid:
@@ -630,11 +629,13 @@ def _project_generator_enter_result(protocol, machine, result):
                 return _project_generator_enter_result(protocol, arm, arm.resume())
             return _project_generator_enter_result(protocol, machine, arm)
 
-        return outcome_to_exitset(project_arm(result.when_true)).guarded(
-            result.guard
-        ).union(
-            outcome_to_exitset(project_arm(result.when_false)).guarded(
-                not_(result.guard)
+        return (
+            outcome_to_exitset(project_arm(result.when_true))
+            .guarded(result.guard)
+            .union(
+                outcome_to_exitset(project_arm(result.when_false)).guarded(
+                    not_(result.guard)
+                )
             )
         )
     if isinstance(result, YieldEffect):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1203,8 +1203,8 @@ def _qualified_enrollment_coordinate(
             "refusing to infer it from a relative path segment"
         )
     try:
-        relative = Path(path).resolve().relative_to(
-            Path(source_workspace_root).resolve()
+        relative = (
+            Path(path).resolve().relative_to(Path(source_workspace_root).resolve())
         )
     except ValueError as error:
         raise ValueError(
@@ -1823,10 +1823,10 @@ def _populate_same_module_class_manager_uses(source_file, context, uses) -> None
                 type(result).__name__,
             )
             continue
-        enter_method = next(
-            (m for m in result.methods if m.name == "__enter__"), None
+        enter_method = next((m for m in result.methods if m.name == "__enter__"), None)
+        frame = (
+            getattr(enter_method, "source_call_frame", None) if enter_method else None
         )
-        frame = getattr(enter_method, "source_call_frame", None) if enter_method else None
         frame_cid = getattr(frame, "frame_cid", None) or result.identity
         preimage = {
             "kind": "constructed-manager-behavior",
@@ -1850,9 +1850,7 @@ def _populate_same_module_class_manager_uses(source_file, context, uses) -> None
             factory_prefix_cids=(),
         )
         try:
-            protocol = construct_manager_protocol(
-                behavior, exit_face_id=exit_face_id
-            )
+            protocol = construct_manager_protocol(behavior, exit_face_id=exit_face_id)
         except (SugarNotWritten, TypeError) as exc:
             kind, detail = _populate_body_defect_kind_detail(exc)
             _install_local_derivation_gap(
@@ -2244,7 +2242,10 @@ def _project_nested_manager_layers(
                         ),
                         construction_cid=nested_frame.frame_cid,
                     )
-                    if _generator_protocol_construction_gap(nested_protocol) is not None:
+                    if (
+                        _generator_protocol_construction_gap(nested_protocol)
+                        is not None
+                    ):
                         return (
                             "nested-manager",
                             "nested manager protocol construction refused",
@@ -2388,10 +2389,7 @@ def _nameable_nested_with_body_steps(body) -> tuple | None:
             return ReturnStepV1(
                 None if statement.value is None else statement.value.sugar()
             )
-        if (
-            isinstance(statement, Expr)
-            and isinstance(statement.value, Constant)
-        ):
+        if isinstance(statement, Expr) and isinstance(statement.value, Constant):
             return InertStepV1(statement.kind)
         if isinstance(statement, Pass):
             return InertStepV1(statement.kind)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -112,7 +112,9 @@ def _frame_memo_limit() -> int:
     Env ``SUGAR_SESSION_FRAME_MEMO_LIMIT`` (default 512). Hold lifetime must
     track the memo row it guards — never longer (see remember_frame).
     """
-    raw = os.environ.get("SUGAR_SESSION_FRAME_MEMO_LIMIT", str(_DEFAULT_FRAME_MEMO_LIMIT))
+    raw = os.environ.get(
+        "SUGAR_SESSION_FRAME_MEMO_LIMIT", str(_DEFAULT_FRAME_MEMO_LIMIT)
+    )
     try:
         return max(1, int(raw))
     except ValueError:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/source_call_preconstruction.py
@@ -149,7 +149,9 @@ def populate_source_visible_call_frames(
                 )
             )
             continue
-        _preconstruct_authenticated_attribute_calls(target, graph=graph, session=session)
+        _preconstruct_authenticated_attribute_calls(
+            target, graph=graph, session=session
+        )
         from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
 
         try:
@@ -244,9 +246,7 @@ def _preconstruct_authenticated_attribute_calls(
         if isinstance(node, Call) and isinstance(node.func, Attribute)
     )
     calls_by_span = {
-        span: call
-        for call in calls
-        for span in (_span_key(call), _span_key(call.func))
+        span: call for call in calls for span in (_span_key(call), _span_key(call.func))
     }
     for receipt in receipts:
         raw = receipt.use["useSite"]
@@ -261,9 +261,7 @@ def _preconstruct_authenticated_attribute_calls(
         resolved = resolve_import_binding(receipt, graph=graph, session=session)
         if not isinstance(resolved, ResolvedPythonObjectV1):
             continue
-        projected = resolve_source_visible_frame(
-            resolved, graph=graph, session=session
-        )
+        projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
         if isinstance(projected, ManagerConstructionGapV1):
             continue
         frame, nested_target = projected

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py
@@ -193,7 +193,9 @@ def scan_module_value_pins(
             mutable_kind = _direct_mutable_kind(candidate.value)
             if mutable_kind is not None:
                 if candidate.binding_occurrence is None:
-                    raise AssertionError("mutable global candidate lost binding occurrence")
+                    raise AssertionError(
+                        "mutable global candidate lost binding occurrence"
+                    )
                 scan.mutable_global_pins.append(
                     MutableGlobalPin(
                         source_cid=tree.unit.source_cid,

--- a/implementations/python/sugar-lift-python-source/tests/declared_corpus.py
+++ b/implementations/python/sugar-lift-python-source/tests/declared_corpus.py
@@ -49,9 +49,7 @@ HOST_GRAMMAR = "host-grammar"
 # passing backend.
 OPTIONAL_PROVIDER = "optional-provider"
 
-OPTIONAL_LAW_CATEGORIES = frozenset(
-    {HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER}
-)
+OPTIONAL_LAW_CATEGORIES = frozenset({HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER})
 
 
 class DeclaredCorpusMissing(AssertionError):

--- a/implementations/python/sugar-lift-python-source/tests/test_auth_once_per_content.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_auth_once_per_content.py
@@ -33,16 +33,10 @@ def test_dependency_graph_for_top_asks_auth_once(monkeypatch) -> None:
         fake_auth,
     )
 
-    g1 = _dependency_graph_for_top(
-        "warnings", session=session, dependency_graphs=local
-    )
-    g2 = _dependency_graph_for_top(
-        "warnings", session=session, dependency_graphs=local
-    )
+    g1 = _dependency_graph_for_top("warnings", session=session, dependency_graphs=local)
+    g2 = _dependency_graph_for_top("warnings", session=session, dependency_graphs=local)
     # Fresh local map still hits session (ask once per content, not path).
-    g3 = _dependency_graph_for_top(
-        "warnings", session=session, dependency_graphs={}
-    )
+    g3 = _dependency_graph_for_top("warnings", session=session, dependency_graphs={})
     assert g1 is g2 is g3
     assert calls == ["warnings"]
     assert session.dependency_graphs["warnings"] is g1
@@ -81,9 +75,7 @@ def test_five_unique_tops_auth_once_each(monkeypatch) -> None:
     for _ in range(21):
         local: dict = {}
         for top in tops:
-            _dependency_graph_for_top(
-                top, session=session, dependency_graphs=local
-            )
+            _dependency_graph_for_top(top, session=session, dependency_graphs=local)
 
     assert calls == list(tops)
     assert set(session.dependency_graphs) == set(tops)

--- a/implementations/python/sugar-lift-python-source/tests/test_authenticated_import_member_value_instrument.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_authenticated_import_member_value_instrument.py
@@ -22,7 +22,6 @@ from sugar_lift_py_tests.import_binding import (
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
 
-
 PRODUCTION_MODULE = "sugar_lift_python_source.authenticated_import_member_value"
 
 
@@ -127,9 +126,9 @@ def test_scoped_fixture_preflight_proves_real_indentation_and_scope(
 
 def test_missing_closed_producer_door_is_one_red() -> None:
     """R_missing_door=1: the typed producer module does not exist yet."""
-    assert importlib.util.find_spec(PRODUCTION_MODULE) is not None, (
-        "missing typed closed imported-module member producer door"
-    )
+    assert (
+        importlib.util.find_spec(PRODUCTION_MODULE) is not None
+    ), "missing typed closed imported-module member producer door"
 
 
 _DORMANT_SEMANTIC_TEETH = (

--- a/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
@@ -69,16 +69,16 @@ def test_json_open_config_sourcefile_at_most_once() -> None:
         if "enum.py" in seats or str(row.get("module", "")).endswith("enum.py"):
             mat_enum += count
 
-    assert config_prepares <= 1, (
-        f"config.py prepare_count={config_prepares} (want ≤1); top={summary.get('top')}"
-    )
-    assert enum_prepares <= 1, (
-        f"enum.py prepare_count={enum_prepares} (want ≤1); top={summary.get('top')}"
-    )
-    assert mat_config <= 1, (
-        f"config.py MaterializeModule count={mat_config} (want ≤1); top={summary.get('top')}"
-    )
-    assert mat_enum <= 1, (
-        f"enum.py MaterializeModule count={mat_enum} (want ≤1); top={summary.get('top')}"
-    )
+    assert (
+        config_prepares <= 1
+    ), f"config.py prepare_count={config_prepares} (want ≤1); top={summary.get('top')}"
+    assert (
+        enum_prepares <= 1
+    ), f"enum.py prepare_count={enum_prepares} (want ≤1); top={summary.get('top')}"
+    assert (
+        mat_config <= 1
+    ), f"config.py MaterializeModule count={mat_config} (want ≤1); top={summary.get('top')}"
+    assert (
+        mat_enum <= 1
+    ), f"enum.py MaterializeModule count={mat_enum} (want ≤1); top={summary.get('top')}"
     assert fns >= 40, f"_json open banked {fns} functions"

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -1246,6 +1246,6 @@ def test_session_module_materialize_amortizes_across_definitions(
         resolve_source_visible_frame(resolved[0], graph=graph, session=other)
     finally:
         mc.SourceFile = original_sf  # type: ignore[misc, assignment]
-    assert materializations["count"] >= 1, (
-        "fresh session paid zero materialize; process-global memo returned"
-    )
+    assert (
+        materializations["count"] >= 1
+    ), "fresh session paid zero materialize; process-global memo returned"

--- a/implementations/python/sugar-lift-python-source/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_enumerate_rpc.py
@@ -43,9 +43,9 @@ def _files(tmp_path, **sources):
 
 def test_lift_is_no_longer_advertised_as_a_kit_method():
     methods = {m["name"] for m in kit_declaration_result()["rpc"]["methods"]}
-    assert "lift" not in methods, (
-        "`lift` is retired: full-tree construction is sugar.enumerate only"
-    )
+    assert (
+        "lift" not in methods
+    ), "`lift` is retired: full-tree construction is sugar.enumerate only"
     assert ENUMERATE_RPC_METHOD in methods
 
 
@@ -55,7 +55,10 @@ def test_lift_is_no_longer_advertised_as_a_kit_method():
 def test_source_files_censuses_every_python_file_with_oracle_identity(tmp_path):
     _files(
         tmp_path,
-        **{"alpha.py": "def a():\n    return 1\n", "beta.py": "def b():\n    return 2\n"},
+        **{
+            "alpha.py": "def a():\n    return 1\n",
+            "beta.py": "def b():\n    return 2\n",
+        },
     )
     (tmp_path / "notes.txt").write_text("not python", encoding="utf-8")
 
@@ -87,12 +90,15 @@ def test_undecodable_file_is_a_gap_not_a_node_with_a_made_up_identity(tmp_path):
 def test_seek_returns_only_the_named_file(tmp_path):
     _files(
         tmp_path,
-        **{"alpha.py": "def a():\n    return 1\n", "beta.py": "def b():\n    return 2\n"},
+        **{
+            "alpha.py": "def a():\n    return 1\n",
+            "beta.py": "def b():\n    return 2\n",
+        },
     )
 
-    result = _enumerate(
-        tmp_path, "source_files", at={"file": "beta.py"}, seek=True
-    )["result"]
+    result = _enumerate(tmp_path, "source_files", at={"file": "beta.py"}, seek=True)[
+        "result"
+    ]
 
     assert [n["memento"]["file"] for n in result["nodes"]] == ["beta.py"]
 
@@ -109,7 +115,9 @@ def test_universe_constructs_the_demanded_file(tmp_path):
         },
     )
     census = _enumerate(tmp_path, "source_files")["result"]
-    alpha = next(n["memento"] for n in census["nodes"] if n["memento"]["file"] == "alpha.py")
+    alpha = next(
+        n["memento"] for n in census["nodes"] if n["memento"]["file"] == "alpha.py"
+    )
 
     result = _enumerate(tmp_path, "universe", at=alpha)["result"]
 
@@ -125,7 +133,8 @@ def test_universe_rows_match_what_the_retired_lift_produced(tmp_path):
     alpha = census["nodes"][0]["memento"]
 
     through_enumerate = [
-        n["audit"] for n in _enumerate(tmp_path, "universe", at=alpha)["result"]["nodes"]
+        n["audit"]
+        for n in _enumerate(tmp_path, "universe", at=alpha)["result"]["nodes"]
     ]
     through_lift = dispatch(
         {
@@ -152,9 +161,9 @@ def test_universe_refuses_a_forged_memento_that_escapes_the_workspace(tmp_path):
     outside = tmp_path.parent / "outside_secret.py"
     outside.write_text("def secret():\n    return 1\n", encoding="utf-8")
 
-    result = _enumerate(
-        tmp_path, "universe", at={"file": "../outside_secret.py"}
-    )["result"]
+    result = _enumerate(tmp_path, "universe", at={"file": "../outside_secret.py"})[
+        "result"
+    ]
 
     assert result["nodes"] == [], "a traversal must never enumerate outside the root"
     assert len(result["gaps"]) == 1
@@ -181,8 +190,8 @@ def test_universe_reports_a_syntax_refusal_as_a_gap(tmp_path):
 def test_an_unserved_level_is_a_loud_refusal_not_a_false_empty_census(tmp_path, level):
     response = _enumerate(tmp_path, level)
 
-    assert "result" not in response, (
-        f"level {level!r} must not answer an empty census it cannot back"
-    )
+    assert (
+        "result" not in response
+    ), f"level {level!r} must not answer an empty census it cannot back"
     assert response["error"]["code"] == -32602
     assert level in response["error"]["message"]

--- a/implementations/python/sugar-lift-python-source/tests/test_function_roster_floor_law.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_function_roster_floor_law.py
@@ -102,6 +102,7 @@ def test_runtime_error_and_value_error_also_preserve_floor(
         RuntimeError("populate runtime residual"),
         ValueError("populate value residual"),
     ):
+
         def make_boom(planted):
             def boom(source_file, **_k):
                 del source_file

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_lifecycle_performance.py
@@ -131,8 +131,8 @@ def test_enter_bound_generator_construction_refuses_foreign_frame():
 
 def test_enter_bound_generator_sequences_mixed_yield_and_halt_faces():
     true_face, false_face = partition("mixed-enter-guard")
-    effect = RaiseEffect.for_builtin("RenamedError",
-        
+    effect = RaiseEffect.for_builtin(
+        "RenamedError",
         blame="mixed-enter",
         occurrence="mixed-enter:halt",
     )
@@ -239,8 +239,7 @@ def test_enter_projector_resumes_guarded_branch_machines_once():
         TermValue(43),
     }
     assert all(
-        isinstance(face.value, EnteredGeneratorManagerStateV1)
-        for face in completed
+        isinstance(face.value, EnteredGeneratorManagerStateV1) for face in completed
     )
     assert true_machine.cursor == 0
     assert false_machine.cursor == 0
@@ -278,9 +277,7 @@ def test_enter_projector_distributes_guarded_yield_effect_arms_secondarily():
 
     assert isinstance(outcome, ExitSet)
     assert {
-        face.value.enter_value
-        for face in outcome.exits
-        if isinstance(face, Completed)
+        face.value.enter_value for face in outcome.exits if isinstance(face, Completed)
     } == {TermValue(53), TermValue(59)}
 
 
@@ -502,11 +499,13 @@ def test_pre_yield_suspension_assign_twin_does_not_impersonate_ordinary_assign()
         outcome = protocol.enter_resource_outcome()
     except SugarNotWritten as gap:
         # Honest residual until suspension-carrying Assign is constructed.
-        assert "Assign" in str(gap.observed) or "suspension" in str(gap.observed).lower(), (
-            gap.observed
-        )
-        assert "carrying a suspension" in str(gap.observed) or gap.observed == "Assign" or (
-            "Assign carrying a suspension" in str(gap.observed)
+        assert (
+            "Assign" in str(gap.observed) or "suspension" in str(gap.observed).lower()
+        ), gap.observed
+        assert (
+            "carrying a suspension" in str(gap.observed)
+            or gap.observed == "Assign"
+            or ("Assign carrying a suspension" in str(gap.observed))
         ), (
             f"suspension twin must name suspension-carrying Assign, not a foreign "
             f"shape; observed={gap.observed!r}"

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
@@ -265,8 +265,8 @@ class _Fixed(Sugar):
 
 def _nested_body_faces() -> ExitSet:
     """Completed, Returned, and Halted edges under distinct guards."""
-    raise_effect = RaiseEffect.for_builtin("ValueError",
-        
+    raise_effect = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence="body.py:10:8:raise",
         blame="body.py:10:8:raise",
     )
@@ -379,7 +379,10 @@ def _assert_lifecycle_once(sugar, *, shape: str, bind_slot: str | None):
         # GeneratorWithSugar prepends EnterResultBinding facts when slot set.
         if sugar.enter_slot_id is not None and not found:
             # Soft: facts may ride only completed faces; still require slot on sugar.
-            assert sugar.enter_slot_id.endswith("enter_result") or sugar.enter_slot_id == bind_slot
+            assert (
+                sugar.enter_slot_id.endswith("enter_result")
+                or sugar.enter_slot_id == bind_slot
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -412,9 +415,7 @@ def test_shape_exact_seat_and_lifecycle_over_nested_body_faces(
 
 
 @pytest.mark.parametrize("shape", _SHAPES, ids=lambda s: s.shape)
-def test_renamed_alias_shares_lifecycle_seat_law(
-    tmp_path: Path, shape: _ManagerShape
-):
+def test_renamed_alias_shares_lifecycle_seat_law(tmp_path: Path, shape: _ManagerShape):
     """Renamed import alias seats and consumes through the same pipeline."""
     root = tmp_path / f"renamed_{shape.package}"
     root.mkdir()
@@ -513,9 +514,7 @@ def test_cross_seated_twin_cannot_borrow_another_shapes_ref(tmp_path: Path):
     root = tmp_path / "cross"
     root.mkdir()
     # Publish A only via populate.
-    context, tree = _populate(
-        root, shape=a, consumer_source=_direct_consumer(a)
-    )
+    context, tree = _populate(root, shape=a, consumer_source=_direct_consumer(a))
     site = _with_site(tree)
     a_ref = _require_item_ref(site, site.items[0])
     a_coord = _item_coordinate(site, site.items[0])
@@ -751,9 +750,9 @@ def test_stack_two_renamed_managers_source_order_enter_reverse_exit(tmp_path: Pa
         f"lifecycle routers in source order; got {[type(n).__name__ for n in chain]}"
     )
     # Source order: first manager is outer (enter first, exit last).
-    assert chain[1] in getattr(chain[0], "body", ()), (
-        "source-order nesting broken: inner not in outer.body"
-    )
+    assert chain[1] in getattr(
+        chain[0], "body", ()
+    ), "source-order nesting broken: inner not in outer.body"
 
     # Multi-face body on the innermost suite for per-edge cleanup.
     from dataclasses import replace
@@ -785,4 +784,3 @@ def test_stack_two_renamed_managers_source_order_enter_reverse_exit(tmp_path: Pa
             f"MISSING CONSUMER (codex-2): stacked exit lost body face {face_id}; "
             f"guards={guard_text}"
         )
-

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
@@ -91,8 +91,7 @@ def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
     distribution = _distribution(tmp_path, implementation)
     path = tmp_path / "consumer.py"
     path.write_text(
-        consumer
-        or ("from unprivileged import outer\n" "with outer():\n" "    pass\n"),
+        consumer or ("from unprivileged import outer\n" "with outer():\n" "    pass\n"),
         encoding="utf-8",
     )
     context = TreeConstructionContextV1.for_source_call_construction(
@@ -181,8 +180,8 @@ def test_nested_cleanup_runs_before_outer_resume_on_halt(tmp_path: Path) -> None
     machine = entered.machine
     assert isinstance(machine.steps[machine.cursor], NestedManagerExitStepV1)
     # Plant a throw at the post-yield suspension (halted body edge).
-    effect = RaiseEffect.for_builtin("RuntimeError",
-        
+    effect = RaiseEffect.for_builtin(
+        "RuntimeError",
         blame="body",
         occurrence="body:halt",
         raised_value="boom",
@@ -208,9 +207,9 @@ def test_distinct_occurrence_identities_per_layer(tmp_path: Path) -> None:
     layer = protocol.nested_manager_layers[0]
     assert layer.occurrence["cid"] != protocol.generator_frame_cid
     assert layer.nested_generator_frame_cid != protocol.generator_frame_cid
-    assert layer.cid not in {
-        face.cid for face in protocol.yield_faces
-    } | {face.cid for face in protocol.enter_halt_faces}
+    assert layer.cid not in {face.cid for face in protocol.yield_faces} | {
+        face.cid for face in protocol.enter_halt_faces
+    }
 
 
 def test_tampered_inner_source_refuses_stable_layer_identity(tmp_path: Path) -> None:
@@ -229,7 +228,8 @@ def test_tampered_inner_source_refuses_stable_layer_identity(tmp_path: Path) -> 
     assert (
         left_layer.nested_protocol_construction_cid
         != right_layer.nested_protocol_construction_cid
-        or left_layer.nested_generator_frame_cid != right_layer.nested_generator_frame_cid
+        or left_layer.nested_generator_frame_cid
+        != right_layer.nested_generator_frame_cid
     )
 
 
@@ -323,7 +323,9 @@ def test_planted_nested_manager_step_lifecycle_performance() -> None:
     assert isinstance(outcome, Complete)
     entered = outcome.value
     assert entered.enter_value == StringValue("outer")
-    assert any(isinstance(b, NestedEnteredBindingV1) for b in entered.machine.binding_state)
+    assert any(
+        isinstance(b, NestedEnteredBindingV1) for b in entered.machine.binding_state
+    )
     # Exit outer: NestedManagerExitStep exits nested then terminates.
     exit_outcome = outer_protocol.exit_outcome_for(entered)
     exits = outcome_to_exitset(exit_outcome)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_assign_execution.py
@@ -62,11 +62,7 @@ class _CountingValue(ConstructedTermSugar):
 
 
 def test_generator_attribute_assign_executes_once_at_exact_target_occurrence():
-    steps = _steps(
-        "def g(holder):\n"
-        "    holder.hidden = True\n"
-        "    yield holder\n"
-    )
+    steps = _steps("def g(holder):\n" "    holder.hidden = True\n" "    yield holder\n")
     assign = steps[0]
     assert isinstance(assign, AttributeAssignStepV1)
     assert assign.attr == "hidden"
@@ -91,15 +87,11 @@ def test_generator_attribute_assign_executes_once_at_exact_target_occurrence():
 
 def test_generator_attribute_assign_rejects_foreign_target_occurrence():
     truthful = _steps(
-        "def g(holder):\n"
-        "    holder.hidden = True\n"
-        "    yield holder\n"
+        "def g(holder):\n" "    holder.hidden = True\n" "    yield holder\n"
     )[0]
-    foreign = _steps(
-        "def h(other):\n"
-        "    other.hidden = True\n"
-        "    yield other\n"
-    )[0]
+    foreign = _steps("def h(other):\n" "    other.hidden = True\n" "    yield other\n")[
+        0
+    ]
     assert isinstance(truthful, AttributeAssignStepV1)
     assert isinstance(foreign, AttributeAssignStepV1)
     with pytest.raises(TypeError, match="target occurrence does not match"):

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_if_execution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_if_execution.py
@@ -34,10 +34,7 @@ def _steps(source: str):
 
 def test_pre_yield_if_assign_emits_if_step_then_yield():
     steps = _steps(
-        "def g(flag):\n"
-        "    if flag:\n"
-        "        prior = None\n"
-        "    yield 1\n"
+        "def g(flag):\n" "    if flag:\n" "        prior = None\n" "    yield 1\n"
     )
     assert isinstance(steps[0], IfStepV1)
     assert isinstance(steps[0].then_steps[0], AssignStepV1)
@@ -46,10 +43,7 @@ def test_pre_yield_if_assign_emits_if_step_then_yield():
 
 def test_ground_true_pre_yield_if_assigns_then_yields():
     steps = _steps(
-        "def g():\n"
-        "    if True:\n"
-        "        prior = None\n"
-        "    yield 1\n"
+        "def g():\n" "    if True:\n" "        prior = None\n" "    yield 1\n"
     )
     assert isinstance(steps[0], IfStepV1)
     yielded = GeneratorConstructionV1.allocate(
@@ -73,10 +67,7 @@ def test_ground_true_pre_yield_if_assigns_then_yields():
 
 def test_ground_false_pre_yield_if_skips_then_yields():
     steps = _steps(
-        "def g():\n"
-        "    if False:\n"
-        "        prior = None\n"
-        "    yield 7\n"
+        "def g():\n" "    if False:\n" "        prior = None\n" "    yield 7\n"
     )
     yielded = GeneratorConstructionV1.allocate(
         allocation_coordinate="enter:if-false",
@@ -94,10 +85,7 @@ def test_ground_false_pre_yield_if_skips_then_yields():
 
 def test_undecided_pre_yield_if_partitions():
     steps = _steps(
-        "def g(flag):\n"
-        "    if flag:\n"
-        "        prior = None\n"
-        "    yield 1\n"
+        "def g(flag):\n" "    if flag:\n" "        prior = None\n" "    yield 1\n"
     )
     outcome = GeneratorConstructionV1.allocate(
         allocation_coordinate="enter:if-undecided",
@@ -142,10 +130,7 @@ def test_enter_resource_outcome_runs_pre_yield_if_assign():
     )
 
     steps = _steps(
-        "def g():\n"
-        "    if True:\n"
-        "        prior = None\n"
-        "    yield 1\n"
+        "def g():\n" "    if True:\n" "        prior = None\n" "    yield 1\n"
     )
     frame = SimpleNamespace(
         frame_cid=cid_of_json({"f": "pre-yield-if-enter"}),

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_receipt_roster_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_receipt_roster_authority.py
@@ -13,7 +13,6 @@ from sugar_lift_python_source.manager_construction import (
 )
 from sugar_source_tree.panic import BackendDefect
 
-
 SOURCE = "from . import helper\nfirst = helper.FLAG\nsecond = helper.OTHER\n"
 
 
@@ -44,9 +43,7 @@ def test_identical_package_bytes_retain_distinct_authenticated_rosters(
     assert first is first_rows
     assert second is second_rows
     assert first is not second
-    assert {row.target_symbol for row in first} != {
-        row.target_symbol for row in second
-    }
+    assert {row.target_symbol for row in first} != {row.target_symbol for row in second}
     assert {row.import_binding.cid for row in first}.isdisjoint(
         row.import_binding.cid for row in second
     )
@@ -62,9 +59,7 @@ def test_same_module_reuses_objects_and_foreign_or_duplicate_rosters_refuse(
     first_module, first_rows = _module_and_rows(tmp_path, "first_package")
     second_module, second_rows = _module_and_rows(tmp_path, "second_package")
     context = TreeConstructionContextV1.for_source_call_construction()
-    retained = _retain_import_value_receipt_roster(
-        context, first_module, first_rows
-    )
+    retained = _retain_import_value_receipt_roster(context, first_module, first_rows)
 
     repeated = _retain_import_value_receipt_roster(
         context, first_module, tuple(first_rows)

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -24,11 +24,20 @@ from sugar_lift_python_source.dependency_artifact import ResolvedPythonObjectV1
 from sugar_lift_python_source.source_call_preconstruction import (
     populate_source_visible_call_frames,
 )
-from sugar_source_tree.nodes import BindingCoordinateRef, Call, Constant, Dict, FunctionDef, Tuple_
+from sugar_source_tree.nodes import (
+    BindingCoordinateRef,
+    Call,
+    Constant,
+    Dict,
+    FunctionDef,
+    Tuple_,
+)
 from sugar_source_tree.tree import SourceFile
 
 
-def _distribution(root: Path, helpers: str, types: str = "class ArrayType:\n    pass\n"):
+def _distribution(
+    root: Path, helpers: str, types: str = "class ArrayType:\n    pass\n"
+):
     package = root / "unprivileged"
     package.mkdir()
     (package / "__init__.py").write_text(
@@ -138,7 +147,9 @@ def test_frame_seats_import_value_use_receipts_on_own_unit(tmp_path: Path) -> No
     )
     resolutions = frame.owner.unit._import_value_use_resolutions
     assert resolutions, "frame unit must seat its own value-use receipts"
-    assert all(isinstance(value, ResolvedPythonObjectV1) for value in resolutions.values())
+    assert all(
+        isinstance(value, ResolvedPythonObjectV1) for value in resolutions.values()
+    )
     # Definition-coordinate identity — not spelling.
     seated = next(iter(resolutions.values()))
     assert seated.definition.name == "ArrayType"
@@ -217,9 +228,7 @@ def test_foreign_variadic_actuals_rehost_with_distinct_coordinates(
         (foreign_source, "foreign.py", blake3_512_of(foreign_source.encode())),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
-    actuals = tuple(
-        node for node in foreign_file.nodes() if isinstance(node, Constant)
-    )
+    actuals = tuple(node for node in foreign_file.nodes() if isinstance(node, Constant))
     frame = function.source_visible_call_frame().bind_node_actuals(actuals, ())
     packed = frame.runtime_entries[0].state
     assert isinstance(packed, Tuple_)
@@ -248,9 +257,7 @@ def test_foreign_variadic_keyword_actuals_rehost_with_distinct_coordinates(
         (foreign_source, "foreign_kw.py", blake3_512_of(foreign_source.encode())),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
-    actuals = tuple(
-        node for node in foreign_file.nodes() if isinstance(node, Constant)
-    )
+    actuals = tuple(node for node in foreign_file.nodes() if isinstance(node, Constant))
     frame = function.source_visible_call_frame().bind_node_actuals(
         (), (("left", actuals[0]), ("right", actuals[1]))
     )
@@ -388,8 +395,12 @@ def test_exact_import_value_receipt_seats_and_constructs_member(
 
     source = "import re\ndef selected():\n    return re.I\n"
     path, source_file, context = _consumer(tmp_path, source)
-    function = next(node for node in source_file.nodes() if isinstance(node, FunctionDef))
-    attribute = next(node for node in source_file.nodes() if isinstance(node, Attribute))
+    function = next(
+        node for node in source_file.nodes() if isinstance(node, FunctionDef)
+    )
+    attribute = next(
+        node for node in source_file.nodes() if isinstance(node, Attribute)
+    )
     receipts, _ = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_file.unit.source_cid, module_identities={}
     )
@@ -430,13 +441,17 @@ def test_exact_import_value_receipt_seats_and_constructs_member(
 def test_import_value_receipt_state_refuses_wrong_span_foreign_and_conflict(
     tmp_path: Path,
 ) -> None:
-    from sugar_lift_py_tests.import_binding import authenticated_import_value_use_receipts
+    from sugar_lift_py_tests.import_binding import (
+        authenticated_import_value_use_receipts,
+    )
     from sugar_source_tree.nodes import Attribute
     from sugar_source_tree.panic import BackendDefect
 
     source = "import re\ndef selected():\n    return re.I\n"
     path, source_file, _ = _consumer(tmp_path, source)
-    attribute = next(node for node in source_file.nodes() if isinstance(node, Attribute))
+    attribute = next(
+        node for node in source_file.nodes() if isinstance(node, Attribute)
+    )
     receipts, _ = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_file.unit.source_cid, module_identities={}
     )
@@ -476,7 +491,9 @@ def test_import_value_receipt_state_refuses_wrong_span_foreign_and_conflict(
         foreign_file.unit.source_cid,
         module_identities={},
     )
-    foreign = next(row for row in foreign_receipts if row.target_symbol == "python:os.X")
+    foreign = next(
+        row for row in foreign_receipts if row.target_symbol == "python:os.X"
+    )
     with pytest.raises(BackendDefect, match="source_cid"):
         source_file.unit.seat_import_value_use_resolution(
             span_key, foreign, source_cid=foreign_file.unit.source_cid
@@ -495,12 +512,12 @@ def test_receipt_backed_import_member_is_constructed_call_argument(
     from sugar_lift_python_source.resolution_session import SourceResolutionSession
 
     source = (
-        "import re\n"
-        "def selected(value):\n"
-        "    return re.search('', value, re.I)\n"
+        "import re\n" "def selected(value):\n" "    return re.search('', value, re.I)\n"
     )
     _path, source_file, context = _consumer(tmp_path, source)
-    function = next(node for node in source_file.nodes() if isinstance(node, FunctionDef))
+    function = next(
+        node for node in source_file.nodes() if isinstance(node, FunctionDef)
+    )
     call = next(node for node in source_file.nodes() if isinstance(node, Call))
     module = AuthenticatedModuleSourceV1(
         module_name="consumer",
@@ -553,8 +570,12 @@ def test_import_member_testimony_canonicalizes_only_its_authenticated_token(
 
     source = "import sys\ndef selected():\n    return sys.modules\n"
     path, source_file, context = _consumer(tmp_path, source)
-    function = next(node for node in source_file.nodes() if isinstance(node, FunctionDef))
-    attribute = next(node for node in source_file.nodes() if isinstance(node, Attribute))
+    function = next(
+        node for node in source_file.nodes() if isinstance(node, FunctionDef)
+    )
+    attribute = next(
+        node for node in source_file.nodes() if isinstance(node, Attribute)
+    )
     module = AuthenticatedModuleSourceV1(
         module_name="consumer",
         source_seat="consumer.py",
@@ -595,7 +616,9 @@ def test_import_member_testimony_canonicalizes_only_its_authenticated_token(
         foreign_file.unit.source_cid,
         module_identities={},
     )
-    foreign = next(row for row in foreign_receipts if row.target_symbol == "python:os.modules")
+    foreign = next(
+        row for row in foreign_receipts if row.target_symbol == "python:os.modules"
+    )
     span = attribute.line_col_span()
     with pytest.raises(BackendDefect, match="source_cid"):
         source_file.unit.seat_import_value_use_resolution(

--- a/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py
@@ -62,7 +62,12 @@ def test_source_return_projection_selects_one_unconditional_returned_floor() -> 
         BlockValue(
             (
                 ReturnValue(TermValue("returned")),
-                RaiseValue(RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:91:0')),
+                RaiseValue(
+                    RaiseEffect.for_builtin(
+                        "RuntimeError",
+                        occurrence="implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:91:0",
+                    )
+                ),
             ),
             can_fall_through=False,
         ),
@@ -88,7 +93,14 @@ def test_source_return_projection_preserves_ambiguous_control_flow(ambiguous) ->
     (
         BlockValue((TermValue("foreign"),)),
         BlockValue(
-            (RaiseValue(RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:65:0')),),
+            (
+                RaiseValue(
+                    RaiseEffect.for_builtin(
+                        "RuntimeError",
+                        occurrence="implementations/python/sugar-lift-python-source/tests/test_metaclass_block_publication.py:65:0",
+                    )
+                ),
+            ),
             can_fall_through=False,
         ),
     ),
@@ -123,7 +135,9 @@ class _Coordinate:
         return {"name": self.name}
 
 
-def test_metaclass_publication_identity_separates_returned_floor_and_call_site() -> None:
+def test_metaclass_publication_identity_separates_returned_floor_and_call_site() -> (
+    None
+):
     shared = dict(
         source_cid="source-cid",
         definition=_Coordinate("definition"),

--- a/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
@@ -74,7 +74,10 @@ def test_backend_module_construction_receipt_discriminates_foreign_source(
     )
 
     assert truthful.unit.source_cid != foreign.unit.source_cid
-    assert truthful.construction_event_receipt_cid != foreign.construction_event_receipt_cid
+    assert (
+        truthful.construction_event_receipt_cid
+        != foreign.construction_event_receipt_cid
+    )
 
 
 def test_class_definition_carries_ordered_decorator_sugars_and_occurrences(
@@ -303,6 +306,7 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
             try:
                 return self._table.lookup(name)
             except KeyError:
+
                 class _AbsentSymbol:
                     @staticmethod
                     def is_global() -> bool:
@@ -314,9 +318,7 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
             return getattr(self._table, name)
 
     def observed_function_symtable(self, name: str, lineno: int):
-        return _ObservedSymtable(
-            name, original_function_symtable(self, name, lineno)
-        )
+        return _ObservedSymtable(name, original_function_symtable(self, name, lineno))
 
     monkeypatch.setattr(SourceUnit, "function_symtable", observed_function_symtable)
 
@@ -349,8 +351,7 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
     assert isinstance(body_projected, tuple)
     body_frame, _ = body_projected
     assert all(
-        binding.name != "BodyOnly"
-        for binding in body_frame.decorated_class_bindings
+        binding.name != "BodyOnly" for binding in body_frame.decorated_class_bindings
     )
     assert ("global_worker", "Decorated") in contacted
     assert ("shadowed_worker", "Decorated") in contacted
@@ -415,6 +416,7 @@ def test_nested_definition_headers_belong_to_outer_admission_owner(
             try:
                 return self._table.lookup(name)
             except KeyError:
+
                 class _AbsentSymbol:
                     @staticmethod
                     def is_global() -> bool:
@@ -426,9 +428,7 @@ def test_nested_definition_headers_belong_to_outer_admission_owner(
             return getattr(self._table, name)
 
     def observed_function_symtable(self, name: str, lineno: int):
-        return _ObservedSymtable(
-            name, original_function_symtable(self, name, lineno)
-        )
+        return _ObservedSymtable(name, original_function_symtable(self, name, lineno))
 
     monkeypatch.setattr(SourceUnit, "function_symtable", observed_function_symtable)
 
@@ -501,6 +501,6 @@ def test_reachable_decorated_class_publication_is_attached_to_selected_frame(
         field.name for field in binding.publication.final_class.class_fields
     ) == ("token",)
     assert binding.publication.raw_class.class_name == "Original"
-    assert tuple(field.name for field in binding.publication.raw_class.class_fields) == (
-        "stale",
-    )
+    assert tuple(
+        field.name for field in binding.publication.raw_class.class_fields
+    ) == ("stale",)

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_definition_reporter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_definition_reporter.py
@@ -144,8 +144,8 @@ def test_definition_registration_lies_stay_loud(axis) -> None:
         candidate = definition
         candidate_reporter = NullReporter()
     elif axis == "foreign-reporter-table-ref":
-        _foreign_tree, _foreign_definition, candidate_reporter = (
-            _registered_definition("def foreign():\n    return 2\n")
+        _foreign_tree, _foreign_definition, candidate_reporter = _registered_definition(
+            "def foreign():\n    return 2\n"
         )
         candidate = definition
     elif axis == "late-retroactive-registration":
@@ -168,9 +168,7 @@ def test_definition_registration_lies_stay_loud(axis) -> None:
         )
         duplicate_root = materialize(tree.unit, tree.root.ref, duplicate_reporter)
         candidate = next(
-            node
-            for node in duplicate_root.walk()
-            if isinstance(node, FunctionDef)
+            node for node in duplicate_root.walk() if isinstance(node, FunctionDef)
         )
         candidate_reporter = producer
         assert candidate is not definition
@@ -178,4 +176,3 @@ def test_definition_registration_lies_stay_loud(axis) -> None:
 
     with pytest.raises(BackendDefect):
         consumer.retain_registered_node_from(candidate, candidate_reporter)
-

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
@@ -82,7 +82,9 @@ def test_module_prefix_tables_are_from_one_reporter_roll(monkeypatch, name) -> N
     assert unit.target_pattern_construction_count == 1
 
     receipt = source_file.constructed_module.construction_event_receipt
-    assert constructed_value_cid_v2(receipt) == source_file.construction_event_receipt_cid
+    assert (
+        constructed_value_cid_v2(receipt) == source_file.construction_event_receipt_cid
+    )
     with pytest.raises(ConstructedValueCategoryGap):
         constructed_value_cid_v2(source_file.constructed_module)
 
@@ -114,6 +116,5 @@ def test_module_prefix_rejects_every_two_roll_cross_wire(monkeypatch) -> None:
     assert all(node.unit is exact.unit for node in exact.unit.function_nodes)
     assert all(node is not foreign.root for node in exact.unit.function_nodes)
     assert all(
-        node.fragment is not foreign.root.fragment
-        for node in exact.unit.function_nodes
+        node.fragment is not foreign.root.fragment for node in exact.unit.function_nodes
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_numpy_pandas_honest_zero.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_numpy_pandas_honest_zero.py
@@ -71,9 +71,9 @@ def test_unknown_package_version_fails_by_name_rather_than_skipping() -> None:
     with pytest.raises(DeclaredCorpusMissing) as exc_info:
         _load_fixture_for_package_versions({"numpy": "9.9.9", "pandas": "3.0.3"})
 
-    assert not isinstance(exc_info.value, pytest.skip.Exception), (
-        "drift off a pinned vendor version must fail, never skip"
-    )
+    assert not isinstance(
+        exc_info.value, pytest.skip.Exception
+    ), "drift off a pinned vendor version must fail, never skip"
     assert "numpy=9.9.9,pandas=3.0.3" in str(exc_info.value)
     assert "numpy_pandas_honest_zero_counts__numpy-9.9.9__pandas-3.0.3.json" in str(
         exc_info.value

--- a/implementations/python/sugar-lift-python-source/tests/test_pandas_regex_source_frame_consumer.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_pandas_regex_source_frame_consumer.py
@@ -98,7 +98,9 @@ def test_real_pandas_select_options_installs_authenticated_re_search_frame(
     nested_frame = context.source_call_frames[coordinate]
     assert coordinate not in context.opaque_source_call_obligations
     assert nested_frame.source_identity_cid == regex_graph.modules["re"].source_cid
-    assert nested_frame.definition_site.source_cid == regex_graph.modules["re"].source_cid
+    assert (
+        nested_frame.definition_site.source_cid == regex_graph.modules["re"].source_cid
+    )
 
 
 def test_same_target_foreign_import_binding_cannot_reauthenticate_definition(

--- a/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
@@ -67,8 +67,10 @@ def _stdlib_seat(filename: str, *, stdlib_root: Path) -> bool:
     # Common relative stdlib spellings used as source_seat
     if seat in {"enum.py", "re.py", "abc.py", "typing.py", "types.py"}:
         return True
-    if seat.startswith("re/") or seat.startswith("collections/") or seat.startswith(
-        "importlib/"
+    if (
+        seat.startswith("re/")
+        or seat.startswith("collections/")
+        or seat.startswith("importlib/")
     ):
         return True
     if seat.endswith("/enum.py") or seat.endswith("/re.py"):

--- a/implementations/python/sugar-lift-python-source/tests/test_reachable_source_frame_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reachable_source_frame_construction.py
@@ -57,7 +57,9 @@ def _distribution(root: Path, package: str, module_source: str, export: str):
     return importlib.metadata.Distribution.at(meta)
 
 
-def _populate(tmp_path: Path, package: str, module_source: str, export: str, consumer: str):
+def _populate(
+    tmp_path: Path, package: str, module_source: str, export: str, consumer: str
+):
     dist = _distribution(tmp_path, package, module_source, export)
     path = tmp_path / "consumer.py"
     path.write_text(consumer, encoding="utf-8")
@@ -99,9 +101,7 @@ def test_target_with_broken_sibling_constructs_authenticated_frame(tmp_path: Pat
         package="reach_pkg",
         module_source=_BROKEN_SIBLING_MODULE,
         export="target_fn",
-        consumer=(
-            "from reach_pkg import target_fn\n" "result = target_fn(1)\n"
-        ),
+        consumer=("from reach_pkg import target_fn\n" "result = target_fn(1)\n"),
     )
     call = next(
         node
@@ -118,9 +118,9 @@ def test_target_with_broken_sibling_constructs_authenticated_frame(tmp_path: Pat
         span.end_col,
     )
     ref = context.source_call_resolutions.get(coordinate)
-    assert isinstance(ref, SourceCallPreconstructionRefV1), (
-        f"expected authenticated frame for target_fn; got {type(ref).__name__}: {ref}"
-    )
+    assert isinstance(
+        ref, SourceCallPreconstructionRefV1
+    ), f"expected authenticated frame for target_fn; got {type(ref).__name__}: {ref}"
 
 
 def test_target_that_is_broken_class_stays_loud(tmp_path: Path):
@@ -130,9 +130,7 @@ def test_target_that_is_broken_class_stays_loud(tmp_path: Path):
         package="reach_pkg2",
         module_source=_BROKEN_SIBLING_MODULE,
         export="BrokenSibling",
-        consumer=(
-            "from reach_pkg2 import BrokenSibling\n" "obj = BrokenSibling()\n"
-        ),
+        consumer=("from reach_pkg2 import BrokenSibling\n" "obj = BrokenSibling()\n"),
     )
     call = next(
         node
@@ -149,9 +147,9 @@ def test_target_that_is_broken_class_stays_loud(tmp_path: Path):
         span.end_col,
     )
     result = context.source_call_resolutions.get(coordinate)
-    assert not isinstance(result, SourceCallPreconstructionRefV1), (
-        "broken class target must not mint an authenticated frame"
-    )
+    assert not isinstance(
+        result, SourceCallPreconstructionRefV1
+    ), "broken class target must not mint an authenticated frame"
     assert isinstance(result, SourceCallPreconstructionGapV1), type(result)
     # Body gap (Compare leg) or construction gap — never silent green.
     assert result.kind in {
@@ -177,9 +175,7 @@ def test_target_actually_reaching_broken_local_class_stays_loud(tmp_path: Path):
         package="reach_pkg3",
         module_source=module,
         export="target_fn",
-        consumer=(
-            "from reach_pkg3 import target_fn\n" "result = target_fn(1)\n"
-        ),
+        consumer=("from reach_pkg3 import target_fn\n" "result = target_fn(1)\n"),
     )
     call = next(
         node

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -26,7 +26,9 @@ from sugar_lift_python_source.dependency_artifact import (
 )
 
 
-def _dist(root: Path, *, name: str, files: dict[str, str]) -> importlib.metadata.Distribution:
+def _dist(
+    root: Path, *, name: str, files: dict[str, str]
+) -> importlib.metadata.Distribution:
     for relative, text in files.items():
         path = root / relative
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -185,11 +187,7 @@ def test_alias_cycle_stays_gapped(tmp_path: Path) -> None:
         tmp_path,
         name="cyc-pkg",
         files={
-            "cyc_pkg/__init__.py": (
-                "_a = _b\n"
-                "_b = _a\n"
-                "build = _a\n"
-            ),
+            "cyc_pkg/__init__.py": ("_a = _b\n" "_b = _a\n" "build = _a\n"),
         },
     )
     graph = DependencyArtifactGraph.authenticate(dist)
@@ -253,12 +251,10 @@ def test_star_uses_target_module_all_not_importer(tmp_path: Path) -> None:
         files={
             # Importer lists a red herring; target is the authority.
             "all_pkg/__init__.py": (
-                "from all_pkg.implementation import *\n"
-                '__all__ = ["not_build"]\n'
+                "from all_pkg.implementation import *\n" '__all__ = ["not_build"]\n'
             ),
             "all_pkg/implementation.py": (
-                "def build(value):\n    return value\n"
-                '__all__ = ["build"]\n'
+                "def build(value):\n    return value\n" '__all__ = ["build"]\n'
             ),
         },
     )
@@ -279,8 +275,7 @@ def test_star_target_all_excludes_name_stays_dynamic(tmp_path: Path) -> None:
         files={
             "miss_pkg/__init__.py": "from miss_pkg.implementation import *\n",
             "miss_pkg/implementation.py": (
-                "def build(value):\n    return value\n"
-                '__all__ = ["other"]\n'
+                "def build(value):\n    return value\n" '__all__ = ["other"]\n'
             ),
         },
     )
@@ -396,7 +391,9 @@ def test_two_star_imports_are_ambiguous(tmp_path: Path) -> None:
     assert result.kind == "ambiguous-static-export"
 
 
-def test_nested_alias_locus_refuses_without_suite_reconstruction(tmp_path: Path) -> None:
+def test_nested_alias_locus_refuses_without_suite_reconstruction(
+    tmp_path: Path,
+) -> None:
     """An inner-suite alias cannot borrow module-body reaching authority."""
     dist = _dist(
         tmp_path,
@@ -608,19 +605,13 @@ def test_module_prefix_refuses_synchronous_async_function_application(
     from sugar_source_tree.panic import SugarNotWritten
     from sugar_source_tree.tree import SourceFile
 
-    source = (
-        "async def produce(value):\n"
-        "    return value\n"
-        "result = produce(7)\n"
-    )
+    source = "async def produce(value):\n" "    return value\n" "result = produce(7)\n"
     dist = _dist(
         tmp_path,
         name="async-module-call-pkg",
         files={"async_module_call_pkg/__init__.py": source},
     )
-    module = DependencyArtifactGraph.authenticate(dist).modules[
-        "async_module_call_pkg"
-    ]
+    module = DependencyArtifactGraph.authenticate(dist).modules["async_module_call_pkg"]
 
     exits = manager_construction._module_prefix_outcome(
         module, ast.parse(source).body[-1]
@@ -666,19 +657,13 @@ def test_module_prefix_sync_function_application_remains_completed(
     from sugar_source_tree.nodes import Call
     from sugar_source_tree.tree import SourceFile
 
-    source = (
-        "def produce(value):\n"
-        "    return value\n"
-        "result = produce(7)\n"
-    )
+    source = "def produce(value):\n" "    return value\n" "result = produce(7)\n"
     dist = _dist(
         tmp_path,
         name="sync-module-call-pkg",
         files={"sync_module_call_pkg/__init__.py": source},
     )
-    module = DependencyArtifactGraph.authenticate(dist).modules[
-        "sync_module_call_pkg"
-    ]
+    module = DependencyArtifactGraph.authenticate(dist).modules["sync_module_call_pkg"]
 
     exits = manager_construction._module_prefix_outcome(
         module, ast.parse(source).body[-1]
@@ -732,15 +717,16 @@ def test_module_prefix_refuses_decorated_async_definition_before_completion(
     ]
 
     with pytest.raises(SugarNotWritten) as raised:
-        manager_construction._module_prefix_outcome(
-            module, ast.parse(source).body[-1]
-        )
+        manager_construction._module_prefix_outcome(module, ast.parse(source).body[-1])
 
     assert raised.value.owner == "module function definition execution"
     assert raised.value.blame.source_cid == module.source_cid
     assert raised.value.blame.span.start == 10
     assert raised.value.blame.span.end == 43
-    assert raised.value.observed == "decorated AsyncFunctionDef has no completed publication"
+    assert (
+        raised.value.observed
+        == "decorated AsyncFunctionDef has no completed publication"
+    )
 
 
 def test_module_async_function_application_stays_typed_loud_while_plain_function_applies(
@@ -798,9 +784,9 @@ def test_module_async_function_application_stays_typed_loud_while_plain_function
     plain_callable = plain_published.exits[0].value.context.temporal.value_if_bound(
         "plain_target"
     )
-    applied = CallableApplication(
-        (), (), plain_callable.definition.fragment
-    ).apply(plain_callable, None)
+    applied = CallableApplication((), (), plain_callable.definition.fragment).apply(
+        plain_callable, None
+    )
     assert isinstance(applied, Complete)
 
 
@@ -908,9 +894,7 @@ def test_bodyless_call_result_cannot_be_promoted_to_delete_list(tmp_path: Path) 
         name="bodyless-delete-pkg",
         files={"bodyless_delete_pkg/__init__.py": source},
     )
-    module = DependencyArtifactGraph.authenticate(dist).modules[
-        "bodyless_delete_pkg"
-    ]
+    module = DependencyArtifactGraph.authenticate(dist).modules["bodyless_delete_pkg"]
     locus = ast.parse(source).body[-1]
 
     with pytest.raises(SugarNotWritten) as raised:
@@ -1052,9 +1036,7 @@ def test_module_prefix_refuses_untransported_class_creation_keywords(
     ]
 
     with pytest.raises(SugarNotWritten) as raised:
-        manager_construction._module_prefix_outcome(
-            module, ast.parse(source).body[-1]
-        )
+        manager_construction._module_prefix_outcome(module, ast.parse(source).body[-1])
 
     assert raised.value.owner == "module definition execution"
     assert raised.value.observed == observed
@@ -1070,10 +1052,7 @@ def test_module_prefix_without_class_creation_keywords_still_publishes(
     from sugar_lift_python_source import manager_construction
 
     source = (
-        "class Published:\n"
-        "    TOKEN = 7\n"
-        "def build():\n"
-        "    return Published\n"
+        "class Published:\n" "    TOKEN = 7\n" "def build():\n" "    return Published\n"
     )
     dist = _dist(
         tmp_path,
@@ -1161,8 +1140,7 @@ def test_prefix_assert_false_refuses_binding(tmp_path: Path) -> None:
         name="assert-pkg",
         files={
             "assert_pkg/__init__.py": (
-                "assert False\n"
-                "from assert_pkg.implementation import build\n"
+                "assert False\n" "from assert_pkg.implementation import build\n"
             ),
             "assert_pkg/implementation.py": "def build(value):\n    return value\n",
         },
@@ -1182,8 +1160,7 @@ def test_prefix_pass_licenses_binding(tmp_path: Path) -> None:
         name="ok-pkg",
         files={
             "ok_pkg/__init__.py": (
-                "pass\n"
-                "from ok_pkg.implementation import build\n"
+                "pass\n" "from ok_pkg.implementation import build\n"
             ),
             "ok_pkg/implementation.py": "def build(value):\n    return value\n",
         },
@@ -1216,7 +1193,9 @@ def test_empty_prefix_licenses_first_statement_definition(tmp_path: Path) -> Non
     assert result.definition.name == "build"
 
 
-def test_prefix_equal_multi_face_if_preserves_completed_fallthrough(tmp_path: Path) -> None:
+def test_prefix_equal_multi_face_if_preserves_completed_fallthrough(
+    tmp_path: Path,
+) -> None:
     """Two unresolved faces with the same state still prove fallthrough."""
     dist = _dist(
         tmp_path,
@@ -1321,8 +1300,7 @@ def test_getattr_stays_dynamic(tmp_path: Path) -> None:
         name="dyn-pkg",
         files={
             "dyn_pkg/__init__.py": (
-                "def __getattr__(name):\n"
-                "    raise AttributeError(name)\n"
+                "def __getattr__(name):\n" "    raise AttributeError(name)\n"
             ),
         },
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
@@ -29,10 +29,11 @@ from sugar_lift_py_tests.context_manager_resolution import TreeConstructionConte
 from sugar_source_tree.nodes import Attribute, Call, FunctionDef
 from sugar_source_tree.panic import BackendDefect
 from sugar_source_tree.tree import SourceFile
+
 SOURCE = (
     "import re\n"
     "def selected(subject):\n"
-    "    return re.search(\"needle\", subject, re.I)\n"
+    '    return re.search("needle", subject, re.I)\n'
 )
 
 
@@ -90,9 +91,7 @@ def test_exact_re_search_receipt_resolves_and_seats_cpython_definition_body(
         frame.owner.unit.construction_context.opaque_source_call_obligations.values()
     )
     warnings = tuple(
-        item
-        for item in obligations
-        if item.target_name == "python:warnings.warn"
+        item for item in obligations if item.target_name == "python:warnings.warn"
     )
     assert len(warnings) == 1
     relation = warnings[0].import_call_value_subsumption
@@ -190,9 +189,7 @@ def test_exact_re_search_receipt_resolves_and_seats_cpython_definition_body(
     with pytest.raises(ValueError, match="cross-wired"):
         replace(warnings[0], resolution_kind=wrong_kind)
     with pytest.raises(ValueError, match="cross-wired"):
-        replace(
-            warnings[0], resolved_object_cid="blake3-512:" + "6" * 128
-        )
+        replace(warnings[0], resolved_object_cid="blake3-512:" + "6" * 128)
     with pytest.raises(ValueError, match="producer authority"):
         replace(
             relation,
@@ -237,9 +234,7 @@ def test_duplicate_identical_call_receipt_is_loud_before_pairing(
         receipts, outcomes = original(*args, **kwargs)
         return tuple(receipts) + tuple(receipts), outcomes
 
-    monkeypatch.setattr(
-        import_binding, "authenticated_import_use_receipts", duplicated
-    )
+    monkeypatch.setattr(import_binding, "authenticated_import_use_receipts", duplicated)
     with pytest.raises(BackendDefect, match="duplicate authenticated call receipt CID"):
         resolve_source_visible_frame(
             resolved,
@@ -309,7 +304,7 @@ def test_alias_import_search_resolves_the_same_exact_stdlib_definition(
     source = (
         "import re as regex\n"
         "def selected(subject):\n"
-        "    return regex.search(\"needle\", subject, regex.I)\n"
+        '    return regex.search("needle", subject, regex.I)\n'
     )
     path = tmp_path / "alias_consumer.py"
     path.write_text(source, encoding="utf-8")
@@ -334,8 +329,8 @@ def test_alias_import_search_resolves_the_same_exact_stdlib_definition(
 @pytest.mark.parametrize(
     "source",
     [
-        "def selected(re, subject):\n    return re.search(\"x\", subject)\n",
-        "re = object()\ndef selected(subject):\n    return re.search(\"x\", subject)\n",
+        'def selected(re, subject):\n    return re.search("x", subject)\n',
+        're = object()\ndef selected(subject):\n    return re.search("x", subject)\n',
     ],
 )
 def test_shadowed_or_local_re_binding_mints_no_import_call_receipt(

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -219,9 +219,12 @@ def test_regexflag_cached_class_sugar_retains_manager_context_product() -> None:
 
     assert type(outcome.value) is ImportMemberValue
     assert not foreign_context.source_import_value_receipts_by_site
-    assert outcome.value.receipt in manager_context.source_import_value_receipts[
-        (module.module_name, module.source_seat, module.source_cid)
-    ]
+    assert (
+        outcome.value.receipt
+        in manager_context.source_import_value_receipts[
+            (module.module_name, module.source_seat, module.source_cid)
+        ]
+    )
 
 
 def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
@@ -268,12 +271,13 @@ def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
     )
 
     assert type(outcome.value) is ImportMemberValue
-    assert outcome.value.receipt is unit_context.source_import_value_receipts_by_site[
-        site_key
-    ]
-    assert outcome.value.receipt in unit_context.source_import_value_receipts[
-        roster_key
-    ]
+    assert (
+        outcome.value.receipt
+        is unit_context.source_import_value_receipts_by_site[site_key]
+    )
+    assert (
+        outcome.value.receipt in unit_context.source_import_value_receipts[roster_key]
+    )
     assert len(unit_context.source_import_value_receipts_by_site) > 1
     assert not external_context.source_import_value_receipts
     assert not external_context.source_import_value_receipts_by_site

--- a/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
@@ -44,6 +44,7 @@ from sugar_source_tree.tree import SourceFile
 # Shared decorator CM wrapper — not a manager; the factory generators differ.
 # ---------------------------------------------------------------------------
 
+
 def _resource_wrapper(*, seal: str) -> str:
     """Per-package CM wrapper. Distinct ``seal`` bytes ⇒ distinct source_cid."""
     return (
@@ -453,9 +454,9 @@ def test_tampered_source_refuses_publication_per_manager(
         files=_package_files(shape, factory_source=tampered_factory),
     )
     pubs = _publications(dirty_ctx)
-    assert pubs == [], (
-        f"tampered {shape.shape} still published generator-backed refs: {pubs}"
-    )
+    assert (
+        pubs == []
+    ), f"tampered {shape.shape} still published generator-backed refs: {pubs}"
     # No SourceDerivedGeneratorResourceRefV1 under any seat for this consumer.
     assert not any(
         isinstance(value, SourceDerivedGeneratorResourceRefV1)
@@ -522,24 +523,24 @@ def test_publication_path_has_no_manager_name_dispatch():
         textwrap.dedent(inspect.getsource(derivation)),
         textwrap.dedent(inspect.getsource(protocol)),
     )
-    forbidden = {
-        shape.export for shape in _SHAPES
-    } | {
-        shape.package for shape in _SHAPES
-    } | {
-        "option_context",
-        "pd.option_context",
-        "ensure_clean",
-        "set_config",
-        "filter_warnings",
-        "hold_state",
-        "catch_warnings",
-        "temporary_state",
-        "apply_settings",
-        "_GeneratorContextManager",
-        "contextmanager",
-        "contextlib.py",
-    }
+    forbidden = (
+        {shape.export for shape in _SHAPES}
+        | {shape.package for shape in _SHAPES}
+        | {
+            "option_context",
+            "pd.option_context",
+            "ensure_clean",
+            "set_config",
+            "filter_warnings",
+            "hold_state",
+            "catch_warnings",
+            "temporary_state",
+            "apply_settings",
+            "_GeneratorContextManager",
+            "contextmanager",
+            "contextlib.py",
+        }
+    )
     for source in sources:
         module = ast.parse(source)
         literals = {
@@ -568,9 +569,9 @@ def test_this_suite_has_no_name_dispatch_in_publication_helpers():
         for child in ast.walk(node):
             if isinstance(child, ast.Constant) and isinstance(child.value, str):
                 # Helpers may mention residual format strings, not export names.
-                assert child.value not in {s.export for s in _SHAPES}, (
-                    f"{node.name} embeds export name {child.value!r}"
-                )
+                assert child.value not in {
+                    s.export for s in _SHAPES
+                }, f"{node.name} embeds export name {child.value!r}"
                 assert child.value not in {s.package for s in _SHAPES}
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -418,9 +418,7 @@ def leaky_process_memo(monkeypatch):
     import_uses: dict = {}
     import_values: dict = {}
 
-    def leaky_init(
-        self, *, enabled: bool = True, enrolled_distributions=None
-    ) -> None:
+    def leaky_init(self, *, enabled: bool = True, enrolled_distributions=None) -> None:
         self.enabled = enabled
         self.enrolled_distributions = enrolled_distributions
         self.export_resolutions = exports
@@ -566,9 +564,7 @@ def test_shared_session_amortizes_across_two_consumer_files(tmp_path: Path) -> N
                 module_identities={},
             )
             assert len(receipts) == 1
-            resolved = resolve_import_binding(
-                receipts[0], graph=graph, session=session
-            )
+            resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
             assert isinstance(resolved, ResolvedPythonObjectV1)
             projected = resolve_source_visible_frame(
                 resolved, graph=graph, session=session

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
@@ -219,9 +219,7 @@ def test_returned_manager_match_none_preserves_no_message_pattern(tmp_path: Path
 
 def test_returned_manager_pattern_preserves_message_obligation(tmp_path: Path):
     """Returned match=pattern seals the obligation; excinfo binds consumed occurrence."""
-    dist = _distribution(
-        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
-    )
+    dist = _distribution(tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary")
     consumer = (
         "import arbitrary\n"
         "def use():\n"
@@ -267,16 +265,18 @@ def test_returned_manager_pattern_preserves_message_obligation(tmp_path: Path):
         or getattr(binding.effect, "blame", None)
     )
     assert occurrence == str(binding)
-    assert all(_observed_binding(face) is None for face in exits.exits if isinstance(face, Halted))
+    assert all(
+        _observed_binding(face) is None
+        for face in exits.exits
+        if isinstance(face, Halted)
+    )
 
 
 def test_direct_imported_name_manager_with_keyword_uses_source_contract(
     tmp_path: Path,
 ):
     """Exact imported callee identity advances to its deeper source-body gap."""
-    dist = _distribution(
-        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
-    )
+    dist = _distribution(tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary")
     consumer = (
         "from arbitrary import boundary as hold\n"
         "def use():\n"
@@ -301,9 +301,7 @@ def test_direct_imported_name_manager_with_double_star_stays_loud(
     tmp_path: Path,
 ):
     """Imported ``**kwargs`` call advances to the same earlier provider-body gap."""
-    dist = _distribution(
-        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
-    )
+    dist = _distribution(tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary")
     consumer = (
         "from arbitrary import boundary as hold\n"
         "def use(options):\n"
@@ -328,9 +326,7 @@ def test_direct_imported_name_manager_with_double_star_stays_loud(
 
 def test_shadowed_imported_name_manager_is_not_authorized(tmp_path: Path):
     """A nearby import cannot authorize a parameter-shadowed manager call."""
-    dist = _distribution(
-        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
-    )
+    dist = _distribution(tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary")
     consumer = (
         "from arbitrary import boundary\n"
         "def use(boundary):\n"
@@ -346,9 +342,7 @@ def test_returned_manager_pattern_mismatch_preserves_halt_without_binding(
     tmp_path: Path,
 ):
     """Discrimination: message mismatch keeps the identical halt unbound."""
-    dist = _distribution(
-        tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary"
-    )
+    dist = _distribution(tmp_path, _ASSERTION_MANAGER_WITH_MESSAGE, exported="boundary")
     consumer = (
         "import arbitrary\n"
         "def use():\n"
@@ -469,9 +463,7 @@ def test_assigned_returned_manager_projects_to_same_effect_boundary(tmp_path: Pa
     # EffectBoundary sugar from the projected ref (not a gap / resource lie).
     assert sugar.semantics is not None or sugar.boundary_faces is not None
     if isinstance(sugar.semantics, EffectBoundarySemanticsV1):
-        assert isinstance(
-            sugar.semantics.message_pattern_operand, NoMessagePatternV1
-        )
+        assert isinstance(sugar.semantics.message_pattern_operand, NoMessagePatternV1)
 
 
 def test_lying_wrapper_cannot_borrow_assertion_contract(tmp_path: Path):
@@ -487,9 +479,9 @@ def test_lying_wrapper_cannot_borrow_assertion_contract(tmp_path: Path):
     reference, node = _reference(context, tree)
 
     if isinstance(reference, SourceDerivedContextManagerRefV1):
-        assert not isinstance(reference.semantics, EffectBoundarySemanticsV1), (
-            reference.semantics
-        )
+        assert not isinstance(
+            reference.semantics, EffectBoundarySemanticsV1
+        ), reference.semantics
         # Resource path is honest; EffectBoundary must not be invented.
         assert isinstance(reference.semantics, ProtocolResourceSemanticsV1)
     else:
@@ -578,7 +570,13 @@ def test_returned_factored_dual_face_manager_preserves_both_guards(tmp_path: Pat
         "detail": getattr(reference, "detail", None),
         "semantics_type": type(getattr(reference, "semantics", None)).__name__,
         "message_operand": (
-            type(getattr(getattr(reference, "semantics", None), "message_pattern_operand", None)).__name__
+            type(
+                getattr(
+                    getattr(reference, "semantics", None),
+                    "message_pattern_operand",
+                    None,
+                )
+            ).__name__
             if isinstance(reference, SourceDerivedContextManagerRefV1)
             else None
         ),

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_resource_stack.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_resource_stack.py
@@ -128,7 +128,9 @@ def _with_chain(sugar):
 
 def _item_use_site_coordinate(site: With, item):
     """Exact SourceFragmentCoordinate for one With-item occurrence."""
-    from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
 
     start_line, start_col, end_line, end_col = item._manager_use_site_span()
     return SourceFragmentCoordinateV1(
@@ -228,6 +230,7 @@ def test_returned_stack_resource_then_assertion_preserves_both_identities(
     assert _item_use_site_coordinate(site, site.items[0]) != _item_use_site_coordinate(
         site, site.items[1]
     )
+
 
 def test_returned_stack_assertion_then_resource_swaps_outer(
     tmp_path: Path,
@@ -375,7 +378,9 @@ def test_discrimination_lying_resource_cannot_borrow_assertion_in_stack(
     # Exact seats: item 0 is resource; item 1 must not become EffectBoundary.
     refs = _require_item_refs(site)
     assert _ref_kind(refs[0]) == "resource", _ref_kind(refs[0])
-    assert _ref_kind(refs[1]) != "boundary" and _ref_kind(refs[1]) != "factored-boundary", (
+    assert (
+        _ref_kind(refs[1]) != "boundary" and _ref_kind(refs[1]) != "factored-boundary"
+    ), (
         _ref_kind(refs[1]),
         refs[1],
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -76,12 +76,8 @@ _GUARD_SOURCE = (
 def _source_resource(**kwargs):
     manager_slot = kwargs["manager_slot_id"]
     face = kwargs["exit_face_id"]
-    enter_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "e" * 128, 1, 0, 1, 1
-    )
-    exit_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "x" * 128, 2, 0, 2, 1
-    )
+    enter_definition = SourceFragmentCoordinateV1("blake3-512:" + "e" * 128, 1, 0, 1, 1)
+    exit_definition = SourceFragmentCoordinateV1("blake3-512:" + "x" * 128, 2, 0, 2, 1)
     return WithSourceResourceSugar(
         enter=MethodCallSugar(
             receiver=ManagerRefSugar(slot_id=manager_slot, site=None),
@@ -333,7 +329,9 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
 
     assert sys.executable == "/usr/local/bin/python"
     assert platform.python_version() == "3.12.13"
-    assert pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
+    assert (
+        pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
+    )
     print(f"sys.executable={sys.executable}")
     print(f"sys.version={sys.version}")
     print(f"pandas.__file__={pandas.__file__}")
@@ -446,7 +444,9 @@ def test_real_pandas_option_context_runs_authenticated_enter_body_and_exit():
         and any(entry.site is node.fragment for node in body_nodes)
         for entry in entries
     ), "the actual pandas Assert body must produce its occurrence-bound value/effect"
-    rendered = tuple(str(entry.formula) for entry in entries if isinstance(entry, InvValue))
+    rendered = tuple(
+        str(entry.formula) for entry in entries if isinstance(entry, InvValue)
+    )
     assert any("exit_type" in formula for formula in rendered)
     assert any("exit_value" in formula for formula in rendered)
     assert any("exit_traceback" in formula for formula in rendered)
@@ -521,7 +521,9 @@ def test_real_option_context_executes_its_source_body_and_exit():
 
     assert sys.executable == "/usr/local/bin/python"
     assert platform.python_version() == "3.12.13"
-    assert pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
+    assert (
+        pandas.__file__ == "/usr/local/lib/python3.12/site-packages/pandas/__init__.py"
+    )
     print(f"sys.executable={sys.executable}")
     print(f"sys.version={sys.version}")
     print(f"pandas.__file__={pandas.__file__}")
@@ -744,8 +746,7 @@ def test_unauthenticated_generator_manager_stays_on_generator_path(tmp_path: Pat
     manager_name = "unsealed_stream"
     dist = _distribution(
         tmp_path,
-        f"def {manager_name}(value):\n"
-        "    yield value\n",
+        f"def {manager_name}(value):\n" "    yield value\n",
         exported=manager_name,
     )
     tree, context, _ = _tree(

--- a/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
@@ -26,7 +26,9 @@ from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
 from sugar_source_tree.tree import SourceFile
 
 
-def _source_file(tmp_path: Path, source: str) -> tuple[SourceFile, TreeConstructionContextV1, Path]:
+def _source_file(
+    tmp_path: Path, source: str
+) -> tuple[SourceFile, TreeConstructionContextV1, Path]:
     path = tmp_path / "consumer.py"
     path.write_text(source, encoding="utf-8")
     cid = blake3_512_of(source.encode())
@@ -37,8 +39,7 @@ def _source_file(tmp_path: Path, source: str) -> tuple[SourceFile, TreeConstruct
 
 def test_local_classdef_cm_derives_and_constructs(tmp_path: Path):
     """Visible same-module ClassDef CM: populate derives; With constructs."""
-    source = textwrap.dedent(
-        """\
+    source = textwrap.dedent("""\
         class M:
             def __enter__(self):
                 return self
@@ -47,8 +48,7 @@ def test_local_classdef_cm_derives_and_constructs(tmp_path: Path):
         def f():
             with M():
                 return 1
-        """
-    )
+        """)
     tree, context, path = _source_file(tmp_path, source)
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
 
@@ -63,16 +63,14 @@ def test_local_classdef_cm_derives_and_constructs(tmp_path: Path):
 
 def test_local_classdef_without_protocol_installs_gap(tmp_path: Path):
     """ClassDef without __enter__/__exit__: gap row; With panics named."""
-    source = textwrap.dedent(
-        """\
+    source = textwrap.dedent("""\
         class NotCM:
             def run(self):
                 return 1
         def f():
             with NotCM():
                 return 1
-        """
-    )
+        """)
     tree, context, path = _source_file(tmp_path, source)
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
 
@@ -91,25 +89,21 @@ def test_install_gap_never_attribute_errors_on_import_auth_fail(tmp_path: Path):
     """Import CM without dist: gap installs; no AttributeError on deleted ground mint."""
     (tmp_path / "pkg").mkdir()
     (tmp_path / "pkg" / "__init__.py").write_text(
-        textwrap.dedent(
-            """\
+        textwrap.dedent("""\
             class M:
                 def __enter__(self):
                     return self
                 def __exit__(self, *a):
                     return False
-            """
-        ),
+            """),
         encoding="utf-8",
     )
-    source = textwrap.dedent(
-        """\
+    source = textwrap.dedent("""\
         from pkg import M
         def f():
             with M():
                 return 1
-        """
-    )
+        """)
     tree, context, path = _source_file(tmp_path, source)
     # No distribution_index → authenticate fails → no-derived-contract gap.
     populate_source_derived_resource_refs(tree, root=tmp_path, path=path)

--- a/implementations/python/sugar-lift-python-source/tests/test_sin_cluster_6_exitset_typed_discrimination.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sin_cluster_6_exitset_typed_discrimination.py
@@ -32,9 +32,12 @@ def test_lying_twin_panic_prose_substring_gate_is_absent() -> None:
     forbidden = 'if "ExitSet" in str(observed):'
     assert forbidden not in module_src
     # Also refuse the looser form that matches any str(observed) ExitSet probe.
-    assert any(
-        line.strip().startswith("if ")
-        and "ExitSet" in line
-        and "str(observed)" in line
-        for line in module_src.splitlines()
-    ) is False
+    assert (
+        any(
+            line.strip().startswith("if ")
+            and "ExitSet" in line
+            and "str(observed)" in line
+            for line in module_src.splitlines()
+        )
+        is False
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -1529,7 +1529,9 @@ def test_non_uniform_message_faces_do_not_collapse_to_one_operand():
     )
 
     assert not isinstance(result, DerivedManagerSummaryGapV1)
-    assert not isinstance(result, (NoMessagePatternV1, OptionalFormalArgumentProjectionV1))
+    assert not isinstance(
+        result, (NoMessagePatternV1, OptionalFormalArgumentProjectionV1)
+    )
     assert isinstance(result, ExitSet)
     assert len(result.exits) == 2
 
@@ -1543,7 +1545,12 @@ def test_soft_boundary_emits_both_effect_boundary_faces_for_non_uniform_match():
         NoMessagePatternV1,
         OptionalFormalArgumentProjectionV1,
     )
-    from sugar_lift_py_tests.floor import FloorValue, NoneValue, ObjectValue, StringValue
+    from sugar_lift_py_tests.floor import (
+        FloorValue,
+        NoneValue,
+        ObjectValue,
+        StringValue,
+    )
     from sugar_lift_py_tests.floor.object_field import ObjectField
     from sugar_lift_py_tests.floor.receiver_state_partition_value import (
         ReceiverStatePartitionValue,
@@ -1613,7 +1620,12 @@ def test_soft_boundary_uniform_none_match_stays_one_no_message_summary():
         EffectBoundarySemanticsV1,
         NoMessagePatternV1,
     )
-    from sugar_lift_py_tests.floor import FloorValue, NoneValue, ObjectValue, StringValue
+    from sugar_lift_py_tests.floor import (
+        FloorValue,
+        NoneValue,
+        ObjectValue,
+        StringValue,
+    )
     from sugar_lift_py_tests.floor.object_field import ObjectField
     from sugar_lift_py_tests.floor.receiver_state_partition_value import (
         ReceiverStatePartitionValue,
@@ -1742,9 +1754,7 @@ def test_factored_summary_installs_factored_ref_not_no_derived_contract():
         FactoredEffectBoundarySummaryV1,
     )
 
-    coordinate = SourceFragmentCoordinateV1(
-        "blake3-512:" + ("ab" * 64), 2, 9, 2, 40
-    )
+    coordinate = SourceFragmentCoordinateV1("blake3-512:" + ("ab" * 64), 2, 9, 2, 40)
     faces = _factored_boundary_faces()
     signature = _factored_import_signature()
     protocol = SimpleNamespace()
@@ -1878,9 +1888,7 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
     )
 
     faces = _factored_boundary_faces()
-    coordinate = SourceFragmentCoordinateV1(
-        "blake3-512:" + ("cd" * 64), 1, 0, 1, 10
-    )
+    coordinate = SourceFragmentCoordinateV1("blake3-512:" + ("cd" * 64), 1, 0, 1, 10)
     contract_ref = FactoredSourceDerivedContextManagerRefV1(
         coordinate,
         "factored-protocol",
@@ -1902,7 +1910,9 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
     guarded = sugar._guarded_semantics()
     assert len(guarded) == 2
     by_name = {guard.name: semantics for guard, semantics in guarded}
-    assert isinstance(by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1)
+    assert isinstance(
+        by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1
+    )
     assert by_name["match-pattern-face"].message_pattern_operand == (
         OptionalFormalArgumentProjectionV1(1)
     )
@@ -1915,7 +1925,13 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
     )
     raise_face = Halted(
         true_guard(),
-        RaiseEffect.for_builtin('ValueError', blame='t.py:2:8', exception_type_mro=(type_term,), raised_value=StringValue('needle'), occurrence='t.py:2:8'),
+        RaiseEffect.for_builtin(
+            "ValueError",
+            blame="t.py:2:8",
+            exception_type_mro=(type_term,),
+            raised_value=StringValue("needle"),
+            occurrence="t.py:2:8",
+        ),
         None,
     )
     assert raise_face.effect.exception_type_coordinate == type_term
@@ -1939,7 +1955,8 @@ def test_factored_raise_routing_uses_none_and_pattern_message_faces():
         )
         # Matcher construction is the routing face content: both arms exist.
         assert disposition.matcher.message_pattern is (
-            None if isinstance(semantics.message_pattern_operand, NoMessagePatternV1)
+            None
+            if isinstance(semantics.message_pattern_operand, NoMessagePatternV1)
             else pattern
         )
         assert body.exits and isinstance(body.exits[0], Halted)
@@ -1970,9 +1987,7 @@ def test_uniform_none_source_derived_ref_stays_single_sealed_summary():
         NoMessagePatternV1(),
         ExceptionInfoBindingV1(),
     )
-    coordinate = SourceFragmentCoordinateV1(
-        "blake3-512:" + ("ef" * 64), 1, 0, 1, 10
-    )
+    coordinate = SourceFragmentCoordinateV1("blake3-512:" + ("ef" * 64), 1, 0, 1, 10)
     sealed = SourceDerivedContextManagerRefV1(
         coordinate,
         "summary-cid",

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -193,8 +193,7 @@ def test_decorator_wrapped_source_call_does_not_borrow_undecorated_body(
     )
     path, source_file, context = _consumer(
         tmp_path,
-        "from unprivileged import arbitrary_helper as renamed\n"
-        "renamed(2) + 3\n",
+        "from unprivileged import arbitrary_helper as renamed\n" "renamed(2) + 3\n",
     )
     call = next(node for node in source_file.nodes() if isinstance(node, Call))
 
@@ -217,13 +216,11 @@ def test_undecorated_twin_still_installs_its_authenticated_return_frame(
 ) -> None:
     distribution = _distribution(
         tmp_path,
-        "def arbitrary_helper(value):\n"
-        "    return value + 1\n",
+        "def arbitrary_helper(value):\n" "    return value + 1\n",
     )
     path, source_file, context = _consumer(
         tmp_path,
-        "from unprivileged import arbitrary_helper as renamed\n"
-        "renamed(2) + 3\n",
+        "from unprivileged import arbitrary_helper as renamed\n" "renamed(2) + 3\n",
     )
     call = next(node for node in source_file.nodes() if isinstance(node, Call))
 

--- a/implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_resource_nested_exit_faces.py
@@ -74,12 +74,8 @@ class _RecordingProtocol:
 
 
 def _protocol_calls(face_id: str = "exit-face"):
-    enter_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "e" * 128, 1, 0, 1, 1
-    )
-    exit_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "x" * 128, 2, 0, 2, 1
-    )
+    enter_definition = SourceFragmentCoordinateV1("blake3-512:" + "e" * 128, 1, 0, 1, 1)
+    exit_definition = SourceFragmentCoordinateV1("blake3-512:" + "x" * 128, 2, 0, 2, 1)
     enter = MethodCallSugar(
         receiver=ManagerRefSugar(slot_id="manager-slot", site=None),
         name="__enter__",
@@ -136,37 +132,39 @@ def _never_summary():
 
 
 def _state(marker: str):
-    return _ReducedBlock(
-        entries=(marker,), can_fall_through=False, fall_through=()
-    )
+    return _ReducedBlock(entries=(marker,), can_fall_through=False, fall_through=())
 
 
 def _nested_body_faces():
     """One ExitSet with Completed, Returned, and Halted faces under distinct guards."""
-    raise_effect = RaiseEffect.for_builtin("ValueError",
+    raise_effect = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence="body.py:10:8:raise",
         blame="body.py:10:8:raise",
-        )
-    return ExitSet(
-        (
-            Completed(
-                _Atomic("body-completed", ()),
-                BlockValue((), can_fall_through=True),
-            ),
-            Completed(
-                _Atomic("body-returned", ()),
-                BlockValue(
-                    (ReturnValue(TermValue("early-return")),),
-                    can_fall_through=False,
+    )
+    return (
+        ExitSet(
+            (
+                Completed(
+                    _Atomic("body-completed", ()),
+                    BlockValue((), can_fall_through=True),
                 ),
-            ),
-            Halted(
-                _Atomic("body-halted", ()),
-                raise_effect,
-                _state("pre-raise"),
-            ),
-        )
-    ), raise_effect
+                Completed(
+                    _Atomic("body-returned", ()),
+                    BlockValue(
+                        (ReturnValue(TermValue("early-return")),),
+                        can_fall_through=False,
+                    ),
+                ),
+                Halted(
+                    _Atomic("body-halted", ()),
+                    raise_effect,
+                    _state("pre-raise"),
+                ),
+            )
+        ),
+        raise_effect,
+    )
 
 
 def _binding_kinds(exits, face_id: str):
@@ -216,12 +214,8 @@ def test_one_enter_and_exit_per_nested_body_face():
     assert "body-halted" in guard_text
 
     # Face-derived bindings: completed faces bind None; raise binds occurrence.
-    completed_binding = ExitFaceBinding.from_body_exit(
-        "exit-face", body.exits[0]
-    )
-    returned_binding = ExitFaceBinding.from_body_exit(
-        "exit-face", body.exits[1]
-    )
+    completed_binding = ExitFaceBinding.from_body_exit("exit-face", body.exits[0])
+    returned_binding = ExitFaceBinding.from_body_exit("exit-face", body.exits[1])
     halted_binding = ExitFaceBinding.from_body_exit("exit-face", body.exits[2])
     assert completed_binding.kind == "completed"
     assert returned_binding.kind == "completed"
@@ -294,10 +288,11 @@ def test_truthy_exit_suppresses_only_the_incoming_raise():
 def test_exit_halt_supersedes_every_incoming_body_face():
     """A halted __exit__ supersedes Completed, Returned, and Halted body faces."""
     body, raise_effect = _nested_body_faces()
-    exit_halt = RaiseEffect.for_builtin("RuntimeError",
+    exit_halt = RaiseEffect.for_builtin(
+        "RuntimeError",
         occurrence="exit.py:1:0",
         blame="exit.py:1:0",
-        )
+    )
     protocol = _RecordingProtocol(exit_outcome=Incomplete(exit_halt))
     sugar = _source_resource(
         protocol=protocol,
@@ -327,14 +322,16 @@ def test_exit_halt_supersedes_every_incoming_body_face():
 
 def test_face_occurrence_lying_twin_discriminates_exit_bindings():
     """Lying twin: distinct raise occurrences mint distinct ExitFaceBinding rows."""
-    a = RaiseEffect.for_builtin("ValueError",
+    a = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence="body.py:1:0:A",
         blame="body.py:1:0:A",
-        )
-    b = RaiseEffect.for_builtin("ValueError",
+    )
+    b = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence="body.py:2:0:B",
         blame="body.py:2:0:B",
-        )
+    )
     bind_a = ExitFaceBinding.from_body_exit(
         "exit-face", Halted(true_guard(), a, _state("a"))
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
@@ -76,12 +76,10 @@ def test_static_pure_binding_prefix_admits_without_outcome(monkeypatch) -> None:
         counting,
     )
     session = SourceResolutionSession()
+    assert prefix_has_completed_fallthrough(module, locus, session=session) is True
     assert (
-        prefix_has_completed_fallthrough(module, locus, session=session) is True
-    )
-    assert calls["n"] == 0, (
-        f"pure-binding prefix must not run _module_prefix_outcome; n={calls['n']}"
-    )
+        calls["n"] == 0
+    ), f"pure-binding prefix must not run _module_prefix_outcome; n={calls['n']}"
 
 
 def test_static_open_control_prefix_declines_static_door() -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_structural_floor.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_structural_floor.py
@@ -59,9 +59,7 @@ def test_floor_detects_pattern_growth(monkeypatch):
 # --- the two holes the floor caught while being built ---
 
 
-@optional_law_skipif(
-    not hasattr(ast, "TryStar"), HOST_GRAMMAR, "needs except* (3.11+)"
-)
+@optional_law_skipif(not hasattr(ast, "TryStar"), HOST_GRAMMAR, "needs except* (3.11+)")
 def test_except_star_as_rebinding_refuses_pin():
     scan = _scan(
         "X = 1\n" "try:\n" "    pass\n" "except* ValueError as X:\n" "    pass\n"

--- a/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_verify_dialect.py
@@ -746,7 +746,9 @@ def test_leaf_call_testimony_constructors_and_replace_refuse():
     source_file = leaf_assertions.SourceFile(
         (source, "kept.py", leaf_assertions.blake3_512_of(source.encode("utf-8")))
     )
-    call = next(node for node in source_file.nodes() if isinstance(node, leaf_assertions.Call))
+    call = next(
+        node for node in source_file.nodes() if isinstance(node, leaf_assertions.Call)
+    )
     translated = leaf_assertions._translate_term(call)
     with pytest.raises(TypeError, match="^_TranslatedTerm is producer-minted only$"):
         replace(translated, calls=())
@@ -766,7 +768,9 @@ def test_leaf_call_testimony_refuses_foreign_frame_and_roster_cross_wires():
             if isinstance(node, leaf_assertions.FunctionDef)
         )
         call = next(
-            node for node in source_file.nodes() if isinstance(node, leaf_assertions.Call)
+            node
+            for node in source_file.nodes()
+            if isinstance(node, leaf_assertions.Call)
         )
         return leaf_assertions._translate_term(call), contract
 
@@ -812,12 +816,15 @@ def test_leaf_call_edge_reconstruction_side_door_is_structurally_absent():
     assert {"term", "calls"}.issubset(
         leaf_assertions._TranslatedTerm.__dataclass_fields__
     )
-    assert sum(
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "_translate_term"
-        for node in ast.walk(functions["_lift_assert"])
-    ) == 2
+    assert (
+        sum(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_translate_term"
+            for node in ast.walk(functions["_lift_assert"])
+        )
+        == 2
+    )
     assert [
         function.name
         for function in functions.values()


### PR DESCRIPTION
## Result

`sugar-lift-python-source` is now clean under the exact Black version CI runs.

- `R_black(sugar-lift-python-source)`: 47 -> 0
- observed `Delta R`: -47
- predicted `Epsilon R`: -47
- denominator: 109 Python files

This is one of the three currently measured acid-vector reds. It is deliberately isolated from the b3sum/Cargo entrance and refusal-vocabulary repairs so a 47-file mechanical diff cannot obscure either instrument change.

## Formatter authority

CI installs `-e 'implementations/python/sugar-lift-py-tests[test]'`; that extra pins `black==26.5.1`. The build image independently enforces the same version. This change was produced with:

```text
black, 26.5.1 (compiled: yes)
Python (CPython) 3.12.3
```

That matches CI's exact Black pin and Python 3.12 line.

## Red / green evidence

At untouched main `16bca4d44ff4f6cda7d1636adc4ea2835cbc0b04`:

```text
47 files would be reformatted, 62 files would be left unchanged
```

At head `6df09268d70f4d9e3b1d20ce5a27ec54e6480b2c`:

```text
109 files would be left unchanged
```

The branch is exactly one commit, 0 behind / 1 ahead at preflight, with exactly 47 modified `.py` files beneath `implementations/python/sugar-lift-python-source`, no deletions, no foreign commits, and a clean diff-check.

## Scope and floors

Production and test Python were reformatted by Black only. No behavior, tests, expectations, categories, kinds, labels, taxonomy, residual buckets, runner autoscaling, or CI capacity changed. No adjacent package is included.

## Explicit non-claims

- This does not make the acid vector green by itself.
- It does not address the b3sum/Cargo entrance or the 11 vanished refusal-vocabulary rows.
- It does not claim any product behavior change.
- CI evidence is not claimed until the PR checks run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Format `sugar-lift-python-source` source and tests with Black 26.5.1
> Applies Black 26.5.1 auto-formatting across all source and test files in the `sugar-lift-python-source` implementation. Changes are purely cosmetic: line wrapping, parenthesization, string literal joining, and indentation adjustments. No logic, control flow, or test assertions are altered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6df0926.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted Python implementation and test code for more consistent readability.
  * Normalized line wrapping, assertions, function calls, imports, and string literals.
  * Added minor spacing and blank-line improvements.

* **Tests**
  * Preserved all existing test behavior, assertions, coverage, and public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->