### PR TITLE
Pass authoritative roster through recensus path smoke

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -373,6 +373,8 @@ def _measure_clean(module, path: Path, workspace: Path) -> dict[str, Any]:
             file_rel=path.name,
             workspace_root=iso,
             contract_refs=refs,
+            distribution="recensus_path_smoke",
+            source_workspace_root=iso,
         )
         row = dict(row)
         row["sites"] = dict(module._ast_site_prevalence(plant))
@@ -413,6 +415,8 @@ def _measure_panic(module, path: Path, workspace: Path) -> dict[str, Any]:
         row = measure_file_via_enumerate(
             file_rel=path.name,
             workspace_root=iso,
+            distribution="recensus_path_smoke",
+            source_workspace_root=iso,
         )
     finally:
         tree_mod.SourceFile.__init__ = original  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

This caller fix follows merged #7227. `recensus-path-smoke` reached `MissingEnrolledDistributionRoster` at `lift_rpc.py:2397`. **The refusal was correct.** The caller genuinely lacked an authoritative roster and had previously proceeded using the substituted `rel.parts[0]` value.

The fix passes `distribution="recensus_path_smoke"` and `source_workspace_root=iso` at the production enumerate call sites used by the clean and panic smoke arms.

**The refusal was not weakened and no default was added.** This is the refusal contract doing exactly its job on its first real exposure: it found a caller silently relying on the old defect. That is a success, not a defect in the refusal.

## Evidence

- HEAD: `e7377055101f1920fe970305cf96791733aa487c`
- Direct parent and merge-base: `25d1dc7d02e75275117d2b958721c299f0d50062`
- `py_compile` passed.
- `git diff --check` passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `distribution` and `source_workspace_root` to `measure_file_via_enumerate` in recensus path smoke
> Updates both `_measure_clean` and `_measure_panic` helpers in [recensus_path_smoke.py](https://github.com/TSavo/sugar/pull/7237/files#diff-419ffb7c8217e7e524f04dca798335ee64add79efdc1d1a2b5a824686a4d0933) to pass `distribution="recensus_path_smoke"` and `source_workspace_root` pointing to the temp ISO workspace when calling `measure_file_via_enumerate`. This supplies the authoritative roster context that was previously omitted from both the clean and panic smoke test paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f256cb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->