### PR TITLE
Guard every workflow with actionlint

### DIFF
--- a/.github/workflows/recensus-path-smoke.yml
+++ b/.github/workflows/recensus-path-smoke.yml
@@ -45,7 +45,22 @@ jobs:
 
       # This must run in a workflow independent of ci.yml: a workflow rejected
       # before dispatch cannot execute its own context-availability tooth.
-      - name: Check workflow contexts available before dispatch
+      - name: Set up Go for version-pinned actionlint
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+          cache: false
+
+      - name: Install actionlint v1.7.12
+        shell: bash
+        env:
+          GOBIN: ${{ runner.temp }}/actionlint/bin
+        run: |
+          set -euo pipefail
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$GOBIN" >> "$GITHUB_PATH"
+
+      - name: Check every workflow before dispatch
         run: python3 tests/test_workflow_context_availability.py
 
       - name: Prepare immutable Python test environment

--- a/tests/test_workflow_context_availability.py
+++ b/tests/test_workflow_context_availability.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
+ACTIONLINT = os.environ.get("ACTIONLINT", "actionlint")
+ACTIONLINT_VERSION = "v1.7.12"
+
+
+def _run_actionlint(*paths: Path) -> subprocess.CompletedProcess[str]:
+    """Run the version-pinned GitHub workflow schema/expression validator."""
+
+    return subprocess.run(
+        [
+            ACTIONLINT,
+            "-oneline",
+            *(str(path) for path in paths),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def _pre_dispatch_runner_context_violations(text: str) -> list[int]:
@@ -85,6 +106,64 @@ def _has_exact_merge_group_trigger(text: str) -> bool:
 
 
 class WorkflowContextAvailabilityTest(unittest.TestCase):
+    def test_actionlint_version_is_pinned(self) -> None:
+        result = subprocess.run(
+            [ACTIONLINT, "-version"],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.splitlines()[0], ACTIONLINT_VERSION)
+
+    def test_actionlint_dispatchability_discriminator(self) -> None:
+        illegal = """\
+name: planted illegal context
+on: workflow_dispatch
+jobs:
+  planted:
+    name: illegal ${{ env.NOT_AVAILABLE_BEFORE_DISPATCH }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo unreachable
+"""
+        lawful = """\
+name: lawful workflow
+on: workflow_dispatch
+jobs:
+  planted:
+    name: lawful static name
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo reachable
+"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "workflow.yml"
+            path.write_text(illegal)
+            rejected = _run_actionlint(path)
+            rejected_output = rejected.stdout + rejected.stderr
+            self.assertNotEqual(rejected.returncode, 0, rejected_output)
+            self.assertIn('context "env" is not allowed here', rejected_output)
+            self.assertIn(f"{path}:5:23", rejected_output)
+
+            path.write_text(lawful)
+            accepted = _run_actionlint(path)
+            self.assertEqual(
+                accepted.returncode,
+                0,
+                accepted.stdout + accepted.stderr,
+            )
+
+    def test_every_workflow_is_schema_and_expression_valid(self) -> None:
+        workflows = tuple(
+            sorted((*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")))
+        )
+        self.assertTrue(workflows, "workflow audit denominator must be non-empty")
+        result = _run_actionlint(*workflows)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_runner_context_availability_discriminator(self) -> None:
         workflow = """\
 env:


### PR DESCRIPTION
## What this changes

Extends the existing independent workflow-context tooth from #7224 instead of creating a second convention. `recensus-path-smoke.yml` now provisions Go 1.26.2, installs actionlint **v1.7.12**, and runs `tests/test_workflow_context_availability.py` before the product smoke. That test invokes the pinned binary across every `.github/workflows/*.yml` and `.yaml` file and fails hard with actionlint diagnostics.

The guard deliberately lives outside `ci.yml`: a `ci.yml` rejected at workflow creation cannot execute a check inside itself.

## Discrimination proof

The tooth creates a parseable planted workflow whose `jobs.<job_id>.name` reads the unavailable `env` context. actionlint rejects it at the exact coordinate. The tooth then replaces that fixture with a lawful workflow and actionlint exits 0. It also verifies the executing binary reports `v1.7.12`.

Observed locally on base `b9812c943738e83715569f6ce633c451ebfe39a3`:

- planted illegal twin: RED, `context "env" is not allowed here` at `workflow.yml:5:23`;
- lawful replacement twin: GREEN;
- complete 15-workflow audit: exit 1 with exactly one live finding, `.github/workflows/control-effect-recensus.yml:68:26`;
- full test module: 7 tests, 6 pass and the all-workflow audit fails only on that live offender;
- `python3 -m py_compile tests/test_workflow_context_availability.py`: exit 0;
- `git diff --check origin/main..HEAD`: exit 0.

The real red is intentional: #7235 owns the decision about whether control-effect recensus should be resurrected. This PR does not repair it. The build must remain loud while an invalid workflow exists.

## Scope limit

actionlint proves YAML schema and expression-context validity. It does **not** prove a valid workflow is reachable, that it executes meaningful work, or that its tooth can distinguish lawful from unlawful product behavior. A green actionlint result is not evidence that CI is adequate. The shell tier and no-op tooth classes remain separate obligations.

## Not claiming

This does not resurrect control-effect-recensus, establish any control-effect census result, or claim workflow reachability/tooth adequacy. It turns creation rejection from a silent zero-job badge into an independently executed, named commit-time failure.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard every workflow with actionlint v1.7.12 in CI
> - Adds `actionlint` v1.7.12 installation steps to [recensus-path-smoke.yml](.github/workflows/recensus-path-smoke.yml), using Go 1.26.2 to install the binary into a temporary directory on `PATH` before the Python audit runs.
> - Adds three new tests in [test_workflow_context_availability.py](https://github.com/TSavo/sugar/pull/7239/files#diff-5307df7d3a1fd27633eae81b3257a33b9d4dfeedafa3ce19737f94678789e1ac): one pins the installed `actionlint` version, one validates that actionlint correctly detects illegal pre-dispatch context usage, and one runs `actionlint` against all `.yml`/`.yaml` files under `.github/workflows/`.
> - Risk: CI fails earlier if Go setup or `actionlint` installation fails, and any existing workflow with schema or expression errors will now cause the test suite to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 16d369e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->