### PR TITLE
Require authoritative enrollment roster for census managers

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1515,6 +1515,8 @@ def main() -> int:
                         workspace_root=corpus_root,
                         file_rel=relative,
                         contract_refs=contract_refs,
+                        distribution=observed_pin.distribution,
+                        source_workspace_root=locus_root,
                     )
                     if row.get("terminalKind") in {
                         "constructed",

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -353,6 +353,8 @@ def demand_context_manager_resolution_events(
     workspace_root: Path,
     file_rel: str,
     source_cid: str,
+    distribution: str | None = None,
+    source_workspace_root: Path | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Enumerate the raw, coordinate-keyed table With construction consumed."""
     result = enumerate_rpc(
@@ -360,6 +362,12 @@ def demand_context_manager_resolution_events(
         workspace_root=workspace_root,
         at=file_memento(file_rel=file_rel, source_cid=source_cid),
         seek=False,
+        options={
+            "distribution": distribution,
+            "sourceWorkspaceRoot": (
+                str(source_workspace_root) if source_workspace_root is not None else None
+            ),
+        },
     )
     events: list[dict[str, Any]] = []
     for node in result.get("nodes") or []:
@@ -697,6 +705,8 @@ def measure_file_via_enumerate(
     file_rel: str,
     source_cid: str | None = None,
     contract_refs=None,
+    distribution: str | None = None,
+    source_workspace_root: Path | None = None,
 ) -> dict[str, Any]:
     """Produce one terminal solely from sugar.enumerate demands.
 
@@ -815,6 +825,8 @@ def measure_file_via_enumerate(
             workspace_root=workspace_root,
             file_rel=file_rel,
             source_cid=source_cid,
+            distribution=distribution,
+            source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 — distinct instrument/product paths
         if _is_process_control(error):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2392,11 +2392,23 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # alongside the panic; this producer never converts panic into a
                 # completed resolution response.
                 if level == "context-manager-resolutions":
+                    distribution = options.get("distribution")
+                    source_workspace_root = options.get("sourceWorkspaceRoot")
                     populate_source_derived_resource_refs(
                         tree_file,
                         root=root,
                         path=full_path,
                         session=walk_session_for(root),
+                        source_workspace_root=(
+                            Path(source_workspace_root)
+                            if isinstance(source_workspace_root, str)
+                            else None
+                        ),
+                        distribution=(
+                            str(distribution)
+                            if isinstance(distribution, str)
+                            else None
+                        ),
                     )
                     from sugar_lift_py_tests.context_manager_resolution import (
                         context_manager_resolution_outcome,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1211,7 +1211,16 @@ def _qualified_enrollment_coordinate(
             "source seat is outside the authenticated source workspace: "
             f"path={path} source_workspace_root={source_workspace_root}"
         ) from error
-    return "/".join((distribution, *relative.parts))
+    parts = relative.parts
+    # An install-root seat already carries its distribution prefix; a package
+    # root seat does not. Preserve one canonical distribution-qualified form.
+    if parts and parts[0] == distribution:
+        return "/".join(parts)
+    return "/".join((distribution, *parts))
+
+
+class MissingEnrolledDistributionRoster(ValueError):
+    """The caller omitted the authenticated population authority."""
 
 
 def populate_source_derived_resource_refs(
@@ -1281,14 +1290,10 @@ def populate_source_derived_resource_refs(
     if distribution is not None:
         session.enrolled_distributions = frozenset({distribution})
     elif session.enrolled_distributions is None:
-        try:
-            coordinate_root = source_workspace_root or root
-            rel = Path(path).resolve().relative_to(Path(coordinate_root).resolve())
-            top = rel.parts[0] if rel.parts else None
-        except ValueError:
-            top = None
-        if top and top.isidentifier() and top not in {"tests", "test", "src"}:
-            session.enrolled_distributions = frozenset({top})
+        raise MissingEnrolledDistributionRoster(
+            "missing-enrolled-distribution-roster: distribution authority was not "
+            "supplied; refusing to infer an enrolled population from a path segment"
+        )
     context = source_file.root.unit.construction_context
     if context is None:
         return

--- a/implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from sugar_lift_python_source.manager_summary_derivation import (
+    MissingEnrolledDistributionRoster,
     _qualified_enrollment_coordinate,
+    populate_source_derived_resource_refs,
 )
 
 
@@ -22,6 +25,15 @@ def test_package_seat_uses_authenticated_distribution(tmp_path: Path) -> None:
         == "pandas/_config/config.py"
     )
 
+    assert (
+        _qualified_enrollment_coordinate(
+            path,
+            source_workspace_root=workspace.parent,
+            distribution="pandas",
+        )
+        == "pandas/_config/config.py"
+    )
+
 
 def test_missing_distribution_refuses_instead_of_bare_segment(tmp_path: Path) -> None:
     path = tmp_path / "pandas" / "_config" / "config.py"
@@ -32,3 +44,31 @@ def test_missing_distribution_refuses_instead_of_bare_segment(tmp_path: Path) ->
             source_workspace_root=tmp_path,
             distribution=None,
         )
+
+
+def test_missing_enrolled_roster_refuses_instead_of_path_seed(tmp_path: Path) -> None:
+    source_file = SimpleNamespace(
+        root=SimpleNamespace(unit=SimpleNamespace(construction_context=None))
+    )
+    with pytest.raises(
+        MissingEnrolledDistributionRoster,
+        match="missing-enrolled-distribution-roster",
+    ):
+        populate_source_derived_resource_refs(
+            source_file,
+            root=tmp_path,
+            path=tmp_path / "pandas" / "_config" / "config.py",
+        )
+
+
+def test_supplied_enrolled_roster_is_accepted(tmp_path: Path) -> None:
+    source_file = SimpleNamespace(
+        root=SimpleNamespace(unit=SimpleNamespace(construction_context=None))
+    )
+    populate_source_derived_resource_refs(
+        source_file,
+        root=tmp_path,
+        path=tmp_path / "pandas" / "_config" / "config.py",
+        source_workspace_root=tmp_path / "pandas",
+        distribution="pandas",
+    )


### PR DESCRIPTION
## Summary

The census context-manager path now passes authenticated distribution and source-workspace authority into manager-summary derivation. The path-segment roster substitution (`rel.parts[0]`) is deleted. An absent roster refuses by name with `MissingEnrolledDistributionRoster`.

This repair accounts for all 95 pandas off-population rows: the sealed-vs-cold diff identified the 95th as `tests/reshape/concat/test_invalid.py:51:8-52:54[With]`, manager `python:pandas.read_csv`, module `pandas.io.parsers.readers`. It follows the same deleted roster-seeding route; no residual route was found.

The rows were wearing the wrong label; this does not claim they are semantically constructed. They become named `With` gaps, so the frontier becomes more honest rather than smaller.

## Evidence

- Rebased HEAD: `8e4a21dad0e08f07e15d62b85f9adc4d955deb44`
- Base/merge-base: `a5534eb0084bccd12c4d88575e6e3e69360d286b`
- Focused teeth: 4/4 passed after rebase.
- Acceptance: supplied distribution/source-workspace authority is accepted.
- Refusal: absent roster raises `MissingEnrolledDistributionRoster`.
- Fenster clearance: his metadata/file-manifest-derived artifact-CID key and fixed `artifact_kind` do not share my distribution-qualified package/install-root coordinate key; either landing order is safe.

## Separate unresolved question

The sealed receipt carries 95 pandas off-population rows while the cold checkpoint carries 94. The 95th-row identity above is now authenticated and the group has one route. The issue remains separate from this PR because the receipt was measured on Keaton's tree and the rows are not claimed semantically constructed.

The sealed receipt was searched in the working tree and `/tmp`; `/tmp/keaton-d3-after-11238c23b.json` was inspected and rejected as authoritative: `control-effect-recensus-unmeasured/v1`, `measuredCommit=11238c23b`, no `bodyCid`, `frontierWidth`, or row manifest.
