### PR TITLE
Provision claim-mass source stamping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,27 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+      - name: Provision Rust and pinned b3sum through the authoritative entrance
+        id: claim_mass_source_stamp_setup
+        uses: ./.github/actions/setup-rust-cache
+      - name: Require the complete source-stamping toolset
+        id: claim_mass_source_stamp_preconditions
+        if: always() && !cancelled()
+        shell: bash
+        env:
+          SOURCE_STAMP_SETUP_OUTCOME: ${{ steps.claim_mass_source_stamp_setup.outcome }}
+        run: |
+          set -uo pipefail
+          source_stamp_status=0
+          python3 tools/sugar_source_stamp.py \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --package sugar-cli \
+            >/dev/null || source_stamp_status=$?
+          if [[ "$SOURCE_STAMP_SETUP_OUTCOME" != success ]]; then
+            echo "::error::claim-mass source stamping refused: authoritative Rust/b3sum setup outcome=$SOURCE_STAMP_SETUP_OUTCOME" >&2
+            exit 2
+          fi
+          exit "$source_stamp_status"
       - name: Install tripwire deps
         run: |
           python -m pip install --quiet \
@@ -232,6 +253,7 @@ jobs:
             -e 'implementations/python/sugar-lift-py-tests[test]'
       - name: Run pin ${{ matrix.pin }}
         id: pin
+        if: ${{ steps.claim_mass_source_stamp_preconditions.outcome == 'success' }}
         shell: bash
         working-directory: implementations/python/sugar-lift-py-tests
         env:

--- a/tests/test_core_matrix_parallel_fanout.py
+++ b/tests/test_core_matrix_parallel_fanout.py
@@ -39,6 +39,24 @@ def test_claim_mass_pins_are_independent_and_matrixed() -> None:
     assert "target: test-claim-mass-tripwires" not in text
 
 
+def test_claim_mass_matrix_uses_the_source_stamp_setup_entrance_once() -> None:
+    workflow = CI.read_text(encoding="utf-8")
+    job = workflow.split("  claim-mass-tripwires:\n", 1)[1].split(
+        "\n  claim-mass-attendance:", 1
+    )[0]
+
+    setup = "uses: ./.github/actions/setup-rust-cache"
+    preflight = "id: claim_mass_source_stamp_preconditions"
+    run_pin = "name: Run pin ${{ matrix.pin }}"
+    assert job.count(setup) == 1
+    assert job.count(preflight) == 1
+    assert job.count("tools/sugar_source_stamp.py") == 1
+    assert job.index(setup) < job.index(preflight) < job.index(run_pin)
+    assert (
+        "steps.claim_mass_source_stamp_preconditions.outcome == 'success'" in job
+    )
+
+
 def test_claim_mass_missing_pin_is_unmeasured(tmp_path: Path) -> None:
     names = subprocess.check_output(
         [sys.executable, str(CLAIM_SHARDS), "--list"],


### PR DESCRIPTION
## Landing order

Depends on #7230 and must land second. Do not squash this into the refusal arrival: the refusal contract must exist before this producer is provisioned. After #7230 lands, retarget this PR to `main`.

## What this changes

The single claim-mass matrix job now enters the existing authoritative `./.github/actions/setup-rust-cache` provisioner once. That one entrance covers pandas, itsdangerous, requests, datetime, and numpy; there are no vendor-specific setup branches.

An always-run source-stamp preflight executes before dependency installation and pytest. It captures the source-stamp command exit directly, without a pipe, and pytest can run only after that preflight succeeds. Missing `b3sum` or `cargo` therefore becomes the deliberate named refusal established in #7230.

## Discovery, not regression

All five matrix variants previously exited 2 in source stamping before any pin comparison. They measured no claim mass. Once this lands, those vendors will measure claim mass for the first time in this merge series. Any newly visible red is newly exposed product evidence, not a regression caused by provisioning.

The missing toolchain had also masked the identity-root defect fixed by #7230: provisioning alone could have allowed the parent to hash failed or empty Cargo output and bank a fabricated but well-formed source stamp. That is why the refusal lands first.

## Evidence

Pinned base: `470827cbc73f8771fc05be8a5d4245844948f8bf`.

- `python3 -m pytest -q tests/test_source_stamp_provisioning.py tests/test_core_matrix_parallel_fanout.py tests/test_sugarbin_shell_tier.py tests/test_python_suite_identity_gate_twins.py`
- Result: 25 passed in 6.36s, exit 0, run locally after rebase onto the pinned base.

## Not claiming

No vendor number was measured and any red after landing is newly exposed evidence, not a regression caused by this repair. This focused evidence does not claim broad-suite or claim-mass status.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add source stamp provisioning and precondition gate to claim-mass-tripwires CI job
> - Adds a Rust/b3sum setup step (via [`.github/actions/setup-rust-cache`](.github/actions/setup-rust-cache)) and a precondition step to the `claim-mass-tripwires` CI job before running matrix pins.
> - The precondition step runs [`tools/sugar_source_stamp.py`](https://github.com/TSavo/sugar/pull/7231/files#diff-3fd8d991eebf8874468c4f7380950ac16544b396c37a8af13a7c0c421e53a35d) for the `sugar-cli` package and exits with code 2 if the setup step did not succeed.
> - Each "Run pin" matrix step is now gated on `steps.claim_mass_source_stamp_preconditions.outcome == 'success'`, skipping execution if the precondition fails.
> - Adds a test in [`tests/test_core_matrix_parallel_fanout.py`](https://github.com/TSavo/sugar/pull/7231/files#diff-486fd936738b88be015182a4858f8a1324d602f185712c237a37100781d5c38a) asserting the setup and precondition steps appear exactly once and in the correct order, and that the pin step is gated correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81d6710.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->