### PR TITLE
Refuse invalid source stamp construction

### DIFF
--- a/tests/test_source_stamp_provisioning.py
+++ b/tests/test_source_stamp_provisioning.py
@@ -1,0 +1,113 @@
+"""Source-stamp provisioning must refuse before executing a partial toolset."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STAMP = ROOT / "tools" / "sugar_source_stamp.py"
+
+
+def _executable(path: Path, *, marker: Path) -> None:
+    path.write_text(
+        "#!/bin/sh\n"
+        f"printf called > {os.fspath(marker)!r}\n"
+        "exit 99\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+@pytest.mark.parametrize(
+    ("present_tool", "missing_tool"),
+    (("cargo", "b3sum"), ("b3sum", "cargo")),
+)
+def test_source_stamp_refuses_missing_required_tool_before_execution(
+    tmp_path: Path, present_tool: str, missing_tool: str
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "tool-was-called"
+    _executable(fake_bin / present_tool, marker=marker)
+    env = os.environ.copy()
+    env["PATH"] = os.fspath(fake_bin)
+
+    completed = subprocess.run(
+        [sys.executable, os.fspath(STAMP), "--repo-root", os.fspath(tmp_path)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert (
+        f"source stamping refused: missing required tool: {missing_tool}"
+        in completed.stderr
+    )
+    assert f"{missing_tool} is required for source stamping" in completed.stderr
+    assert "FileNotFoundError" not in completed.stderr
+    assert "Traceback" not in completed.stderr
+    assert not marker.exists(), "preflight executed a partial source-stamp toolset"
+
+
+def test_source_stamp_names_every_missing_required_tool(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "empty-bin"
+    fake_bin.mkdir()
+    env = os.environ.copy()
+    env["PATH"] = os.fspath(fake_bin)
+
+    completed = subprocess.run(
+        [sys.executable, os.fspath(STAMP), "--repo-root", os.fspath(tmp_path)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert (
+        "source stamping refused: missing required tools: b3sum, cargo"
+        in completed.stderr
+    )
+    assert "b3sum and cargo are required for source stamping" in completed.stderr
+    assert "FileNotFoundError" not in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_source_stamp_never_hashes_a_failed_cargo_preimage(tmp_path: Path) -> None:
+    rust_workspace = tmp_path / "implementations" / "rust"
+    rust_workspace.mkdir(parents=True)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "cargo").write_text("#!/bin/sh\nexit 41\n", encoding="utf-8")
+    (fake_bin / "b3sum").write_text(
+        "#!/bin/sh\n/bin/cat >/dev/null\nprintf '%0128d\\n' 0\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "cargo").chmod(0o755)
+    (fake_bin / "b3sum").chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = os.fspath(fake_bin)
+
+    completed = subprocess.run(
+        [sys.executable, os.fspath(STAMP), "--repo-root", os.fspath(tmp_path)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert "cargo could not construct the source-stamp preimage" in completed.stderr
+    assert "cargo is required for source stamping" in completed.stderr

--- a/tools/sugar_source_stamp.py
+++ b/tools/sugar_source_stamp.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -38,6 +39,33 @@ SKIP_DIRS = {
     "__pycache__",
 }
 SKIP_FILES = {".DS_Store"}
+
+
+def resolve_source_stamp_tools(cargo: str) -> tuple[str, str] | None:
+    """Resolve the complete toolset before constructing any stamp bytes."""
+
+    commands = (("b3sum", "b3sum"), ("cargo", cargo))
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+    for name, command in commands:
+        path = shutil.which(command)
+        if path is None:
+            missing.append(name)
+        else:
+            resolved[name] = os.path.abspath(path)
+
+    if missing:
+        if len(missing) == 1:
+            named = f"missing required tool: {missing[0]}"
+            required = f"{missing[0]} is required for source stamping"
+        else:
+            named = f"missing required tools: {', '.join(missing)}"
+            required = f"{' and '.join(missing)} are required for source stamping"
+        print(f"::error::source stamping refused: {named}; {required}", file=sys.stderr)
+        return None
+
+    return resolved["b3sum"], resolved["cargo"]
+
 
 def emit(label: bytes, value: bytes) -> None:
     out = sys.stdout.buffer
@@ -179,24 +207,6 @@ def write_stream(
     for package_root in local_roots:
         seen |= walk_emit(root, package_root)
 
-def stamp_from_stream() -> str:
-    import hashlib
-
-    # When called as library: re-hash stream via external b3sum preferred.
-    # This fallback is blake3 if available, else sha256 prefixed differently.
-    data = sys.stdin.buffer.read()
-    try:
-        from blake3 import blake3  # type: ignore
-
-        digest = blake3(data).hexdigest(length=64)  # 32 bytes? length is output bytes in blake3 py
-        # blake3 hexdigest() default 32 bytes = 64 hex; we need 64 bytes = 128 hex
-        digest = blake3(data).digest(length=64).hex()
-    except Exception:
-        # Prefer matching b3sum -l 64; fall back only if blake3 missing.
-        digest = hashlib.blake2b(data, digest_size=64).hexdigest()
-    return f"blake3-512_{digest}"
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, required=True)
@@ -214,14 +224,20 @@ def main(argv: list[str] | None = None) -> int:
         help="write the raw stamp preimage stream to stdout",
     )
     args = parser.parse_args(argv)
-    rust_workspace = args.rust_workspace or (args.repo_root / "implementations" / "rust")
+    rust_workspace = args.rust_workspace or (
+        args.repo_root / "implementations" / "rust"
+    )
+    tools = resolve_source_stamp_tools(args.cargo)
+    if tools is None:
+        return 2
+    b3sum, cargo = tools
 
     if args.stream:
         write_stream(
             repo_root=args.repo_root,
             rust_workspace=rust_workspace,
             package=args.package,
-            cargo=args.cargo,
+            cargo=cargo,
         )
         return 0
 
@@ -231,42 +247,39 @@ def main(argv: list[str] | None = None) -> int:
          "--repo-root", str(args.repo_root),
          "--rust-workspace", str(rust_workspace),
          "--package", args.package,
-         "--cargo", args.cargo],
+         "--cargo", cargo],
         stdout=subprocess.PIPE,
     )
     assert proc.stdout is not None
     b3 = subprocess.run(
-        ["b3sum", "-l", "64", "--no-names"],
+        [b3sum, "-l", "64", "--no-names"],
         stdin=proc.stdout,
         capture_output=True,
         check=False,
     )
-    proc.wait()
+    preimage_status = proc.wait()
+    if preimage_status != 0:
+        print(
+            "::error::source stamping refused: cargo could not construct the "
+            f"source-stamp preimage (exit {preimage_status}); cargo is required "
+            "for source stamping",
+            file=sys.stderr,
+        )
+        return 2
     if b3.returncode == 0 and b3.stdout:
         digest = b3.stdout.decode().strip()
         if len(digest) == 128 and all(c in "0123456789abcdef" for c in digest):
             print(f"blake3-512_{digest}")
             return 0
-    # Fallback: in-process blake3
-    proc2 = subprocess.run(
-        [sys.executable, __file__, "--stream",
-         "--repo-root", str(args.repo_root),
-         "--rust-workspace", str(rust_workspace),
-         "--package", args.package,
-         "--cargo", args.cargo],
-        capture_output=True,
-        check=True,
+    stderr = b3.stderr.decode("utf-8", "replace").strip()
+    detail = f"; stderr={stderr}" if stderr else ""
+    print(
+        "::error::source stamping refused: b3sum did not produce a valid "
+        f"blake3-512 digest (exit {b3.returncode}){detail}; b3sum is required "
+        "for source stamping",
+        file=sys.stderr,
     )
-    try:
-        from blake3 import blake3  # type: ignore
-
-        digest = blake3(proc2.stdout).digest(length=64).hex()
-    except Exception:
-        import hashlib
-
-        digest = hashlib.blake2b(proc2.stdout, digest_size=64).hexdigest()
-    print(f"blake3-512_{digest}")
-    return 0
+    return 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this changes

This makes source-stamp construction refuse deliberately before emitting an identity when either `b3sum` or `cargo` is absent, when the Cargo preimage producer exits nonzero, or when `b3sum` does not return a valid BLAKE3-512 digest. The refusal names the failed tool and states that it is required for source stamping. It also removes the mislabeled non-BLAKE3 fallback.

## Why this is urgent

The parent previously ignored the Cargo preimage child exit. It could therefore accept a `b3sum` of failed or empty output and present that digest as a valid content address. That is presence-without-content at the identity root: a well-formed source stamp computed over nothing, capable of corrupting every downstream identity while looking valid.

The same path also had a fallback that could compute BLAKE2b bytes and label them `blake3-512`.

The missing CI toolchain crashed first, and that accident protected us. Fixing provisioning alone would have unmasked this path and could have banked fabricated stamps while the producer appeared green. This refusal must therefore land before the provisioning change; it is intentionally a separate arrival and must not be squashed with its producer.

## Historical identity audit

The exact BLAKE3-512 digest of empty input is absent from current tracked source-stamp receipts and source-stamp-addressed release names inspected. The one tracked occurrence is an intentional Java BLAKE3 empty-input test and is not a source stamp. I am **not** claiming the non-BLAKE3 fallback never fired: historical outputs carry no algorithm/provenance marker, so shape alone cannot distinguish a genuine BLAKE3 stamp from a mislabeled fallback. No poisoned identity is presently identified; the historical interval is not exonerated by this audit.

## Evidence

Pinned base: `470827cbc73f8771fc05be8a5d4245844948f8bf`.

- `python3 -m pytest -q tests/test_source_stamp_provisioning.py tests/test_core_matrix_parallel_fanout.py tests/test_sugarbin_shell_tier.py tests/test_python_suite_identity_gate_twins.py`
- Result: 25 passed in 6.36s, exit 0, run locally after rebase onto the pinned base.

## Not claiming

No vendor number was measured and any red after landing is newly exposed evidence, not a regression caused by this repair. This focused evidence does not claim broad-suite or claim-mass status.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse invalid source stamp construction when required tools are missing or cargo preimage fails
> - Adds a preflight check in [`sugar_source_stamp.py`](https://github.com/TSavo/sugar/pull/7230/files#diff-3fd8d991eebf8874468c4f7380950ac16544b396c37a8af13a7c0c421e53a35d) that resolves `b3sum` and `cargo` via `shutil.which` before doing any work; exits with code 2 and a structured `::error::` message naming the missing tool(s) if either is absent.
> - Adds a post-preimage check that exits with code 2 if the `cargo` subprocess returns a non-zero status, preventing `b3sum` from being called on a failed preimage.
> - Removes the in-process blake3/blake2b hashing fallback (`stamp_from_stream`); the script now only produces a digest when external `b3sum` succeeds.
> - Risk: any caller relying on the in-process hashing fallback will now get an exit code 2 and no digest instead of a silently computed hash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7264ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->