### PR TITLE
Land claim-mass source-stamp provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,27 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+      - name: Provision Rust and pinned b3sum through the authoritative entrance
+        id: claim_mass_source_stamp_setup
+        uses: ./.github/actions/setup-rust-cache
+      - name: Require the complete source-stamping toolset
+        id: claim_mass_source_stamp_preconditions
+        if: always() && !cancelled()
+        shell: bash
+        env:
+          SOURCE_STAMP_SETUP_OUTCOME: ${{ steps.claim_mass_source_stamp_setup.outcome }}
+        run: |
+          set -uo pipefail
+          source_stamp_status=0
+          python3 tools/sugar_source_stamp.py \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --package sugar-cli \
+            >/dev/null || source_stamp_status=$?
+          if [[ "$SOURCE_STAMP_SETUP_OUTCOME" != success ]]; then
+            echo "::error::claim-mass source stamping refused: authoritative Rust/b3sum setup outcome=$SOURCE_STAMP_SETUP_OUTCOME" >&2
+            exit 2
+          fi
+          exit "$source_stamp_status"
       - name: Install tripwire deps
         run: |
           python -m pip install --quiet \
@@ -232,6 +253,7 @@ jobs:
             -e 'implementations/python/sugar-lift-py-tests[test]'
       - name: Run pin ${{ matrix.pin }}
         id: pin
+        if: ${{ steps.claim_mass_source_stamp_preconditions.outcome == 'success' }}
         shell: bash
         working-directory: implementations/python/sugar-lift-py-tests
         env:

--- a/tests/test_core_matrix_parallel_fanout.py
+++ b/tests/test_core_matrix_parallel_fanout.py
@@ -39,6 +39,24 @@ def test_claim_mass_pins_are_independent_and_matrixed() -> None:
     assert "target: test-claim-mass-tripwires" not in text
 
 
+def test_claim_mass_matrix_uses_the_source_stamp_setup_entrance_once() -> None:
+    workflow = CI.read_text(encoding="utf-8")
+    job = workflow.split("  claim-mass-tripwires:\n", 1)[1].split(
+        "\n  claim-mass-attendance:", 1
+    )[0]
+
+    setup = "uses: ./.github/actions/setup-rust-cache"
+    preflight = "id: claim_mass_source_stamp_preconditions"
+    run_pin = "name: Run pin ${{ matrix.pin }}"
+    assert job.count(setup) == 1
+    assert job.count(preflight) == 1
+    assert job.count("tools/sugar_source_stamp.py") == 1
+    assert job.index(setup) < job.index(preflight) < job.index(run_pin)
+    assert (
+        "steps.claim_mass_source_stamp_preconditions.outcome == 'success'" in job
+    )
+
+
 def test_claim_mass_missing_pin_is_unmeasured(tmp_path: Path) -> None:
     names = subprocess.check_output(
         [sys.executable, str(CLAIM_SHARDS), "--list"],


### PR DESCRIPTION
## Why this carrier exists

#7231 merged the provisioning commit into its stacked base branch after #7230 landed, so GitHub marks #7231 merged even though its commit is not reachable from `main`. This PR carries that same provisioning-only change onto current main as the required second arrival.

#7230 is already present on main as the first, separate refusal arrival. Do not squash this with #7230.

## Change

The single claim-mass matrix job enters the existing `./.github/actions/setup-rust-cache` provisioner once for pandas, itsdangerous, requests, datetime, and numpy. An unpiped source-stamp preflight runs before pytest, and pytest is conditional on its success.

## Evidence

Rebased onto main `a6f2480357`. Focused command: `python3 -m pytest -q tests/test_source_stamp_provisioning.py tests/test_core_matrix_parallel_fanout.py tests/test_sugarbin_shell_tier.py tests/test_python_suite_identity_gate_twins.py`; 25 passed in 6.91s, exit 0.

## Not claiming

No vendor number was measured and any red after landing is newly exposed evidence, not a regression caused by this repair. Old source-stamp outputs carry no algorithm provenance, so this work cannot prove the former non-BLAKE3 fallback never fired.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add source-stamp provisioning precondition to claim-mass-tripwires CI job
> - Adds a Rust/b3sum setup step (via `./.github/actions/setup-rust-cache`) and a precondition step to the `claim-mass-tripwires` job in [ci.yml](.github/workflows/ci.yml) that runs `tools/sugar_source_stamp.py` before any matrix pin executions.
> - The "Run pin" step is now gated on the precondition step outcome being `success`; the job exits early with code 2 if the setup step did not succeed.
> - Adds a test in [test_core_matrix_parallel_fanout.py](tests/test_core_matrix_parallel_fanout.py) that validates the single occurrence and correct ordering of the setup and precondition steps, and confirms the pin step is gated on the precondition outcome.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9a7032.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->