### PR TITLE
Format remaining Python packages with Black 26.5.1

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -442,6 +442,7 @@ def format_unmeasured_axis(axis: str, *, reason: str) -> str:
         f"Measurement did not complete; residual is not a completed zero."
     )
 
+
 def timed_enum_file(
     path: Path,
     *,

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_supervisor.py
@@ -632,7 +632,9 @@ class SupervisedEnumSupervisor:
         )
 
         cache_root = resolve_cache_root()
-        cache = ProcessFloorTerminalCache(cache_root) if cache_root is not None else None
+        cache = (
+            ProcessFloorTerminalCache(cache_root) if cache_root is not None else None
+        )
         tip = resolve_measurement_tip()
         demand_cid = demand_table_cid(self.demand_table_path)
         timeout_ms = int(round(self.file_timeout * 1000))

--- a/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_supervised_enum_worker.py
@@ -176,7 +176,9 @@ def _initialize(
     demand_table_identity = None
     if demand_table_path:
         from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
-        from sugar_lift_py_tests.no_call_body_attribution import SHARED_DEMAND_TABLE_CONTENT_KEY
+        from sugar_lift_py_tests.no_call_body_attribution import (
+            SHARED_DEMAND_TABLE_CONTENT_KEY,
+        )
         from sugar_lift_py_tests.prebuilt_demand_table import (
             DemandTableArtifactRefusal,
             load_prebuilt_demand_table,

--- a/implementations/python/sugar-lift-py-tests/scripts/and_then_construction_panic_partition.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/and_then_construction_panic_partition.py
@@ -71,7 +71,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
-
 SCOREBOARD_AUTHORITY = False
 
 # Production modules that own and_then / exit-conversion panic mouths.
@@ -115,9 +114,11 @@ def repo_root_from_here() -> Path:
     here = Path(__file__).resolve()
     # .../sugar-lift-py-tests/scripts/this.py → repo root = parents[3]
     for parent in here.parents:
-        if (parent / "implementations" / "python").is_dir() and (
-            parent / "Agents.md"
-        ).is_file() or (parent / "AGENTS.md").is_file():
+        if (
+            (parent / "implementations" / "python").is_dir()
+            and (parent / "Agents.md").is_file()
+            or (parent / "AGENTS.md").is_file()
+        ):
             return parent
     return here.parents[3]
 

--- a/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/bare_exception_zero_tolerance.py
@@ -213,16 +213,10 @@ def main() -> int:
             ],
             totals={
                 "R_bare_exceptions": residual_count,
-                "completed": sum(
-                    row.category == OUTCOME_COMPLETED for row in rows
-                ),
-                "typedGaps": sum(
-                    row.category == OUTCOME_TYPED_GAP for row in rows
-                ),
+                "completed": sum(row.category == OUTCOME_COMPLETED for row in rows),
+                "typedGaps": sum(row.category == OUTCOME_TYPED_GAP for row in rows),
                 "timeouts": sum(row.category == "timeout" for row in rows),
-                "nativeCrashes": sum(
-                    row.category == "native-crash" for row in rows
-                ),
+                "nativeCrashes": sum(row.category == "native-crash" for row in rows),
             },
             measured=True,
         )

--- a/implementations/python/sugar-lift-py-tests/scripts/compatibility_door_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compatibility_door_law.py
@@ -235,6 +235,7 @@ def _produces_meaning(
     # than thin-wrap, but the comment itself admits the dual entry.
     return _comment_names_normative_peer(lead)
 
+
 def _leading_comment_block(source: str, def_lineno: int) -> str:
     """Comments immediately above ``def`` (1-indexed), stopping at code."""
     lines = source.splitlines()
@@ -479,10 +480,7 @@ def discrimination_self_test() -> bool:
             parents=True, exist_ok=True
         )
 
-        dirty = (
-            root
-            / "sugar-lift-py-tests/src/sugar_lift_py_tests/compat_plant.py"
-        )
+        dirty = root / "sugar-lift-py-tests/src/sugar_lift_py_tests/compat_plant.py"
         dirty.write_text(
             '''
 # Legacy helper -- kept for backward compatibility with existing callers.

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -121,9 +121,7 @@ def _runtime_attestation_fields(
         return None, f"runtimeIdentity/v1 malformed: {type(error).__name__}: {error}"
     if claimed_cid != recomputed_cid:
         return None, "runtimeCid is not recomputable from runtimeIdentity/v1"
-    observed_required = (
-        f"{identity.get('implementation')}-{identity.get('version')}"
-    )
+    observed_required = f"{identity.get('implementation')}-{identity.get('version')}"
     if required != observed_required:
         return None, (
             "requiredRuntime mismatches its runtimeIdentity/v1: "
@@ -136,9 +134,9 @@ def _runtime_attestation_fields(
     }, None
 
 
-def resolve_executing_runtime_attestation() -> tuple[
-    dict[str, Any] | None, dict[str, Any]
-]:
+def resolve_executing_runtime_attestation() -> (
+    tuple[dict[str, Any] | None, dict[str, Any]]
+):
     """Authenticate the executing interpreter before any producer input opens."""
     from sugar_lift_py_tests import authenticated_pytest as runtime_authority
 
@@ -392,7 +390,9 @@ def _validate_edge_witness(
                 }
             )
     if attested["missingKeys"] or attested["extraKeys"] or attested["duplicateKeys"]:
-        failures.append({"edgeId": edge_id, "reason": "key conservation failed", **attested})
+        failures.append(
+            {"edgeId": edge_id, "reason": "key conservation failed", **attested}
+        )
     return attested, failures
 
 
@@ -407,12 +407,16 @@ def _terminal_row_failures(file: str, row: Mapping[str, Any]) -> list[dict[str, 
         )
         return failures
     input_key = row.get("inputKey")
-    if not isinstance(input_key, dict) or not isinstance(input_key.get("sourceCid"), str):
+    if not isinstance(input_key, dict) or not isinstance(
+        input_key.get("sourceCid"), str
+    ):
         failures.append({"file": file, "reason": "inputKey lacks sourceCid"})
     elif "functionKeyManifest" in input_key:
         function_keys = input_key.get("functionKeyManifest")
         if not isinstance(function_keys, list):
-            failures.append({"file": file, "reason": "functionKeyManifest is not a list"})
+            failures.append(
+                {"file": file, "reason": "functionKeyManifest is not a list"}
+            )
         else:
             if len(function_keys) != int(row.get("functionsTotal") or 0):
                 failures.append(
@@ -503,13 +507,17 @@ def _terminal_row_failures(file: str, row: Mapping[str, Any]) -> list[dict[str, 
                 {
                     "file": file,
                     "reason": "non-authenticated ConstructionPanic payload",
-                    "missing": sorted(required - set(panic or {}))
-                    if isinstance(panic, dict)
-                    else sorted(required),
+                    "missing": (
+                        sorted(required - set(panic or {}))
+                        if isinstance(panic, dict)
+                        else sorted(required)
+                    ),
                 }
             )
         elif not isinstance(panic.get("construction_trace"), list):
-            failures.append({"file": file, "reason": "construction_trace is not ordered"})
+            failures.append(
+                {"file": file, "reason": "construction_trace is not ordered"}
+            )
         elif chain_length != len(panic["construction_trace"]):
             failures.append(
                 {"file": file, "reason": "observed_chain_length disagrees with trace"}
@@ -667,12 +675,16 @@ def _frontier_manifests_for_common_seal(
     inputs = edge.get("inputKeyManifest")
     outputs = edge.get("outputKeyManifest")
     return (
-        [dict(row) for row in inputs if isinstance(row, Mapping)]
-        if isinstance(inputs, list)
-        else [],
-        [dict(row) for row in outputs if isinstance(row, Mapping)]
-        if isinstance(outputs, list)
-        else [],
+        (
+            [dict(row) for row in inputs if isinstance(row, Mapping)]
+            if isinstance(inputs, list)
+            else []
+        ),
+        (
+            [dict(row) for row in outputs if isinstance(row, Mapping)]
+            if isinstance(outputs, list)
+            else []
+        ),
     )
 
 
@@ -696,7 +708,10 @@ def _validate_frontier_attestation_for_common_seal(
         else None
     )
     expected_source_cid = _source_file_cid(Path(__file__).resolve())
-    if not isinstance(stage, Mapping) or stage.get("sourceFileCid") != expected_source_cid:
+    if (
+        not isinstance(stage, Mapping)
+        or stage.get("sourceFileCid") != expected_source_cid
+    ):
         raise ValueError("compose validator stage source CID is absent or stale")
 
     edges = frontier_attestation.get("edges")
@@ -741,9 +756,9 @@ def _validate_frontier_attestation_for_common_seal(
         or final_edge["duplicateKeys"]
     ):
         raise ValueError("frontier final disjoint union does not conserve")
-    overlap = {
-        _render_key(row) for row in constructed if isinstance(row, Mapping)
-    } & {_render_key(row) for row in panicked if isinstance(row, Mapping)}
+    overlap = {_render_key(row) for row in constructed if isinstance(row, Mapping)} & {
+        _render_key(row) for row in panicked if isinstance(row, Mapping)
+    }
     if overlap:
         raise ValueError("frontier constructed and panic manifests overlap")
     final_seal = frontier_attestation.get("finalSeal")
@@ -850,8 +865,7 @@ def mint_partial(
         int(
             (r or {}).get("functionsEnumerated")
             if (r or {}).get("functionsEnumerated") is not None
-            else (r or {}).get("functionsTotal")
-            or 0
+            else (r or {}).get("functionsTotal") or 0
         )
         for _, r in terminals
     )
@@ -919,9 +933,7 @@ def mint_partial(
         },
         "shardFileSetCid": shard_file_set_cid(assigned),
         "terminalFiles": terminal_files,
-        "terminalRows": [
-            {"file": f, "result": r} for f, r in terminals
-        ],
+        "terminalRows": [{"file": f, "result": r} for f, r in terminals],
         "subDenominator": {
             "files": {
                 "enrolled": len(assigned),
@@ -1319,9 +1331,7 @@ def seal_board_from_aggregate(
         ),
         "composeMode": "lpt-enrollment-v1" if plan else "k1-compose-v1",
         "corpusAuthentication": {
-            "aggregateHash": aggregate_hash
-            or (plan or {}).get("aggregateHash")
-            or "",
+            "aggregateHash": aggregate_hash or (plan or {}).get("aggregateHash") or "",
             "requiredAggregateHash": _PANDAS_3_0_3_AGGREGATE_HASH,
             "manifestShapeCid": manifest_shape_cid
             or (plan or {}).get("manifestShapeCid")
@@ -1477,8 +1487,7 @@ def unmeasured_envelope(
         # measurementClass OMITTED — dual belt A
         "status": "unmeasured",
         "measured": False,
-        "measuredCommit": measured_commit
-        or (plan or {}).get("measuredCommit"),
+        "measuredCommit": measured_commit or (plan or {}).get("measuredCommit"),
         "planCid": (plan or {}).get("planCid"),
         "missingShards": list(missing_shards),
         "unmeasuredReasons": dict(unmeasured_reasons),
@@ -1718,9 +1727,11 @@ def compose_from_partials(
                 "compose": "common conservation mint refused the census board"
             },
             measured_commit=str(plan.get("measuredCommit") or ""),
-            instrument_failures=[failure]
-            if isinstance(failure, Mapping)
-            else [{"reason": "common conservation mint refused without diagnostic"}],
+            instrument_failures=(
+                [failure]
+                if isinstance(failure, Mapping)
+                else [{"reason": "common conservation mint refused without diagnostic"}]
+            ),
             d3_residency_exposure=d3_residency_exposure,
             runtime_attestation=runtime,
         )
@@ -1843,11 +1854,11 @@ def main(argv: list[str] | None = None) -> int:
             continue
         if isinstance(data, dict) and data.get("kind") == KIND_PARTIAL:
             partials.append(data)
-    status, body = compose_from_partials(
-        plan, partials, runtime_attestation=runtime
-    )
+    status, body = compose_from_partials(plan, partials, runtime_attestation=runtime)
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    args.out.write_text(
+        json.dumps(body, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     print(
         f"COMPOSE status={status} out={args.out} "
         f"missing={body.get('missingShards')} bodyCid={body.get('bodyCid')}",

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_consumer_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_consumer_codomain_law.py
@@ -61,7 +61,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Iterator, NamedTuple, Sequence
 
-
 # ---------------------------------------------------------------------------
 # Roots to scan (kit construction + consumers only)
 # ---------------------------------------------------------------------------
@@ -238,9 +237,11 @@ def index_module(path: Path) -> ModuleIndex | None:
             left = node.left
             if isinstance(left, ast.Attribute) and left.attr == "kind":
                 for op, comp in zip(node.ops, node.comparators):
-                    if isinstance(op, (ast.Eq, ast.NotEq)) and isinstance(
-                        comp, ast.Constant
-                    ) and isinstance(comp.value, str):
+                    if (
+                        isinstance(op, (ast.Eq, ast.NotEq))
+                        and isinstance(comp, ast.Constant)
+                        and isinstance(comp.value, str)
+                    ):
                         idx.kind_literals.add(comp.value)
                     if isinstance(op, (ast.In, ast.NotIn)):
                         if isinstance(comp, (ast.Tuple, ast.List, ast.Set)):
@@ -267,9 +268,7 @@ def transitive_bases(
     return acc
 
 
-def all_descendants(
-    classes: dict[str, set[str]], root: str
-) -> set[str]:
+def all_descendants(classes: dict[str, set[str]], root: str) -> set[str]:
     cache: dict[str, set[str]] = {}
     out: set[str] = set()
     for name in classes:
@@ -313,7 +312,9 @@ def _function_kind_sets(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
             if isinstance(op, ast.Eq) and isinstance(comp, ast.Constant):
                 if isinstance(comp.value, str):
                     kinds.add(comp.value)
-            if isinstance(op, ast.In) and isinstance(comp, (ast.Tuple, ast.List, ast.Set)):
+            if isinstance(op, ast.In) and isinstance(
+                comp, (ast.Tuple, ast.List, ast.Set)
+            ):
                 for elt in comp.elts:
                     if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
                         kinds.add(elt.value)
@@ -444,9 +445,12 @@ def collect_produced(
             if name in _BINDING_STATE_FAMILY or any(
                 b in _BINDING_STATE_FAMILY for b in bases
             ):
-                if name.endswith("Binding") or name.endswith("State") or name.endswith(
-                    "StateV1"
-                ) or name in _BINDING_STATE_FAMILY:
+                if (
+                    name.endswith("Binding")
+                    or name.endswith("State")
+                    or name.endswith("StateV1")
+                    or name in _BINDING_STATE_FAMILY
+                ):
                     binding.add(name)
 
     # Explicit family always produced
@@ -627,9 +631,7 @@ def find_gaps(
 
     if indexes is not None:
         gaps.extend(
-            find_expression_mint_not_term_gaps(
-                indexes, classes, constructed, repo=repo
-            )
+            find_expression_mint_not_term_gaps(indexes, classes, constructed, repo=repo)
         )
 
     # Core binding-state currency (what binding_state_read_node must totalize).
@@ -656,7 +658,10 @@ def find_gaps(
                 accepted_sugars = {
                     a for a in door.accepted_types if a.endswith("Sugar")
                 }
-                if accepted_sugars and _CONSTRUCTED_TERM_ROOT not in door.accepted_types:
+                if (
+                    accepted_sugars
+                    and _CONSTRUCTED_TERM_ROOT not in door.accepted_types
+                ):
                     candidates |= {
                         c
                         for c in constructed
@@ -667,9 +672,7 @@ def find_gaps(
                     "binding_state_read_node",
                     "_construct_binding_projection",
                 }:
-                    candidates |= set(binding_core) | (
-                        binding & binding_core
-                    )
+                    candidates |= set(binding_core) | (binding & binding_core)
                     # Also any extra Binding* produced in the family that is
                     # clearly a state species construction can mint.
                     candidates |= {
@@ -718,9 +721,7 @@ def find_gaps(
             missing = sorted(
                 k
                 for k in kind_literals
-                if k not in door.kind_set
-                and k[:1].isupper()
-                and k in classes
+                if k not in door.kind_set and k[:1].isupper() and k in classes
             )
             for k in missing[:12]:
                 gaps.append(
@@ -784,7 +785,9 @@ def run(roots: Sequence[Path], repo: Path) -> tuple[list[Gap], dict[str, object]
     for g in gaps:
         key = (g.axis, g.door, g.produced, g.door_line)
         uniq[key] = g
-    ordered = sorted(uniq.values(), key=lambda g: (g.axis, g.door_path, g.door_line, g.produced))
+    ordered = sorted(
+        uniq.values(), key=lambda g: (g.axis, g.door_path, g.door_line, g.produced)
+    )
     summary = {
         "modules_indexed": len(indexes),
         "classes": len(classes),
@@ -836,7 +839,7 @@ def binding_state_read_node(state):
         f"write arm for LoopProjectedBinding"
     )
 '''
-    clean = '''
+    clean = """
 class GuardedBinding:
     pass
 
@@ -863,7 +866,7 @@ def binding_state_read_node(state):
         requested="Node|Unbound|Guarded|LoopProjected",
         fix="write arm",
     )
-'''
+"""
     # Dynamic-discharge proxy plant: Expression mints Sugar outside CTS.
     planted_expr = '''
 class Sugar:
@@ -917,18 +920,16 @@ class ObjectPlaceStateV1(Expression):
         expr_fixture.write_text(clean_expr, encoding="utf-8")
         green_expr_gaps, green_expr_summary = run((expr_root,), root)
 
-    red_ok = (
-        red_summary["R_total"] >= 1
-        and any(g.produced == "LoopProjectedBinding" for g in red_gaps)
+    red_ok = red_summary["R_total"] >= 1 and any(
+        g.produced == "LoopProjectedBinding" for g in red_gaps
     )
     green_ok = green_summary["R_total"] == 0
-    expr_red_ok = (
-        red_expr_summary.get("R_expression_construct_not_term", 0) >= 1
-        and any(
-            g.produced == "ConstructedObjectPlaceSugar"
-            and g.axis == "R_expression_construct_not_term"
-            for g in red_expr_gaps
-        )
+    expr_red_ok = red_expr_summary.get(
+        "R_expression_construct_not_term", 0
+    ) >= 1 and any(
+        g.produced == "ConstructedObjectPlaceSugar"
+        and g.axis == "R_expression_construct_not_term"
+        for g in red_expr_gaps
     )
     expr_green_ok = green_expr_summary["R_total"] == 0
     return red_ok and green_ok and expr_red_ok and expr_green_ok
@@ -959,10 +960,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.self_test:
         ok = discrimination_self_test()
-        print(
-            "CONSTRUCTION-CONSUMER-CODOMAIN SELF-TEST "
-            + ("GREEN" if ok else "RED")
-        )
+        print("CONSTRUCTION-CONSUMER-CODOMAIN SELF-TEST " + ("GREEN" if ok else "RED"))
         print(
             json.dumps(
                 {
@@ -1024,13 +1022,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print(f"  ... {len(gaps) - 80} more")
         else:
             print()
-            print(
-                "  ZERO IS BANKABLE EVIDENCE, NOT ABSENCE OF AN INSTRUMENT."
-            )
+            print("  ZERO IS BANKABLE EVIDENCE, NOT ABSENCE OF AN INSTRUMENT.")
             print(
                 "  R_total=0 under THIS instrument reach (static AST on enrolled"
                 " doors + Expression._construct_sugar mint→term proxy)."
-                " Not \"the class is closed forever\" — remaining gaps may still"
+                ' Not "the class is closed forever" — remaining gaps may still'
                 " be dynamic-only (getattr factories, runtime type mutations)."
                 " Those are caught by require_constructed_term_sugar TypeError"
                 " at discharge and sealed-board twins, not by this scan."

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -134,9 +134,7 @@ def _phase_begin(name: str) -> float:
 
 
 def _phase_end(name: str, t0: float) -> None:
-    _narrate(
-        f"RECENSUS PHASE END: {name} elapsed_s={time.perf_counter() - t0:.3f}"
-    )
+    _narrate(f"RECENSUS PHASE END: {name} elapsed_s={time.perf_counter() - t0:.3f}")
 
 
 def _phase_call(name: str, fn):
@@ -174,9 +172,7 @@ def _consume_sealed_files_complete(
             raise TypeError("sealed board denominator testimony is not an object")
         files = denominator["files"]
         if not isinstance(files, dict):
-            raise TypeError(
-                "sealed board denominator.files testimony is not an object"
-            )
+            raise TypeError("sealed board denominator.files testimony is not an object")
         complete = files["complete"]
         if complete is not True:
             raise ValueError(
@@ -285,9 +281,7 @@ class _EngineStdoutHeartbeat(logging.Handler):
         self._last_emit = now
         try:
             msg = self.format(record)
-            extra = (
-                f" suppressed={self._suppressed}" if self._suppressed else ""
-            )
+            extra = f" suppressed={self._suppressed}" if self._suppressed else ""
             self._suppressed = 0
             print(
                 f"RECENSUS ENGINE heartbeat{extra} {msg[:240]}",
@@ -355,9 +349,10 @@ def _occurrence_key(
 # Conservation: every sync with-item constructs or does not.
 # No kind vocabulary. Unconstructed rows are panics waiting to be written.
 WITH_CENSUS_CONSERVATION_IDENTITY = (
-    "site:with-item == constructed + unconstructed "
-    "(no residual kind taxonomy)"
+    "site:with-item == constructed + unconstructed " "(no residual kind taxonomy)"
 )
+
+
 def _tally_cm_resolutions(
     context=None,
     *,
@@ -499,7 +494,6 @@ def _attested_cm_counts(result: dict[str, Any]) -> tuple[int, int]:
     )
 
 
-
 def _backend_defect_key(exc: object) -> str:
     """Classify demand/resolution table hygiene — never construction mass.
 
@@ -629,8 +623,6 @@ def _measure_file(
         "Use sugar.enumerate via recensus_enumerate_consumer; "
         "do not re-open a private SourceFile walk."
     )
-
-
 
 
 def _is_process_control(error: BaseException) -> bool:
@@ -953,6 +945,7 @@ def main() -> int:
         require_pin,
         write_pin,
     )
+
     # Path-shape CID only (relative path names). Content authentication is the
     # pin aggregate. Do NOT call demand_table_identity.corpus_manifest_cid here:
     # that is the content manifest (root, abs paths) -> (blake3, count), a
@@ -1087,9 +1080,7 @@ def main() -> int:
         assigned = list(shard_plan["bins"][args.shard_index])
         unknown = sorted(set(assigned) - set(file_names))
         if unknown:
-            parser.error(
-                f"plan bin contains files not in this walk: {unknown[:5]}"
-            )
+            parser.error(f"plan bin contains files not in this walk: {unknown[:5]}")
         file_names = [f for f in file_names if f in set(assigned)]
         by_file = {f: by_file[f] for f in file_names}
         _narrate(
@@ -1149,9 +1140,7 @@ def main() -> int:
             return 78
         contract_refs = _phase_call(
             "demand_table_load",
-            lambda: install_prebuilt_demand_table(
-                prebuilt, root=workspace_root
-            ),
+            lambda: install_prebuilt_demand_table(prebuilt, root=workspace_root),
         )
         demand_table_cid = prebuilt.content_cid
         _narrate(
@@ -1308,9 +1297,7 @@ def main() -> int:
                 row_families = raw.get("families") or {}
                 live_snw += int(row_families.get("SugarNotWritten") or 0)
                 live_other_gaps += sum(
-                    int(v)
-                    for k, v in row_families.items()
-                    if k != "SugarNotWritten"
+                    int(v) for k, v in row_families.items() if k != "SugarNotWritten"
                 )
                 if cat == "panic":
                     live_panic += 1
@@ -1356,10 +1343,15 @@ def main() -> int:
             force = status not in {"lifting…", "ok", "…"}
             if not force and now - _last_progress_stdout < _JOB_LOG_MAX_SILENCE_S:
                 return
-            if force and now - _last_progress_stdout < 2.0 and status in {
-                "done",
-                "cpanic",
-            }:
+            if (
+                force
+                and now - _last_progress_stdout < 2.0
+                and status
+                in {
+                    "done",
+                    "cpanic",
+                }
+            ):
                 # Allow dense end-of-file lines without flooding.
                 pass
             _last_progress_stdout = now
@@ -1530,9 +1522,7 @@ def main() -> int:
                             ),
                         )
                         sites = _ast_site_prevalence(path)
-                        with_partition = _with_census_partition(
-                            resolution_rows, sites
-                        )
+                        with_partition = _with_census_partition(resolution_rows, sites)
                         row["withResolutionRows"] = resolution_rows
                         row["cmResolutions"] = {
                             "constructed": with_partition["constructed"],
@@ -1541,9 +1531,9 @@ def main() -> int:
                         row["astSites"] = dict(sites)
                         from compose_control_effect_board import EDGE_WITH_PARTITION
 
-                        row.setdefault("edgeWitnesses", {})[
-                            EDGE_WITH_PARTITION
-                        ] = with_partition["edgeWitness"]
+                        row.setdefault("edgeWitnesses", {})[EDGE_WITH_PARTITION] = (
+                            with_partition["edgeWitness"]
+                        )
                 except ConstructionPanic:
                     raise
                 except BaseException as error:  # noqa: BLE001 -- per-file terminal
@@ -1569,9 +1559,7 @@ def main() -> int:
                 # functionsClean may be null when clean ratio is refused.
                 # Law: never treat null clean as 0-of-N and mint clean%=100.
                 _raw_clean = row.get("functionsClean")
-                if row.get("cleanRatioRefused") or (
-                    _raw_clean is None and fn > 0
-                ):
+                if row.get("cleanRatioRefused") or (_raw_clean is None and fn > 0):
                     live_clean_refused = True
                     clean = 0
                 else:
@@ -1749,8 +1737,6 @@ def main() -> int:
                         "mode=batch-end-of-lift degraded=shelf-stale-next-plan"
                     )
             progress_stream.close()
-
-
 
     # Tripwire: the lift loop must never rebind `families` to a row dict.
     if not isinstance(families, Counter):
@@ -1951,6 +1937,7 @@ def main() -> int:
             for gap in (result.get("desugarDesignedGaps") or [])
         )
     )
+
     # stableZero -- RULING ON PLACEMENT.
     #
     # This is a ONE-FLOOR term and is deliberately named

--- a/implementations/python/sugar-lift-py-tests/scripts/corpus_enrollment_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/corpus_enrollment_law.py
@@ -408,9 +408,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 1
 
     try:
-        report = measure_enrollment(
-            corpus_root=corpus_root, recensus_payload=payload
-        )
+        report = measure_enrollment(corpus_root=corpus_root, recensus_payload=payload)
     except Exception as error:
         print(
             f"CORPUS-ENROLLMENT LAW RED: measurement failed: "

--- a/implementations/python/sugar-lift-py-tests/scripts/law_of_one_vector_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/law_of_one_vector_law.py
@@ -121,7 +121,15 @@ def _cite_self_sealing(repo: Path) -> Citation:
     rel = "implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py"
     mod, err = _load_script(repo, rel, "loo_cite_self_sealing")
     if err:
-        return Citation("instrument", "self_sealing", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
+        return Citation(
+            "instrument",
+            "self_sealing",
+            rel,
+            -1,
+            {},
+            [err],
+            "missing_owner" if "missing" in err else "collect_error",
+        )
     try:
         # roots default inside scan_roots — never omit via wrong kwargs only.
         findings, errors = mod.scan_roots(repo=repo)
@@ -137,14 +145,30 @@ def _cite_self_sealing(repo: Path) -> Citation:
             list(errors),
         )
     except Exception as exc:  # noqa: BLE001
-        return Citation("instrument", "self_sealing", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
+        return Citation(
+            "instrument",
+            "self_sealing",
+            rel,
+            -1,
+            {},
+            [f"{type(exc).__name__}: {exc}"],
+            "collect_error",
+        )
 
 
 def _cite_swallowed_throw(repo: Path) -> Citation:
     rel = "implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py"
     mod, err = _load_script(repo, rel, "loo_cite_swallowed")
     if err:
-        return Citation("product", "swallowed_throw_second_mechanism", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
+        return Citation(
+            "product",
+            "swallowed_throw_second_mechanism",
+            rel,
+            -1,
+            {},
+            [err],
+            "missing_owner" if "missing" in err else "collect_error",
+        )
     try:
         python_root = repo / "implementations/python"
         offenders = mod.scan_python_root(python_root)
@@ -154,17 +178,36 @@ def _cite_swallowed_throw(repo: Path) -> Citation:
             "swallowed_throw_second_mechanism",
             rel,
             sum(counts.values()),
-            {"by_axis": counts, "source": "swallowed_throw_second_mechanism_law.scan_python_root"},
+            {
+                "by_axis": counts,
+                "source": "swallowed_throw_second_mechanism_law.scan_python_root",
+            },
         )
     except Exception as exc:  # noqa: BLE001
-        return Citation("product", "swallowed_throw_second_mechanism", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
+        return Citation(
+            "product",
+            "swallowed_throw_second_mechanism",
+            rel,
+            -1,
+            {},
+            [f"{type(exc).__name__}: {exc}"],
+            "collect_error",
+        )
 
 
 def _cite_construction_panic_catch(repo: Path) -> Citation:
     rel = "implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py"
     mod, err = _load_script(repo, rel, "loo_cite_panic_catch")
     if err:
-        return Citation("product", "construction_panic_catch", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
+        return Citation(
+            "product",
+            "construction_panic_catch",
+            rel,
+            -1,
+            {},
+            [err],
+            "missing_owner" if "missing" in err else "collect_error",
+        )
     try:
         kit = repo / "implementations/python/sugar-lift-py-tests"
         offenders = mod.scan_repository(kit)
@@ -174,17 +217,36 @@ def _cite_construction_panic_catch(repo: Path) -> Citation:
             "construction_panic_catch",
             rel,
             len(panic),
-            {"source": "construction_panic_catch_law.scan_repository", "raw_rows": len(offenders)},
+            {
+                "source": "construction_panic_catch_law.scan_repository",
+                "raw_rows": len(offenders),
+            },
         )
     except Exception as exc:  # noqa: BLE001
-        return Citation("product", "construction_panic_catch", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
+        return Citation(
+            "product",
+            "construction_panic_catch",
+            rel,
+            -1,
+            {},
+            [f"{type(exc).__name__}: {exc}"],
+            "collect_error",
+        )
 
 
 def _cite_enumeration_soft_skip(repo: Path) -> Citation:
     rel = "implementations/python/sugar-lift-py-tests/scripts/enumeration_binding_soft_skip_law.py"
     mod, err = _load_script(repo, rel, "loo_cite_enum_soft")
     if err:
-        return Citation("product", "enumeration_binding_soft_skip", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
+        return Citation(
+            "product",
+            "enumeration_binding_soft_skip",
+            rel,
+            -1,
+            {},
+            [err],
+            "missing_owner" if "missing" in err else "collect_error",
+        )
     try:
         kit = repo / "implementations/python/sugar-lift-py-tests"
         paths = mod.production_scan_roots(kit)
@@ -197,14 +259,30 @@ def _cite_enumeration_soft_skip(repo: Path) -> Citation:
             {"source": "enumeration_binding_soft_skip_law.scan_sources"},
         )
     except Exception as exc:  # noqa: BLE001
-        return Citation("product", "enumeration_binding_soft_skip", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
+        return Citation(
+            "product",
+            "enumeration_binding_soft_skip",
+            rel,
+            -1,
+            {},
+            [f"{type(exc).__name__}: {exc}"],
+            "collect_error",
+        )
 
 
 def _cite_source_audit_presence(repo: Path) -> Citation:
     rel = "implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py"
     mod, err = _load_script(repo, rel, "loo_cite_presence")
     if err:
-        return Citation("product", "source_audit_presence_identity", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
+        return Citation(
+            "product",
+            "source_audit_presence_identity",
+            rel,
+            -1,
+            {},
+            [err],
+            "missing_owner" if "missing" in err else "collect_error",
+        )
     try:
         roots = [
             repo / "implementations/python/sugar-lift-py-tests/src",
@@ -224,7 +302,15 @@ def _cite_source_audit_presence(repo: Path) -> Citation:
             [str(u) for u in unreadable[:20]],
         )
     except Exception as exp:  # noqa: BLE001
-        return Citation("product", "source_audit_presence_identity", rel, -1, {}, [f"{type(exp).__name__}: {exp}"], "collect_error")
+        return Citation(
+            "product",
+            "source_audit_presence_identity",
+            rel,
+            -1,
+            {},
+            [f"{type(exp).__name__}: {exp}"],
+            "collect_error",
+        )
 
 
 def _cite_one_matcher(repo: Path) -> Citation:
@@ -232,7 +318,15 @@ def _cite_one_matcher(repo: Path) -> Citation:
     rel = "implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py"
     mod, err = _load_script(repo, rel, "loo_cite_one_matcher")
     if err:
-        return Citation("product", "one_matcher_match_decided_false", rel, -1, {}, [err], "missing_owner" if "missing" in err else "collect_error")
+        return Citation(
+            "product",
+            "one_matcher_match_decided_false",
+            rel,
+            -1,
+            {},
+            [err],
+            "missing_owner" if "missing" in err else "collect_error",
+        )
     try:
         # Child's structural scan over production packages
         files = mod._production_py_files()
@@ -253,7 +347,15 @@ def _cite_one_matcher(repo: Path) -> Citation:
             },
         )
     except Exception as exc:  # noqa: BLE001
-        return Citation("product", "one_matcher_match_decided_false", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
+        return Citation(
+            "product",
+            "one_matcher_match_decided_false",
+            rel,
+            -1,
+            {},
+            [f"{type(exc).__name__}: {exc}"],
+            "collect_error",
+        )
 
 
 def _cite_builtin_name_vendor_gates(repo: Path) -> Citation:
@@ -263,7 +365,15 @@ def _cite_builtin_name_vendor_gates(repo: Path) -> Citation:
     )
     path = repo / rel
     if not path.is_file():
-        return Citation("product", "builtin_name_or_vendor_gates", rel, -1, {}, [f"missing owner file: {rel}"], "missing_owner")
+        return Citation(
+            "product",
+            "builtin_name_or_vendor_gates",
+            rel,
+            -1,
+            {},
+            [f"missing owner file: {rel}"],
+            "missing_owner",
+        )
     try:
         # Import as package if possible; else load file and call collect with roots
         sys.path.insert(0, str(repo / "implementations/python/sugar-lift-py-tests/src"))
@@ -290,11 +400,21 @@ def _cite_builtin_name_vendor_gates(repo: Path) -> Citation:
             "partition": "docs/spelling-dispatch-partition.md",
             "membrane_open_lexical_ast_id": by.get("open_lexical_ast_id", 0),
             "membrane_open_lexical_attr_name": by.get("open_lexical_attr_name", 0),
-            "fabrication_denylist_axis": by.get("exception_name_fabrication_denylist", 0),
+            "fabrication_denylist_axis": by.get(
+                "exception_name_fabrication_denylist", 0
+            ),
         }
         return Citation("product", "builtin_name_or_vendor_gates", rel, r, detail)
     except Exception as exc:  # noqa: BLE001
-        return Citation("product", "builtin_name_or_vendor_gates", rel, -1, {}, [f"{type(exc).__name__}: {exc}"], "collect_error")
+        return Citation(
+            "product",
+            "builtin_name_or_vendor_gates",
+            rel,
+            -1,
+            {},
+            [f"{type(exc).__name__}: {exc}"],
+            "collect_error",
+        )
 
 
 # Climb notes — parent does NOT audit these; names the required hatch.
@@ -306,7 +426,10 @@ CLIMB_NOT_AUDIT = (
             "Codomain climb: RaiseEffect / Halted faces must require authenticated "
             "type coordinate (non-Optional). Auditor forever is ceremony if None still constructs."
         ),
-        "related_children": ["self_sealing PRESENCE-ONLY (tests only)", "RaiseEffect constructor work"],
+        "related_children": [
+            "self_sealing PRESENCE-ONLY (tests only)",
+            "RaiseEffect constructor work",
+        ],
     },
     {
         "face": "dual_producers_one_fact",
@@ -315,7 +438,10 @@ CLIMB_NOT_AUDIT = (
             "One door: delete the second path so dual production is unrepresentable; "
             "then delete any ratchet that watched it. Parent must not keep a permanent axis."
         ),
-        "related_children": ["one_matcher_match_decided_false", "source_audit_presence_identity"],
+        "related_children": [
+            "one_matcher_match_decided_false",
+            "source_audit_presence_identity",
+        ],
     },
 )
 
@@ -350,12 +476,42 @@ MEMBRANE_HONEST = (
 
 
 COLLECTORS: list[tuple[str, str, str, Callable[[Path], Citation]]] = [
-    ("product", "one_matcher_match_decided_false", "test_match_decided_one_matcher_law", _cite_one_matcher),
-    ("product", "swallowed_throw_second_mechanism", "swallowed_throw_second_mechanism_law", _cite_swallowed_throw),
-    ("product", "construction_panic_catch", "construction_panic_catch_law", _cite_construction_panic_catch),
-    ("product", "enumeration_binding_soft_skip", "enumeration_binding_soft_skip_law", _cite_enumeration_soft_skip),
-    ("product", "source_audit_presence_identity", "source_audit_presence_identity_law", _cite_source_audit_presence),
-    ("product", "builtin_name_or_vendor_gates", "builtin_closed_operation_instrument", _cite_builtin_name_vendor_gates),
+    (
+        "product",
+        "one_matcher_match_decided_false",
+        "test_match_decided_one_matcher_law",
+        _cite_one_matcher,
+    ),
+    (
+        "product",
+        "swallowed_throw_second_mechanism",
+        "swallowed_throw_second_mechanism_law",
+        _cite_swallowed_throw,
+    ),
+    (
+        "product",
+        "construction_panic_catch",
+        "construction_panic_catch_law",
+        _cite_construction_panic_catch,
+    ),
+    (
+        "product",
+        "enumeration_binding_soft_skip",
+        "enumeration_binding_soft_skip_law",
+        _cite_enumeration_soft_skip,
+    ),
+    (
+        "product",
+        "source_audit_presence_identity",
+        "source_audit_presence_identity_law",
+        _cite_source_audit_presence,
+    ),
+    (
+        "product",
+        "builtin_name_or_vendor_gates",
+        "builtin_closed_operation_instrument",
+        _cite_builtin_name_vendor_gates,
+    ),
     ("instrument", "self_sealing", "self_sealing_instrument_law", _cite_self_sealing),
 ]
 
@@ -430,7 +586,9 @@ def main(argv: list[str] | None = None) -> int:
     citations = collect_citations(repo)
     print(format_report(citations))
     product_r = sum(c.R for c in citations if c.layer == "product" and c.status == "ok")
-    instrument_r = sum(c.R for c in citations if c.layer == "instrument" and c.status == "ok")
+    instrument_r = sum(
+        c.R for c in citations if c.layer == "instrument" and c.status == "ok"
+    )
     bad = [c for c in citations if c.status != "ok" or c.R != 0]
     if args.json is not None:
         args.json.write_text(

--- a/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/native_crash_zero_tolerance.py
@@ -86,9 +86,7 @@ def r_native_crashes(offenders: Sequence[NativeCrashOffender]) -> int:
 
 def format_report(offenders: Sequence[NativeCrashOffender]) -> str:
     lines = [
-        format_completed_axis_report(
-            "R_native_crashes", r_native_crashes(offenders)
-        ),
+        format_completed_axis_report("R_native_crashes", r_native_crashes(offenders)),
         (
             "Replacement: corpus children terminate with completed testimony, "
             "typed gap, bare-exception row, or loud timeout; never signal."

--- a/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/pandas_floor_summary.py
@@ -61,7 +61,9 @@ def _floor_summary_outcome(
 
     def validate() -> None:
         if not measured:
-            reason = "; ".join(reasons) or "floor producer marked measurement incomplete"
+            reason = (
+                "; ".join(reasons) or "floor producer marked measurement incomplete"
+            )
             raise ValueError(reason)
         if not ordered_files:
             raise ValueError("a floor summary requires a non-empty measured corpus")
@@ -71,9 +73,7 @@ def _floor_summary_outcome(
             observed = Counter(row_files)
             missing = sorted((expected - observed).elements())
             extra = sorted((observed - expected).elements())
-            duplicates = sorted(
-                file for file, count in observed.items() if count > 1
-            )
+            duplicates = sorted(file for file, count in observed.items() if count > 1)
             raise ValueError(
                 "floor rows must account for every corpus file exactly once: "
                 f"expectedRows={len(ordered_files)} observedRows={len(row_files)} "

--- a/implementations/python/sugar-lift-py-tests/scripts/process_floor_measurement_cache.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/process_floor_measurement_cache.py
@@ -104,10 +104,7 @@ def resolve_cache_root() -> Path | None:
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         return (
-            Path(workspace).resolve()
-            / ".cache"
-            / "sugar"
-            / "process-floor-terminals"
+            Path(workspace).resolve() / ".cache" / "sugar" / "process-floor-terminals"
         )
     home = os.environ.get("HOME")
     if home:
@@ -214,9 +211,7 @@ class ProcessFloorTerminalCache:
             raise CacheRefuse(f"cache row missing terminal in {path}")
         category = str(terminal.get("category") or "")
         if category not in CACHEABLE_CATEGORIES:
-            raise CacheRefuse(
-                f"refusing non-cacheable category {category!r} in {path}"
-            )
+            raise CacheRefuse(f"refusing non-cacheable category {category!r} in {path}")
         return dict(terminal)
 
     def store(self, key: MeasurementKey, terminal: Mapping[str, Any]) -> Path | None:

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -210,7 +210,9 @@ def _panic_from_exception(
     }
 
 
-def _panic_from_audit(raw: Mapping[str, Any], *, file_rel: str) -> dict[str, Any] | None:
+def _panic_from_audit(
+    raw: Mapping[str, Any], *, file_rel: str
+) -> dict[str, Any] | None:
     gap = raw.get("gap")
     if not isinstance(gap, dict):
         return None
@@ -285,7 +287,9 @@ def _instrument_failure_row(
     functions_total: int,
     functions_enumerated: int,
 ) -> dict[str, Any]:
-    observed_type = _qualified_type(error) if isinstance(error, BaseException) else "builtins.str"
+    observed_type = (
+        _qualified_type(error) if isinstance(error, BaseException) else "builtins.str"
+    )
     functions_not_enumerated = max(0, functions_total - functions_enumerated)
     row: dict[str, Any] = {
         "functionsTotal": functions_total,
@@ -300,9 +304,7 @@ def _instrument_failure_row(
         "cleanRatioRefused": True,
         "cleanRefuseReason": f"instrument failure during {phase}",
         "functionsAuthenticated": functions_total,
-        "astSites": (
-            {"site:function-def": functions_total} if functions_total else {}
-        ),
+        "astSites": ({"site:function-def": functions_total} if functions_total else {}),
         "rosterPreservedAfterResidualFailure": bool(
             phase in {"residual", "outer-shell-escape"}
             and functions_total > 0
@@ -365,7 +367,9 @@ def demand_context_manager_resolution_events(
         options={
             "distribution": distribution,
             "sourceWorkspaceRoot": (
-                str(source_workspace_root) if source_workspace_root is not None else None
+                str(source_workspace_root)
+                if source_workspace_root is not None
+                else None
             ),
         },
     )
@@ -468,8 +472,8 @@ def _complete_d3_residency_observation(
     audit_open = _take_d3_audit_open_observation(source_cid)
     if isinstance(audit_open, dict):
         row.update(audit_open)
-        row["presenceConfirmed"] = (
-            row.get("presentBeforeDemand") == row.get("presentAtAuditOpen")
+        row["presenceConfirmed"] = row.get("presentBeforeDemand") == row.get(
+            "presentAtAuditOpen"
         )
     else:
         row["presenceConfirmed"] = False
@@ -515,9 +519,9 @@ def _empty_shell(
             if ast_fn is not None
             else ({"site:function-def": functions_total} if functions_total else {})
         ),
-        "functionsAuthenticated": int(ast_fn)
-        if ast_fn is not None
-        else functions_total,
+        "functionsAuthenticated": (
+            int(ast_fn) if ast_fn is not None else functions_total
+        ),
         "desugarFamilies": {},
         "desugarCategories": {},
         "desugarByCategoryOwner": {},
@@ -559,7 +563,11 @@ def _functions_clean(
             except (TypeError, ValueError):
                 return None, True, "sourceAudit.functionsClean unreadable"
             if clean < 0 or clean > functions_total:
-                return None, True, f"functionsClean={clean} outside [0,{functions_total}]"
+                return (
+                    None,
+                    True,
+                    f"functionsClean={clean} outside [0,{functions_total}]",
+                )
             return clean, False, None
     residual_n = len(construction_panics)
     if residual_n > 0:
@@ -678,9 +686,7 @@ def terminal_from_enumerate(
         clean_refuse_reason=clean_reason,
         ast_fn=ast_fn if ast_fn is not None else functions_total,
         roster_preserved_after_residual_failure=(
-            residual_phase_failed
-            and functions_total > 0
-            and functions_enumerated > 0
+            residual_phase_failed and functions_total > 0 and functions_enumerated > 0
         ),
     )
     if construction_panics:

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -130,28 +130,34 @@ def _module_sugar_constructed_identity(
     if not isinstance(input_key, dict):
         return None
     return {
-        "file": input_key.get("file")
-        if isinstance(input_key.get("file"), str)
-        else None,
-        "sourceCid": input_key.get("sourceCid")
-        if isinstance(input_key.get("sourceCid"), str)
-        else None,
+        "file": (
+            input_key.get("file") if isinstance(input_key.get("file"), str) else None
+        ),
+        "sourceCid": (
+            input_key.get("sourceCid")
+            if isinstance(input_key.get("sourceCid"), str)
+            else None
+        ),
         "rowId": row.get("rowId") if isinstance(row.get("rowId"), str) else None,
-        "stageId": row.get("stageId")
-        if isinstance(row.get("stageId"), str)
-        else None,
-        "observedEventType": row.get("observedEventType")
-        if isinstance(row.get("observedEventType"), str)
-        else None,
-        "category": row.get("category")
-        if isinstance(row.get("category"), str)
-        else None,
-        "terminalKind": row.get("terminalKind")
-        if isinstance(row.get("terminalKind"), str)
-        else None,
-        "final_terminal": row.get("final_terminal")
-        if isinstance(row.get("final_terminal"), str)
-        else None,
+        "stageId": row.get("stageId") if isinstance(row.get("stageId"), str) else None,
+        "observedEventType": (
+            row.get("observedEventType")
+            if isinstance(row.get("observedEventType"), str)
+            else None
+        ),
+        "category": (
+            row.get("category") if isinstance(row.get("category"), str) else None
+        ),
+        "terminalKind": (
+            row.get("terminalKind")
+            if isinstance(row.get("terminalKind"), str)
+            else None
+        ),
+        "final_terminal": (
+            row.get("final_terminal")
+            if isinstance(row.get("final_terminal"), str)
+            else None
+        ),
     }
 
 
@@ -177,16 +183,16 @@ def _load_recensus():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     # Workers stay non-authoritative. The separate compose door owns the seal.
-    assert getattr(module, "SCOREBOARD_AUTHORITY", None) is False, (
-        "control_effect_recensus must remain SCOREBOARD_AUTHORITY=False"
-    )
+    assert (
+        getattr(module, "SCOREBOARD_AUTHORITY", None) is False
+    ), "control_effect_recensus must remain SCOREBOARD_AUTHORITY=False"
     from compose_control_effect_board import (
         SCOREBOARD_AUTHORITY as compose_authority,
     )
 
-    assert compose_authority is True, (
-        "compose_control_effect_board must remain the sole scoreboard authority"
-    )
+    assert (
+        compose_authority is True
+    ), "compose_control_effect_board must remain the sole scoreboard authority"
     return module
 
 
@@ -831,9 +837,7 @@ def main(argv: list[str] | None = None) -> int:
             f"elapsed_s={elapsed:.1f} sealed={sealed}"
         )
         if elapsed > 60:
-            _narrate(
-                f"PATH_SMOKE WARNING elapsed_s={elapsed:.1f} exceeded 60s budget"
-            )
+            _narrate(f"PATH_SMOKE WARNING elapsed_s={elapsed:.1f} exceeded 60s budget")
         return 0 if path_verdict == "PATH_OK" else 1
 
     except Exception as exc:  # noqa: BLE001 — crash is UNMEASURED path

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke_discrimination.py
@@ -58,7 +58,12 @@ def _run_arm(lie: str, out_dir: Path) -> tuple[int, dict[str, Any], float]:
     if proc.stdout:
         print(proc.stdout, end="" if proc.stdout.endswith("\n") else "\n", flush=True)
     if proc.stderr:
-        print(proc.stderr, end="" if proc.stderr.endswith("\n") else "\n", file=sys.stderr, flush=True)
+        print(
+            proc.stderr,
+            end="" if proc.stderr.endswith("\n") else "\n",
+            file=sys.stderr,
+            flush=True,
+        )
     seal = out_dir / "path_verdict.json"
     body: dict[str, Any] = {}
     if seal.is_file():

--- a/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/self_sealing_instrument_law.py
@@ -197,12 +197,20 @@ def _is_empty_test(test: ast.AST, name: str) -> bool:
             return True
     if isinstance(test, ast.Compare) and len(test.ops) == 1:
         left, op, right = test.left, test.ops[0], test.comparators[0]
-        if isinstance(op, (ast.Eq, ast.Is)) and isinstance(left, ast.Name) and left.id == name:
+        if (
+            isinstance(op, (ast.Eq, ast.Is))
+            and isinstance(left, ast.Name)
+            and left.id == name
+        ):
             if isinstance(right, (ast.List, ast.Tuple, ast.Set)) and not right.elts:
                 return True
             if isinstance(right, ast.Constant) and right.value in (0, None, False, ""):
                 return True
-        if isinstance(op, (ast.Eq, ast.Is)) and isinstance(right, ast.Name) and right.id == name:
+        if (
+            isinstance(op, (ast.Eq, ast.Is))
+            and isinstance(right, ast.Name)
+            and right.id == name
+        ):
             if isinstance(left, (ast.List, ast.Tuple, ast.Set)) and not left.elts:
                 return True
         if isinstance(op, ast.Eq) and isinstance(left, ast.Call):
@@ -278,14 +286,26 @@ def _is_presence_only_identity(test: ast.AST) -> str | None:
     if not isinstance(test, ast.Compare) or len(test.ops) != 1:
         return None
     left, op, right = test.left, test.ops[0], test.comparators[0]
-    if isinstance(op, ast.IsNot) and isinstance(right, ast.Constant) and right.value is None:
+    if (
+        isinstance(op, ast.IsNot)
+        and isinstance(right, ast.Constant)
+        and right.value is None
+    ):
         if _is_identity_bearing(left):
             return f"assert {_unparse(left)} is not None (presence-only identity)"
-    if isinstance(op, ast.NotEq) and isinstance(right, ast.Constant) and right.value is None:
+    if (
+        isinstance(op, ast.NotEq)
+        and isinstance(right, ast.Constant)
+        and right.value is None
+    ):
         if _is_identity_bearing(left):
             return f"assert {_unparse(left)} != None (presence-only identity)"
     # flipped: None is not x
-    if isinstance(op, ast.IsNot) and isinstance(left, ast.Constant) and left.value is None:
+    if (
+        isinstance(op, ast.IsNot)
+        and isinstance(left, ast.Constant)
+        and left.value is None
+    ):
         if _is_identity_bearing(right):
             return f"assert None is not {_unparse(right)} (presence-only identity)"
     return None

--- a/implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/source_audit_presence_identity_law.py
@@ -129,8 +129,10 @@ def _status_by_cid_membership(node: ast.AST) -> bool:
         return False
     test = node.test
     # entry.cid in something
-    if isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(
-        test.ops[0], ast.In
+    if (
+        isinstance(test, ast.Compare)
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.In)
     ):
         left = test.left
         if _is_cid_attr(left):
@@ -251,7 +253,7 @@ def scan_roots(roots: Iterable[Path]) -> tuple[list[Offender], list[dict]]:
 # Historical twins — the shapes SIN CLUSTER 7 actually shipped
 # ---------------------------------------------------------------------------
 
-HISTORICAL_LIFT_RPC_CID_ALONE = '''
+HISTORICAL_LIFT_RPC_CID_ALONE = """
 def _roll_call_audit_leaf(full_path, file_rel):
     report = discharge(source_file)
     present_cids = {entry.cid for entry in report.present}
@@ -272,9 +274,9 @@ def _roll_call_audit_leaf(full_path, file_rel):
         },
     }
     return source_audit
-'''
+"""
 
-HISTORICAL_TREE_ENUMERATE_CID_ALONE = '''
+HISTORICAL_TREE_ENUMERATE_CID_ALONE = """
 def source_audit_from_roll_call(full_path, file_rel):
     report = discharge(sf)
     present_cids = {e.cid for e in report.present}
@@ -285,9 +287,9 @@ def source_audit_from_roll_call(full_path, file_rel):
     warranted = sum(1 for locus in loci if locus["status"] == "warranted")
     unresolved = len(loci) - warranted
     return {"loci": loci, "totals": {"source_warranted": warranted, "source_unresolved": unresolved}}
-'''
+"""
 
-PRODUCTION_ONE_DOOR = '''
+PRODUCTION_ONE_DOOR = """
 def source_audit_from_report(report, file_rel):
     present_keys = {_roll_call_identity(entry) for entry in report.present}
     loci = []
@@ -302,7 +304,7 @@ def _roll_call_audit_leaf(full_path, file_rel):
     report = discharge(source_file)
     source_audit = source_audit_from_report(report, file_rel)
     return source_audit
-'''
+"""
 
 
 def self_test() -> int:
@@ -323,7 +325,9 @@ def self_test() -> int:
                 f"{label}: expected clean, got {[(o.kind, o.line) for o in found]}"
             )
 
-    expect("historical lift_rpc CID-alone", HISTORICAL_LIFT_RPC_CID_ALONE, min_offenders=2)
+    expect(
+        "historical lift_rpc CID-alone", HISTORICAL_LIFT_RPC_CID_ALONE, min_offenders=2
+    )
     expect(
         "historical tree_enumerate CID-alone",
         HISTORICAL_TREE_ENUMERATE_CID_ALONE,

--- a/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/swallowed_throw_second_mechanism_law.py
@@ -176,7 +176,9 @@ def _pure_reraise(handler: ast.ExceptHandler) -> bool:
         if isinstance(last, ast.Raise):
             return True
         if isinstance(last, ast.If):
-            return bool(last.orelse) and ends_raise(last.body) and ends_raise(last.orelse)
+            return (
+                bool(last.orelse) and ends_raise(last.body) and ends_raise(last.orelse)
+            )
         return False
 
     return ends_raise(body)
@@ -225,7 +227,11 @@ def _except_assigns_raw_source(handler: ast.ExceptHandler) -> bool:
         if not isinstance(stmt, ast.Assign):
             continue
         for target in stmt.targets:
-            if isinstance(target, ast.Name) and target.id in {"value", "decoded", "lit"}:
+            if isinstance(target, ast.Name) and target.id in {
+                "value",
+                "decoded",
+                "lit",
+            }:
                 # value = text / value = unit.source[...] / value = source[...]
                 rhs = stmt.value
                 if isinstance(rhs, ast.Name) and rhs.id in {

--- a/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/vendor_special_case_law.py
@@ -93,6 +93,7 @@ def construction_recognition_scope(package: Path) -> InstrumentScanScope:
         instrument_self=_INSTRUMENT_SELF,
     )
 
+
 VENDORS = frozenset(
     {
         "numpy",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py
@@ -169,7 +169,11 @@ _RUNTIME_SEMANTIC_FIELDS = (
 def _runtime_identity_wire(
     identity: RuntimeIdentityV1 | Mapping[str, Any],
 ) -> dict[str, Any]:
-    wire = identity.to_wire() if isinstance(identity, RuntimeIdentityV1) else dict(identity)
+    wire = (
+        identity.to_wire()
+        if isinstance(identity, RuntimeIdentityV1)
+        else dict(identity)
+    )
     if set(wire) != _RUNTIME_IDENTITY_FIELDS:
         raise RuntimeIdentityResolutionFailure(
             "runtimeIdentity/v1 fields differ from the closed schema: "
@@ -405,9 +409,7 @@ def activate_checkout_import_roots(repo_root: Path, search_path: list[str]) -> N
         # already on sys.path (the common authenticated-pytest entry shape).
         import importlib.util
 
-        tool = (
-            Path(repo_root).resolve() / "tools" / "managed_checkout_pythonpath.py"
-        )
+        tool = Path(repo_root).resolve() / "tools" / "managed_checkout_pythonpath.py"
         spec = importlib.util.spec_from_file_location(
             "managed_checkout_pythonpath", tool
         )
@@ -469,7 +471,9 @@ def authenticate_environment() -> (
     # Prefer the already-loaded package (process-start path) over a second
     # import_module after path mutation, which would leave a wrong copy in
     # sys.modules if the first import came from site-packages.
-    lift = sys.modules.get("sugar_lift_py_tests") or import_module("sugar_lift_py_tests")
+    lift = sys.modules.get("sugar_lift_py_tests") or import_module(
+        "sugar_lift_py_tests"
+    )
     pandas_distribution = metadata.distribution("pandas")
     numpy_distribution = metadata.distribution("numpy")
     pandas_identity = authenticate_distribution(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py
@@ -150,12 +150,8 @@ class FunctionsPopulationV1:
             )
         object.__setattr__(self, "tip", _require_nonempty_str("tip", self.tip))
         object.__setattr__(self, "pin", _require_nonempty_str("pin", self.pin))
-        object.__setattr__(
-            self, "count", _require_int_ge0("count", self.count)
-        )
-        object.__setattr__(
-            self, "unit", _require_nonempty_str("unit", self.unit)
-        )
+        object.__setattr__(self, "count", _require_int_ge0("count", self.count))
+        object.__setattr__(self, "unit", _require_nonempty_str("unit", self.unit))
         object.__setattr__(
             self, "witness", _require_nonempty_str("witness", self.witness)
         )
@@ -197,12 +193,8 @@ class FunctionsEnumeratedV1:
             )
         object.__setattr__(self, "tip", _require_nonempty_str("tip", self.tip))
         object.__setattr__(self, "pin", _require_nonempty_str("pin", self.pin))
-        object.__setattr__(
-            self, "count", _require_int_ge0("count", self.count)
-        )
-        object.__setattr__(
-            self, "unit", _require_nonempty_str("unit", self.unit)
-        )
+        object.__setattr__(self, "count", _require_int_ge0("count", self.count))
+        object.__setattr__(self, "unit", _require_nonempty_str("unit", self.unit))
         object.__setattr__(
             self, "witness", _require_nonempty_str("witness", self.witness)
         )
@@ -247,9 +239,7 @@ class FunctionsCleanV1:
             )
         object.__setattr__(self, "tip", _require_nonempty_str("tip", self.tip))
         object.__setattr__(self, "pin", _require_nonempty_str("pin", self.pin))
-        object.__setattr__(
-            self, "unit", _require_nonempty_str("unit", self.unit)
-        )
+        object.__setattr__(self, "unit", _require_nonempty_str("unit", self.unit))
         object.__setattr__(
             self, "witness", _require_nonempty_str("witness", self.witness)
         )
@@ -272,9 +262,7 @@ class FunctionsCleanV1:
                     "FunctionsCleanV1 measured body requires a non-negative count; "
                     "absent clean must set refused=True (never default count to 0)"
                 )
-            object.__setattr__(
-                self, "count", _require_int_ge0("count", self.count)
-            )
+            object.__setattr__(self, "count", _require_int_ge0("count", self.count))
             if self.refuse_reason is not None:
                 raise BoardFunctionFactError(
                     "FunctionsCleanV1 measured body forbids refuse_reason"
@@ -327,9 +315,7 @@ def seal_functions_population_v1(
     pin_s = _require_nonempty_str("pin", pin)
     wit = _require_nonempty_str("witness", witness)
     body = {"count": count, "unit": UNIT}
-    cid = _fact_cid(
-        tip=tip_s, pin=pin_s, axis=AXIS_POPULATION, body=body, witness=wit
-    )
+    cid = _fact_cid(tip=tip_s, pin=pin_s, axis=AXIS_POPULATION, body=body, witness=wit)
     return FunctionsPopulationV1(
         tip=tip_s,
         pin=pin_s,
@@ -365,9 +351,7 @@ def seal_functions_enumerated_v1(
     pin_s = _require_nonempty_str("pin", pin)
     wit = _require_nonempty_str("witness", witness)
     body = {"count": count, "unit": UNIT}
-    cid = _fact_cid(
-        tip=tip_s, pin=pin_s, axis=AXIS_ENUMERATED, body=body, witness=wit
-    )
+    cid = _fact_cid(tip=tip_s, pin=pin_s, axis=AXIS_ENUMERATED, body=body, witness=wit)
     return FunctionsEnumeratedV1(
         tip=tip_s,
         pin=pin_s,
@@ -401,8 +385,7 @@ def seal_functions_clean_v1(
     if refused:
         count: int | None = None
         reason = refuse_reason or (
-            "one or more files refused functionsClean "
-            "(would be tautological clean%)"
+            "one or more files refused functionsClean " "(would be tautological clean%)"
         )
         body = {
             "count": None,
@@ -419,9 +402,7 @@ def seal_functions_clean_v1(
         count = _require_int_ge0("clean", reading.value)
         reason = None
         body = {"count": count, "refused": False, "unit": UNIT}
-    cid = _fact_cid(
-        tip=tip_s, pin=pin_s, axis=AXIS_CLEAN, body=body, witness=wit
-    )
+    cid = _fact_cid(tip=tip_s, pin=pin_s, axis=AXIS_CLEAN, body=body, witness=wit)
     return FunctionsCleanV1(
         tip=tip_s,
         pin=pin_s,
@@ -452,18 +433,14 @@ def board_fields_from_sealed_facts(
 
     This is the enforcement point: a bare int cannot become a board field.
     """
-    if isinstance(population, int) or not isinstance(
-        population, FunctionsPopulationV1
-    ):
+    if isinstance(population, int) or not isinstance(population, FunctionsPopulationV1):
         raise BoardFunctionFactError(
             "board_fields_from_sealed_facts refuses non-FunctionsPopulationV1 for "
             f"population (got {type(population).__name__}); a bare int or "
             "LocalReading cannot become a board field. Close the consumer: "
             "compose accepts only the sealed meaning type."
         )
-    if isinstance(enumerated, int) or not isinstance(
-        enumerated, FunctionsEnumeratedV1
-    ):
+    if isinstance(enumerated, int) or not isinstance(enumerated, FunctionsEnumeratedV1):
         raise BoardFunctionFactError(
             "board_fields_from_sealed_facts refuses non-FunctionsEnumeratedV1 for "
             f"enumerated (got {type(enumerated).__name__}); a bare int or "
@@ -477,7 +454,11 @@ def board_fields_from_sealed_facts(
             "cannot become a board field. Close the consumer: compose accepts "
             "only the sealed meaning type."
         )
-    if not population.is_sealed() or not enumerated.is_sealed() or not clean.is_sealed():
+    if (
+        not population.is_sealed()
+        or not enumerated.is_sealed()
+        or not clean.is_sealed()
+    ):
         raise BoardFunctionFactError(
             "board_fields_from_sealed_facts requires sealed facts "
             f"(population.sealed={population.is_sealed()}, "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/claim_envelope.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/claim_envelope.py
@@ -155,6 +155,7 @@ def _authoring_to_value(a: Authoring) -> Value:
             pairs.append(("rationale", vstr(a.rationale)))
         return vobj(pairs)
     from sugar_lift_py_tests.gap.panic import construction_panic_gap
+
     construction_panic_gap(
         owner="claim_envelope.authoring",
         blame="claim_envelope",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/conservation_mint.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/conservation_mint.py
@@ -19,9 +19,7 @@ from typing import Any
 
 CONSERVATION_WITNESS_SCHEMA = "sugar.conservation-witness.v1"
 
-_CID_PATTERN = re.compile(
-    r"(?:blake3-512:[0-9a-f]{128}|sha256:[0-9a-f]{64})"
-)
+_CID_PATTERN = re.compile(r"(?:blake3-512:[0-9a-f]{128}|sha256:[0-9a-f]{64})")
 _WITNESS_AUTHORITY = object()
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -799,7 +799,11 @@ def decode_resolved_contract_refs(raw: Any) -> ResolvedContractRefsV1:
             "gap",
         }:
             gap = resolution["gap"]
-            if not isinstance(gap, dict) or not isinstance(gap.get("kind"), str) or not gap.get("kind"):
+            if (
+                not isinstance(gap, dict)
+                or not isinstance(gap.get("kind"), str)
+                or not gap.get("kind")
+            ):
                 raise ContractRefProtocolError(
                     "malformed context-manager resolution gap"
                 )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py
@@ -113,12 +113,20 @@ class DemandTableIdentityV1:
 
     @classmethod
     def from_mapping(cls, raw: Mapping[str, object]) -> "DemandTableIdentityV1":
-        required = ("contentKey", "corpusManifestCid", "schemaVersion",
-                    "producerSourceCid", "resolutionConfigCid",
-                    "parserIdentity", "fileCount")
+        required = (
+            "contentKey",
+            "corpusManifestCid",
+            "schemaVersion",
+            "producerSourceCid",
+            "resolutionConfigCid",
+            "parserIdentity",
+            "fileCount",
+        )
         missing = [key for key in required if key not in raw]
         if missing:
-            raise ValueError(f"demand table semantic identity missing fields: {missing}")
+            raise ValueError(
+                f"demand table semantic identity missing fields: {missing}"
+            )
         return cls(
             content_key=str(raw["contentKey"]),
             corpus_manifest_cid=str(raw["corpusManifestCid"]),

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py
@@ -238,8 +238,6 @@ class OutcomeWalk:
 # --------------------------------------------------------------------------
 
 
-
-
 class DesugarAxis:
     """Accumulates the four disjoint desugar-layer quantities for a file/run."""
 
@@ -295,7 +293,6 @@ class DesugarAxis:
             if verdict is not None and hasattr(verdict, "row"):
                 row["classification"] = verdict.row()
         self.defects.append(row)
-
 
     # -- the one door -------------------------------------------------------
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -539,9 +539,7 @@ class CallSiteValue(FloorValue):
         dug = self._dig_floor_or_none(None, owner="CallSiteValue.contains")
         if dug is not None and dug is not self:
             return dug.contains(item, site)
-        return self.undecided_contains(
-            item, site, owner="CallSiteValue.contains"
-        )
+        return self.undecided_contains(item, site, owner="CallSiteValue.contains")
 
     def subscript(self, index, site):
         return self.undecided_subscript(index, site, owner="CallSiteValue.subscript")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/complex_value.py
@@ -142,12 +142,18 @@ class ComplexValue(FloorValue):
     def setattr(self, name, value, site):
         del name, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ComplexValue.setattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="ComplexValue.setattr"
+        )
 
     def delattr(self, name, site):
         del name
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ComplexValue.delattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="ComplexValue.delattr"
+        )
 
     def setitem(self, index, value, site):
         """Complex numbers reject subscript store with exact TypeError."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/decorated_class_value.py
@@ -6,7 +6,6 @@ from sugar_lift_python_source.canonical import cid_of_json
 
 from .floor_value import FloorValue
 
-
 _APPLICATION_AUTHORITY = object()
 _PUBLICATION_AUTHORITY = object()
 _MEMBER_AUTHORITY = object()
@@ -69,11 +68,22 @@ class DecoratorApplicationPublicationV1:
 
     def __post_init__(self):
         if getattr(self, "_authority", None) is not _APPLICATION_AUTHORITY:
-            raise ValueError("decorated class publication application is not producer-minted")
+            raise ValueError(
+                "decorated class publication application is not producer-minted"
+            )
         callable_cid = _floor_cid(self.callable_floor)
         input_cid = _floor_cid(self.input_floor)
         output_cid = _floor_cid(self.output_floor)
-        application_cid = cid_of_json({"kind": "decorated-class-application", "schemaVersion": "1", "occurrence": self.occurrence.wire(), "callableFloorCid": callable_cid, "inputFloorCid": input_cid, "outputFloorCid": output_cid})
+        application_cid = cid_of_json(
+            {
+                "kind": "decorated-class-application",
+                "schemaVersion": "1",
+                "occurrence": self.occurrence.wire(),
+                "callableFloorCid": callable_cid,
+                "inputFloorCid": input_cid,
+                "outputFloorCid": output_cid,
+            }
+        )
         if (
             self.callable_floor_cid != callable_cid
             or self.input_floor_cid != input_cid
@@ -204,7 +214,21 @@ class DecoratedClassPublicationV1:
             raise ValueError("decorated class publication final result mismatch")
         raw_cid = _floor_cid(self.raw_class)
         final_cid = _floor_cid(self.final_class)
-        publication_cid = cid_of_json({"kind": "decorated-class-publication", "schemaVersion": "1", "sourceCid": self.source_cid, "definition": self.definition.wire(), "bindingOccurrence": self.binding_occurrence.wire(), "rawClassCid": raw_cid, "decoratorApplications": [a.application_cid for a in self.decorator_applications], "finalClassCid": final_cid, "moduleConstructionReceiptCid": self.module_construction_receipt_cid})
+        publication_cid = cid_of_json(
+            {
+                "kind": "decorated-class-publication",
+                "schemaVersion": "1",
+                "sourceCid": self.source_cid,
+                "definition": self.definition.wire(),
+                "bindingOccurrence": self.binding_occurrence.wire(),
+                "rawClassCid": raw_cid,
+                "decoratorApplications": [
+                    a.application_cid for a in self.decorator_applications
+                ],
+                "finalClassCid": final_cid,
+                "moduleConstructionReceiptCid": self.module_construction_receipt_cid,
+            }
+        )
         if (
             self.raw_class_cid != raw_cid
             or self.final_class_cid != final_cid
@@ -474,7 +498,15 @@ class DecoratedClassMemberValue(FloorValue):
         if self.publication_cid != self.publication.publication_cid:
             raise ValueError("decorated class member publication CID mismatch")
         floor_cid = _floor_cid(self.member_floor)
-        member_cid = cid_of_json({"kind": "decorated-class-member-publication", "schemaVersion": "1", "publicationCid": self.publication.publication_cid, "memberDefinition": self.member_definition.wire(), "memberFloorCid": floor_cid})
+        member_cid = cid_of_json(
+            {
+                "kind": "decorated-class-member-publication",
+                "schemaVersion": "1",
+                "publicationCid": self.publication.publication_cid,
+                "memberDefinition": self.member_definition.wire(),
+                "memberFloorCid": floor_cid,
+            }
+        )
         if self.member_floor_cid != floor_cid or self.member_cid != member_cid:
             raise ValueError("decorated class member CID mismatch")
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/effect_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/effect_coordinate.py
@@ -96,8 +96,6 @@ class ObservedExceptionInfoValue(ExceptionInfoCoordinate):
             from sugar_lift_py_tests.outcome import Complete
 
             return Complete(
-                ObservedEffectValue(
-                    slot_id=self.slot_id, effect=self.effect, site=site
-                )
+                ObservedEffectValue(slot_id=self.slot_id, effect=self.effect, site=site)
             )
         return super().attribute(name, site)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ellipsis_value.py
@@ -69,12 +69,18 @@ class EllipsisValue(FloorValue):
     def setattr(self, name, value, site):
         del name, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="EllipsisValue.setattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="EllipsisValue.setattr"
+        )
 
     def delattr(self, name, site):
         del name
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="EllipsisValue.delattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="EllipsisValue.delattr"
+        )
 
     def setitem(self, index, value, site):
         """Ellipsis rejects subscript store with exact TypeError."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py
@@ -282,9 +282,7 @@ class FloorValue:
         # Default: a record entry posts no exit. ReturnValue overrides.
         return ()
 
-    def add_with(
-        self, operation: AddOperation, ctx: ReduceContext | None
-    ) -> Outcome:
+    def add_with(self, operation: AddOperation, ctx: ReduceContext | None) -> Outcome:
         del ctx
         return self._operation_construction_gap(operation, "add_with")
 
@@ -480,9 +478,7 @@ class FloorValue:
         del ctx
         return self._operation_construction_gap(operation, "iter_with")
 
-    def next_with(
-        self, operation: NextOperation, ctx: ReduceContext | None
-    ) -> Outcome:
+    def next_with(self, operation: NextOperation, ctx: ReduceContext | None) -> Outcome:
         del ctx
         return self._operation_construction_gap(operation, "next_with")
 
@@ -1197,9 +1193,7 @@ class FloorValue:
 
     def _undecided_ordering_law(self, other, site, *, owner: str, operator: str):
         """Backward-compatible name: refuse ordering meaning (always throws)."""
-        self._refuse_ordering_meaning(
-            other, site, owner=owner, operator=operator
-        )
+        self._refuse_ordering_meaning(other, site, owner=owner, operator=operator)
 
     def less_than_from_left(self, left, site):
         """Default RHS law for ``left < self`` — never invents FOL meaning.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/ground_exit.py
@@ -161,6 +161,4 @@ def ground_type_error(*, site, owner: str) -> Outcome:
     completed RaiseValue.  Undecided native dispatch stays on the named-refusal
     / construction-panic laws; this door is only for the decided TypeError.
     """
-    return ground_exceptional_exit(
-        exception_name="TypeError", site=site, owner=owner
-    )
+    return ground_exceptional_exit(exception_name="TypeError", site=site, owner=owner)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guard_stable_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/guard_stable_value.py
@@ -14,4 +14,3 @@ class GuardStableValue(FloorValue):
     def guarded(self, formula):
         del formula
         return self
-

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_alias_value.py
@@ -76,19 +76,13 @@ class ImportAliasValue(FloorValue):
     # undecided_* instead — vocabulary already on FloorValue.
 
     def subscript(self, index, site):
-        return self.undecided_subscript(
-            index, site, owner="ImportAliasValue.subscript"
-        )
+        return self.undecided_subscript(index, site, owner="ImportAliasValue.subscript")
 
     def attribute(self, name, site):
-        return self.undecided_attribute(
-            name, site, owner="ImportAliasValue.attribute"
-        )
+        return self.undecided_attribute(name, site, owner="ImportAliasValue.attribute")
 
     def contains(self, item, site):
-        return self.undecided_contains(
-            item, site, owner="ImportAliasValue.contains"
-        )
+        return self.undecided_contains(item, site, owner="ImportAliasValue.contains")
 
     def getattr_static(self, name: str, site):
         """Static getattr on an inert import alias — undecided, not missing floor."""

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/import_member_value.py
@@ -19,7 +19,6 @@ from typing import Any
 
 from .floor_value import FloorValue
 
-
 _IMPORT_MEMBER_AUTHORITY = object()
 
 
@@ -44,8 +43,7 @@ class ImportMemberValue(FloorValue):
             raise TypeError("ImportMemberValue requires exact authenticated receipt")
         self.receipt.revalidate()
         if (
-            self.qualified_name
-            != self.receipt.target_symbol.removeprefix("python:")
+            self.qualified_name != self.receipt.target_symbol.removeprefix("python:")
             or self.source_cid != self.receipt.source_cid
             or self.import_binding_cid != self.receipt.import_binding.cid
             or self.use_cid != self.receipt.use["cid"]
@@ -100,14 +98,10 @@ class ImportMemberValue(FloorValue):
         )
 
     def attribute(self, name, site):
-        return self.undecided_attribute(
-            name, site, owner="ImportMemberValue.attribute"
-        )
+        return self.undecided_attribute(name, site, owner="ImportMemberValue.attribute")
 
     def contains(self, item, site):
-        return self.undecided_contains(
-            item, site, owner="ImportMemberValue.contains"
-        )
+        return self.undecided_contains(item, site, owner="ImportMemberValue.contains")
 
     def attribute_with(self, operation: Any, ctx: object):
         del ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/iterator_value.py
@@ -46,7 +46,10 @@ class ListIteratorValue(FloorValue):
         return ctor(
             "python:list_iterator",
             (
-                ctor("array", tuple(value.to_term(owner=owner) for value in self.elements)),
+                ctor(
+                    "array",
+                    tuple(value.to_term(owner=owner) for value in self.elements),
+                ),
                 TermValue(self.index).to_term(owner=owner),
             ),
             symbol_kind="coordinate",
@@ -55,22 +58,38 @@ class ListIteratorValue(FloorValue):
     def setattr(self, name, value, site):
         del name, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ListIteratorValue.setattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="ListIteratorValue.setattr",
+        )
 
     def delattr(self, name, site):
         del name
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="ListIteratorValue.delattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="ListIteratorValue.delattr",
+        )
 
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="ListIteratorValue.setitem")
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ListIteratorValue.setitem"
+        )
 
     def delitem(self, index, site):
         del index
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="ListIteratorValue.delitem")
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="ListIteratorValue.delitem"
+        )
 
     def next_with(self, operation, ctx):
         del ctx
@@ -96,22 +115,38 @@ class TupleIteratorValue(FloorValue):
     def setattr(self, name, value, site):
         del name, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="TupleIteratorValue.setattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="TupleIteratorValue.setattr",
+        )
 
     def delattr(self, name, site):
         del name
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="TupleIteratorValue.delattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError",
+            site=site,
+            owner="TupleIteratorValue.delattr",
+        )
 
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="TupleIteratorValue.setitem")
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TupleIteratorValue.setitem"
+        )
 
     def delitem(self, index, site):
         del index
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="TupleIteratorValue.delitem")
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="TupleIteratorValue.delitem"
+        )
 
     def next_with(self, operation, ctx):
         del ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/list_value.py
@@ -258,8 +258,7 @@ class ListValue(FloorValue):
         if isinstance(index, SliceValue):
             bounds = (index.lower, index.upper, index.step)
             if all(
-                bound is None
-                or (type(bound) is TermValue and type(bound.value) is int)
+                bound is None or (type(bound) is TermValue and type(bound.value) is int)
                 for bound in bounds
             ):
                 lower, upper, step = (
@@ -279,9 +278,7 @@ class ListValue(FloorValue):
                 return Complete(
                     ListValue(tuple(self.elements[slice(lower, upper, step)]))
                 )
-            return self.undecided_subscript(
-                index, site, owner="ListValue.subscript"
-            )
+            return self.undecided_subscript(index, site, owner="ListValue.subscript")
 
         if type(index) is TermValue and isinstance(index.value, int):
             i = index.value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mapping_object_value.py
@@ -17,6 +17,7 @@ class MappingObjectValue(ObjectValue):
     """
 
     entries: tuple = ()
+
     def guarded(self, formula):
         """A constructed mapping state contributes no independent control.
 
@@ -77,17 +78,21 @@ class MappingObjectValue(ObjectValue):
                 "__class__", self.defining_class, blame=f"{self.class_name}.__setitem__"
             )
         )
-        return super().call_method_value(
+        return (
+            super()
+            .call_method_value(
                 "__setitem__",
                 (index, value),
                 owner="MappingObjectValue.setitem",
                 blame=site,
                 ctx=method_ctx,
-            ).and_then(
+            )
+            .and_then(
                 lambda callsite: callsite.reduce_source_outcome(method_ctx).and_then(
                     self._project_setitem_receiver
                 )
             )
+        )
 
     def mapping_builtin_setitem(self, index, value, site):
         """Apply authenticated builtin-dict storage without source redispatch."""
@@ -172,7 +177,9 @@ class MappingObjectValue(ObjectValue):
                 from sugar_lift_py_tests.outcome import Complete
 
                 return Complete(
-                    TupleValue(tuple(TupleValue((key, value)) for key, value in self.entries))
+                    TupleValue(
+                        tuple(TupleValue((key, value)) for key, value in self.entries)
+                    )
                 )
         return super().call_method_value(
             name,
@@ -196,7 +203,7 @@ class MappingObjectValue(ObjectValue):
             _closed_member_equal(key, candidate) for candidate, _ in self.entries
         )
         if any(decision is None for decision in decisions):
-            
+
             construction_panic_gap(
                 owner="MappingObjectValue.get",
                 blame=blame,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/mutable_global_value.py
@@ -82,7 +82,10 @@ class MutableGlobalValue(FloorValue):
 
         raises = atomic(
             "python.mutable_dict_lookup_raises_key_error",
-            [self.to_term(owner="mutable global lookup"), index.to_term(owner="mutable global lookup")],
+            [
+                self.to_term(owner="mutable global lookup"),
+                index.to_term(owner="mutable global lookup"),
+            ],
         )
         halted_face, completed_face = partition(
             ("mutable-global-dict-subscript", _occurrence_key(site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/none_value.py
@@ -135,9 +135,7 @@ class NoneValue(FloorValue):
         if self._unorderable_ground_peer(left):
             from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
-            return ground_type_error(
-                site=site, owner="NoneValue.less_than_from_left"
-            )
+            return ground_type_error(site=site, owner="NoneValue.less_than_from_left")
         return super().less_than_from_left(left, site)
 
     def _unorderable_ground_peer(self, other) -> bool:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/object_value.py
@@ -438,9 +438,7 @@ class ObjectValue(FloorValue):
             blame=operation.blame,
         )
 
-    def next_with(
-        self, operation: NextOperation, ctx: ReduceContext | None
-    ) -> Outcome:
+    def next_with(self, operation: NextOperation, ctx: ReduceContext | None) -> Outcome:
         del ctx
         return self.call_method_value(
             "__next__",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/predicate_value.py
@@ -78,22 +78,34 @@ class PredicateValue(FloorValue):
     def setattr(self, name, value, site):
         del name, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="PredicateValue.setattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="PredicateValue.setattr"
+        )
 
     def delattr(self, name, site):
         del name
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="AttributeError", site=site, owner="PredicateValue.delattr")
+
+        return ground_exceptional_exit(
+            exception_name="AttributeError", site=site, owner="PredicateValue.delattr"
+        )
 
     def setitem(self, index, value, site):
         del index, value
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="PredicateValue.setitem")
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="PredicateValue.setitem"
+        )
 
     def delitem(self, index, site):
         del index
         from sugar_lift_py_tests.floor.ground_exit import ground_exceptional_exit
-        return ground_exceptional_exit(exception_name="TypeError", site=site, owner="PredicateValue.delitem")
+
+        return ground_exceptional_exit(
+            exception_name="TypeError", site=site, owner="PredicateValue.delitem"
+        )
 
     def guarded(self, formula):
         """A carried boolean rides under a guard unchanged.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py
@@ -9,7 +9,6 @@ from .exception_value import ExceptionValue
 from .exception_cause_value import ExceptionCauseValue
 from .floor_value import FloorValue
 
-
 # Placeholder strings that invent exceptional-exit meaning outside the tree.
 # Identity/citation must come from Sugar/the tree — never these spellings.
 # Retirement: when exception_name is a closed typed constructor that can only
@@ -174,8 +173,7 @@ def _require_authenticated_exceptional_exit_citation(effect) -> None:
         _refuse_uncited_exit(
             effect,
             observed=(
-                "raise face has neither exception_name nor "
-                "exception_type_coordinate"
+                "raise face has neither exception_name nor " "exception_type_coordinate"
             ),
             requested=(
                 "an authenticated exception identity (name or type coordinate) "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_owned_mutation_result.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/receiver_owned_mutation_result.py
@@ -65,4 +65,3 @@ class ReceiverOwnedMutationResult(FloorValue):
                 self.result.to_term(owner=owner),
             ),
         )
-

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py
@@ -95,9 +95,7 @@ def rewrap_pending(pending, outcome, *, owner, blame):
     # carries its own formal coordinate, and fusing them would attribute one
     # obligation to a formal that does not own it.
     if isinstance(outcome, ContractConditionalConstructionV1):
-        return replace(
-            outcome, demands=merge_demands(pending.demands, outcome.demands)
-        )
+        return replace(outcome, demands=merge_demands(pending.demands, outcome.demands))
 
     # AN EFFECT: the obligation was incurred BEFORE the effect, on the path that
     # reached it (`o.x = p[k]` evaluates `p[k]`, then the store answers). It is
@@ -134,14 +132,10 @@ def rewrap_pending(pending, outcome, *, owner, blame):
         for exit_ in outcome.exits:
             owed = merge_pending(exit_.pending_contracts, (pending,))
             if isinstance(exit_, Completed):
-                exits.append(
-                    Completed(exit_.guard, exit_.value, exit_.faces, owed)
-                )
+                exits.append(Completed(exit_.guard, exit_.value, exit_.faces, owed))
             else:
                 exits.append(
-                    Halted(
-                        exit_.guard, exit_.effect, exit_.state, exit_.faces, owed
-                    )
+                    Halted(exit_.guard, exit_.effect, exit_.state, exit_.faces, owed)
                 )
         joined = ExitSet(tuple(exits)).normalize()
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py
@@ -154,9 +154,7 @@ class StringValue(GuardStableValue):
         if self._unorderable_ground_peer(left):
             from sugar_lift_py_tests.floor.ground_exit import ground_type_error
 
-            return ground_type_error(
-                site=site, owner="StringValue.less_than_from_left"
-            )
+            return ground_type_error(site=site, owner="StringValue.less_than_from_left")
         return super().less_than_from_left(left, site)
 
     def less_equal(self, other, site):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py
@@ -148,6 +148,7 @@ class SymbolicValue(FloorValue):
             runtime_effect_evidence_from_terms,
         )
         from sugar_lift_py_tests.outcome import Incomplete
+
         operation = ctor(
             "adt.is_python_type",
             [value.to_term(owner="isinstance value"), term],
@@ -491,9 +492,7 @@ class SymbolicValue(FloorValue):
         # Membership on an unknown container is a third value: neither
         # Complete(py.in) nor TypeError is honest without container-type
         # testimony. Named refusal, not fabrication.
-        return self.undecided_contains(
-            item, site, owner="SymbolicValue.contains"
-        )
+        return self.undecided_contains(item, site, owner="SymbolicValue.contains")
 
     def format_data_model(self, spec, site, ctx):
         """Construct ``format(symbolic, spec)`` as an exact data-model coordinate.
@@ -820,6 +819,7 @@ class SymbolicValue(FloorValue):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+
         index_term = index.to_term(owner="SymbolicValue.setitem index")
         value_term = value.to_term(owner="SymbolicValue.setitem value")
         return Complete(
@@ -847,6 +847,7 @@ class SymbolicValue(FloorValue):
         from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
         from sugar_lift_py_tests.ir import ctor
         from sugar_lift_py_tests.outcome import Complete
+
         index_term = index.to_term(owner="SymbolicValue.delitem index")
         return Complete(
             CallSiteValue(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_coordinate_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_coordinate_value.py
@@ -12,7 +12,6 @@ from .closed_operation_witness import (
 )
 from .floor_value import FloorValue
 
-
 _TUPLE_COORDINATE_OWNER = object()
 
 
@@ -79,9 +78,7 @@ class TupleCoordinateValue(FloorValue):
         runtime: PythonRuntimeIdentity,
     ) -> "TupleCoordinateValue":
         source_term = source.to_term(owner="python.tuple.construct")
-        term = ctor(
-            "python.tuple.construct", (source_term,), symbol_kind="coordinate"
-        )
+        term = ctor("python.tuple.construct", (source_term,), symbol_kind="coordinate")
         witness = ClosedSemanticOperationWitness.mint(
             runtime, "python.tuple.construct", (source_term,), term
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/tuple_value.py
@@ -356,8 +356,7 @@ class TupleValue(FloorValue):
         if type(index) is SliceValue:
             bounds = (index.lower, index.upper, index.step)
             if all(
-                bound is None
-                or (type(bound) is TermValue and type(bound.value) is int)
+                bound is None or (type(bound) is TermValue and type(bound.value) is int)
                 for bound in bounds
             ):
                 lower, upper, step = (
@@ -377,9 +376,7 @@ class TupleValue(FloorValue):
                 return Complete(
                     TupleValue(tuple(self.elements[slice(lower, upper, step)]))
                 )
-            return self.undecided_subscript(
-                index, site, owner="TupleValue.subscript"
-            )
+            return self.undecided_subscript(index, site, owner="TupleValue.subscript")
 
         if type(index) is TermValue and isinstance(index.value, int):
             i = index.value

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py
@@ -37,10 +37,9 @@ class FormalFloorBindingV1:
     coordinate: object | None = field(default=None, compare=False, repr=False)
 
     def __post_init__(self) -> None:
-        if (
-            not isinstance(self.coordinate_cid, str)
-            or not self.coordinate_cid.startswith("blake3-512:")
-        ):
+        if not isinstance(
+            self.coordinate_cid, str
+        ) or not self.coordinate_cid.startswith("blake3-512:"):
             raise FormalFloorBindingGap(
                 "FormalFloorBindingV1.coordinate_cid must be an authenticated "
                 f"blake3-512 CID, got {self.coordinate_cid!r}"
@@ -59,8 +58,7 @@ class FormalFloorBindingV1:
                 type(self.coordinate) is not BindingCoordinateV1
                 or self.coordinate.cid != self.coordinate_cid
                 or cid_of_json(self.coordinate.preimage) != self.coordinate.cid
-                or BindingCoordinateV1.decode(self.coordinate.wire())
-                != self.coordinate
+                or BindingCoordinateV1.decode(self.coordinate.wire()) != self.coordinate
             ):
                 raise FormalFloorBindingGap(
                     "projected formal floor binding has foreign coordinate testimony"
@@ -205,9 +203,7 @@ class AttributeAssignStepV1:
     occurrence: object = field(compare=False, repr=False)
 
     def __post_init__(self) -> None:
-        _require_constructed_term(
-            self.receiver, owner="AttributeAssignStepV1.receiver"
-        )
+        _require_constructed_term(self.receiver, owner="AttributeAssignStepV1.receiver")
         _require_constructed_term(self.value, owner="AttributeAssignStepV1.value")
         try:
             observed_target_cid = self.occurrence.seal().cid
@@ -250,7 +246,9 @@ class AssertStepV1:
                 span.end_col,
             )
         except (AttributeError, TypeError) as exc:
-            raise TypeError("AssertStepV1 requires an authenticated occurrence") from exc
+            raise TypeError(
+                "AssertStepV1 requires an authenticated occurrence"
+            ) from exc
         if observed_coordinate != self.assert_coordinate:
             raise TypeError(
                 "AssertStepV1 assert occurrence does not match its authenticated coordinate"
@@ -701,9 +699,7 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "kind": "assert",
             "assertCid": step.assert_cid,
             "assertCoordinate": step.assert_coordinate.wire(),
-            "test": _generator_value_testimony(
-                step.assert_sugar.test, owner=owner
-            ),
+            "test": _generator_value_testimony(step.assert_sugar.test, owner=owner),
         }
     if isinstance(step, ImportFromStepV1):
         return {
@@ -722,8 +718,7 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             "coordinate": step.coordinate.wire(),
             "guard": _generator_value_testimony(step.guard, owner=owner),
             "bodySteps": [
-                _generator_step_testimony(item, owner=owner)
-                for item in step.body_steps
+                _generator_step_testimony(item, owner=owner) for item in step.body_steps
             ],
         }
     if isinstance(step, FinallyStepV1):
@@ -802,9 +797,7 @@ def _generator_step_testimony(step: object, *, owner: str) -> dict:
             ],
         }
     if isinstance(step, NestedManagerStepV1):
-        nested_cid = getattr(
-            step.nested_protocol, "protocol_construction_cid", None
-        )
+        nested_cid = getattr(step.nested_protocol, "protocol_construction_cid", None)
         return {
             "kind": "nested-manager",
             "fragmentCid": step.fragment_cid,
@@ -940,9 +933,7 @@ class GeneratorConstructionV1:
         projected_floor_bindings = tuple(
             item for item in formal_floor_bindings if item.coordinate is not None
         )
-        projected_cids = tuple(
-            item.coordinate_cid for item in projected_floor_bindings
-        )
+        projected_cids = tuple(item.coordinate_cid for item in projected_floor_bindings)
         if len(projected_cids) != len(set(projected_cids)):
             raise FormalFloorBindingGap(
                 "projected formal floor bindings must not duplicate a coordinate"
@@ -1213,9 +1204,7 @@ class GeneratorConstructionV1:
             if isinstance(outcome, Incomplete):
                 return ExitSet.halted(outcome.effect, state=self)
             if not isinstance(outcome, Complete):
-                return self._gap(
-                    requested, f"assert returned {type(outcome).__name__}"
-                )
+                return self._gap(requested, f"assert returned {type(outcome).__name__}")
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
         if isinstance(step, ImportFromStepV1):
@@ -1233,9 +1222,7 @@ class GeneratorConstructionV1:
 
             outcome = step.import_sugar.desugar(self._guard_evaluation_context())
             if not isinstance(outcome, Complete):
-                return self._gap(
-                    requested, f"import returned {type(outcome).__name__}"
-                )
+                return self._gap(requested, f"import returned {type(outcome).__name__}")
             machine = replace(self, cursor=self.cursor + 1)
             return machine._transition(requested)
         if isinstance(step, WhileStepV1):
@@ -1259,7 +1246,9 @@ class GeneratorConstructionV1:
             outcome = step.raise_sugar.desugar(self._guard_evaluation_context())
             if isinstance(outcome, Incomplete):
                 return ExitSet.halted(outcome.effect, state=self)
-            return self._gap(requested, f"raise did not halt ({type(outcome).__name__})")
+            return self._gap(
+                requested, f"raise did not halt ({type(outcome).__name__})"
+            )
         if isinstance(step, TermStepV1):
             outcome = step.term.desugar(self._guard_evaluation_context())
             from sugar_lift_py_tests.outcome import Complete, Incomplete
@@ -1422,7 +1411,10 @@ class GeneratorConstructionV1:
             step.fragment_cid,
             step.occurrence,
         )
-        machine = replace(self, steps=(*self.steps[: self.cursor], runtime, *self.steps[self.cursor + 1 :]))
+        machine = replace(
+            self,
+            steps=(*self.steps[: self.cursor], runtime, *self.steps[self.cursor + 1 :]),
+        )
         return machine._transition(requested)
 
     def _transition_yield_from(self, step: YieldFromStepV1, requested: str):
@@ -1531,7 +1523,9 @@ class GeneratorConstructionV1:
                 machine = replace(self, cursor=self.cursor + 1)
                 return machine._transition(requested)
             return ExitSet.halted(effect, state=self)
-        if not isinstance(outcome, Complete) or not isinstance(outcome.value, NextResult):
+        if not isinstance(outcome, Complete) or not isinstance(
+            outcome.value, NextResult
+        ):
             return self._gap(requested, f"next_with returned {type(outcome).__name__}")
 
         unpack = PositionalUnpackOperation(
@@ -1543,10 +1537,16 @@ class GeneratorConstructionV1:
         ).submit(outcome.value.value, self._guard_evaluation_context())
         if isinstance(unpack, Incomplete):
             return ExitSet.halted(unpack.effect, state=self)
-        if not isinstance(unpack, Complete) or not isinstance(unpack.value, UnpackMemberRoster):
-            return self._gap(requested, f"target unpack returned {type(unpack).__name__}")
+        if not isinstance(unpack, Complete) or not isinstance(
+            unpack.value, UnpackMemberRoster
+        ):
+            return self._gap(
+                requested, f"target unpack returned {type(unpack).__name__}"
+            )
         bindings = tuple(
-            GeneratorLoopBindingV1(coordinate, member, unpack.value.occurrence, unpack.value.demand_cid)
+            GeneratorLoopBindingV1(
+                coordinate, member, unpack.value.occurrence, unpack.value.demand_cid
+            )
             for coordinate, member in zip(
                 step.target_coordinates, unpack.value.members, strict=True
             )
@@ -1558,7 +1558,9 @@ class GeneratorConstructionV1:
             recurrence,
             *self.steps[self.cursor + 1 :],
         )
-        machine = replace(self, steps=steps, binding_state=(*self.binding_state, *bindings))
+        machine = replace(
+            self, steps=steps, binding_state=(*self.binding_state, *bindings)
+        )
         return machine._transition(requested)
 
     def _transition_nested_manager(self, step: NestedManagerStepV1, requested: str):
@@ -1727,14 +1729,16 @@ class GeneratorConstructionV1:
                 branch_faces = frozenset({then_face, else_face})
                 return ExitSet(
                     tuple(
-                        Completed(
-                            exit_.guard,
-                            exit_.value,
-                            exit_.faces | branch_faces,
-                            exit_.pending_contracts,
+                        (
+                            Completed(
+                                exit_.guard,
+                                exit_.value,
+                                exit_.faces | branch_faces,
+                                exit_.pending_contracts,
+                            )
+                            if isinstance(exit_, Completed)
+                            else exit_
                         )
-                        if isinstance(exit_, Completed)
-                        else exit_
                         for exit_ in factored.exits
                     )
                 )
@@ -1742,9 +1746,7 @@ class GeneratorConstructionV1:
 
         def _project_guard_operand(value):
             projected = self._guard_truth(value)
-            if projected is None or isinstance(
-                projected, GeneratorTransitionGapV1
-            ):
+            if projected is None or isinstance(projected, GeneratorTransitionGapV1):
                 _refuse_transition(projected)
             return projected
 
@@ -1816,9 +1818,7 @@ class GeneratorConstructionV1:
             temporal = base.temporal
 
         for binding in self.formal_floor_bindings:
-            temporal = temporal.bind_value(
-                binding.coordinate_cid, binding.floor_value
-            )
+            temporal = temporal.bind_value(binding.coordinate_cid, binding.floor_value)
         for item in self.binding_state:
             if isinstance(item, GeneratorAssignBindingV1) and item.value is not None:
                 temporal = temporal.bind_value(item.name, item.value)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py
@@ -88,7 +88,6 @@ import ast
 from dataclasses import dataclass
 from pathlib import Path
 
-
 VENDOR_CM_ROOTS: frozenset[str] = frozenset(
     {
         "pytest",
@@ -184,9 +183,7 @@ def exception_type_names(type_node: ast.AST | None) -> frozenset[str]:
 
 
 def is_panic_type_name(name: str) -> bool:
-    return name == "ConstructionPanic" or (
-        name != "<bare>" and name.endswith("Panic")
-    )
+    return name == "ConstructionPanic" or (name != "<bare>" and name.endswith("Panic"))
 
 
 def production_python_scan_roots(repo: Path) -> list[Path]:
@@ -419,13 +416,14 @@ class _Visitor(ast.NodeVisitor):
             return "vendor_cm"
 
         if isinstance(node.left, ast.Name) and node.left.id == "type_name":
-            if any(isinstance(op, (ast.In, ast.NotIn, ast.Eq, ast.NotEq)) for op in node.ops):
+            if any(
+                isinstance(op, (ast.In, ast.NotIn, ast.Eq, ast.NotEq))
+                for op in node.ops
+            ):
                 return "type_name_gate"
 
         attr_names = {
-            operand.attr
-            for operand in operands
-            if isinstance(operand, ast.Attribute)
+            operand.attr for operand in operands if isinstance(operand, ast.Attribute)
         }
         has_str_constant = any(
             isinstance(operand, ast.Constant) and isinstance(operand.value, str)
@@ -467,9 +465,7 @@ class _Visitor(ast.NodeVisitor):
         """
         operands = (node.left, *node.comparators)
         attr_names = {
-            operand.attr
-            for operand in operands
-            if isinstance(operand, ast.Attribute)
+            operand.attr for operand in operands if isinstance(operand, ast.Attribute)
         }
         has_str_constant = any(
             isinstance(operand, ast.Constant) and isinstance(operand.value, str)
@@ -550,9 +546,7 @@ class _Visitor(ast.NodeVisitor):
         return False
 
     def _compare_is_generic_builtin_verdict(self, node: ast.Compare) -> bool:
-        names = {
-            child.id for child in ast.walk(node) if isinstance(child, ast.Name)
-        }
+        names = {child.id for child in ast.walk(node) if isinstance(child, ast.Name)}
         if not (names & _GENERIC_BUILTIN_VERDICT_NAMES):
             return False
         bools = {

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/collect_panic_audit.py
@@ -358,9 +358,7 @@ def _run_subprocess_with_file_watchdog(
                 f"the timeout aborted the remaining unattempted files "
                 f"({population_prose})"
             )
-            combined_stderr = (
-                f"{stderr.rstrip()}\n{timeout_row}\n{population_row}\n"
-            )
+            combined_stderr = f"{stderr.rstrip()}\n{timeout_row}\n{population_row}\n"
             return CommandResult(124, stdout, combined_stderr)
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py
@@ -150,9 +150,7 @@ class InstrumentScanScope:
             "declaredRoots": [str(p) for p in self.declared_roots],
             "selfExclusion": True,
             "authPinExclusion": True,
-            "instrumentSelfPaths": sorted(
-                str(p) for p in self.instrument_self_paths
-            ),
+            "instrumentSelfPaths": sorted(str(p) for p in self.instrument_self_paths),
             "authPinInventoryBasenames": sorted(AUTH_PIN_INVENTORY_BASENAMES),
         }
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/numpy_wall.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/numpy_wall.py
@@ -331,11 +331,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        root = (
-            args.root.resolve()
-            if args.root is not None
-            else resolve_repo_root()
-        )
+        root = args.root.resolve() if args.root is not None else resolve_repo_root()
     except RepoRootUnresolved as error:
         parser.error(str(error))
     output_dir = args.output_dir or (root / ".sugar" / "numpy-wall")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/pandas_wall.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/pandas_wall.py
@@ -550,11 +550,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        root = (
-            args.root.resolve()
-            if args.root is not None
-            else resolve_repo_root()
-        )
+        root = args.root.resolve() if args.root is not None else resolve_repo_root()
     except RepoRootUnresolved as error:
         parser.error(str(error))
     output_dir = args.output_dir or (root / ".sugar" / "pandas-wall")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -449,10 +449,17 @@ def _importorskip_module(value: Node | None, state: "State | None") -> str | Non
     func = value.func
     if func.kind == "Name":
         binding = _unique_import_def_from_state(state, func.id)
-        if binding is not None and binding.target_symbol == "python:pytest.importorskip":
+        if (
+            binding is not None
+            and binding.target_symbol == "python:pytest.importorskip"
+        ):
             return module
         return None
-    if func.kind == "Attribute" and func.attr == "importorskip" and func.value.kind == "Name":
+    if (
+        func.kind == "Attribute"
+        and func.attr == "importorskip"
+        and func.value.kind == "Name"
+    ):
         binding = _unique_import_def_from_state(state, func.value.id)
         if binding is not None and binding.target_symbol == "python:pytest":
             return module
@@ -532,17 +539,13 @@ class _Pass:
             # name_targets (closed-coordinate projection).  Value-use receipts
             # are stricter: unique ImportDef only — shadowing, reassignment,
             # unbound join, and wildcard ambiguity do not authorize a value.
-            name_binding = self._unique_import_def(
-                node.id, state, allow_unbound=True
-            )
+            name_binding = self._unique_import_def(node.id, state, allow_unbound=True)
             if name_binding is not None:
                 span = node.line_col_span()
                 self.name_targets[
                     (span.start_line, span.start_col, span.end_line, span.end_col)
                 ] = name_binding.target_symbol
-            value_binding = self._unique_import_def(
-                node.id, state, allow_unbound=False
-            )
+            value_binding = self._unique_import_def(node.id, state, allow_unbound=False)
             if value_binding is not None:
                 self._enroll_value_use(node, value_binding, ())
             return
@@ -1250,9 +1253,7 @@ def authenticated_import_uses(
     source_cid: str,
     module_identities: dict[str, dict[str, Any]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[tuple[int, int, int, int], str]]:
-    runner = _run_lexical_import_pass(
-        root, path, source, source_cid, module_identities
-    )
+    runner = _run_lexical_import_pass(root, path, source, source_cid, module_identities)
     return runner.rows, runner.outcomes
 
 
@@ -1268,9 +1269,7 @@ def authenticated_import_value_uses(
     Same lexical pass as call uses; separate row surface so Call-target
     receipts stay byte-identical.
     """
-    runner = _run_lexical_import_pass(
-        root, path, source, source_cid, module_identities
-    )
+    runner = _run_lexical_import_pass(root, path, source, source_cid, module_identities)
     return runner.value_rows, runner.value_outcomes
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1974,9 +1974,7 @@ def _roll_call_audit_leaf(
                     "requested": str(
                         getattr(panic, "requested", f"constructed {node.kind}")
                     ),
-                    "fix": str(
-                        getattr(panic, "fix", f"write {node.kind}.sugar")
-                    ),
+                    "fix": str(getattr(panic, "fix", f"write {node.kind}.sugar")),
                     "entrance": "sugar.enumerate:facts:auditFrontier",
                     "observedEventType": (
                         f"{type(panic).__module__}.{type(panic).__qualname__}"
@@ -2283,9 +2281,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 if level == "facts":
                     expected_source_cid = None
                     if isinstance(at, dict):
-                        expected_source_cid = at.get("source_cid") or at.get(
-                            "file_cid"
-                        )
+                        expected_source_cid = at.get("source_cid") or at.get("file_cid")
                     leaf = _roll_call_audit_leaf(
                         full_path,
                         file_rel,
@@ -2405,9 +2401,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                             else None
                         ),
                         distribution=(
-                            str(distribution)
-                            if isinstance(distribution, str)
-                            else None
+                            str(distribution) if isinstance(distribution, str) else None
                         ),
                     )
                     from sugar_lift_py_tests.context_manager_resolution import (
@@ -2708,9 +2702,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # Abstract contracts keyed by authenticated def identity
                 # (source_cid), never by callee spelling. Spelling by_name[t]
                 # reopened first-match after FunctionBindingMiss (#6946 residual).
-                by_source_cid = {
-                    m["source_cid"]: (m, d) for _n, m, d in universes
-                }
+                by_source_cid = {m["source_cid"]: (m, d) for _n, m, d in universes}
                 cued = []
                 cue_gaps: List[Dict[str, Any]] = []
                 seen = set()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/loop_construction.py
@@ -635,9 +635,7 @@ def decode_loop_construction_v1(graph: Any) -> LoopConstructionV1:
         record(operation.raw["binderTransformCid"], "loop-binder-transform")
         record(operation.raw["iteratorTestimonyCid"], "loop-iterator-testimony")
     else:
-        initial_test = record(
-            operation.raw["testTransformCid"], "loop-test-transform"
-        )
+        initial_test = record(operation.raw["testTransformCid"], "loop-test-transform")
         if initial_test.raw["inputStateCid"] != pre_state.state_cid:
             raise LoopWireError("initial test input state mismatch")
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -305,9 +305,7 @@ def _exceptional_exit_effects(outcome: object) -> tuple[object, ...]:
     raise_effect_types = (RaiseEffect, UndeterminedRaiseEffect)
     if isinstance(outcome, Incomplete):
         return (
-            (outcome.effect,)
-            if isinstance(outcome.effect, raise_effect_types)
-            else ()
+            (outcome.effect,) if isinstance(outcome.effect, raise_effect_types) else ()
         )
     if isinstance(outcome, Complete):
         value = outcome.value
@@ -321,8 +319,7 @@ def _exceptional_exit_effects(outcome: object) -> tuple[object, ...]:
         return tuple(
             face.effect
             for face in outcome.exits
-            if isinstance(face, Halted)
-            and isinstance(face.effect, raise_effect_types)
+            if isinstance(face, Halted) and isinstance(face.effect, raise_effect_types)
         )
     return ()
 
@@ -768,7 +765,6 @@ def discover_no_call_body_probes(
     )
 
 
-
 def require_expected_denominators(
     probes: Iterable[BodyProbe],
     *,
@@ -813,9 +809,7 @@ def run_authenticated_attribution(
         payload = pull_shared_demand_table(
             repo_root, Path(scratch) / "python-demand-table.json"
         )
-    disposition = discover_no_call_body_probes(
-        payload, corpus.root, families=families
-    )
+    disposition = discover_no_call_body_probes(payload, corpus.root, families=families)
     probes = require_expected_denominators(
         disposition.probes,
         families=families,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/inplace_binary_operator_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/inplace_binary_operator_operation.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, ClassVar
 
-
 # Surface operator spelling (as ObjectValue / BinaryOperator.symbol) → Floor binary.
 _SURFACE_BINARY: dict[str, Callable] = {
     "+": lambda left, right, site: left.add(right, site),
@@ -121,6 +120,4 @@ def discharge_inplace(left, right, site, *, surface: str):
         ),
         None,
     )
-    return after_inplace_notimplemented(
-        projected, lambda: binary(left, right, site)
-    )
+    return after_inplace_notimplemented(projected, lambda: binary(left, right, site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
@@ -78,7 +78,10 @@ class PositionalUnpackOperation:
 
     def demand_cid(self) -> str:
         """Content address of this unpack demand (site + arity layout)."""
-        from sugar_lift_py_tests.caller_parameter_contract import _cid, source_coordinate
+        from sugar_lift_py_tests.caller_parameter_contract import (
+            _cid,
+            source_coordinate,
+        )
 
         try:
             source_node = source_coordinate(self.blame)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_disposition.py
@@ -264,11 +264,7 @@ def _exit_suppression_contract_verdict(disposition, effect) -> str:
     coordinate = _require_exception_type_coordinate(effect, owner=owner)
     if not disposition.exception_type_coordinates:
         return "restore"
-    return (
-        "suppress"
-        if disposition.suppresses_coordinate(coordinate)
-        else "restore"
-    )
+    return "suppress" if disposition.suppresses_coordinate(coordinate) else "restore"
 
 
 def _suppresses_verdict(disposition, effect) -> str:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py
@@ -116,9 +116,7 @@ class PartitionFace:
     """
 
 
-def partition_family(
-    owner: object, sides: tuple
-) -> tuple[PartitionFace, ...]:
+def partition_family(owner: object, sides: tuple) -> tuple[PartitionFace, ...]:
     """Mint an EXHAUSTIVE family of faces over ONE authenticated origin (#6356).
 
     ``partition`` covers a two-way split. A producer that decides among n
@@ -265,9 +263,7 @@ def _merge_faces(
     left_sides = _sides_by_partition(left)
     right_sides = _sides_by_partition(right)
     shared = left_sides.keys() & right_sides.keys()
-    return frozenset(
-        face for face in (left | right) if face.partition in shared
-    )
+    return frozenset(face for face in (left | right) if face.partition in shared)
 
 
 def _faces_exclusive(
@@ -539,7 +535,9 @@ class ExitSet(Generic[T]):
     def union(self, other: "ExitSet[T]") -> "ExitSet[T]":
         return ExitSet((*self.exits, *other.exits)).normalize()
 
-    def guarded(self, guard: Formula, face: PartitionFace | None = None) -> "ExitSet[T]":
+    def guarded(
+        self, guard: Formula, face: PartitionFace | None = None
+    ) -> "ExitSet[T]":
         """Restrict every exit to one branch of an enclosing partition.
 
         ``face`` is the caller's testimony that ``guard`` is one named side of a
@@ -564,9 +562,7 @@ class ExitSet(Generic[T]):
             if isinstance(exit_, Completed):
                 exits.append(Completed(combined, exit_.value, faces, owed))
             else:
-                exits.append(
-                    Halted(combined, exit_.effect, exit_.state, faces, owed)
-                )
+                exits.append(Halted(combined, exit_.effect, exit_.state, faces, owed))
         return ExitSet(tuple(exits)).normalize()
 
     def with_partition_face(self, partition_id: str, face: int) -> "ExitSet[T]":
@@ -858,9 +854,7 @@ class ExitSet(Generic[T]):
                     exits.append(Completed(guard, following.value, faces, owed))
                 else:
                     exits.append(
-                        Halted(
-                            guard, following.effect, following.state, faces, owed
-                        )
+                        Halted(guard, following.effect, following.state, faces, owed)
                     )
         return ExitSet(tuple(exits)).normalize()
 
@@ -905,18 +899,14 @@ class ExitSet(Generic[T]):
                     incoming.pending_contracts, clean.pending_contracts
                 )
                 if isinstance(clean, Halted):
-                    exits.append(
-                        Halted(guard, clean.effect, clean.state, faces, owed)
-                    )
+                    exits.append(Halted(guard, clean.effect, clean.state, faces, owed))
                     continue
                 if restores(clean.value):
                     if isinstance(incoming, Completed):
                         exits.append(Completed(guard, incoming.value, faces, owed))
                     else:
                         exits.append(
-                            Halted(
-                                guard, incoming.effect, incoming.state, faces, owed
-                            )
+                            Halted(guard, incoming.effect, incoming.state, faces, owed)
                         )
                 else:
                     # Terminal cleanup completion supersedes (return in finally).
@@ -1040,7 +1030,6 @@ class ExitSet(Generic[T]):
                 _place(exits, guard, verdict, carried, faces, owed)
         return ExitSet(tuple(exits)).normalize()
 
-
     def and_exit_truthiness(self, exit_es: "ExitSet[object]", *, site: object):
         """Run a source-constructed ``__exit__`` and retain both truth faces.
 
@@ -1134,9 +1123,7 @@ class ExitSet(Generic[T]):
                 # ExitSet whenever no linear shape denotes it.
                 return normalized
             return Complete(exit_.value)
-        return Incomplete(
-            exit_.effect, pending_contracts=exit_.pending_contracts
-        )
+        return Incomplete(exit_.effect, pending_contracts=exit_.pending_contracts)
 
 
 def sole_completed_outcome(outcome):
@@ -1291,7 +1278,7 @@ def outcome_to_exitset(outcome) -> ExitSet:
         ).normalize()
 
     if isinstance(outcome, NativeOperationExitCarrierV1):
-        
+
         construction_panic_gap(
             owner="outcome_to_exitset",
             blame=outcome.demand.source_node,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/incomplete.py
@@ -83,11 +83,7 @@ class Incomplete:
         # never has to know the set exists.
         return (
             self,
-            *(
-                row
-                for entry in self.pending_contracts
-                for row in entry.contribution()
-            ),
+            *(row for entry in self.pending_contracts for row in entry.contribution()),
         )
 
     def guarded(self, formula):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -27,7 +27,10 @@ from typing import Any, Mapping
 
 from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
-from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1, demand_table_identity
+from sugar_lift_py_tests.demand_table_identity import (
+    DemandTableIdentityV1,
+    demand_table_identity,
+)
 
 SCHEMA = "python-provisional-demand-table/v1"
 
@@ -240,7 +243,9 @@ def load_prebuilt_demand_table(
             f"want={SCHEMA!r}"
         )
     try:
-        semantic_identity = DemandTableIdentityV1.from_mapping(raw.get("semanticIdentity") or {})
+        semantic_identity = DemandTableIdentityV1.from_mapping(
+            raw.get("semanticIdentity") or {}
+        )
     except (TypeError, ValueError) as exc:
         raise DemandTableArtifactRefusal(
             f"prebuilt demand table semantic identity invalid: {exc}"

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -26,17 +26,23 @@ class MutableGlobalBindingV1:
             raise ValueError("mutable global binding occurrence/source CID mismatch")
         if not self.name or self.kind not in {"dict", "list", "set"}:
             raise ValueError("mutable global binding requires a closed mutable kind")
-        object.__setattr__(self, "cid", cid_of_json({
-            "kind": "mutable-global-binding",
-            "schemaVersion": "1",
-            "sourceCid": self.source_cid,
-            "bindingOccurrence": self.binding_occurrence.to_dict(),
-            "name": self.name,
-            "mutableKind": self.kind,
-            "term": self.term,
-            "line": self.line,
-            "col": self.col,
-        }))
+        object.__setattr__(
+            self,
+            "cid",
+            cid_of_json(
+                {
+                    "kind": "mutable-global-binding",
+                    "schemaVersion": "1",
+                    "sourceCid": self.source_cid,
+                    "bindingOccurrence": self.binding_occurrence.to_dict(),
+                    "name": self.name,
+                    "mutableKind": self.kind,
+                    "term": self.term,
+                    "line": self.line,
+                    "col": self.col,
+                }
+            ),
+        )
 
 
 def _reauthenticate_binding_coordinates(coordinates: tuple) -> None:
@@ -185,9 +191,11 @@ class BoundSourceCallActualsV1:
                 and pair.coordinate.projection_path[: len(root.projection_path)]
                 == root.projection_path
             )
-            suffix = pair.coordinate.projection_path[
-                len(matching[0][0].projection_path) :
-            ] if len(matching) == 1 else ()
+            suffix = (
+                pair.coordinate.projection_path[len(matching[0][0].projection_path) :]
+                if len(matching) == 1
+                else ()
+            )
             if (
                 len(matching) != 1
                 or len(suffix) != 2
@@ -258,9 +266,8 @@ class BoundSourceCallActualsV1:
                 continue
             _reauthenticate_native_coordinates((stored_coordinate,))
             ordinal = stored_coordinate.ordinal
-            if (
-                stored_coordinate.coordinate_cid != demanded_cid
-                or ordinal >= len(self.pairs)
+            if stored_coordinate.coordinate_cid != demanded_cid or ordinal >= len(
+                self.pairs
             ):
                 raise SourceCallBindingGap(
                     "native carrier demand is foreign to the retained source frame"
@@ -579,9 +586,7 @@ class SourceVisibleCallFrameV1:
             )
         by_cid = {coordinate.coordinate_cid: coordinate for coordinate in native}
         demanded = pending.demand.operand_coordinate_cids
-        for coordinate_cid, stored in zip(
-            demanded, pending.coordinates, strict=True
-        ):
+        for coordinate_cid, stored in zip(demanded, pending.coordinates, strict=True):
             if coordinate_cid is None:
                 if stored is not None:
                     raise SourceCallBindingGap(
@@ -658,7 +663,9 @@ class SourceVisibleCallFrameV1:
                                 _same_unit_actual_node(
                                     self.owner.unit,
                                     value,
-                                    coordinate.project("variadic-keyword", actual_index),
+                                    coordinate.project(
+                                        "variadic-keyword", actual_index
+                                    ),
                                 ),
                             )
                             for actual_index, (key, value) in enumerate(named.items())
@@ -821,9 +828,7 @@ def _same_unit_actual_node(owner_unit, node, coordinate):
         )
     site_cid = site.get("source_cid") or site.get("sourceCid")
     if site_cid != owner_unit.source_cid:
-        raise SourceCallBindingGap(
-            "formal binding site is not on the frame owner unit"
-        )
+        raise SourceCallBindingGap("formal binding site is not on the frame owner unit")
     span_info = site.get("span")
     if not isinstance(span_info, dict):
         raise SourceCallBindingGap("formal binding site missing sealed span")

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py
@@ -166,11 +166,7 @@ class DynamicUnpackStoreAssignSugar(Sugar):
         return typed_red_effect_witness(
             name="dynamic_unpack_store_star",
             owner_sugar="DynamicUnpackStoreAssignSugar",
-            source=(
-                "def A(o, xs):\n"
-                "    o.x, *rest = xs\n"
-                "    return rest\n"
-            ),
+            source=("def A(o, xs):\n" "    o.x, *rest = xs\n" "    return rest\n"),
             effect_class="SequenceUnpackRuntimeEffect",
             reason_needle="sequence unpack",
             blame_needle="at least 1 members",
@@ -214,9 +210,7 @@ class DynamicUnpackStoreAssignSugar(Sugar):
             )
         )
 
-    def _apply_authenticated_roster(
-        self, roster, *, expected_demand_cid: str, ctx
-    ):
+    def _apply_authenticated_roster(self, roster, *, expected_demand_cid: str, ctx):
         """Zip targets only after the roster testifies this unpack occurrence."""
         from sugar_lift_py_tests.gap.panic import construction_panic_gap
         from sugar_lift_py_tests.operations.positional_unpack_operation import (
@@ -263,9 +257,7 @@ class DynamicUnpackStoreAssignSugar(Sugar):
         return reduce_block_to_exitset(
             tuple(
                 ApplyUnpackMemberSugar(target, member, self.site)
-                for target, member in zip(
-                    self.targets, roster.members, strict=True
-                )
+                for target, member in zip(self.targets, roster.members, strict=True)
             ),
             ctx,
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/attribute_sugar.py
@@ -167,7 +167,5 @@ class AttributeSugar(ConstructedTermSugar):
 
     def desugar(self, ctx: object = None) -> Outcome:
         return self.receiver.desugar(ctx).and_then(
-            lambda receiver: self.project_attribute(
-                receiver, self.name, self.site, ctx
-            )
+            lambda receiver: self.project_attribute(receiver, self.name, self.site, ctx)
         )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/augassign_sugar.py
@@ -60,9 +60,7 @@ class AugAssignSugar(Sugar):
                     operator=self.operator,
                     projector=self.operation,
                     site=self.op_site,
-                ).and_then(
-                    lambda result: Complete(ScopeRebind(self.name, result))
-                )
+                ).and_then(lambda result: Complete(ScopeRebind(self.name, result)))
             )
         )
 
@@ -149,9 +147,7 @@ class SubscriptAugAssignSugar(Sugar):
                             operator=self.operator,
                             projector=self.operation,
                             site=self.op_site,
-                        ).and_then(
-                            lambda result: self._store(receiver, index, result)
-                        )
+                        ).and_then(lambda result: self._store(receiver, index, result))
                     )
                 )
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py
@@ -120,9 +120,7 @@ def select_boolop_operand(
             return on_continue()
 
         rhs_guard = formula if op_kind == "And" else complement_guard(formula)
-        rhs_face, stop_face = partition(
-            ("BoolOpSugar", str(site), index, op_kind)
-        )
+        rhs_face, stop_face = partition(("BoolOpSugar", str(site), index, op_kind))
         rhs = outcome_to_exitset(on_continue()).guarded(rhs_guard, rhs_face)
         stopped = ExitSet.completed(
             selected_operand, complement_guard(rhs_guard)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -220,8 +220,8 @@ class CallSiteSugar(ConstructedTermSugar):
                 owner := self.source_call_frame.owner, (FunctionDef, AsyncFunctionDef)
             ):
                 table = owner.unit.function_symtable(
-                owner.name, owner.line_col_span().start_line
-            )
+                    owner.name, owner.line_col_span().start_line
+                )
             free_names = tuple(
                 symbol.get_name()
                 for symbol in table.get_symbols()
@@ -233,14 +233,11 @@ class CallSiteSugar(ConstructedTermSugar):
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
                     blame=self.site,
-                        observed=(
-                            "closure bindings lack producer coordinates: "
-                            f"{free_names!r}"
-                        ),
+                    observed=(
+                        "closure bindings lack producer coordinates: " f"{free_names!r}"
+                    ),
                     requested="captured binding coordinate testimony",
-                        fix=(
-                            "enroll producer-owned closure actuals before body reduction"
-                        ),
+                    fix=("enroll producer-owned closure actuals before body reduction"),
                 )
         if self.contract_resolution_gap is not None:
             from sugar_source_tree.panic import OpaqueSourceCallResolutionGap

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py
@@ -133,9 +133,7 @@ def publish_undecided_ordering_edges(left, right, site, op_kind: str, outcome):
     construction_panic_gap(
         owner="publish_undecided_ordering_edges",
         blame=site,
-        observed=(
-            f"residual Complete(PredicateValue) on ordering desugar ({op_kind})"
-        ),
+        observed=(f"residual Complete(PredicateValue) on ordering desugar ({op_kind})"),
         requested=(
             "named SugarNotWritten for undecided operands, or Sugar-owned "
             "TrueBool/FalseBool/RaiseValue for decided ground"
@@ -381,13 +379,9 @@ class ComparisonOpSugar(ConstructedTermSugar):
                 left.equals(right, self.site),
             ).and_then(lambda predicate: predicate.negate())
         if self.op_kind == "Is":
-            return construct_identity_comparison(
-                left, right, self.site, negated=False
-            )
+            return construct_identity_comparison(left, right, self.site, negated=False)
         if self.op_kind == "IsNot":
-            return construct_identity_comparison(
-                left, right, self.site, negated=True
-            )
+            return construct_identity_comparison(left, right, self.site, negated=True)
         if self.op_kind == "In":
             # a in b: the CONTAINER (right) owns membership -- b.contains(a).
             return self._membership(right, left)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -38,7 +38,9 @@ class ComprehensionTargetSugar:
         from sugar_lift_py_tests.ir import ctor, str_const
 
         if self.source_name is not None:
-            return ctor("python:comprehension-name-target", (str_const(self.source_name),))
+            return ctor(
+                "python:comprehension-name-target", (str_const(self.source_name),)
+            )
         assert self.coordinates is not None
         return ctor(
             "python:comprehension-destructure-target",
@@ -108,9 +110,7 @@ class ComprehensionSugar(ConstructedTermSugar):
             "py.generatorexp",
         }:
             raise ValueError(f"unknown comprehension kind {self.kind!r}")
-        require_constructed_term_sugar(
-            self.element, owner="ComprehensionSugar.element"
-        )
+        require_constructed_term_sugar(self.element, owner="ComprehensionSugar.element")
         if self.key is not None:
             require_constructed_term_sugar(self.key, owner="ComprehensionSugar.key")
 
@@ -139,7 +139,9 @@ class ComprehensionSugar(ConstructedTermSugar):
                 str_const(self.kind),
                 ctor(
                     "python:comprehension-generators",
-                    tuple(generator.to_term(owner=owner) for generator in self.generators),
+                    tuple(
+                        generator.to_term(owner=owner) for generator in self.generators
+                    ),
                 ),
                 self.element.to_term(owner=owner),
                 key,
@@ -180,17 +182,11 @@ class ComprehensionSugar(ConstructedTermSugar):
         it the generator stays an opaque coordinate and ``not expected_exceptions``
         refuses at the UnaryOp producer.
         """
-        if (
-            index == 0
-            and len(self.generators) == 1
-            and not generator.filters
-        ):
+        if index == 0 and len(self.generators) == 1 and not generator.filters:
             finite = self._finite_map(generator, iterable, ctx)
             if finite is not None:
                 return finite
-        return self._desugar_filters(
-            generator, 0, (), iterable, index, resolved, ctx
-        )
+        return self._desugar_filters(generator, 0, (), iterable, index, resolved, ctx)
 
     def _finite_map(self, generator, iterable, ctx):
         from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
@@ -214,7 +210,10 @@ class ComprehensionSugar(ConstructedTermSugar):
             members = iterable.elements
         elif isinstance(iterable, (ListIteratorValue, TupleIteratorValue)):
             members = iterable.elements[iterable.index :]
-        elif isinstance(iterable, ComprehensionValue) and iterable.finite_elements is not None:
+        elif (
+            isinstance(iterable, ComprehensionValue)
+            and iterable.finite_elements is not None
+        ):
             members = iterable.finite_elements
         if members is None:
             return None
@@ -248,9 +247,7 @@ class ComprehensionSugar(ConstructedTermSugar):
                                 element_term,
                             )
                         ),
-                        ctor(
-                            "python:loop.exhaustion", [], symbol_kind="coordinate"
-                        ),
+                        ctor("python:loop.exhaustion", [], symbol_kind="coordinate"),
                     ],
                     symbol_kind="coordinate",
                 )
@@ -440,7 +437,9 @@ def _projection(element, index: int, arity: int):
     )
 
 
-def _target_leaves(target: ComprehensionTargetSugar) -> tuple[ComprehensionTargetSugar, ...]:
+def _target_leaves(
+    target: ComprehensionTargetSugar,
+) -> tuple[ComprehensionTargetSugar, ...]:
     if target.source_name is not None:
         return (target,)
     assert target.coordinates is not None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py
@@ -146,8 +146,7 @@ class SubscriptDeleteEffectSugar(Sugar):
 
     def _delete(self, receiver, index) -> Outcome:
         coordinates = tuple(
-            getattr(operand, "formal_coordinate", None)
-            for operand in (receiver, index)
+            getattr(operand, "formal_coordinate", None) for operand in (receiver, index)
         )
         if any(coordinate is not None for coordinate in coordinates):
             # Undischarged demand awaiting caller actuals — not a refusal.
@@ -194,8 +193,7 @@ class SubscriptDeleteEffectSugar(Sugar):
         )
 
         coordinates = tuple(
-            getattr(operand, "formal_coordinate", None)
-            for operand in (receiver, index)
+            getattr(operand, "formal_coordinate", None) for operand in (receiver, index)
         )
         if not any(coordinate is not None for coordinate in coordinates):
             raise ValueError(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -78,9 +78,7 @@ class EqualityOpSugar(ConstructedTermSugar):
 
     def apply_reduced(self, left, right, ctx: object = None) -> Outcome:
         """Apply equality/refinement to operands already evaluated once."""
-        return _equals_and_refine(
-            left, right, self.site, ctx, self.left_coordinate
-        )
+        return _equals_and_refine(left, right, self.site, ctx, self.left_coordinate)
 
 
 def _finite_equality_face(value, peer, *, matches: bool):
@@ -161,8 +159,7 @@ def _equals_with_derived_residue(left, right, site, ctx):
     if isinstance(left, CallSiteValue):
         residue = left.derived_equality_residue(ctx)
         if residue is not None and (
-            isinstance(outcome, Complete)
-            and isinstance(outcome.value, PredicateValue)
+            isinstance(outcome, Complete) and isinstance(outcome.value, PredicateValue)
         ):
             outcome = Complete(
                 replace(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/guarded_binding_read_sugar.py
@@ -147,9 +147,8 @@ def _projection_term(state, *, owner: str):
             symbol_kind="coordinate",
         )
     if isinstance(state, LoopGuardedProjection):
-        if (
-            not isinstance(state.target_cid, str)
-            or not state.target_cid.startswith("blake3-512:")
+        if not isinstance(state.target_cid, str) or not state.target_cid.startswith(
+            "blake3-512:"
         ):
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py
@@ -238,7 +238,9 @@ class IfExpSugar(ConstructedTermSugar):
         # that is first-match-wins carries them exactly. Nothing is capped,
         # nothing is pruned, no arm is dropped, and no halted arm is touched --
         # the halted face already grows linearly at the exit level.
-        exits = exits.factor_completed()  # `factored_operand`'s half that stays an ExitSet
+        exits = (
+            exits.factor_completed()
+        )  # `factored_operand`'s half that stays an ExitSet
 
         # A partition with a single completed face and no halt is a plain value
         # again (normalize may have merged the faces): collapse rather than hand

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_sugar.py
@@ -46,7 +46,11 @@ def _ground_atomic_truth(formula):
         _ConstStr,
     )
 
-    if not isinstance(formula, _Atomic) or formula.name != "=" or len(formula.args) != 2:
+    if (
+        not isinstance(formula, _Atomic)
+        or formula.name != "="
+        or len(formula.args) != 2
+    ):
         return None
     left, right = formula.args
     const_types = (_ConstInt, _ConstReal, _ConstBool, _ConstStr)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py
@@ -168,11 +168,13 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
                     owner="LoopRecurrenceSugar",
                     blame=str(self.site),
                 )
-            return IteratorOperation(
-                owner="LoopRecurrenceSugar", blame=self.site
-            ).submit(iterable, runtime_ctx).and_then(
-                lambda iterator: self._advance_iterator(
-                    iterator, runtime, runtime_ctx, entries=()
+            return (
+                IteratorOperation(owner="LoopRecurrenceSugar", blame=self.site)
+                .submit(iterable, runtime_ctx)
+                .and_then(
+                    lambda iterator: self._advance_iterator(
+                        iterator, runtime, runtime_ctx, entries=()
+                    )
                 )
             )
 
@@ -243,9 +245,13 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
                     if isinstance(exit_, Halted):
                         exits.append(Halted(exit_.guard, exit_.effect, face.state))
                     else:
-                        entries = (exit_.value,) if pending is None else (
-                            pending,
-                            exit_.value,
+                        entries = (
+                            (exit_.value,)
+                            if pending is None
+                            else (
+                                pending,
+                                exit_.value,
+                            )
                         )
                         exits.append(
                             Completed(
@@ -261,7 +267,13 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
         from sugar_lift_py_tests.floor.block_value import BlockValue
         from sugar_lift_py_tests.floor.iterator_value import NextResult
         from sugar_lift_py_tests.operations.next_operation import NextOperation
-        from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted, Incomplete
+        from sugar_lift_py_tests.outcome import (
+            Complete,
+            Completed,
+            ExitSet,
+            Halted,
+            Incomplete,
+        )
         from sugar_lift_py_tests.sugar.function_universe_sugar import (
             reduce_block_to_exitset,
         )
@@ -277,8 +289,12 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             ):
                 return self._finish_iterator(runtime, ctx, entries=entries)
             return outcome
-        if not isinstance(outcome, Complete) or not isinstance(outcome.value, NextResult):
-            raise TypeError("NextOperation must produce NextResult or a named exception")
+        if not isinstance(outcome, Complete) or not isinstance(
+            outcome.value, NextResult
+        ):
+            raise TypeError(
+                "NextOperation must produce NextResult or a named exception"
+            )
 
         next_result = outcome.value
         projected = self._project_iteration_target(
@@ -384,13 +400,17 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
             if not isinstance(unpacked, Complete) or not isinstance(
                 unpacked.value, UnpackMemberRoster
             ):
-                raise TypeError("positional target unpack omitted its authenticated roster")
+                raise TypeError(
+                    "positional target unpack omitted its authenticated roster"
+                )
             if (
                 unpacked.value.occurrence is not target.fragment
                 or unpacked.value.demand_cid != operation.demand_cid()
                 or len(unpacked.value.members) != len(target.elts)
             ):
-                raise TypeError("positional target unpack returned cross-wired testimony")
+                raise TypeError(
+                    "positional target unpack returned cross-wired testimony"
+                )
             bindings = []
             for index, (child, member) in enumerate(
                 zip(target.elts, unpacked.value.members, strict=True)
@@ -421,7 +441,9 @@ class LoopRecurrenceSugar(ConstructedTermSugar):
                 state.temporal.value_if_bound(target_name) is not target_value
                 or state.temporal.value_if_bound(coordinate_cid) is not target_value
             ):
-                raise TypeError("loop control state lacks exact iteration target identity")
+                raise TypeError(
+                    "loop control state lacks exact iteration target identity"
+                )
         return state
 
     def _finish_iterator(self, runtime, ctx, *, entries):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_result_sugar.py
@@ -66,9 +66,11 @@ class MappingPopResultSugar(ConstructedTermSugar):
                 fix="retain pop as typed loud until its receiver floors",
             )
         entries = receiver.mapping_entries()
-        decisions = tuple(_closed_member_equal(key, candidate) for candidate, _ in entries)
+        decisions = tuple(
+            _closed_member_equal(key, candidate) for candidate, _ in entries
+        )
         if any(decision is None for decision in decisions):
-            
+
             construction_panic_gap(
                 owner="MappingPopResultSugar",
                 blame=self.site,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_state_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/mapping_pop_state_sugar.py
@@ -67,9 +67,11 @@ class MappingPopStateSugar(ConstructedTermSugar):
             )
 
         entries = receiver.mapping_entries()
-        decisions = tuple(_closed_member_equal(key, candidate) for candidate, _ in entries)
+        decisions = tuple(
+            _closed_member_equal(key, candidate) for candidate, _ in entries
+        )
         if any(decision is None for decision in decisions):
-            
+
             construction_panic_gap(
                 owner="MappingPopStateSugar",
                 blame=self.site,
@@ -92,4 +94,6 @@ class MappingPopStateSugar(ConstructedTermSugar):
         if not matching:
             return Complete(receiver)
         index = matching[0]
-        return Complete(receiver.mapping_with_entries(entries[:index] + entries[index + 1 :]))
+        return Complete(
+            receiver.mapping_with_entries(entries[:index] + entries[index + 1 :])
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/match_sugar.py
@@ -355,10 +355,14 @@ class MatchSugar(Sugar):
                     nested = MatchSugar(sub, self.cases, self.site).desugar(ctx)
                     nested_es = _outcome_as_exitset(nested)
                     parts = parts.union(_restrict(nested_es, face.guard))
-            return parts.normalize() if parts.exits else Complete(
-                __import__(
-                    "sugar_lift_py_tests.floor.block_value", fromlist=["BlockValue"]
-                ).BlockValue((), can_fall_through=True)
+            return (
+                parts.normalize()
+                if parts.exits
+                else Complete(
+                    __import__(
+                        "sugar_lift_py_tests.floor.block_value", fromlist=["BlockValue"]
+                    ).BlockValue((), can_fall_through=True)
+                )
             )
 
         if not isinstance(subject_out, Complete):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/slice_sugar.py
@@ -109,17 +109,11 @@ class SliceSugar(ConstructedTermSugar):
                         )
                     )
                 factored = factored_operand(plain)
-                return factored.and_then(
-                    lambda value: Complete((*collected, value))
-                )
+                return factored.and_then(lambda value: Complete((*collected, value)))
 
             outcome = outcome.and_then(_step)
 
         built = outcome.and_then(
-            lambda values: Complete(
-                SliceValue(values[0], values[1], values[2])
-            )
+            lambda values: Complete(SliceValue(values[0], values[1], values[2]))
         )
-        return rewrap_pending(
-            pending, built, owner="SliceSugar", blame=str(self.site)
-        )
+        return rewrap_pending(pending, built, owner="SliceSugar", blame=str(self.site))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/spread_sugar.py
@@ -116,9 +116,7 @@ def _collect(sugars: tuple, ctx, done: tuple, finish):
     # a spread with no guarded operand desugars to exactly what it did before.
     built = ExitSet((*halted, *tail.exits)).normalize().collapse()
     # Re-attach every hoisted obligation to the finished display, or be loud.
-    return rewrap_pending(
-        pending, built, owner="spread display", blame=str(finish)
-    )
+    return rewrap_pending(pending, built, owner="spread display", blame=str(finish))
 
 
 @dataclass(frozen=True)
@@ -206,9 +204,7 @@ class SpreadDictSugar(ConstructedTermSugar):
         for key, value in self.entries:
             if key is not None:
                 require_constructed_term_sugar(key, owner="SpreadDictSugar.entries.key")
-            require_constructed_term_sugar(
-                value, owner="SpreadDictSugar.entries.value"
-            )
+            require_constructed_term_sugar(value, owner="SpreadDictSugar.entries.value")
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py
@@ -61,9 +61,7 @@ class AttributeStoreEffectSugar(Sugar):
     def desugar_store(self, ctx: object, value) -> Outcome:
         """Store an RHS already reduced once by a chained assignment."""
         return self.receiver.desugar(ctx).and_then(
-            lambda receiver: self.project_setattr(
-                receiver, self.attr, value, self.site
-            )
+            lambda receiver: self.project_setattr(receiver, self.attr, value, self.site)
         )
 
     def _store(self, receiver, value) -> Outcome:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py
@@ -37,9 +37,10 @@ class SubscriptSugar(ConstructedTermSugar):
     def __post_init__(self) -> None:
         require_constructed_term_sugar(self.receiver, owner="SubscriptSugar.receiver")
         require_constructed_term_sugar(self.index, owner="SubscriptSugar.index")
-        if self.use_occurrence is not None and type(
-            self.use_occurrence
-        ) is not SourceFragmentCoordinateV1:
+        if (
+            self.use_occurrence is not None
+            and type(self.use_occurrence) is not SourceFragmentCoordinateV1
+        ):
             raise TypeError(
                 "SubscriptSugar.use_occurrence must be SourceFragmentCoordinateV1"
             )
@@ -170,6 +171,4 @@ class SubscriptSugar(ConstructedTermSugar):
             and type(receiver).subscript_with is not FloorValue.subscript_with
         ):
             return receiver.subscript_with(operation, ctx)
-        return receiver.subscript_with_occurrence(
-            index, self.site, self.use_occurrence
-        )
+        return receiver.subscript_with_occurrence(index, self.site, self.use_occurrence)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_star_sugar.py
@@ -141,18 +141,14 @@ class TryStarSugar(Sugar):
                         continue
                     matched = regroup_except_star(face.residual, matched_parts)
                     base_ctx = (
-                        face.state.context
-                        if face.state.context is not None
-                        else ctx
+                        face.state.context if face.state.context is not None else ctx
                     )
                     handler_ctx = bind_in_flight_effect(
                         base_ctx, slot_id, matched, blame=self.site
                     )
                     if slot_id is not None:
                         # Shared typed ReduceContext surface.
-                        handler_ctx = handler_ctx.with_observed_effect(
-                            slot_id, matched
-                        )
+                        handler_ctx = handler_ctx.with_observed_effect(slot_id, matched)
                     seed = replace(face.state, context=handler_ctx)
                     handler_exits = promote_raise_halts(
                         _reduce_block_from_state(handler_body, seed)
@@ -359,9 +355,7 @@ def _reduce_block_from_state(statements, state):
 
     exits = ExitSet.completed(state)
     for statement in statements:
-        exits = exits.sequence(
-            lambda s, stmt=statement: _reduce_one_from(s, stmt)
-        )
+        exits = exits.sequence(lambda s, stmt=statement: _reduce_one_from(s, stmt))
     return exits
 
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py
@@ -141,10 +141,7 @@ def _and_finally_with_raise_context(pre_finally, finalbody, *, ctx, site):
 
     exits: list = []
     for incoming in pre_finally.exits:
-        if (
-            isinstance(incoming, Halted)
-            and isinstance(incoming.effect, RaiseEffect)
-        ):
+        if isinstance(incoming, Halted) and isinstance(incoming.effect, RaiseEffect):
             finally_ctx = bind_in_flight_effect(
                 ctx, finally_slot, incoming.effect, blame=site
             )
@@ -155,9 +152,7 @@ def _and_finally_with_raise_context(pre_finally, finalbody, *, ctx, site):
         for clean in cleanup_es.exits:
             guard = _and_guards(incoming.guard, clean.guard)
             faces = incoming.faces | clean.faces
-            owed = merge_pending(
-                incoming.pending_contracts, clean.pending_contracts
-            )
+            owed = merge_pending(incoming.pending_contracts, clean.pending_contracts)
             if isinstance(clean, Halted):
                 effect = clean.effect
                 # Supersede: cleanup halt wins; retain body raise as context.
@@ -169,15 +164,11 @@ def _and_finally_with_raise_context(pre_finally, finalbody, *, ctx, site):
                     and effect is not incoming.effect
                 ):
                     effect = replace(effect, context_effect=incoming.effect)
-                exits.append(
-                    Halted(guard, effect, clean.state, faces, owed)
-                )
+                exits.append(Halted(guard, effect, clean.state, faces, owed))
                 continue
             if _finally_restores(clean.value):
                 if isinstance(incoming, Completed):
-                    exits.append(
-                        Completed(guard, incoming.value, faces, owed)
-                    )
+                    exits.append(Completed(guard, incoming.value, faces, owed))
                 else:
                     exits.append(
                         Halted(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py
@@ -94,9 +94,7 @@ class WithEffectBoundarySugar(Sugar):
             # faces are alternative guards over the same body occurrence —
             # re-reducing would re-enter nested resources and invent a second
             # evaluation of the same source suite under each message face.
-            body_es_once = promote_raise_halts(
-                reduce_block_to_exitset(self.body, ctx)
-            )
+            body_es_once = promote_raise_halts(reduce_block_to_exitset(self.body, ctx))
             for face_guard, semantics in self._guarded_semantics():
                 expected = project_formal_selector_v1(
                     semantics.expected_type_operand,
@@ -457,9 +455,7 @@ def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode,
             raise SugarNotWritten(
                 blame=site,
                 owner="WithEffectBoundarySugar.warning_observation",
-                observed=(
-                    f"{len(observations)} authenticated warning observations"
-                ),
+                observed=(f"{len(observations)} authenticated warning observations"),
                 requested=(
                     "exactly one source-authenticated WarningObservationValue "
                     "on the completed face"
@@ -471,9 +467,7 @@ def _route_warning_boundary(*, body, ctx, manager_exit, expected, pattern, mode,
             )
         index, observation = observations[0]
         # ONE matcher: identity + optional message. No local MatchDecided mint.
-        verdict = warning_effect_message_verdict(
-            observation.effect, expected, pattern
-        )
+        verdict = warning_effect_message_verdict(observation.effect, expected, pattern)
 
         def successful(guard, faces):
             assert index is not None

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -77,9 +77,7 @@ def find_function_by_name(sf: SourceFile, name: str):
     if len(functions) == 1:
         return functions[0]
     if not functions:
-        raise FunctionBindingMiss(
-            name=name, reason="no module-direct function binding"
-        )
+        raise FunctionBindingMiss(name=name, reason="no module-direct function binding")
     raise FunctionBindingMiss(
         name=name,
         reason=f"{len(functions)} competing module-direct function bindings",
@@ -546,9 +544,7 @@ def source_audit_from_roll_call(full_path: Path, file_rel: str) -> dict:
     return source_audit_from_report(report, file_rel)
 
 
-def source_audit_membership_from_registration(
-    full_path: Path, file_rel: str
-) -> dict:
+def source_audit_membership_from_registration(full_path: Path, file_rel: str) -> dict:
     """Roll-call **membership** only: materialize + register, no sugar discharge.
 
     Used by R_silent, which keys on whether a disk locus is in

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/witness_harness.py
@@ -38,6 +38,8 @@ def _py_source() -> Path:
 
 def _py_pytest_witness() -> Path:
     return _root() / "implementations" / "python" / "sugar-lift-py-pytest-witness"
+
+
 _SUGAR_BUILD_LOCK = Lock()
 _RESOLVED_SUGAR_BIN: Path | None = None
 
@@ -87,8 +89,7 @@ class WitnessPipelineResult:
 
 def _pythonpath() -> str:
     return os.pathsep.join(
-        str(path / "src")
-        for path in (_py_pytest_witness(), _py_tests(), _py_source())
+        str(path / "src") for path in (_py_pytest_witness(), _py_tests(), _py_source())
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_assertion_boundary_exitset_consumer.py
@@ -62,7 +62,14 @@ def _raise(name: str, marker: str, *, message: object | None = None):
         )
     return Halted(
         true_guard(),
-        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(f'producer.py:1:{marker}'), exception_name=name, blame=f'producer.py:1:{marker}', exception_type_mro=(_identity(name),), raised_value=raised_value),
+        RaiseEffect(
+            exception_type_coordinate=_identity(name),
+            occurrence=AuthenticatedRaiseLocus.of(f"producer.py:1:{marker}"),
+            exception_name=name,
+            blame=f"producer.py:1:{marker}",
+            exception_type_mro=(_identity(name),),
+            raised_value=raised_value,
+        ),
         _state(marker),
     )
 
@@ -254,8 +261,8 @@ def test_pandas_common_143_composes_compare_exit_with_assertion_contract():
     producer_coordinate = _identity("TypeError")
     assert producer_coordinate == expected.identity
 
-    producer_effect = RaiseEffect.for_builtin("TypeError",
-        
+    producer_effect = RaiseEffect.for_builtin(
+        "TypeError",
         blame="pandas/tests/arithmetic/common.py:144:8",
         occurrence="pandas/tests/arithmetic/common.py:144:8",
         exception_type_mro=(producer_coordinate,),
@@ -627,8 +634,8 @@ def test_factored_none_face_consumes_matching_raise_and_binds_exact_occurrence()
     from sugar_lift_py_tests.floor import StringValue
 
     occurrence = "producer.py:4:8:factored-none"
-    producer = RaiseEffect.for_builtin("ValueError",
-        
+    producer = RaiseEffect.for_builtin(
+        "ValueError",
         blame=occurrence,
         occurrence=occurrence,
         exception_type_mro=(_identity("ValueError"),),
@@ -667,8 +674,8 @@ def test_factored_pattern_face_binds_only_on_held_arm_not_complement():
     from sugar_lift_py_tests.floor import StringValue
 
     occurrence = "producer.py:8:4:factored-pattern"
-    producer = RaiseEffect.for_builtin("ValueError",
-        
+    producer = RaiseEffect.for_builtin(
+        "ValueError",
         blame=occurrence,
         occurrence=occurrence,
         exception_type_mro=(_identity("ValueError"),),
@@ -718,8 +725,8 @@ def test_factored_as_binding_faces_keep_distinct_guards_and_identities():
     )
     from sugar_lift_py_tests.floor import StringValue
 
-    producer = RaiseEffect.for_builtin("ValueError",
-        
+    producer = RaiseEffect.for_builtin(
+        "ValueError",
         blame="producer.py:1:0",
         occurrence="producer.py:1:0",
         exception_type_mro=(_identity("ValueError"),),
@@ -762,8 +769,8 @@ def test_factored_none_face_without_as_slot_consumes_without_binding():
     """Discrimination twin: no observation slot means no binding testimony."""
     from sugar_lift_py_tests.floor import StringValue
 
-    producer = RaiseEffect.for_builtin("ValueError",
-        
+    producer = RaiseEffect.for_builtin(
+        "ValueError",
         blame="producer.py:2:0",
         occurrence="producer.py:2:0",
         exception_type_mro=(_identity("ValueError"),),

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_native_operation_demand.py
@@ -108,7 +108,10 @@ def test_formal_attribute_completes_or_halts_from_authenticated_actual() -> None
         [str_const("builtins"), str_const("AttributeError")],
     )
     assert halted.exits[0].effect.exception_type_coordinate == attribute_error
-    assert isinstance(halted.exits[0].effect.occurrence_id, str) and ":" in halted.exits[0].effect.occurrence_id, (
+    assert (
+        isinstance(halted.exits[0].effect.occurrence_id, str)
+        and ":" in halted.exits[0].effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.exits[0].effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_attribute_store_desugar.py
@@ -221,7 +221,10 @@ def test_readable_immutable_receiver_raises_on_store(tmp_path):
 
 @pytest.mark.parametrize(
     ("receiver", "owner"),
-    ((StringValue("abc"), "StringValue.setattr"), (BytesValue(b"abc"), "BytesValue.setattr")),
+    (
+        (StringValue("abc"), "StringValue.setattr"),
+        (BytesValue(b"abc"), "BytesValue.setattr"),
+    ),
 )
 def test_immutable_scalar_attribute_store_has_exact_owner_occurrence(
     tmp_path, receiver, owner
@@ -518,7 +521,10 @@ def test_real_pandas_name_store_caller_faces_and_discrimination() -> None:
     ):
         assert isinstance(halt, Halted)
         assert "AttributeError" in repr(halt.effect.exception_type_coordinate)
-        assert isinstance(halt.effect.occurrence_id, str) and ":" in halt.effect.occurrence_id, (
+        assert (
+            isinstance(halt.effect.occurrence_id, str)
+            and ":" in halt.effect.occurrence_id
+        ), (
             "authenticated raise locus must be a file:line:col occurrence id, "
             f"not presence-only; got {halt.effect.occurrence_id!r}"
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_attribute_mutation.py
@@ -1,7 +1,9 @@
 import pytest
 
 from sugar_lift_py_tests.floor import BlockValue, BuiltinExceptionClassValue, TermValue
-from sugar_lift_py_tests.floor.authenticated_exception_type_value import AuthenticatedExceptionTypeValue
+from sugar_lift_py_tests.floor.authenticated_exception_type_value import (
+    AuthenticatedExceptionTypeValue,
+)
 from sugar_lift_py_tests.ir import str_const
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.tree import SourceFile
@@ -9,8 +11,12 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "authenticated_exception_type_attribute_mutation.py"
-    path.write_text("def mutate_exception_type(exc_type):\n    exc_type.attr = 7\n    del exc_type.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def mutate_exception_type(exc_type):\n    exc_type.attr = 7\n    del exc_type.attr\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -19,17 +25,33 @@ def _value():
     return AuthenticatedExceptionTypeValue(carried, str_const("exception-type"))
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "BuiltinExceptionClassValue.setattr", 0), ("delattr", "BuiltinExceptionClassValue.delattr", 1)))
-def test_authenticated_exception_type_attribute_mutations_dispatch_to_exact_carried_owner(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = _value()
-    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "BuiltinExceptionClassValue.setattr", 0),
+        ("delattr", "BuiltinExceptionClassValue.delattr", 1),
+    ),
+)
+def test_authenticated_exception_type_attribute_mutations_dispatch_to_exact_carried_owner(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = _value()
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_authenticated_exception_type_attribute_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = _value()
-    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = _value()
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_authenticated_exception_type_subscript_mutation.py
@@ -16,7 +16,9 @@ def _sites(tmp_path):
         "    exc_type[0] = 7\n"
         "    del exc_type[0]\n"
     )
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -25,17 +27,33 @@ def _value():
     return AuthenticatedExceptionTypeValue(carried, str_const("exception-type"))
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "ExceptionClassValue.setitem", 0), ("delitem", "ExceptionClassValue.delitem", 1)))
-def test_authenticated_exception_type_subscript_mutations_dispatch_to_exact_carried_owner(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = _value()
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "ExceptionClassValue.setitem", 0),
+        ("delitem", "ExceptionClassValue.delitem", 1),
+    ),
+)
+def test_authenticated_exception_type_subscript_mutations_dispatch_to_exact_carried_owner(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = _value()
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_authenticated_exception_type_subscript_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = _value()
-    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = _value()
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_bare_error_named_panics.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bare_error_named_panics.py
@@ -45,7 +45,9 @@ def test_ordered_binding_keys_non_str_panics() -> None:
         _ordered_binding_keys(["ok", 12])  # type: ignore[list-item]
         raise AssertionError("expected SugarNotWritten")
     except SugarNotWritten as gap:
-        assert "int" in gap.observed or "12" in gap.observed or "not a str" in gap.observed
+        assert (
+            "int" in gap.observed or "12" in gap.observed or "not a str" in gap.observed
+        )
         assert gap.fix
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_binop_method_caller.py
@@ -151,8 +151,11 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('TypeError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -305,9 +308,7 @@ def test_discrimination_self_is_not_an_add_operand() -> None:
 def test_positional_keyword_and_default_calls_discharge() -> None:
     sites = (
         _method_callsite(METHOD_BODY + "\nAdder().combine(1, 2)\n"),
-        _method_callsite(
-            METHOD_BODY + "\nAdder().combine(left=1, right=2)\n"
-        ),
+        _method_callsite(METHOD_BODY + "\nAdder().combine(left=1, right=2)\n"),
         _method_callsite(METHOD_DEFAULTS + "\nAdder().combine(1)\n"),
     )
     for site in sites:
@@ -319,9 +320,7 @@ def test_positional_keyword_and_default_calls_discharge() -> None:
 
 def test_discrimination_default_is_not_keyword_override() -> None:
     default = _method_callsite(METHOD_DEFAULTS + "\nAdder().combine(1)\n")
-    override = _method_callsite(
-        METHOD_DEFAULTS + "\nAdder().combine(1, right=9)\n"
-    )
+    override = _method_callsite(METHOD_DEFAULTS + "\nAdder().combine(1, right=9)\n")
     assert default.arg_values[2] == TermValue(2)
     assert override.arg_values[2] == TermValue(9)
     assert _returned_term(default.producer_outcome(None)).value == 3
@@ -336,9 +335,7 @@ def test_discrimination_default_is_not_keyword_override() -> None:
 def test_compatible_operands_complete_with_correct_value() -> None:
     _, _method, pending = _method_definition()
     left_cid, right_cid = _left_right_cids(pending)
-    exits = pending.discharge(
-        {left_cid: TermValue(10), right_cid: TermValue(5)}
-    )
+    exits = pending.discharge({left_cid: TermValue(10), right_cid: TermValue(5)})
     assert isinstance(exits.exits[0], Completed)
     assert _returned_term(exits).value == 15
 
@@ -369,9 +366,7 @@ def test_incompatible_operands_typeerror_with_exact_pre_effect_state() -> None:
         "formal add carrier"
     )
     left_cid, right_cid = _left_right_cids(pending)
-    exits = pending.discharge(
-        {left_cid: NoneValue(), right_cid: TermValue(2)}
-    )
+    exits = pending.discharge({left_cid: NoneValue(), right_cid: TermValue(2)})
     halted = _only_halted(exits, require_pre_effect_state=True)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
     assert halted.state is testimony.state
@@ -473,8 +468,7 @@ def test_off_by_one_callsite_args_do_not_match_truthful_binding() -> None:
     assert len(off_by_one) == 2
     assert off_by_one != truthful
     assert not (
-        isinstance(off_by_one[0], ObjectValue)
-        and off_by_one[0].class_name == "Adder"
+        isinstance(off_by_one[0], ObjectValue) and off_by_one[0].class_name == "Adder"
     )
 
 
@@ -487,18 +481,14 @@ def test_swapped_operand_twins_fail_against_truthful_sum() -> None:
     _, _method, pending = _method_definition()
     left_cid, right_cid = _left_right_cids(pending)
 
-    truthful = pending.discharge(
-        {left_cid: TermValue(10), right_cid: TermValue(5)}
-    )
+    truthful = pending.discharge({left_cid: TermValue(10), right_cid: TermValue(5)})
     assert isinstance(truthful.exits[0], Completed)
     assert _returned_term(truthful).value == 15
 
     # Swapped numeric still sums (commutative) — use asymmetric TypeError twin:
     # left=None right=2 vs left=2 right=None may both TypeError but wrong
     # completion is the bite for a lying map that claims sum 15 from None.
-    lying = pending.discharge(
-        {left_cid: NoneValue(), right_cid: TermValue(2)}
-    )
+    lying = pending.discharge({left_cid: NoneValue(), right_cid: TermValue(2)})
     lying_face = lying.exits[0]
     if isinstance(lying_face, Completed):
         assert _returned_term(lying).value != 15

--- a/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py
@@ -7,7 +7,16 @@ from sugar_lift_py_tests.outcome import Incomplete
 
 
 def test_unguarded_incomplete_raise_stops_block_fallthrough():
-    block = BlockValue((Incomplete(RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:19:0')),))
+    block = BlockValue(
+        (
+            Incomplete(
+                RaiseEffect.for_builtin(
+                    "OSError",
+                    occurrence="implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:19:0",
+                )
+            ),
+        )
+    )
 
     assert not block.follow_rest().continues
 
@@ -16,7 +25,10 @@ def test_guarded_incomplete_raise_preserves_the_complementary_tail():
     block = BlockValue(
         (
             Incomplete(
-                RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:10:0'),
+                RaiseEffect.for_builtin(
+                    "OSError",
+                    occurrence="implementations/python/sugar-lift-py-tests/tests/test_block_value_hard_incomplete_follow.py:10:0",
+                ),
                 branch_conditions=(make_var("condition"),),
             ),
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -6,9 +6,7 @@ import importlib.util
 from pathlib import Path
 
 _SCRIPT = (
-    Path(__file__).resolve().parents[1]
-    / "scripts"
-    / "compose_control_effect_board.py"
+    Path(__file__).resolve().parents[1] / "scripts" / "compose_control_effect_board.py"
 )
 
 
@@ -34,12 +32,8 @@ def test_functions_three_meanings_not_one_figure() -> None:
 
     tip = "deadbeef"
     pin = "pin-test"
-    pop = seal_functions_population_v1(
-        LocalReading(100, "pop"), tip=tip, pin=pin
-    )
-    enum = seal_functions_enumerated_v1(
-        LocalReading(90, "enum"), tip=tip, pin=pin
-    )
+    pop = seal_functions_population_v1(LocalReading(100, "pop"), tip=tip, pin=pin)
+    enum = seal_functions_enumerated_v1(LocalReading(90, "enum"), tip=tip, pin=pin)
     clean = seal_functions_clean_v1(
         LocalReading(80, "clean"), tip=tip, pin=pin, refused=False
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_operand_sequence.py
@@ -138,9 +138,7 @@ def _formal_carrier():
     outcome = BoolOpSugar(
         "And",
         (
-            _ProbeSugar(
-                "left", SymbolicValue(make_var("left"), formal), evaluations
-            ),
+            _ProbeSugar("left", SymbolicValue(make_var("left"), formal), evaluations),
             _ProbeSugar("right", right, evaluations),
         ),
         node.fragment,
@@ -229,9 +227,7 @@ def test_halted_left_truth_test_propagates_and_never_reaches_right() -> None:
     truth_calls: list[str] = []
     effect = RaiseEffect(
         exception_type_coordinate=_identity("LeftTruthError"),
-        occurrence=AuthenticatedRaiseLocus.of(
-            "test_bool_op_operand_sequence.py:1:0"
-        ),
+        occurrence=AuthenticatedRaiseLocus.of("test_bool_op_operand_sequence.py:1:0"),
         exception_name="LeftTruthError",
         blame="test_bool_op_operand_sequence.py:1:0",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_bool_op_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bool_op_term.py
@@ -46,9 +46,9 @@ def test_identical_boolop_preimages_yield_identical_terms():
 
 def test_changed_boolop_occurrence_changes_term():
     first, second = _sites("left and right\nleft and right\n")
-    assert _boolop(site=first).to_term(owner="first") != _boolop(
-        site=second
-    ).to_term(owner="second")
+    assert _boolop(site=first).to_term(owner="first") != _boolop(site=second).to_term(
+        owner="second"
+    )
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_middle_leg_control.py
@@ -30,7 +30,10 @@ def _expression(expression: str):
 def _raise_occurrence(outcome) -> str:
     if isinstance(outcome, Complete):
         assert isinstance(outcome.value, RaiseValue)
-        assert isinstance(outcome.value.effect.occurrence_id, str) and ":" in outcome.value.effect.occurrence_id, (
+        assert (
+            isinstance(outcome.value.effect.occurrence_id, str)
+            and ":" in outcome.value.effect.occurrence_id
+        ), (
             "authenticated raise locus must be a file:line:col occurrence id, "
             f"not presence-only; got {outcome.value.effect.occurrence_id!r}"
         )
@@ -38,7 +41,10 @@ def _raise_occurrence(outcome) -> str:
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
-    assert isinstance(halted[0].effect.occurrence_id, str) and ":" in halted[0].effect.occurrence_id, (
+    assert (
+        isinstance(halted[0].effect.occurrence_id, str)
+        and ":" in halted[0].effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted[0].effect.occurrence_id!r}"
     )
@@ -54,9 +60,7 @@ def _caller_outcomes(calls: str):
     tree = _tree(source)
     comparisons = tuple(node for node in tree.nodes() if isinstance(node, Compare))
     outcomes = tuple(
-        node.sugar().desugar(None)
-        for node in tree.nodes()
-        if isinstance(node, Call)
+        node.sugar().desugar(None) for node in tree.nodes() if isinstance(node, Call)
     )
     assert len(comparisons) == 3
     return outcomes, comparisons
@@ -105,8 +109,7 @@ def test_successful_three_leg_chain_returns_exact_last_operand() -> None:
 
 def test_middle_typeerror_blocks_toxic_and_safe_membership_with_exact_state() -> None:
     (toxic, safe), comparisons = _caller_outcomes(
-        "choose(1, 2, None, 1, None, 3)\n"
-        "choose(1, 2, None, 1, 1, [1])\n"
+        "choose(1, 2, None, 1, None, 3)\n" "choose(1, 2, None, 1, 1, [1])\n"
     )
     toxic_halt = _only_halted(toxic)
     safe_halt = _only_halted(safe)
@@ -122,8 +125,7 @@ def test_middle_typeerror_blocks_toxic_and_safe_membership_with_exact_state() ->
 
 def test_first_typeerror_blocks_distinct_middle_and_membership_twins() -> None:
     (toxic, safe), comparisons = _caller_outcomes(
-        "choose(None, 2, None, 1, None, 3)\n"
-        "choose(None, 2, 1, 2, 1, [1])\n"
+        "choose(None, 2, None, 1, None, 3)\n" "choose(None, 2, 1, 2, 1, [1])\n"
     )
     toxic_halt = _only_halted(toxic)
     safe_halt = _only_halted(safe)

--- a/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_boolop_mixed_compare_families.py
@@ -26,7 +26,10 @@ def _expression(source_expression: str):
 def _raise_occurrence(outcome) -> str:
     if isinstance(outcome, Complete):
         assert isinstance(outcome.value, RaiseValue)
-        assert isinstance(outcome.value.effect.occurrence_id, str) and ":" in outcome.value.effect.occurrence_id, (
+        assert (
+            isinstance(outcome.value.effect.occurrence_id, str)
+            and ":" in outcome.value.effect.occurrence_id
+        ), (
             "authenticated raise locus must be a file:line:col occurrence id, "
             f"not presence-only; got {outcome.value.effect.occurrence_id!r}"
         )
@@ -34,7 +37,10 @@ def _raise_occurrence(outcome) -> str:
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
-    assert isinstance(halted[0].effect.occurrence_id, str) and ":" in halted[0].effect.occurrence_id, (
+    assert (
+        isinstance(halted[0].effect.occurrence_id, str)
+        and ":" in halted[0].effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted[0].effect.occurrence_id!r}"
     )
@@ -107,20 +113,14 @@ def test_swapping_families_swaps_laws_without_collapsing_occurrences() -> None:
 
 
 def _caller_outcomes(calls: str):
-    source = (
-        "def mixed(a, b, c, d):\n"
-        "    return a < b and c in d\n"
-        f"\n{calls}"
-    )
+    source = "def mixed(a, b, c, d):\n" "    return a < b and c in d\n" f"\n{calls}"
     tree = SourceFile(
         (source, "boolop-mixed-caller.py", blake3_512_of(source.encode())),
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
     )
     comparisons = tuple(node for node in tree.nodes() if isinstance(node, Compare))
     outcomes = tuple(
-        node.sugar().desugar(None)
-        for node in tree.nodes()
-        if isinstance(node, Call)
+        node.sugar().desugar(None) for node in tree.nodes() if isinstance(node, Call)
     )
     assert len(comparisons) == 2
     return outcomes, comparisons
@@ -140,8 +140,7 @@ def _formal_occurrence(compare: Compare) -> str:
 
 def test_first_leg_halt_blocks_toxic_and_safe_membership_with_exact_state() -> None:
     (toxic, safe), comparisons = _caller_outcomes(
-        "mixed(None, 1, None, 3)\n"
-        "mixed(None, 1, 1, [1])\n"
+        "mixed(None, 1, None, 3)\n" "mixed(None, 1, 1, [1])\n"
     )
     toxic_halt = _only_halted(toxic)
     safe_halt = _only_halted(safe)
@@ -155,7 +154,9 @@ def test_first_leg_halt_blocks_toxic_and_safe_membership_with_exact_state() -> N
     assert toxic_halt.state == safe_halt.state
 
 
-def test_truthful_first_leg_routes_membership_halt_to_second_occurrence_and_state() -> None:
+def test_truthful_first_leg_routes_membership_halt_to_second_occurrence_and_state() -> (
+    None
+):
     (outcome,), comparisons = _caller_outcomes("mixed(1, 2, None, 3)\n")
     halted = _only_halted(outcome)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_attribute_delete.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_attribute_delete.py
@@ -13,7 +13,13 @@ from sugar_source_tree.tree import SourceFile
 def _site(tmp_path):
     path = tmp_path / "builtin_attr_delete.py"
     path.write_text("def f(obj):\n    del obj.attr\n")
-    return next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body[0].fragment
+    return (
+        next(
+            SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+        )
+        .body[0]
+        .fragment
+    )
 
 
 @dataclass(frozen=True)
@@ -33,7 +39,9 @@ class _Receiver(Sugar):
     ("receiver", "owner"),
     ((ListValue(()), "ListValue.delattr"), (NoneValue(), "NoneValue.delattr")),
 )
-def test_builtin_without_instance_dict_delete_has_exact_owner_occurrence(tmp_path, receiver, owner):
+def test_builtin_without_instance_dict_delete_has_exact_owner_occurrence(
+    tmp_path, receiver, owner
+):
     site = _site(tmp_path)
     outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", site).desugar()
     assert isinstance(outcome, Incomplete)
@@ -43,6 +51,10 @@ def test_builtin_without_instance_dict_delete_has_exact_owner_occurrence(tmp_pat
 
 
 @pytest.mark.parametrize("receiver", (ListValue(()), NoneValue()))
-def test_builtin_without_instance_dict_delete_cannot_fabricate_completion(tmp_path, receiver):
-    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", _site(tmp_path)).desugar()
+def test_builtin_without_instance_dict_delete_cannot_fabricate_completion(
+    tmp_path, receiver
+):
+    outcome = AttributeDeleteEffectSugar(
+        _Receiver(receiver), "attr", _site(tmp_path)
+    ).desugar()
     assert not isinstance(outcome, Complete)

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_closed_operation_instrument.py
@@ -84,7 +84,9 @@ def test_instrument_truthful_floor_shape_is_zero(tmp_path: Path) -> None:
     assert report.offenders == ()
 
 
-def test_instrument_structurally_sees_spelling_gates_of_cluster_five(tmp_path: Path) -> None:
+def test_instrument_structurally_sees_spelling_gates_of_cluster_five(
+    tmp_path: Path,
+) -> None:
     """Sin cluster 5 shapes: name gates outside authenticated coordinates.
 
     The instrument must catch each by AST shape, not by the legacy
@@ -181,7 +183,9 @@ def test_instrument_fixed_cluster_five_production_sites_are_zero() -> None:
         for row in report.offenders
         if row.path in targets and row.axis == "name_or_vendor_gates"
     ]
-    assert hits == [], "cluster-5 production sites still gate on spelling:\n" + "\n".join(
+    assert (
+        hits == []
+    ), "cluster-5 production sites still gate on spelling:\n" + "\n".join(
         f"{row.path}:{row.line}: {row.observed}" for row in hits
     )
 
@@ -204,7 +208,9 @@ def test_instrument_sees_type_name_eq_string_spelling_gate(tmp_path: Path) -> No
     assert any("type_name" in row.observed for row in gates)
 
 
-def test_instrument_sees_effect_router_name_equality_spelling_gate(tmp_path: Path) -> None:
+def test_instrument_sees_effect_router_name_equality_spelling_gate(
+    tmp_path: Path,
+) -> None:
     """Planted ``observed[1] == matcher.name`` style name equality is a gate."""
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
@@ -392,7 +398,9 @@ def test_instrument_does_not_scan_idd_or_plant_self(tmp_path: Path) -> None:
     assert report.offenders == ()
 
 
-def test_partition_does_not_count_lexical_attr_name_as_identity_gate(tmp_path: Path) -> None:
+def test_partition_does_not_count_lexical_attr_name_as_identity_gate(
+    tmp_path: Path,
+) -> None:
     """field.name == name is open-domain membrane, not name_or_vendor_gates."""
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
@@ -411,7 +419,9 @@ def test_partition_does_not_count_lexical_attr_name_as_identity_gate(tmp_path: P
     assert report.r["open_lexical_attr_name"] >= 1
 
 
-def test_partition_func_id_string_is_open_lexical_not_type_identity(tmp_path: Path) -> None:
+def test_partition_func_id_string_is_open_lexical_not_type_identity(
+    tmp_path: Path,
+) -> None:
     """func.id == \"range\" is permanent open-domain membrane."""
     from sugar_lift_py_tests.idd.builtin_closed_operation_instrument import (
         collect_builtin_closed_operation_report,
@@ -421,7 +431,7 @@ def test_partition_func_id_string_is_open_lexical_not_type_identity(tmp_path: Pa
         tmp_path,
         "nodes.py",
         "def _concrete(iterable):\n"
-        "    if iterable.func.id == \"range\":\n"
+        '    if iterable.func.id == "range":\n'
         "        return True\n"
         "    return False\n",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_ancestry.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_ancestry.py
@@ -30,7 +30,9 @@ def _residual_raises(source: str) -> tuple[str, ...]:
     """Every raise that survived the `try` — the effects still on the wall."""
     from sugar_lift_python_source.canonical import blake3_512_of
 
-    source_file = SourceFile((source, "/tmp/ancestry.py", blake3_512_of(source.encode())))
+    source_file = SourceFile(
+        (source, "/tmp/ancestry.py", blake3_512_of(source.encode()))
+    )
     function = next(iter(source_file.functions()))
     exit_set = outcome_to_exitset(function.sugar().desugar())
     names: list[str] = []
@@ -125,9 +127,9 @@ def test_ancestry_is_directional_subclass_does_not_catch_superclass():
 
 
 def test_except_arithmetic_error_does_not_catch_os_error():
-    assert _residual_raises(_try_source(raised="OSError", handled="ArithmeticError")) == (
-        "OSError",
-    )
+    assert _residual_raises(
+        _try_source(raised="OSError", handled="ArithmeticError")
+    ) == ("OSError",)
 
 
 def test_keyboard_interrupt_is_not_an_exception():

--- a/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_class_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_builtin_exception_class_subscript_mutation.py
@@ -20,8 +20,10 @@ def _sites(tmp_path):
 
 @pytest.mark.parametrize(
     ("operation", "owner", "site_index"),
-    (("setitem", "BuiltinExceptionClassValue.setitem", 0),
-     ("delitem", "BuiltinExceptionClassValue.delitem", 1)),
+    (
+        ("setitem", "BuiltinExceptionClassValue.setitem", 0),
+        ("delitem", "BuiltinExceptionClassValue.delitem", 1),
+    ),
 )
 def test_builtin_exception_class_subscript_mutations_have_exact_owner_occurrences(
     tmp_path, operation, owner, site_index

--- a/implementations/python/sugar-lift-py-tests/tests/test_bv32_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bv32_attribute_mutation.py
@@ -8,22 +8,39 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "bv32_attribute_mutation.py"
-    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "Bv32Value.setattr", 0), ("delattr", "Bv32Value.delattr", 1)))
-def test_bv32_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = Bv32Value(num(1))
-    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (("setattr", "Bv32Value.setattr", 0), ("delattr", "Bv32Value.delattr", 1)),
+)
+def test_bv32_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = Bv32Value(num(1))
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
     assert outcome.value.effect.exception_name == "AttributeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_bv32_attribute_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = Bv32Value(num(1))
-    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = Bv32Value(num(1))
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_bv32_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_bv32_subscript_mutation.py
@@ -8,22 +8,39 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "bv32_subscript_mutation.py"
-    path.write_text("def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "Bv32Value.setitem", 0), ("delitem", "Bv32Value.delitem", 1)))
-def test_bv32_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = Bv32Value(num(1))
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (("setitem", "Bv32Value.setitem", 0), ("delitem", "Bv32Value.delitem", 1)),
+)
+def test_bv32_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = Bv32Value(num(1))
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_bv32_subscript_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = Bv32Value(num(1))
-    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = Bv32Value(num(1))
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callsite_positional_actual_exitset.py
@@ -147,7 +147,9 @@ def test_outer_call_sequences_retained_three_arm_source_actual_once() -> None:
     assert len(outer_completed) == 1
     assert outer_completed[0].guard == produced_completed[0].guard
     assert outer_completed[0].faces == produced_completed[0].faces
-    assert outer_completed[0].pending_contracts == produced_completed[0].pending_contracts
+    assert (
+        outer_completed[0].pending_contracts == produced_completed[0].pending_contracts
+    )
     projected_call = outer_completed[0].value
     assert isinstance(projected_call, CallSiteValue)
     assert projected_call.target_name == "len"
@@ -226,7 +228,9 @@ def test_ordinary_floor_operation_actual_projection_is_identity() -> None:
 def test_retained_source_completion_is_private_and_remint_closed() -> None:
     """Lying twins: constructor and foreign dataclass remints gain no retention."""
     retained = next(
-        item for item in fields(CallSiteValue) if item.name == "_retained_source_completion"
+        item
+        for item in fields(CallSiteValue)
+        if item.name == "_retained_source_completion"
     )
     assert retained.init is False
     inner, body, _ = _source_call_partition()
@@ -309,9 +313,7 @@ def test_identity_memo_starts_only_after_producer_seats_retained_wrapper(
     produced = inner.producer_outcome(None)
 
     assert body.reductions == 1
-    wrapper = next(
-        face.value for face in produced.exits if isinstance(face, Completed)
-    )
+    wrapper = next(face.value for face in produced.exits if isinstance(face, Completed))
     assert wrapper is not inner
     assert callsite_module._callsite_coordinate_memo_size() == 1
     first_hash = hash(wrapper)

--- a/implementations/python/sugar-lift-py-tests/tests/test_callsite_retained_completion_replay.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_callsite_retained_completion_replay.py
@@ -66,7 +66,8 @@ def _retained_source_call(original: FloorValue | None = None):
     ),
 )
 def test_retained_source_completion_refuses_different_producer_replay(
-    replay_kind: str, replacement_value: int,
+    replay_kind: str,
+    replacement_value: int,
 ) -> None:
     """Lying twin: even equal completion replay cannot republish testimony."""
     retained, body, original = _retained_source_call()
@@ -116,8 +117,9 @@ def test_retained_source_completion_refuses_every_second_reduction_door(
     assert projected.value is original
 
 
-def test_legacy_operation_projection_paths_consume_retained_value_without_reduction(
-) -> None:
+def test_legacy_operation_projection_paths_consume_retained_value_without_reduction() -> (
+    None
+):
     """Legacy callers read the seat; neither path may re-enter the source body."""
     retained, body, original = _retained_source_call()
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_chained_compare_production_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_chained_compare_production_instrument.py
@@ -19,10 +19,7 @@ from sugar_source_tree.tree import SourceFile
 
 def _helper(expression: str) -> str:
     return (
-        "def chain():\n"
-        f"    if {expression}:\n"
-        "        return 1\n"
-        "    return 0\n"
+        "def chain():\n" f"    if {expression}:\n" "        return 1\n" "    return 0\n"
     )
 
 
@@ -65,9 +62,11 @@ def _type_error_identity():
 
 def test_successful_chain_selects_the_true_body() -> None:
     tree = _tree()
-    outcome = next(
-        node for node in tree.nodes() if isinstance(node, Compare)
-    ).sugar().desugar(None)
+    outcome = (
+        next(node for node in tree.nodes() if isinstance(node, Compare))
+        .sugar()
+        .desugar(None)
+    )
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
@@ -75,9 +74,11 @@ def test_successful_chain_selects_the_true_body() -> None:
 def test_false_first_leg_selects_false_body_and_emits_no_second_occurrence() -> None:
     tree = _tree("chain()\n", _helper("2 < 1 < None"))
     first_site, second_site = _pair_sites(tree)
-    outcome = next(
-        node for node in tree.nodes() if isinstance(node, Compare)
-    ).sugar().desugar(None)
+    outcome = (
+        next(node for node in tree.nodes() if isinstance(node, Compare))
+        .sugar()
+        .desugar(None)
+    )
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, FalseBoolLiteralSugar)
@@ -128,7 +129,11 @@ def test_undecidable_ordering_legs_keep_exact_guards_and_occurrences() -> None:
 @pytest.mark.parametrize(
     ("expression", "raise_atoms", "identity_first"),
     (
-        ("a < b == c", {"python.lt_dispatch_raises", "python.eq_dispatch_raises"}, False),
+        (
+            "a < b == c",
+            {"python.lt_dispatch_raises", "python.eq_dispatch_raises"},
+            False,
+        ),
         ("a is b < c", {"python.lt_dispatch_raises"}, True),
         (
             "a in b < c",
@@ -148,6 +153,7 @@ def test_mixed_chain_legs_retain_separate_exception_laws(
     assert isinstance(outcome, ExitSet)
 
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
+
     def atoms(formula):
         name = getattr(formula, "name", None)
         if isinstance(name, str):

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_definition_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_definition_subscript_mutation.py
@@ -8,11 +8,7 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "class_definition_subscript_mutation.py"
-    path.write_text(
-        "def mutate_class(C):\n"
-        "    C[0] = 7\n"
-        "    del C[0]\n"
-    )
+    path.write_text("def mutate_class(C):\n" "    C[0] = 7\n" "    del C[0]\n")
     body = next(
         SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
     ).body

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_subscript_mutation.py
@@ -7,11 +7,7 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "class_subscript_mutation.py"
-    path.write_text(
-        "def mutate_class(C):\n"
-        "    C[0] = 7\n"
-        "    del C[0]\n"
-    )
+    path.write_text("def mutate_class(C):\n" "    C[0] = 7\n" "    del C[0]\n")
     body = next(
         SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
     ).body

--- a/implementations/python/sugar-lift-py-tests/tests/test_class_value_isinstance_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_class_value_isinstance_coordinate.py
@@ -57,4 +57,6 @@ def test_lying_twin_spelling_does_not_override_authenticated_type() -> None:
 def test_missing_type_term_throws() -> None:
     with pytest.raises(SugarNotWritten) as caught:
         _class().python_isinstance("tuple", None, "site")
-    assert "type_term" in caught.value.observed or "python:type" in caught.value.requested
+    assert (
+        "type_term" in caught.value.observed or "python:type" in caught.value.requested
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -212,9 +212,7 @@ def _assert_named_ordering_or_membership_refusal(thunk) -> SugarNotWritten:
 def _assert_compare_dual(node, *, atom: str) -> None:
     """Legacy name: equality still dual-edges; ordering/membership throw named."""
     if atom in {"py.lt", "py.le", "py.gt", "py.ge", "py.in"}:
-        _assert_named_ordering_or_membership_refusal(
-            lambda: node.sugar().desugar(None)
-        )
+        _assert_named_ordering_or_membership_refusal(lambda: node.sugar().desugar(None))
         return
     _assert_dual_dispatch(
         node.sugar().desugar(None), atom=atom, blame=str(node.fragment)

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_if_method_caller.py
@@ -147,8 +147,11 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('TypeError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -299,9 +302,7 @@ def test_discrimination_self_is_not_a_less_than_operand() -> None:
 def test_positional_keyword_and_default_calls_select_correct_branch() -> None:
     sites = (
         _method_callsite(METHOD_BODY + "\nChooser().choose(1, 2)\n"),
-        _method_callsite(
-            METHOD_BODY + "\nChooser().choose(left=1, right=2)\n"
-        ),
+        _method_callsite(METHOD_BODY + "\nChooser().choose(left=1, right=2)\n"),
         _method_callsite(METHOD_DEFAULTS + "\nChooser().choose(1)\n"),
     )
     for site in sites:
@@ -312,9 +313,7 @@ def test_positional_keyword_and_default_calls_select_correct_branch() -> None:
         if isinstance(outcome, Complete):
             from sugar_lift_py_tests.outcome.exit_set import true_guard
 
-            assert (
-                _returned_term(Completed(true_guard(), outcome.value)).value == 1
-            )
+            assert _returned_term(Completed(true_guard(), outcome.value)).value == 1
         else:
             assert _returned_term(_only_completed(outcome)).value == 1
 
@@ -353,9 +352,7 @@ def test_incompatible_ordering_typeerror_with_exact_pre_effect_state() -> None:
     left_cid, right_cid = _left_right_cids(pending)
     from sugar_lift_py_tests.floor import NoneValue
 
-    exits = pending.discharge(
-        {left_cid: NoneValue(), right_cid: TermValue(2)}
-    )
+    exits = pending.discharge({left_cid: NoneValue(), right_cid: TermValue(2)})
     halted = _only_halted(exits, require_pre_effect_state=True)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
     assert halted.state is testimony.state
@@ -435,8 +432,7 @@ def test_off_by_one_callsite_args_do_not_match_truthful_binding() -> None:
     assert len(off_by_one) == 2
     assert off_by_one != truthful
     assert not (
-        isinstance(off_by_one[0], ObjectValue)
-        and off_by_one[0].class_name == "Chooser"
+        isinstance(off_by_one[0], ObjectValue) and off_by_one[0].class_name == "Chooser"
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_keyword_default_vertical.py
@@ -11,13 +11,14 @@ from sugar_lift_py_tests.context_manager_contract import (
     EffectBoundaryDisposition,
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.effect.expectation_not_met_effect import ExpectationNotMetEffect
+from sugar_lift_py_tests.effect.expectation_not_met_effect import (
+    ExpectationNotMetEffect,
+)
 from sugar_lift_py_tests.ir import ctor, str_const
 from sugar_lift_py_tests.outcome import Complete, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
-
 
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
@@ -81,7 +82,10 @@ def _named_type_error(outcome: object) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _exception_identity("TypeError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -101,7 +105,8 @@ def test_real_pandas_ordering_helper_and_positional_caller_are_content_pinned() 
     helper = next(
         node
         for node in ast.walk(helper_tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "assert_invalid_comparison"
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "assert_invalid_comparison"
     )
     assert helper.lineno == 89
     with_node = next(node for node in ast.walk(helper) if isinstance(node, ast.With))
@@ -109,19 +114,24 @@ def test_real_pandas_ordering_helper_and_positional_caller_are_content_pinned() 
     assert with_node.lineno == 143
     assert isinstance(manager, ast.Call)
     assert ast.unparse(manager.args[0]) == "TypeError"
-    assert [(keyword.arg, ast.unparse(keyword.value)) for keyword in manager.keywords] == [
-        ("match", "msg")
-    ]
+    assert [
+        (keyword.arg, ast.unparse(keyword.value)) for keyword in manager.keywords
+    ] == [("match", "msg")]
     msg = next(
         node
         for node in helper.body
         if isinstance(node, ast.Assign)
-        and any(isinstance(target, ast.Name) and target.id == "msg" for target in node.targets)
+        and any(
+            isinstance(target, ast.Name) and target.id == "msg"
+            for target in node.targets
+        )
     )
     assert isinstance(msg.value, ast.Call)
     assert ast.unparse(msg.value.func) == "'|'.join"
     assert len(msg.value.args) == 1 and isinstance(msg.value.args[0], ast.List)
-    assert tuple(ast.literal_eval(item) for item in msg.value.args[0].elts) == MATCH_PARTS
+    assert (
+        tuple(ast.literal_eval(item) for item in msg.value.args[0].elts) == MATCH_PARTS
+    )
     comparison = next(
         node
         for node in ast.walk(with_node)
@@ -136,7 +146,10 @@ def test_real_pandas_ordering_helper_and_positional_caller_are_content_pinned() 
         if isinstance(node, ast.Call)
         and ast.unparse(node.func).endswith("assert_invalid_comparison")
     ]
-    assert any(node.lineno == 90 and len(node.args) == 3 and not node.keywords for node in calls)
+    assert any(
+        node.lineno == 90 and len(node.args) == 3 and not node.keywords
+        for node in calls
+    )
 
 
 def test_helper_alone_is_undischarged_and_all_three_bindings_reach_one_demand() -> None:
@@ -144,19 +157,29 @@ def test_helper_alone_is_undischarged_and_all_three_bindings_reach_one_demand() 
     assert isinstance(pending, NativeOperationExitCarrierV1)
     assert pending.demand.operator == "less_than"
 
-    halted = tuple(_named_type_error(outcome) for outcome in (positional, keyword, default))
+    halted = tuple(
+        _named_type_error(outcome) for outcome in (positional, keyword, default)
+    )
     assert len({face.effect.occurrence_id for face in halted}) == 1
     assert isinstance(normal, ExitSet)
     assert len(normal.exits) == 1
     assert not any(isinstance(face, Halted) for face in normal.exits)
 
 
-def test_wrong_boundary_type_does_not_consume_or_create_the_exception_identity() -> None:
+def test_wrong_boundary_type_does_not_consume_or_create_the_exception_identity() -> (
+    None
+):
     _, (_, keyword, _, _) = _program_outcomes()
     producer_halt = _named_type_error(keyword)
     separately_minted_expected = _Expected("TypeError")
-    assert producer_halt.effect.exception_type_coordinate == separately_minted_expected.identity
-    assert producer_halt.effect.exception_type_coordinate is not separately_minted_expected.identity
+    assert (
+        producer_halt.effect.exception_type_coordinate
+        == separately_minted_expected.identity
+    )
+    assert (
+        producer_halt.effect.exception_type_coordinate
+        is not separately_minted_expected.identity
+    )
 
     projected = keyword.and_exit(
         ExitSet.completed(object()),
@@ -184,7 +207,8 @@ def test_swapped_ordering_retains_distinct_ordered_coordinates() -> None:
     assert isinstance(forward, NativeOperationExitCarrierV1)
     assert isinstance(swapped, NativeOperationExitCarrierV1)
     assert forward.demand.operand_coordinate_cids == tuple(
-        coordinate.coordinate_cid for coordinate in forward_function.formal_coordinates()
+        coordinate.coordinate_cid
+        for coordinate in forward_function.formal_coordinates()
     )
     assert swapped.demand.operand_coordinate_cids == tuple(
         coordinate.coordinate_cid
@@ -195,8 +219,10 @@ def test_swapped_ordering_retains_distinct_ordered_coordinates() -> None:
 
 def test_identity_law_never_acquires_a_native_operation_carrier() -> None:
     source = "def helper(left, right=2):\n    return left is right\n"
-    outcome = next(
-        node for node in _tree(source).nodes() if isinstance(node, FunctionDef)
-    ).sugar().desugar(None)
+    outcome = (
+        next(node for node in _tree(source).nodes() if isinstance(node, FunctionDef))
+        .sugar()
+        .desugar(None)
+    )
     assert isinstance(outcome, Complete)
     assert not isinstance(outcome, NativeOperationExitCarrierV1)

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_through_if_sugar.py
@@ -9,12 +9,16 @@ from sugar_lift_py_tests.context_manager_contract import (
     EffectBoundaryDisposition,
 )
 from sugar_lift_py_tests.effect import ExpectationNotMetEffect
-from sugar_lift_py_tests.floor import CallSiteValue, GuardedReturn, ReturnValue, TermValue
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    GuardedReturn,
+    ReturnValue,
+    TermValue,
+)
 from sugar_lift_py_tests.outcome import Completed, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
-
 
 HELPER = (
     "def helper(left, right):\n"
@@ -33,9 +37,7 @@ def _tree(calls: str = "") -> SourceFile:
 
 
 def _function_outcome():
-    function = next(
-        node for node in _tree().nodes() if isinstance(node, FunctionDef)
-    )
+    function = next(node for node in _tree().nodes() if isinstance(node, FunctionDef))
     return function.sugar().desugar(None)
 
 
@@ -132,7 +134,10 @@ def test_exceptional_condition_bypasses_both_bodies() -> None:
         halted.effect.exception_type_coordinate
         == _expected_exception("TypeError").exception_type_identity()
     )
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -207,6 +212,4 @@ def test_identity_condition_never_acquires_a_carrier() -> None:
     )
     function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
 
-    assert not isinstance(
-        function.sugar().desugar(None), NativeOperationExitCarrierV1
-    )
+    assert not isinstance(function.sugar().desugar(None), NativeOperationExitCarrierV1)

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_attribute_mutation.py
@@ -6,7 +6,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "complex_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -14,7 +16,11 @@ def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     value = ComplexValue(1.0, 2.0)
     return (
-        (value.setattr("attr", TermValue(7), store_site), "ComplexValue.setattr", store_site),
+        (
+            value.setattr("attr", TermValue(7), store_site),
+            "ComplexValue.setattr",
+            store_site,
+        ),
         (value.delattr("attr", delete_site), "ComplexValue.delattr", delete_site),
     )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_literal_constructed_term_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_literal_constructed_term_codomain_law.py
@@ -91,12 +91,8 @@ def test_one_codomain_door_accepts_complex_and_ellipsis() -> None:
     complex_lit = ComplexLiteralSugar(real=0.0, imag=2.0, site=site)
     ellipsis_lit = EllipsisLiteralSugar(site=site)
     for owner in _OWNERS:
-        assert (
-            require_constructed_term_sugar(complex_lit, owner=owner) is complex_lit
-        )
-        assert (
-            require_constructed_term_sugar(ellipsis_lit, owner=owner) is ellipsis_lit
-        )
+        assert require_constructed_term_sugar(complex_lit, owner=owner) is complex_lit
+        assert require_constructed_term_sugar(ellipsis_lit, owner=owner) is ellipsis_lit
 
 
 def test_binop_slot_constructs_with_complex_literal() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_complex_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_complex_subscript_mutation.py
@@ -7,7 +7,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "complex_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -15,8 +17,16 @@ def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     receiver = ComplexValue(1.0, 2.0)
     return (
-        (receiver.setitem(TermValue(0), TermValue(7), store_site), "ComplexValue.setitem", store_site),
-        (receiver.delitem(TermValue(0), delete_site), "ComplexValue.delitem", delete_site),
+        (
+            receiver.setitem(TermValue(0), TermValue(7), store_site),
+            "ComplexValue.setitem",
+            store_site,
+        ),
+        (
+            receiver.delitem(TermValue(0), delete_site),
+            "ComplexValue.delitem",
+            delete_site,
+        ),
     )
 
 
@@ -30,4 +40,6 @@ def test_complex_subscript_mutations_have_exact_owner_occurrences(tmp_path):
 
 def test_complex_subscript_mutations_cannot_fabricate_completion(tmp_path):
     for outcome, _, _ in _outcomes(tmp_path):
-        assert not (isinstance(outcome, Complete) and not hasattr(outcome.value, "effect"))
+        assert not (
+            isinstance(outcome, Complete) and not hasattr(outcome.value, "effect")
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -232,10 +232,7 @@ def test_finite_comprehensions_transport_exact_constructed_objects_in_order():
 
 
 def test_finite_comprehension_refuses_swapped_tuple_target_coordinates():
-    source = (
-        "def build():\n"
-        "    return [(left, right) for left, right in [(1, 2)]]\n"
-    )
+    source = "def build():\n" "    return [(left, right) for left, right in [(1, 2)]]\n"
     source_file = _source_file(source)
     comprehension = next(
         node for node in source_file.nodes() if node.kind == "ListComp"

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_value_length.py
@@ -32,12 +32,8 @@ class _ListcompLookalike:
         ((TermValue(7), TermValue(7), TermValue(9)), 3),
     ],
 )
-def test_listcomp_finite_roster_length_counts_exact_members(
-    elements, expected
-) -> None:
-    value = ComprehensionValue(
-        ctor("py.listcomp", ()), finite_elements=elements
-    )
+def test_listcomp_finite_roster_length_counts_exact_members(elements, expected) -> None:
+    value = ComprehensionValue(ctor("py.listcomp", ()), finite_elements=elements)
 
     outcome = value.length(object())
 
@@ -102,9 +98,7 @@ def test_valid_foreign_listcomp_constructor_and_site_are_retained_exactly() -> N
     assert first.site is first_site
     assert foreign.site is foreign_site
     assert first.term == ctor("call:len", (first_term,), symbol_kind="builtin")
-    assert foreign.term == ctor(
-        "call:len", (foreign_term,), symbol_kind="builtin"
-    )
+    assert foreign.term == ctor("call:len", (foreign_term,), symbol_kind="builtin")
     assert foreign.term != first.term
 
 
@@ -125,14 +119,10 @@ def test_exitset_listcomp_length_preserves_halt_guard_and_pending() -> None:
         pending_contracts=(completed_pending,),
     )
 
-    result = ExitSet((halted, completed)).and_then(
-        lambda value: value.length(object())
-    )
+    result = ExitSet((halted, completed)).and_then(lambda value: value.length(object()))
 
     halted_after = next(face for face in result.exits if isinstance(face, Halted))
-    completed_after = next(
-        face for face in result.exits if isinstance(face, Completed)
-    )
+    completed_after = next(face for face in result.exits if isinstance(face, Completed))
     assert halted_after is halted
     assert halted_after.guard == halted.guard
     assert halted_after.pending_contracts == (halted_pending,)

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_object_place_is_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_object_place_is_term.py
@@ -27,11 +27,7 @@ from pathlib import Path
 
 _KIT = Path(__file__).resolve().parents[1]
 _PLACE = (
-    _KIT
-    / "src"
-    / "sugar_lift_py_tests"
-    / "sugar"
-    / "constructed_object_place_sugar.py"
+    _KIT / "src" / "sugar_lift_py_tests" / "sugar" / "constructed_object_place_sugar.py"
 )
 _ATTR = _KIT / "src" / "sugar_lift_py_tests" / "sugar" / "attribute_sugar.py"
 _NODES = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_spread_literal_roster.py
@@ -102,9 +102,7 @@ def test_ellipsis_literal_is_constructed_term_in_subscript() -> None:
     sf = _sf(source, "ellipsis_sub.py")
     # Constant ... nodes
     constants = [
-        n
-        for n in sf.root.walk()
-        if isinstance(n, Constant) and n.value is Ellipsis
+        n for n in sf.root.walk() if isinstance(n, Constant) and n.value is Ellipsis
     ]
     # Prefer constructing via subscript which owns the index
     subs = [n for n in sf.root.walk() if isinstance(n, Subscript)]
@@ -141,13 +139,14 @@ def test_multi_function_file_with_star_call_enumerates_full_roster() -> None:
             workspace_root=workspace,
             file_rel="mod.py",
         )
-    assert row.get("category") in {"completed", "panic"}, (
-        f"spread call zero-banked the file: {row.get('defect') or row}"
-    )
+    assert row.get("category") in {
+        "completed",
+        "panic",
+    }, f"spread call zero-banked the file: {row.get('defect') or row}"
     # Full roster: helper, body, other
-    assert int(row.get("functionsTotal") or 0) == 3, (
-        f"expected functionsTotal=3 (full roster), got {row!r}"
-    )
+    assert (
+        int(row.get("functionsTotal") or 0) == 3
+    ), f"expected functionsTotal=3 (full roster), got {row!r}"
     # Not a TypeError residual dressed as clean zero
     defect_msg = str((row.get("defect") or {}).get("message") or "")
     assert "ConstructedTermSugar" not in defect_msg

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -130,7 +130,9 @@ def test_missing_constructed_term_obligation_refuses_at_instantiation():
 
 
 def test_generator_payload_admission_refuses_arbitrary_sugar():
-    with pytest.raises(TypeError, match="YieldStepV1.value requires ConstructedTermSugar"):
+    with pytest.raises(
+        TypeError, match="YieldStepV1.value requires ConstructedTermSugar"
+    ):
         YieldStepV1(_ArbitrarySugar())
 
 
@@ -239,9 +241,9 @@ def test_equivalent_call_reconstruction_has_the_same_term():
 
 
 def test_changed_resolved_contract_authority_changes_call_term():
-    assert _call(contract=_contract("a")).to_term(
-        owner="first-contract"
-    ) != _call(contract=_contract("b")).to_term(owner="second-contract")
+    assert _call(contract=_contract("a")).to_term(owner="first-contract") != _call(
+        contract=_contract("b")
+    ).to_term(owner="second-contract")
 
 
 def test_exception_definition_term_is_canonical_call_authority():
@@ -306,9 +308,7 @@ def test_collection_reconstruction_and_occurrence_discriminate(build):
     assert build(first).to_term(owner="first") == build(first).to_term(
         owner="reconstructed"
     )
-    assert build(first).to_term(owner="first") != build(second).to_term(
-        owner="second"
-    )
+    assert build(first).to_term(owner="first") != build(second).to_term(owner="second")
 
 
 @pytest.mark.parametrize(

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_consumer_codomain_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_consumer_codomain_law.py
@@ -34,8 +34,7 @@ def test_live_roots_are_stable_zero() -> None:
     roots = [repo / p for p in _SCANNER._DEFAULT_PACKAGES]
     gaps, summary = _SCANNER.run(roots, repo)
     assert summary["R_total"] == 0, (
-        f"R_total={summary['R_total']} gaps="
-        f"{[g.to_dict() for g in gaps[:5]]}"
+        f"R_total={summary['R_total']} gaps=" f"{[g.to_dict() for g in gaps[:5]]}"
     )
     # Exit-code contract (same as CI axis) without re-printing the full report.
     assert (1 if gaps else 0) == 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -164,9 +164,7 @@ def audit():
 
     offenders = _SCANNER.scan_repository(tmp_path)
 
-    assert {
-        (row.path, row.kind) for row in offenders
-    } == {
+    assert {(row.path, row.kind) for row in offenders} == {
         (
             "src/sugar_lift_py_tests/audit_only/collect_construction_gaps.py",
             "construction-panic-catch-outside-membrane",
@@ -269,9 +267,7 @@ def test_current_named_membranes_match_their_exact_handler_shapes() -> None:
     )
 
     assert [
-        row
-        for row in offenders
-        if row.path.endswith(named_membrane_suffixes)
+        row for row in offenders if row.path.endswith(named_membrane_suffixes)
     ] == []
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_consumer_resolution_report.py
@@ -18,7 +18,6 @@ from sugar_lift_py_tests.consumer_resolution_report import (
 from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
 from sugar_lift_py_tests.no_call_body_attribution import AttributionOutcome
 
-
 STAMP = "blake3-512_" + "b" * 128
 MANIFEST = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604ed"
@@ -126,7 +125,10 @@ def test_matching_three_artifacts_print_to_the_consumer_edge(capsys):
         ("source stamp", lambda r: replace(r, source_stamp="blake3-512_" + "0" * 128)),
         ("runtime", lambda r: replace(r, runtime="cpython-3.12.12")),
         ("profile/platform", lambda r: replace(r, profile="debug")),
-        ("corpus identity", lambda r: replace(r, corpus_manifest_cid="sha256:" + "0" * 64)),
+        (
+            "corpus identity",
+            lambda r: replace(r, corpus_manifest_cid="sha256:" + "0" * 64),
+        ),
     ],
 )
 def test_each_request_coordinate_misses_by_its_own_name(coordinate, mutate):
@@ -134,7 +136,9 @@ def test_each_request_coordinate_misses_by_its_own_name(coordinate, mutate):
     with pytest.raises(ConsumerResolutionMiss) as caught:
         resolve_consumer_hit(mutate(request), binary, demand, launcher, caller)
     assert caught.value.coordinate == coordinate
-    assert str(caught.value).startswith(f"consumer resolution MISS: {coordinate} differs:")
+    assert str(caught.value).startswith(
+        f"consumer resolution MISS: {coordinate} differs:"
+    )
 
 
 def test_platform_difference_is_the_same_named_coordinate_as_profile():
@@ -163,9 +167,7 @@ def test_historical_path_shape_digest_is_a_named_corpus_identity_miss():
             demand.identity, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
         ),
     )
-    launcher = replace(
-        launcher, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST
-    )
+    launcher = replace(launcher, corpus_manifest_cid=HISTORICAL_PATH_SHAPE_DIGEST)
     with pytest.raises(ConsumerResolutionMiss) as caught:
         resolve_consumer_hit(request, binary, demand, launcher, caller)
     assert caught.value.coordinate == "corpus identity"

--- a/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_contains_method_caller.py
@@ -150,8 +150,11 @@ def _only_halted(outcome: object, *, require_pre_effect_state: bool = True) -> H
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('TypeError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -226,7 +229,9 @@ def _unwrap_return(value):
             value = statements[-1]
             continue
         break
-    raise AssertionError(f"unprojected membership value: {type(value).__name__} {value!r}")
+    raise AssertionError(
+        f"unprojected membership value: {type(value).__name__} {value!r}"
+    )
 
 
 def _membership_bool(outcome) -> bool:
@@ -290,9 +295,7 @@ def test_discrimination_self_is_not_a_contains_operand() -> None:
 def test_positional_keyword_and_default_calls_discharge() -> None:
     sites = (
         _method_callsite(METHOD_BODY + "\nChecker().has([1, 2], 1)\n"),
-        _method_callsite(
-            METHOD_BODY + "\nChecker().has(container=[1, 2], item=1)\n"
-        ),
+        _method_callsite(METHOD_BODY + "\nChecker().has(container=[1, 2], item=1)\n"),
         _method_callsite(METHOD_DEFAULTS + "\nChecker().has([1, 2])\n"),
     )
     for site in sites:
@@ -346,9 +349,7 @@ def test_non_container_receiver_yields_named_typeerror_with_pre_effect() -> None
         "formal contains carrier"
     )
     container_cid, item_cid = _container_item_cids(pending)
-    exits = pending.discharge(
-        {container_cid: NoneValue(), item_cid: TermValue(1)}
-    )
+    exits = pending.discharge({container_cid: NoneValue(), item_cid: TermValue(1)})
     halted = _only_halted(exits, require_pre_effect_state=True)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
     assert halted.state is testimony.state
@@ -450,8 +451,7 @@ def test_off_by_one_callsite_args_do_not_match_truthful_binding() -> None:
     assert len(off_by_one) == 2
     assert off_by_one != truthful
     assert not (
-        isinstance(off_by_one[0], ObjectValue)
-        and off_by_one[0].class_name == "Checker"
+        isinstance(off_by_one[0], ObjectValue) and off_by_one[0].class_name == "Checker"
     )
 
 
@@ -467,16 +467,12 @@ def test_swapped_container_item_twins_fail_against_truthful_membership() -> None
     container = ListValue((TermValue(1), TermValue(2)))
     item = TermValue(1)
 
-    truthful = pending.discharge(
-        {container_cid: container, item_cid: item}
-    )
+    truthful = pending.discharge({container_cid: container, item_cid: item})
     assert isinstance(truthful.exits[0], Completed)
 
     # Swapped: container slot gets item (TermValue), item slot gets list.
     # Non-container receiver → TypeError halt, not present-member True.
-    lying = pending.discharge(
-        {container_cid: item, item_cid: container}
-    )
+    lying = pending.discharge({container_cid: item, item_cid: container})
     lying_face = lying.exits[0]
     if isinstance(lying_face, Completed):
         # Must not claim the same completed membership as truthful.

--- a/implementations/python/sugar-lift-py-tests/tests/test_corpus_enrollment_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_corpus_enrollment_law.py
@@ -10,7 +10,6 @@ import importlib.util
 import json
 from pathlib import Path
 
-
 _KIT = Path(__file__).resolve().parents[1]
 _SCANNER_PATH = _KIT / "scripts" / "corpus_enrollment_law.py"
 _SPEC = importlib.util.spec_from_file_location("corpus_enrollment_law", _SCANNER_PATH)
@@ -78,9 +77,7 @@ def test_enrollment_from_recensus_missing_terminals(tmp_path: Path) -> None:
             ],
         }
     }
-    report = _SCANNER.measure_enrollment(
-        corpus_root=root, recensus_payload=payload
-    )
+    report = _SCANNER.measure_enrollment(corpus_root=root, recensus_payload=payload)
     assert report.measured_enrollment is True
     assert report.denominator_files == 3
     assert report.enrolled_files == 2
@@ -118,17 +115,19 @@ def test_cli_exits_1_when_unenrolled_nonzero(tmp_path: Path) -> None:
                 "denominator": {
                     "enrolledFiles": [
                         _SCANNER.relative_file_identity(a, corpus_root=root),
-                        _SCANNER.relative_file_identity(root / "b.py", corpus_root=root),
+                        _SCANNER.relative_file_identity(
+                            root / "b.py", corpus_root=root
+                        ),
                     ],
                     "missingFiles": [
-                        _SCANNER.relative_file_identity(root / "b.py", corpus_root=root),
+                        _SCANNER.relative_file_identity(
+                            root / "b.py", corpus_root=root
+                        ),
                     ],
                 }
             }
         ),
         encoding="utf-8",
     )
-    code = _SCANNER.main(
-        ["--corpus-root", str(root), "--from-recensus", str(receipt)]
-    )
+    code = _SCANNER.main(["--corpus-root", str(root), "--from-recensus", str(receipt)])
     assert code == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_dangling_floor_terms_residue.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dangling_floor_terms_residue.py
@@ -18,7 +18,6 @@ from sugar_lift_py_tests.ir import _Ctor, make_var
 from sugar_lift_py_tests.outcome import Complete, Incomplete
 from sugar_source_tree.tree import SourceFile
 
-
 ROOT = Path(__file__).parents[1] / "src" / "sugar_lift_py_tests" / "floor"
 TARGETS = (
     ROOT / "call_site_value.py",

--- a/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_binding_target_publication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_binding_target_publication.py
@@ -58,9 +58,7 @@ def _classes(tmp_path: Path):
         encoding="utf-8",
     )
     tree = SourceFile.from_path(path)
-    definitions = tuple(
-        item for item in tree.root.body if isinstance(item, ClassDef)
-    )
+    definitions = tuple(item for item in tree.root.body if isinstance(item, ClassDef))
     replacement, original, same_name_foreign = definitions
     raw = _class_value(original)
     final = _class_value(replacement)
@@ -182,9 +180,7 @@ def test_class_definition_value_refuses_missing_or_wrong_binding_authority() -> 
     with pytest.raises(TypeError):
         ClassDefinitionValue("Original", "class-cid", (), None)  # type: ignore[call-arg]
 
-    with pytest.raises(
-        TypeError, match="exact SourceFragmentCoordinateV1"
-    ):
+    with pytest.raises(TypeError, match="exact SourceFragmentCoordinateV1"):
         ClassDefinitionValue(
             "Original",
             "class-cid",

--- a/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_decorated_class_publication.py
@@ -87,9 +87,7 @@ def test_replacing_decorator_publication_ties_member_to_final_class(
 def test_publication_refuses_decorator_chain_reconstruction(
     variant: str, tmp_path: Path, monkeypatch
 ) -> None:
-    publication, raw, _, final, first, second, _ = _publication(
-        tmp_path, monkeypatch
-    )
+    publication, raw, _, final, first, second, _ = _publication(tmp_path, monkeypatch)
     applications = {
         "swapped": (second, first),
         "omitted": (second,),

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_formal_caller.py
@@ -180,7 +180,10 @@ def _assert_named_halt(outcome, expected: str) -> Halted:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity(expected)
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -213,17 +216,13 @@ def test_delitem_producer_method_is_enrolled_or_named_missing() -> None:
     """Pin the one-door mint method that store already has."""
     assert hasattr(SubscriptStoreEffectSugar, "mint_setitem_carrier")
     if not hasattr(SubscriptDeleteEffectSugar, "mint_delitem_carrier"):
-        raise AssertionError(
-            f"missing producer method {MISSING_DELITEM_PRODUCER}"
-        )
+        raise AssertionError(f"missing producer method {MISSING_DELITEM_PRODUCER}")
 
 
 def test_delattr_producer_method_is_enrolled_or_named_missing() -> None:
     assert hasattr(AttributeStoreEffectSugar, "mint_setattr_named_carrier")
     if not hasattr(AttributeDeleteEffectSugar, "mint_delattr_named_carrier"):
-        raise AssertionError(
-            f"missing producer method {MISSING_DELATTR_PRODUCER}"
-        )
+        raise AssertionError(f"missing producer method {MISSING_DELATTR_PRODUCER}")
 
 
 def test_delitem_projector_is_enrolled_or_named_missing() -> None:
@@ -294,9 +293,10 @@ def test_name_deletion_is_out_of_scope_for_delitem_and_delattr_named() -> None:
     function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
     pending = function.sugar().desugar(None)
     if isinstance(pending, NativeOperationExitCarrierV1):
-        assert pending.demand.operator not in {"delitem", "delattr_named"}, (
-            "Name deletion must not mint delitem/delattr_named"
-        )
+        assert pending.demand.operator not in {
+            "delitem",
+            "delattr_named",
+        }, "Name deletion must not mint delitem/delattr_named"
     # Positive: attribute/subscript delete still own those operators.
     _, item = _delitem_helper()
     assert _require_delitem_carrier(item).demand.operator == "delitem"
@@ -490,9 +490,9 @@ def test_missing_attribute_halts_with_named_attributeerror_and_pre_effect() -> N
     _, pending = _delattr_helper()
     pending = _require_delattr_carrier(pending)
     testimony = pending.pre_effect_state
-    assert testimony is not None, (
-        "reducer did not enroll ReducerPreEffectStateV1 on formal delattr_named"
-    )
+    assert (
+        testimony is not None
+    ), "reducer did not enroll ReducerPreEffectStateV1 on formal delattr_named"
     obj_cid, _ = pending.demand.operand_coordinate_cids
     receiver = ObjectValue(class_name="Widget", fields=(), methods=())
     exits = pending.discharge({obj_cid: receiver})
@@ -626,9 +626,9 @@ def test_read_does_not_authorize_delete_on_getter_only_property() -> None:
     )
     exits = pending.discharge({obj_cid: receiver})
     halted = exits.exits[0]
-    assert isinstance(halted, Halted), (
-        "read-authorizes-delete twin: getter-only property must not complete delete"
-    )
+    assert isinstance(
+        halted, Halted
+    ), "read-authorizes-delete twin: getter-only property must not complete delete"
     assert halted.effect.exception_type_coordinate == _identity("AttributeError")
 
 
@@ -734,9 +734,7 @@ def test_floor_delete_is_not_the_formal_carrier_twin() -> None:
     assert isinstance(floor, Complete)
     _, pending = _delitem_helper()
     # Formal demand (when present) is a carrier, not a floor Complete.
-    assert not (
-        isinstance(pending, Complete) and isinstance(pending.value, ListValue)
-    )
+    assert not (isinstance(pending, Complete) and isinstance(pending.value, ListValue))
     if isinstance(pending, NativeOperationExitCarrierV1):
         assert pending.demand.operator == "delitem"
     else:

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_name_binding.py
@@ -114,21 +114,25 @@ def test_del_removes_binding_later_read_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.exception_name == "NameError"
     assert halted.effect.name == "x"
-    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+    assert (
+        isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence!r}"
     )
-    assert "unbound name 'x'" in str(
-        getattr(halted.effect, "reason", "")
-        or getattr(halted.effect, "exception_name", "")
-    ) or halted.effect.name == "x"
+    assert (
+        "unbound name 'x'"
+        in str(
+            getattr(halted.effect, "reason", "")
+            or getattr(halted.effect, "exception_name", "")
+        )
+        or halted.effect.name == "x"
+    )
 
 
 def test_delete_name_sugar_prior_is_bound_value_not_spelling() -> None:
     """DeleteNameSugar carries the prior binding state, not a name-lookup."""
-    function, _ = _function_outcome(
-        "def f():\n" "    x = 1\n" "    del x\n"
-    )
+    function, _ = _function_outcome("def f():\n" "    x = 1\n" "    del x\n")
     deletes = [
         s for s in _universe_statements(function) if isinstance(s, DeleteNameSugar)
     ]
@@ -145,9 +149,7 @@ def test_delete_name_sugar_prior_is_bound_value_not_spelling() -> None:
 
 def test_post_delete_binding_trace_is_unbound_at_delete_site() -> None:
     """Substitution trace: after del, name maps to UnboundBinding at delete site."""
-    function, _ = _function_outcome(
-        "def f():\n" "    x = 1\n" "    del x\n"
-    )
+    function, _ = _function_outcome("def f():\n" "    x = 1\n" "    del x\n")
     sugar = function.sugar()
     trace = getattr(sugar, "substitution_trace", None)
     assert trace is not None
@@ -169,11 +171,7 @@ def test_post_delete_binding_trace_is_unbound_at_delete_site() -> None:
 def test_value_captured_before_del_survives() -> None:
     """``x = 1; y = x; del x; return y`` → Completed return TermValue(1)."""
     _, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    y = x\n"
-        "    del x\n"
-        "    return y\n"
+        "def f():\n" "    x = 1\n" "    y = x\n" "    del x\n" "    return y\n"
     )
     completed = _sole_completed(outcome)
     assert _returned(completed).value == TermValue(1)
@@ -191,11 +189,7 @@ def test_del_then_return_constant_completes() -> None:
 def test_rebind_after_del_restores_binding() -> None:
     """``del x; x = 2; return x`` → TermValue(2)."""
     _, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    del x\n"
-        "    x = 2\n"
-        "    return x\n"
+        "def f():\n" "    x = 1\n" "    del x\n" "    x = 2\n" "    return x\n"
     )
     completed = _sole_completed(outcome)
     assert _returned(completed).value == TermValue(2)
@@ -241,17 +235,11 @@ def test_conditional_del_builds_guarded_projection_on_later_read() -> None:
     when_true → UnboundProjection; when_false → prior bound value.
     """
     function, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    if flag:\n"
-        "        del x\n"
-        "    return x\n"
+        "def f():\n" "    x = 1\n" "    if flag:\n" "        del x\n" "    return x\n"
     )
     # Structure pin on the return sugar.
     returns = [
-        s
-        for s in _universe_statements(function)
-        if type(s).__name__ == "ReturnSugar"
+        s for s in _universe_statements(function) if type(s).__name__ == "ReturnSugar"
     ]
     assert len(returns) == 1
     read = returns[0].value
@@ -278,11 +266,7 @@ def test_conditional_del_builds_guarded_projection_on_later_read() -> None:
 def test_true_branch_del_factors_unbound_and_retained_faces() -> None:
     """``if True: del x; return x`` factors complementary guards (not collapsed silent)."""
     _, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    if True:\n"
-        "        del x\n"
-        "    return x\n"
+        "def f():\n" "    x = 1\n" "    if True:\n" "        del x\n" "    return x\n"
     )
     assert len(outcome.exits) >= 2
     kinds = {type(e).__name__ for e in outcome.exits}
@@ -295,11 +279,7 @@ def test_true_branch_del_factors_unbound_and_retained_faces() -> None:
 def test_false_branch_del_retains_binding_on_completed_arm() -> None:
     """``if False: del x; return x`` — completed arm returns 1 (binding retained)."""
     _, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    if False:\n"
-        "        del x\n"
-        "    return x\n"
+        "def f():\n" "    x = 1\n" "    if False:\n" "        del x\n" "    return x\n"
     )
     completed = [e for e in outcome.exits if isinstance(e, Completed)]
     assert completed
@@ -318,6 +298,7 @@ def test_false_branch_del_retains_binding_on_completed_arm() -> None:
                 values.append(getattr(s, "value", None))
     assert any(v == TermValue(1) or v == 1 for v in values), values
 
+
 # ===========================================================================
 # Absent local → authenticated NameError
 # ===========================================================================
@@ -330,7 +311,9 @@ def test_del_absent_local_is_nameerror() -> None:
     assert isinstance(halted.effect, NameErrorEffect)
     assert halted.effect.exception_name == "NameError"
     assert halted.effect.name == "x"
-    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+    assert (
+        isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence!r}"
     )
@@ -340,7 +323,11 @@ def test_del_absent_is_not_silent_completion_twin() -> None:
     _, outcome = _function_outcome("def f():\n" "    del x\n")
     with pytest.raises(AssertionError):
         assert all(isinstance(e, Completed) for e in outcome.exits)
-    assert any(isinstance(e.effect, NameErrorEffect) for e in outcome.exits if isinstance(e, Halted))
+    assert any(
+        isinstance(e.effect, NameErrorEffect)
+        for e in outcome.exits
+        if isinstance(e, Halted)
+    )
 
 
 def test_unboundlocal_only_when_source_authority_distinguishes() -> None:
@@ -372,9 +359,7 @@ def test_attribute_delete_is_not_delete_name_sugar() -> None:
     kind, never discharges attribute delete.
     """
     tree = _tree("def f(obj):\n    del obj.attr\n")
-    function = next(
-        node for node in tree.nodes() if isinstance(node, FunctionDef)
-    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
     statements = _universe_statements(function)
     assert any(isinstance(s, AttributeDeleteEffectSugar) for s in statements)
     assert not any(isinstance(s, DeleteNameSugar) for s in statements)
@@ -387,9 +372,7 @@ def test_subscript_delete_is_not_delete_name_sugar() -> None:
     kind, never discharges subscript delete.
     """
     tree = _tree("def f(obj, i):\n    del obj[i]\n")
-    function = next(
-        node for node in tree.nodes() if isinstance(node, FunctionDef)
-    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
     statements = _universe_statements(function)
     assert any(isinstance(s, SubscriptDeleteEffectSugar) for s in statements)
     assert not any(isinstance(s, DeleteNameSugar) for s in statements)
@@ -403,11 +386,7 @@ def test_subscript_delete_is_not_delete_name_sugar() -> None:
 def test_delete_targets_exact_name_not_a_homophone() -> None:
     """``del x`` unbinds x; y remains bound."""
     _, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    y = 2\n"
-        "    del x\n"
-        "    return y\n"
+        "def f():\n" "    x = 1\n" "    y = 2\n" "    del x\n" "    return y\n"
     )
     completed = _sole_completed(outcome)
     assert _returned(completed).value == TermValue(2)
@@ -415,11 +394,7 @@ def test_delete_targets_exact_name_not_a_homophone() -> None:
 
 def test_delete_x_does_not_unbind_xx_by_spelling() -> None:
     _, outcome = _function_outcome(
-        "def f():\n"
-        "    x = 1\n"
-        "    xx = 2\n"
-        "    del x\n"
-        "    return xx\n"
+        "def f():\n" "    x = 1\n" "    xx = 2\n" "    del x\n" "    return xx\n"
     )
     completed = _sole_completed(outcome)
     assert _returned(completed).value == TermValue(2)

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_readback_laws.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_readback_laws.py
@@ -116,7 +116,9 @@ def _post_dict(completed: Completed) -> DictValue:
         dicts = [s for s in record.statements if isinstance(s, DictValue)]
         assert dicts, f"{CODEX3}: no DictValue post-state in {record.statements!r}"
         return dicts[-1]
-    raise AssertionError(f"{CODEX3}: unprojected delete post-state {type(value).__name__}")
+    raise AssertionError(
+        f"{CODEX3}: unprojected delete post-state {type(value).__name__}"
+    )
 
 
 def _post_object(completed: Completed) -> ObjectValue:
@@ -128,14 +130,16 @@ def _post_object(completed: Completed) -> ObjectValue:
         objs = [s for s in record.statements if isinstance(s, ObjectValue)]
         assert objs, f"{CODEX3}: no ObjectValue post-state"
         return objs[-1]
-    raise AssertionError(f"{CODEX3}: unprojected delattr post-state {type(value).__name__}")
+    raise AssertionError(
+        f"{CODEX3}: unprojected delattr post-state {type(value).__name__}"
+    )
 
 
 def _keyerror_raise(outcome, *, site) -> RaiseValue:
     """Authenticated read face: Complete(RaiseValue KeyError) at the given locus."""
-    assert isinstance(outcome, Complete), (
-        f"{CODEX3}: expected Complete KeyError raise, got {type(outcome).__name__}"
-    )
+    assert isinstance(
+        outcome, Complete
+    ), f"{CODEX3}: expected Complete KeyError raise, got {type(outcome).__name__}"
     assert isinstance(outcome.value, RaiseValue), outcome.value
     raise_value = outcome.value
     assert raise_value.effect.exception_name == "KeyError"
@@ -145,15 +149,18 @@ def _keyerror_raise(outcome, *, site) -> RaiseValue:
         raise_value.effect.occurrence_id is not None
     )
     # Same source fragment as the delete when readback uses the delete site.
-    assert str(site) in str(raise_value.effect.occurrence) or str(
-        raise_value.effect.occurrence
-    ) == str(site) or site is raise_value.effect.occurrence or (
-        getattr(raise_value.effect.occurrence, "filename", None)
-        == getattr(site, "filename", None)
-    ) or "Delete" in str(raise_value.effect.occurrence) or "delitem" in str(
-        raise_value.effect.occurrence
-    ).lower() or str(raise_value.effect.blame) == str(site) or str(site) in str(
-        raise_value.effect.blame
+    assert (
+        str(site) in str(raise_value.effect.occurrence)
+        or str(raise_value.effect.occurrence) == str(site)
+        or site is raise_value.effect.occurrence
+        or (
+            getattr(raise_value.effect.occurrence, "filename", None)
+            == getattr(site, "filename", None)
+        )
+        or "Delete" in str(raise_value.effect.occurrence)
+        or "delitem" in str(raise_value.effect.occurrence).lower()
+        or str(raise_value.effect.blame) == str(site)
+        or str(site) in str(raise_value.effect.blame)
     ), (
         f"{CODEX3}: KeyError occurrence lineage lost delete locus; "
         f"occurrence={raise_value.effect.occurrence!r} site={site!r}"
@@ -177,9 +184,7 @@ def test_completed_delitem_readback_yields_named_keyerror_with_delete_lineage() 
             (StringValue("b"), TermValue(2)),
         )
     )
-    exits = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("a")}
-    )
+    exits = pending.discharge({obj_cid: original, key_cid: StringValue("a")})
     assert isinstance(exits.exits[0], Completed)
     post = _post_dict(exits.exits[0])
     assert not any(k.value == "a" for k, _ in post.entries)
@@ -203,9 +208,7 @@ def test_discrimination_completed_delitem_does_not_fabricate_deleted_value() -> 
     site = function.body[0].fragment
     obj_cid, key_cid = pending.demand.operand_coordinate_cids
     original = DictValue(((StringValue("a"), TermValue(1)),))
-    exits = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("a")}
-    )
+    exits = pending.discharge({obj_cid: original, key_cid: StringValue("a")})
     post = _post_dict(exits.exits[0])
     missing = post.subscript(StringValue("a"), site)
     with pytest.raises(AssertionError):
@@ -220,7 +223,9 @@ def test_discrimination_completed_delitem_does_not_fabricate_deleted_value() -> 
 # ===========================================================================
 
 
-def test_completed_delattr_removes_field_and_read_is_attributeerror_or_named_gap() -> None:
+def test_completed_delattr_removes_field_and_read_is_attributeerror_or_named_gap() -> (
+    None
+):
     """After ``del obj.field``, field is absent; read is AttributeError."""
     function, pending = _delattr_pending()
     delete_site = function.body[0].fragment
@@ -238,9 +243,7 @@ def test_completed_delattr_removes_field_and_read_is_attributeerror_or_named_gap
     try:
         read = post.attribute("field", delete_site)
     except SugarNotWritten as err:
-        raise AssertionError(
-            f"{FLOOR_ATTR}: {err}"
-        ) from err
+        raise AssertionError(f"{FLOOR_ATTR}: {err}") from err
     except ConstructionPanic as err:
         raise AssertionError(
             f"{FLOOR_ATTR}: ConstructionPanic on missing field read: {err}"
@@ -269,9 +272,7 @@ def test_discrimination_delattr_does_not_leave_readable_old_value() -> None:
     exits = pending.discharge({obj_cid: receiver})
     post = _post_object(exits.exits[0])
     with pytest.raises(AssertionError):
-        assert any(
-            f.name == "field" and f.value == TermValue(7) for f in post.fields
-        )
+        assert any(f.name == "field" and f.value == TermValue(7) for f in post.fields)
 
 
 # ===========================================================================
@@ -285,9 +286,7 @@ def test_delete_then_restore_setitem_reads_new_value() -> None:
     site = function.body[0].fragment
     obj_cid, key_cid = pending.demand.operand_coordinate_cids
     original = DictValue(((StringValue("a"), TermValue(1)),))
-    deleted = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("a")}
-    )
+    deleted = pending.discharge({obj_cid: original, key_cid: StringValue("a")})
     post = _post_dict(deleted.exits[0])
     restored = post.setitem(StringValue("a"), TermValue(99), site)
     assert isinstance(restored, Complete)
@@ -337,15 +336,13 @@ def test_readback_after_halted_delete_still_sees_original() -> None:
             (StringValue("b"), TermValue(2)),
         )
     )
-    exits = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("missing")}
-    )
+    exits = pending.discharge({obj_cid: original, key_cid: StringValue("missing")})
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("KeyError")
-    assert halted.state is pending.pre_effect_state.state, (
-        f"{CODEX1}: halt state identity lost"
-    )
+    assert (
+        halted.state is pending.pre_effect_state.state
+    ), f"{CODEX1}: halt state identity lost"
     # Original receiver still carries pre-delete content.
     present = original.subscript(StringValue("a"), site)
     assert isinstance(present, Complete)
@@ -359,9 +356,7 @@ def test_discrimination_halted_delete_is_not_a_completed_empty_dict() -> None:
     function, pending = _delitem_pending()
     obj_cid, key_cid = pending.demand.operand_coordinate_cids
     original = DictValue(((StringValue("a"), TermValue(1)),))
-    exits = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("missing")}
-    )
+    exits = pending.discharge({obj_cid: original, key_cid: StringValue("missing")})
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     with pytest.raises(AssertionError):
@@ -381,9 +376,7 @@ def test_lying_keyerror_wrong_occurrence_refuses() -> None:
     delete_site = function.body[0].fragment
     obj_cid, key_cid = pending.demand.operand_coordinate_cids
     original = DictValue(((StringValue("a"), TermValue(1)),))
-    exits = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("a")}
-    )
+    exits = pending.discharge({obj_cid: original, key_cid: StringValue("a")})
     post = _post_dict(exits.exits[0])
     missing = post.subscript(StringValue("a"), delete_site)
     raise_value = _keyerror_raise(missing, site=delete_site)
@@ -400,9 +393,7 @@ def test_lying_fabricated_deleted_value_refuses_against_keyerror() -> None:
     site = function.body[0].fragment
     obj_cid, key_cid = pending.demand.operand_coordinate_cids
     original = DictValue(((StringValue("a"), TermValue(1)),))
-    exits = pending.discharge(
-        {obj_cid: original, key_cid: StringValue("a")}
-    )
+    exits = pending.discharge({obj_cid: original, key_cid: StringValue("a")})
     post = _post_dict(exits.exits[0])
     missing = post.subscript(StringValue("a"), site)
     assert not (

--- a/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_delete_state_joins.py
@@ -80,15 +80,10 @@ CODEX3 = (
 
 DELITEM_HELPER = "def helper(obj, key):\n    del obj[key]\n"
 MULTI_PRIOR_STORE = (
-    "def multi(obj, key):\n"
-    "    a = [0]\n"
-    "    a[0] = 9\n"
-    "    del obj[key]\n"
+    "def multi(obj, key):\n" "    a = [0]\n" "    a[0] = 9\n" "    del obj[key]\n"
 )
 METHOD_DROP = (
-    "class Holder:\n"
-    "    def drop(self, obj, key):\n"
-    "        del obj[key]\n"
+    "class Holder:\n" "    def drop(self, obj, key):\n" "        del obj[key]\n"
 )
 
 
@@ -132,17 +127,16 @@ def _delitem_keyerror_halt(
     function = next(
         node
         for node in tree.nodes()
-        if isinstance(node, FunctionDef)
-        and node.name in {"helper", "multi", "drop"}
+        if isinstance(node, FunctionDef) and node.name in {"helper", "multi", "drop"}
     )
     pending = function.sugar().desugar(None)
-    assert isinstance(pending, NativeOperationExitCarrierV1), (
-        f"{CODEX1}: expected delitem carrier, got {type(pending).__name__}"
-    )
+    assert isinstance(
+        pending, NativeOperationExitCarrierV1
+    ), f"{CODEX1}: expected delitem carrier, got {type(pending).__name__}"
     assert pending.demand.operator == "delitem"
-    assert pending.pre_effect_state is not None, (
-        f"{CODEX1}: reducer did not enroll pre_effect_state on delitem carrier"
-    )
+    assert (
+        pending.pre_effect_state is not None
+    ), f"{CODEX1}: reducer did not enroll pre_effect_state on delitem carrier"
     obj_cid, key_cid = pending.demand.operand_coordinate_cids
     exits = pending.discharge(
         {
@@ -154,13 +148,16 @@ def _delitem_keyerror_halt(
     halted = exits.exits[0]
     assert isinstance(halted, Halted), halted
     assert halted.effect.exception_type_coordinate == _identity("KeyError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
-    assert halted.state is pending.pre_effect_state.state, (
-        f"{CODEX1}: halt.state is not enrolled pre-effect state identity"
-    )
+    assert (
+        halted.state is pending.pre_effect_state.state
+    ), f"{CODEX1}: halt.state is not enrolled pre-effect state identity"
     return pending, halted
 
 
@@ -237,9 +234,9 @@ def test_earlier_bindings_survive_delete_halt_in_multi_statement_body() -> None:
     pending, halted = _delitem_keyerror_halt(MULTI_PRIOR_STORE)
     assert halted.state is not None, f"{CODEX1}: multi-statement halt dropped state"
     lists = [e for e in halted.state.entries if isinstance(e, ListValue)]
-    assert lists == [ListValue((TermValue(9),))], (
-        f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
-    )
+    assert lists == [
+        ListValue((TermValue(9),))
+    ], f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
     assert halted.state is pending.pre_effect_state.state
 
 
@@ -280,17 +277,16 @@ def test_bound_method_delete_retains_obj_key_demand_not_self() -> None:
     )
     assert pending.demand.operator == "delitem"
     names = tuple(value.term.name for value in pending.operands)
-    assert names == ("obj", "key"), (
-        f"{CODEX3}: delitem formals shifted by self: {names}"
-    )
+    assert names == (
+        "obj",
+        "key",
+    ), f"{CODEX3}: delitem formals shifted by self: {names}"
     method_formals = tuple(p.name for p in method.params)
     assert method_formals[0] == "self"
     assert method_formals[1:] == ("obj", "key")
     # Self formal coordinate is not a delitem operand.
     self_coord = method.formal_coordinates()[0]
-    assert self_coord.coordinate_cid not in set(
-        pending.demand.operand_coordinate_cids
-    )
+    assert self_coord.coordinate_cid not in set(pending.demand.operand_coordinate_cids)
 
 
 def test_bound_method_delete_callsite_prepends_self_without_shifting_args() -> None:
@@ -306,9 +302,9 @@ def test_bound_method_delete_callsite_prepends_self_without_shifting_args() -> N
     )
     assert len(calls) == 1
     constructed = calls[0].sugar().desugar(None)
-    assert isinstance(constructed, Complete), (
-        f"{CODEX3}: expected Complete(CallSiteValue), got {type(constructed).__name__}"
-    )
+    assert isinstance(
+        constructed, Complete
+    ), f"{CODEX3}: expected Complete(CallSiteValue), got {type(constructed).__name__}"
     site = constructed.value
     assert isinstance(site, CallSiteValue)
     assert site.parameters == ("self", "obj", "key")
@@ -337,18 +333,20 @@ def test_bound_method_delete_producer_outcome_halts_with_named_keyerror() -> Non
     site = calls[0].sugar().desugar(None).value
     assert isinstance(site, CallSiteValue)
     outcome = site.producer_outcome(None)
-    assert isinstance(outcome, ExitSet), (
-        f"{CODEX3}: expected ExitSet halt, got {type(outcome).__name__}"
-    )
+    assert isinstance(
+        outcome, ExitSet
+    ), f"{CODEX3}: expected ExitSet halt, got {type(outcome).__name__}"
     halted = next((e for e in outcome.exits if isinstance(e, Halted)), None)
     assert halted is not None, f"{CODEX3}: no Halted face in {outcome.exits!r}"
     assert halted.effect.exception_name == "KeyError" or (
         halted.effect.exception_type_coordinate == _identity("KeyError")
     )
-    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
-    assert halted.state is not None, (
-        f"{CODEX1}: bound-method delete halt dropped pre-effect state"
+    assert (
+        halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
     )
+    assert (
+        halted.state is not None
+    ), f"{CODEX1}: bound-method delete halt dropped pre-effect state"
 
 
 # ===========================================================================
@@ -364,9 +362,9 @@ def test_fabricated_empty_state_is_not_pre_delete_when_store_preceded() -> None:
     assert halted.state is pending.pre_effect_state.state
     with pytest.raises(AssertionError):
         assert halted.state is fabricated
-    assert any(isinstance(e, ListValue) for e in halted.state.entries), (
-        f"{CODEX1}: prior store absent from entries={halted.state.entries!r}"
-    )
+    assert any(
+        isinstance(e, ListValue) for e in halted.state.entries
+    ), f"{CODEX1}: prior store absent from entries={halted.state.entries!r}"
 
 
 def test_handler_value_is_not_fabricated_fresh_block_twin() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_desugar_repro.py
@@ -6,9 +6,7 @@ from pathlib import Path
 from sugar_lift_py_tests.gap.info import ConstructionGap
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
-_SCRIPT = (
-    Path(__file__).parents[1] / "scripts" / "desugar_repro.py"
-)
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "desugar_repro.py"
 _SPEC = importlib.util.spec_from_file_location("desugar_repro", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 _MOD = importlib.util.module_from_spec(_SPEC)

--- a/implementations/python/sugar-lift-py-tests/tests/test_dict_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dict_attribute_mutation.py
@@ -12,7 +12,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "dict_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -21,7 +23,8 @@ class _Value(Sugar):
     value: object
 
     @classmethod
-    def witnesses(cls): return ()
+    def witnesses(cls):
+        return ()
 
     def desugar(self, ctx=None):
         del ctx
@@ -31,9 +34,14 @@ class _Value(Sugar):
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     receiver = DictValue(())
-    store = AttributeStoreEffectSugar(_Value(receiver), _Value(TermValue(7)), "attr", store_site).desugar()
+    store = AttributeStoreEffectSugar(
+        _Value(receiver), _Value(TermValue(7)), "attr", store_site
+    ).desugar()
     delete = AttributeDeleteEffectSugar(_Value(receiver), "attr", delete_site).desugar()
-    return ((store, "DictValue.setattr", store_site), (delete, "DictValue.delattr", delete_site))
+    return (
+        (store, "DictValue.setattr", store_site),
+        (delete, "DictValue.delattr", delete_site),
+    )
 
 
 def test_dict_attribute_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_dict_literal_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dict_literal_attribute_mutation.py
@@ -7,22 +7,42 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "dict_literal_attribute_mutation.py"
-    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "DictLiteralValue.setattr", 0), ("delattr", "DictLiteralValue.delattr", 1)))
-def test_dict_literal_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = DictLiteralValue(())
-    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "DictLiteralValue.setattr", 0),
+        ("delattr", "DictLiteralValue.delattr", 1),
+    ),
+)
+def test_dict_literal_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = DictLiteralValue(())
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
     assert outcome.value.effect.exception_name == "AttributeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_dict_literal_attribute_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = DictLiteralValue(())
-    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = DictLiteralValue(())
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_dispatch_targets_resolve.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_dispatch_targets_resolve.py
@@ -103,7 +103,9 @@ def _broken_promises() -> list[str]:
             if not module.startswith("sugar_"):
                 continue  # third-party availability is the closure's business
             if not _resolves(module, name):
-                broken.append(f"{path.relative_to(SRC)}:{line} from {module} import {name}")
+                broken.append(
+                    f"{path.relative_to(SRC)}:{line} from {module} import {name}"
+                )
     return broken
 
 
@@ -131,9 +133,6 @@ def test_the_audit_actually_recognizes(tmp_path) -> None:
     # And the walker must actually see a function-local import, not just
     # module-level ones -- that distinction is the whole point.
     tree = ast.parse(
-        "import os\n"
-        "def f():\n"
-        "    from sugar_x.y import z\n"
-        "    return z\n"
+        "import os\n" "def f():\n" "    from sugar_x.y import z\n" "    return z\n"
     )
     assert _function_local_imports(tree) == [("sugar_x.y", "z", 3)]

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_boundary_observation_conserves_demands.py
@@ -95,11 +95,22 @@ def _raise_effect(name: str):
 
     identity = ctor(
         "python:exception_type_identity",
-        [__import__("sugar_lift_py_tests.ir", fromlist=["str_const"]).str_const(
-            "builtins"
-        ), __import__("sugar_lift_py_tests.ir", fromlist=["str_const"]).str_const(name)],
+        [
+            __import__("sugar_lift_py_tests.ir", fromlist=["str_const"]).str_const(
+                "builtins"
+            ),
+            __import__("sugar_lift_py_tests.ir", fromlist=["str_const"]).str_const(
+                name
+            ),
+        ],
     )
-    return RaiseEffect(exception_type_coordinate=identity, occurrence=AuthenticatedRaiseLocus.of(f'{SRC}:3:8'), exception_name=name, blame=f'{SRC}:3:8', exception_type_mro=(identity,))
+    return RaiseEffect(
+        exception_type_coordinate=identity,
+        occurrence=AuthenticatedRaiseLocus.of(f"{SRC}:3:8"),
+        exception_name=name,
+        blame=f"{SRC}:3:8",
+        exception_type_mro=(identity,),
+    )
 
 
 class _AlwaysMatches:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_router.py
@@ -30,7 +30,12 @@ from sugar_lift_py_tests.floor.warning_observation_value import WarningObservati
 
 
 def _raise_incomplete(name: str) -> Incomplete:
-    return Incomplete(RaiseEffect.for_builtin(name, occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_router.py:33:0'))
+    return Incomplete(
+        RaiseEffect.for_builtin(
+            name,
+            occurrence="implementations/python/sugar-lift-py-tests/tests/test_effect_router.py:33:0",
+        )
+    )
 
 
 def _some_fact() -> InvValue:

--- a/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py
@@ -78,7 +78,14 @@ def test_wrong_match_does_not_bind_slot() -> None:
     from sugar_lift_py_tests.effect_router import route
     from sugar_lift_py_tests.outcome import Incomplete
 
-    entries = (Incomplete(RaiseEffect.for_builtin('KeyError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:81:0')),)
+    entries = (
+        Incomplete(
+            RaiseEffect.for_builtin(
+                "KeyError",
+                occurrence="implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:81:0",
+            )
+        ),
+    )
     out = route(
         entries,
         Expects(matcher=EffectMatcher(kind="raise", name="ValueError")),
@@ -98,8 +105,16 @@ def test_observed_effect_projects_only_an_authenticated_context_preimage() -> No
     from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
     inner_value = TermValue(7)
-    inner = RaiseEffect.for_builtin('ImportError', raised_value=inner_value, occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:101:0')
-    outer = RaiseEffect.for_builtin('ValueError', context_effect=inner, occurrence='implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:102:0')
+    inner = RaiseEffect.for_builtin(
+        "ImportError",
+        raised_value=inner_value,
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:101:0",
+    )
+    outer = RaiseEffect.for_builtin(
+        "ValueError",
+        context_effect=inner,
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_effect_slot_binding_testimony.py:102:0",
+    )
 
     projected = ObservedEffectValue(slot_id="S", effect=outer).attribute(
         "__context__", site=None
@@ -132,13 +147,13 @@ def test_effect_ref_observes_the_same_effect_the_route_deposited() -> None:
     from sugar_lift_py_tests.sugar.effect_ref_sugar import EffectRefSugar
 
     inner_value = TermValue(11)
-    inner = RaiseEffect.for_builtin("ImportError",
-        
+    inner = RaiseEffect.for_builtin(
+        "ImportError",
         raised_value=inner_value,
         occurrence="inner.py:1:0",
     )
-    routed = RaiseEffect.for_builtin("ValueError",
-        
+    routed = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence="outer.py:2:4",
         context_effect=inner,
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_attribute_mutation.py
@@ -6,10 +6,15 @@ from sugar_source_tree.tree import SourceFile
 def _outcomes(tmp_path):
     path = tmp_path / "ellipsis_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     s, d = body[0].fragment, body[1].fragment
     value = EllipsisValue()
-    return ((value.setattr("attr", TermValue(7), s), "EllipsisValue.setattr", s), (value.delattr("attr", d), "EllipsisValue.delattr", d))
+    return (
+        (value.setattr("attr", TermValue(7), s), "EllipsisValue.setattr", s),
+        (value.delattr("attr", d), "EllipsisValue.delattr", d),
+    )
 
 
 def test_ellipsis_attribute_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ellipsis_subscript_mutation.py
@@ -6,10 +6,15 @@ from sugar_source_tree.tree import SourceFile
 def _outcomes(tmp_path):
     path = tmp_path / "ellipsis_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     s, d = body[0].fragment, body[1].fragment
     value = EllipsisValue()
-    return ((value.setitem(TermValue(0), TermValue(7), s), "EllipsisValue.setitem", s), (value.delitem(TermValue(0), d), "EllipsisValue.delitem", d))
+    return (
+        (value.setitem(TermValue(0), TermValue(7), s), "EllipsisValue.setitem", s),
+        (value.delitem(TermValue(0), d), "EllipsisValue.delitem", d),
+    )
 
 
 def test_ellipsis_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_attribute_mutation.py
@@ -7,7 +7,9 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path, monkeypatch):
     path = tmp_path / "encoded_string_attribute_mutation.py"
-    path.write_text("def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n")
+    path.write_text(
+        "def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n"
+    )
     monkeypatch.chdir(tmp_path)
     body = next(SourceFile.from_path(path.name).functions()).body
     return body[0].fragment, body[1].fragment

--- a/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_encoded_string_subscript_mutation.py
@@ -7,7 +7,9 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "encoded_string_subscript_mutation.py"
-    path.write_text("def f(value, replacement):\n    value[0] = replacement\n    del value[0]\n")
+    path.write_text(
+        "def f(value, replacement):\n    value[0] = replacement\n    del value[0]\n"
+    )
     body = next(
         SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
     ).body

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_explicit_population.py
@@ -38,12 +38,12 @@ def test_lying_twin_production_roots_are_not_a_silent_cli_default() -> None:
         "bare_exception_zero_tolerance.py",
     ):
         source = (_SCRIPTS / name).read_text(encoding="utf-8")
-        assert "default=list(production_roots" not in source, (
-            f"{name} still silently defaults paths to production_roots"
-        )
-        assert "require_explicit_scan_roots" in source, (
-            f"{name} must refuse empty path sets at the door"
-        )
+        assert (
+            "default=list(production_roots" not in source
+        ), f"{name} still silently defaults paths to production_roots"
+        assert (
+            "require_explicit_scan_roots" in source
+        ), f"{name} must refuse empty path sets at the door"
 
 
 def test_truthful_named_root_discovers_python(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_loop_post_binding_partition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_loop_post_binding_partition.py
@@ -78,17 +78,16 @@ def test_enum_post_binding_preserves_three_states_and_two_outward_routes(
             record
             for record in graph["records"]
             if record.get("kind") == "loop-post-binding"
-            and record["bindingCoordinateCid"]
-            == kwargs["binding_coordinate"].cid
+            and record["bindingCoordinateCid"] == kwargs["binding_coordinate"].cid
         )
         assert {record["exitPartitionArity"] for record in post_records} == {3}
         assert len(projected.completed_faces) == len(post_records) == 3
-        assert {
-            face.completion_kind for face in projected.completed_faces
-        } == {"BreakExit", "BodyFallthrough", "NormalExhaustion"}
-        assert len(
-            {face.guard_formula_cid for face in projected.completed_faces}
-        ) == 3
+        assert {face.completion_kind for face in projected.completed_faces} == {
+            "BreakExit",
+            "BodyFallthrough",
+            "NormalExhaustion",
+        }
+        assert len({face.guard_formula_cid for face in projected.completed_faces}) == 3
         root = graph["root"]
         assert len(root["breakExitObligationCids"]) == 1
         assert root["exhaustionExitObligationCid"]

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_setitem_lineage.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_setitem_lineage.py
@@ -26,9 +26,7 @@ def _source_receiver(source: str):
     tree = SourceFile(
         (source, "enum_setitem_lineage.py", blake3_512_of(source.encode()))
     )
-    definition = next(
-        node for node in tree.root.body if isinstance(node, ClassDef)
-    )
+    definition = next(node for node in tree.root.body if isinstance(node, ClassDef))
     context = ReduceContext.root(owner="test_enum_setitem_lineage")
     class_outcome = definition.sugar().desugar(context)
     assert isinstance(class_outcome, Complete)
@@ -48,9 +46,9 @@ def _source_method_outcome(receiver, context, key="member", value=7):
         ctx=context,
     )
     assert isinstance(selected, Complete)
-    assert isinstance(selected.value, CallSiteValue), (
-        "a source __setitem__ override must be selected before builtin dict mutation"
-    )
+    assert isinstance(
+        selected.value, CallSiteValue
+    ), "a source __setitem__ override must be selected before builtin dict mutation"
     return receiver.setitem_with_context(
         StringValue(key), TermValue(value), "setitem-site", context
     )
@@ -164,7 +162,5 @@ def test_type_new_consumes_the_post_setitem_namespace_not_its_pre_state() -> Non
     assert isinstance(created.value, RuntimeClassValue)
     class_dict = created.value.attribute("__dict__", "dict-site")
     assert isinstance(class_dict, Complete)
-    assert class_dict.value.entries == (
-        (StringValue("_member_map_"), TermValue(7)),
-    )
+    assert class_dict.value.entries == ((StringValue("_member_map_"), TermValue(7)),)
     assert class_dict.value.entries != namespace.entries

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_function_contract_rows_no_swallow.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_function_contract_rows_no_swallow.py
@@ -27,12 +27,8 @@ import pytest
 
 from sugar_source_tree.panic import SugarNotWritten
 
-
 _LIFT_RPC = (
-    Path(__file__).resolve().parents[1]
-    / "src"
-    / "sugar_lift_py_tests"
-    / "lift_rpc.py"
+    Path(__file__).resolve().parents[1] / "src" / "sugar_lift_py_tests" / "lift_rpc.py"
 )
 
 _CONTRACT_ROWS_CALL = "function_contract_rows"
@@ -69,9 +65,8 @@ def _except_exception_continue_wrappers(
             return False  # bare except is a different sin class; other teeth
         if isinstance(t, ast.Name) and t.id == "Exception":
             pass
-        elif (
-            isinstance(t, ast.Tuple)
-            and any(isinstance(e, ast.Name) and e.id == "Exception" for e in t.elts)
+        elif isinstance(t, ast.Tuple) and any(
+            isinstance(e, ast.Name) and e.id == "Exception" for e in t.elts
         ):
             pass
         else:
@@ -79,9 +74,7 @@ def _except_exception_continue_wrappers(
         # body is continue (optionally with pass-only noise)
         if not handler.body:
             return False
-        return all(
-            isinstance(stmt, (ast.Continue, ast.Pass)) for stmt in handler.body
-        )
+        return all(isinstance(stmt, (ast.Continue, ast.Pass)) for stmt in handler.body)
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Try):
@@ -156,7 +149,7 @@ def test_lying_twin_except_exception_continue_manufactures_absence() -> None:
 
 def test_ast_tooth_lying_twin_planted_swallow_is_visible() -> None:
     """AST tooth must recognize the planted except Exception: continue shape."""
-    planted = '''
+    planted = """
 def _handle_enumerate():
     for call in calls:
         try:
@@ -169,7 +162,7 @@ def _handle_enumerate():
             continue
         if rows is None:
             continue
-'''
+"""
     offenders = _except_exception_continue_wrappers(
         planted, call_name=_CONTRACT_ROWS_CALL, path="planted.py"
     )
@@ -184,7 +177,7 @@ def test_ast_tooth_does_not_flag_sugar_not_written_gap_recording() -> None:
     This tooth owns only the Exception-continue swallow class. Other soft
     membranes get their own instruments.
     """
-    clean = '''
+    clean = """
 def universe_arm():
     for fn in functions:
         try:
@@ -192,16 +185,15 @@ def universe_arm():
         except SugarNotWritten as gap:
             gaps.append(gap.observed)
             continue
-'''
+"""
     assert (
-        _except_exception_continue_wrappers(
-            clean, call_name=_CONTRACT_ROWS_CALL
-        )
-        == []
+        _except_exception_continue_wrappers(clean, call_name=_CONTRACT_ROWS_CALL) == []
     )
 
 
-def test_production_lift_rpc_has_zero_exception_continue_on_function_contract_rows() -> None:
+def test_production_lift_rpc_has_zero_exception_continue_on_function_contract_rows() -> (
+    None
+):
     """Production door: R=0 for Exception-continue wraps of function_contract_rows."""
     assert _LIFT_RPC.is_file(), _LIFT_RPC
     source = _LIFT_RPC.read_text(encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumeration_binding_soft_skip_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumeration_binding_soft_skip_law.py
@@ -60,15 +60,13 @@ def test_scanner_flags_soft_function_binding_miss_continue(tmp_path: Path) -> No
     """Lying twin: except FunctionBindingMiss: continue is red."""
     bad = tmp_path / "lift_rpc.py"
     bad.write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             def dig(call):
                 try:
                     fn = resolve_function_for_call(call)
                 except FunctionBindingMiss:
                     continue
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     offenders = _SCANNER.scan_sources([bad], root=tmp_path)
@@ -80,27 +78,26 @@ def test_scanner_flags_fn_none_soft_skip(tmp_path: Path) -> None:
     """Lying twin: except FunctionBindingMiss: fn = None reopens soft-None."""
     bad = tmp_path / "lift_rpc.py"
     bad.write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             def dig(call):
                 try:
                     fn = resolve_function_for_call(call)
                 except FunctionBindingMiss:
                     fn = None
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     offenders = _SCANNER.scan_sources([bad], root=tmp_path)
-    assert any(o.kind == "function-binding-miss-soft-skip" for o in offenders), offenders
+    assert any(
+        o.kind == "function-binding-miss-soft-skip" for o in offenders
+    ), offenders
 
 
 def test_scanner_flags_spelling_by_name_with_resolve(tmp_path: Path) -> None:
     """Lying twin: by_name[t] on resolve path is the spelling second door."""
     bad = tmp_path / "lift_rpc.py"
     bad.write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             def dig(calls, universes):
                 by_name = {name: (m, d) for name, m, d in universes}
                 for call in calls:
@@ -108,8 +105,7 @@ def test_scanner_flags_spelling_by_name_with_resolve(tmp_path: Path) -> None:
                     t = call.func.id
                     if t in by_name:
                         cued.append(by_name[t])
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     offenders = _SCANNER.scan_sources([bad], root=tmp_path)
@@ -120,8 +116,7 @@ def test_scanner_allows_gap_append_then_continue(tmp_path: Path) -> None:
     """Truthful membrane: named gap then continue is not soft silence."""
     ok = tmp_path / "lift_rpc.py"
     ok.write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             def dig(call, at, gaps):
                 try:
                     fn = resolve_function_for_call(call)
@@ -131,8 +126,7 @@ def test_scanner_allows_gap_append_then_continue(tmp_path: Path) -> None:
                         "reason": f"FunctionBindingMiss name={miss.name!r} reason={miss.reason}",
                     })
                     continue
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     offenders = _SCANNER.scan_sources([ok], root=tmp_path)
@@ -178,15 +172,13 @@ def test_universe_dig_binding_miss_emits_gap_not_spelling_contract(
     FunctionBindingMiss.
     """
     (tmp_path / "mod.py").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             def pack(a, *rest):
                 return (a, rest)
 
             def test_a():
                 assert unknown_callee(1) == 1
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     call_at = _call_site_memento(tmp_path, "test_a")
@@ -196,9 +188,9 @@ def test_universe_dig_binding_miss_emits_gap_not_spelling_contract(
         name = (node.get("memento") or {}).get("source_function_name") or (
             node.get("memento") or {}
         ).get("function_name")
-        assert name != "pack", (
-            f"spelling fallback served pack after binding miss: {node}"
-        )
+        assert (
+            name != "pack"
+        ), f"spelling fallback served pack after binding miss: {node}"
     gap_text = " ".join(str(g.get("reason", "")) for g in result["gaps"])
     assert "FunctionBindingMiss" in gap_text, (
         f"expected FunctionBindingMiss gap, got nodes={result['nodes']!r} "
@@ -216,8 +208,7 @@ def test_universe_dig_prefers_module_binding_not_method_spelling(
     identity abstract must serve module ``pack(a, *rest)``.
     """
     (tmp_path / "mod.py").write_text(
-        textwrap.dedent(
-            """
+        textwrap.dedent("""
             class Holder:
                 def pack(self, *items):
                     return items
@@ -227,17 +218,14 @@ def test_universe_dig_prefers_module_binding_not_method_spelling(
 
             def test_a():
                 assert pack(1, 2) == (1, (2,))
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     call_at = _call_site_memento(tmp_path, "test_a")
     result = _enumerate("universe", tmp_path, at=call_at, seek=True)
     assert result["nodes"], result
     miss_gaps = [
-        g
-        for g in result["gaps"]
-        if "FunctionBindingMiss" in str(g.get("reason", ""))
+        g for g in result["gaps"] if "FunctionBindingMiss" in str(g.get("reason", ""))
     ]
     assert miss_gaps == [], result["gaps"]
     mementos = [n.get("memento") or {} for n in result["nodes"]]

--- a/implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_except_as_target_cleanup.py
@@ -58,9 +58,7 @@ def _name_error(outcome, *, name: str = "e"):
 
 def _return_value(outcome):
     assert isinstance(outcome, Complete), outcome
-    returns = [
-        s for s in outcome.value.record.statements if isinstance(s, ReturnValue)
-    ]
+    returns = [s for s in outcome.value.record.statements if isinstance(s, ReturnValue)]
     assert returns, outcome.value.record.statements
     return returns[0].value
 
@@ -266,7 +264,10 @@ def test_handler_halt_plus_finally_read_e_keeps_handler_exception_as_context():
     assert effect.context_effect.exception_name == "RuntimeError"
     # Primary is NameError for e, not the handler RuntimeError alone.
     assert effect.exception_name == "NameError"
-    assert isinstance(effect.context_effect.occurrence, str) and ":" in effect.context_effect.occurrence, (
+    assert (
+        isinstance(effect.context_effect.occurrence, str)
+        and ":" in effect.context_effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {effect.context_effect.occurrence!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_class_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_class_subscript_mutation.py
@@ -7,22 +7,42 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "exception_class_subscript_mutation.py"
-    path.write_text("def f(exc_type, replacement):\n    exc_type[0] = replacement\n    del exc_type[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(exc_type, replacement):\n    exc_type[0] = replacement\n    del exc_type[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "ExceptionClassValue.setitem", 0), ("delitem", "ExceptionClassValue.delitem", 1)))
-def test_exception_class_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = ExceptionClassValue("module.CustomError")
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "ExceptionClassValue.setitem", 0),
+        ("delitem", "ExceptionClassValue.delitem", 1),
+    ),
+)
+def test_exception_class_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = ExceptionClassValue("module.CustomError")
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_exception_class_subscript_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = ExceptionClassValue("module.CustomError")
-    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = ExceptionClassValue("module.CustomError")
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_context_reraise.py
@@ -125,7 +125,10 @@ def test_implicit_context_second_outgoing_first_authenticated_context():
     assert effect.cause_value is None
     assert isinstance(effect.context_effect, RaiseEffect)
     assert effect.context_effect.exception_name == "ValueError"
-    assert isinstance(effect.context_effect.occurrence, str) and ":" in effect.context_effect.occurrence, (
+    assert (
+        isinstance(effect.context_effect.occurrence, str)
+        and ":" in effect.context_effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {effect.context_effect.occurrence!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_group_nesting.py
@@ -159,9 +159,7 @@ def test_outer_except_star_partitions_nested_group_preserving_topology():
     effect = _grouped_halt(
         _desugar(
             "def f():\n"
-            "    try:\n"
-            + raise_body
-            + "    except* TypeError:\n"
+            "    try:\n" + raise_body + "    except* TypeError:\n"
             "        pass\n",
             name=name,
         )
@@ -280,9 +278,7 @@ def test_occurrence_identities_survive_two_level_partition():
     residual = _grouped_halt(
         _desugar(
             "def f():\n"
-            "    try:\n"
-            + raise_body
-            + "    except* TypeError:\n"
+            "    try:\n" + raise_body + "    except* TypeError:\n"
             "        pass\n",
             name=name,
         )
@@ -387,9 +383,7 @@ def test_twin_wrong_type_preserves_original_nested_group():
     effect = _grouped_halt(
         _desugar(
             "def f():\n"
-            "    try:\n"
-            + raise_body
-            + "    except* OSError:\n"
+            "    try:\n" + raise_body + "    except* OSError:\n"
             "        raise RuntimeError('must-not-run')\n",
             name=name,
         )
@@ -432,9 +426,7 @@ def test_twin_never_selects_only_first_nested_leaf_of_repeated_type():
     effect = _grouped_halt(
         _desugar(
             "def f():\n"
-            "    try:\n"
-            + raise_body
-            + "    except* TypeError:\n"
+            "    try:\n" + raise_body + "    except* TypeError:\n"
             "        pass\n",
             name=name,
         )
@@ -495,9 +487,7 @@ def test_nested_handler_preserves_temporal_bindings_across_inner_try_star():
         name="nested_temporal_y.py",
     )
     assert isinstance(outcome, Complete), outcome
-    returns = [
-        s for s in outcome.value.record.statements if isinstance(s, ReturnValue)
-    ]
+    returns = [s for s in outcome.value.record.statements if isinstance(s, ReturnValue)]
     assert returns, outcome.value.record.statements
     assert returns[0].value.value == 1
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_exception_value_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exception_value_subscript_mutation.py
@@ -7,22 +7,42 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "exception_value_subscript_mutation.py"
-    path.write_text("def f(exc, replacement):\n    exc[0] = replacement\n    del exc[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(exc, replacement):\n    exc[0] = replacement\n    del exc[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "ExceptionValue.setitem", 0), ("delitem", "ExceptionValue.delitem", 1)))
-def test_exception_value_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = ExceptionValue("ValueError", (), site)
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "ExceptionValue.setitem", 0),
+        ("delitem", "ExceptionValue.delitem", 1),
+    ),
+)
+def test_exception_value_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = ExceptionValue("ValueError", (), site)
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_exception_value_subscript_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = ExceptionValue("ValueError", (), store_site)
-    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = ExceptionValue("ValueError", (), store_site)
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_exit_suppression_contract.py
@@ -29,7 +29,12 @@ def _guard():
 def _value_error(*, coordinate=None, mro=None, name="ValueError"):
     if coordinate is None and mro is None:
         coordinate, mro = _builtin_exception_identity("ValueError")
-    return RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of('exit_suppression.py:1:0'), exception_name=name, exception_type_mro=mro)
+    return RaiseEffect(
+        exception_type_coordinate=coordinate,
+        occurrence=AuthenticatedRaiseLocus.of("exit_suppression.py:1:0"),
+        exception_name=name,
+        exception_type_mro=mro,
+    )
 
 
 def test_truthful_contract_suppresses_matching_coordinate() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_disposition_suppresses_coordinate.py
@@ -29,7 +29,12 @@ def _guard():
 def _key_error(*, coordinate=None, mro=None, name="KeyError"):
     if coordinate is None and mro is None:
         coordinate, mro = _builtin_exception_identity("KeyError")
-    return RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of('suppress.py:1:0'), exception_name=name, exception_type_mro=mro)
+    return RaiseEffect(
+        exception_type_coordinate=coordinate,
+        occurrence=AuthenticatedRaiseLocus.of("suppress.py:1:0"),
+        exception_name=name,
+        exception_type_mro=mro,
+    )
 
 
 def test_truthful_suppresses_matching_coordinate() -> None:
@@ -73,7 +78,12 @@ def test_name_less_matcher_throws_not_suppress() -> None:
 def test_name_less_effect_with_coordinate_does_not_equal_name_less_matcher() -> None:
     """THE historical bug: None == None suppressed a coordinate-authenticated halt."""
     coordinate, mro = _builtin_exception_identity("KeyError")
-    effect = RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of('suppress.py:2:0'), exception_name=None, exception_type_mro=mro)
+    effect = RaiseEffect(
+        exception_type_coordinate=coordinate,
+        occurrence=AuthenticatedRaiseLocus.of("suppress.py:2:0"),
+        exception_name=None,
+        exception_type_mro=mro,
+    )
     with pytest.raises(SugarNotWritten):
         exit_disposition_effect(
             Suppresses(EffectMatcher(kind="raise", name=None)),  # type: ignore[arg-type]

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set.py
@@ -26,14 +26,20 @@ def test_single_unconditional_completed_collapses_to_complete():
 
 
 def test_single_unconditional_halted_collapses_to_incomplete():
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:209:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:209:0",
+    )
 
     assert ExitSet.halted(effect).collapse() == Incomplete(effect)
 
 
 def test_conditional_halt_keeps_halted_and_complementary_completed_exits():
     condition = _guard("condition")
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:198:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:198:0",
+    )
 
     exits = ExitSet.conditional_halt(condition, effect, "state")
 
@@ -61,7 +67,10 @@ def test_normalize_drops_unsatisfiable_exit():
 
 def test_sequencing_maps_only_completed_exits():
     condition = _guard("condition")
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:173:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:173:0",
+    )
     exits = ExitSet.conditional_halt(condition, effect, 1)
 
     sequenced = exits.sequence(lambda value: ExitSet.completed(value + 1))
@@ -74,7 +83,10 @@ def test_sequencing_maps_only_completed_exits():
 
 def test_block_reduction_retains_complement_of_guarded_halt():
     condition = _guard("condition")
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:165:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:165:0",
+    )
 
     class GuardedHalt:
         def desugar(self, ctx=None):
@@ -96,22 +108,34 @@ def test_and_finally_cleanup_completion_restores_incoming_completed():
 
 
 def test_and_finally_cleanup_completion_restores_incoming_halted():
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:131:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:131:0",
+    )
     incoming = ExitSet.halted(effect)
     after = incoming.and_finally(lambda: ExitSet.completed("cleanup-done"))
     assert after.collapse() == Incomplete(effect)
 
 
 def test_and_finally_cleanup_halt_supersedes_incoming():
-    original = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:106:0')
-    cleanup = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:166:0')
+    original = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:106:0",
+    )
+    cleanup = RaiseEffect.for_builtin(
+        "RuntimeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:166:0",
+    )
     incoming = ExitSet.halted(original)
     after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
     assert after.collapse() == Incomplete(cleanup)
 
 
 def test_and_finally_cleanup_halt_supersedes_completed():
-    cleanup = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:158:0')
+    cleanup = RaiseEffect.for_builtin(
+        "RuntimeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:158:0",
+    )
     incoming = ExitSet.completed("ok")
     after = incoming.and_finally(lambda: ExitSet.halted(cleanup))
     assert after.collapse() == Incomplete(cleanup)
@@ -128,7 +152,10 @@ def test_and_finally_terminal_cleanup_completion_supersedes():
 
 def test_and_finally_runs_cleanup_on_every_conditional_exit():
     condition = _guard("condition")
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:99:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:99:0",
+    )
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     seen = []
 
@@ -155,22 +182,34 @@ def test_and_exit_completion_keeps_body_completed():
 
 
 def test_and_exit_halt_supersedes_body_completed():
-    exit_halt = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:114:0')
+    exit_halt = RaiseEffect.for_builtin(
+        "RuntimeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:114:0",
+    )
     incoming = ExitSet.completed("body")
     after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_halt_supersedes_body_halted():
-    body = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:77:0')
-    exit_halt = RaiseEffect.for_builtin('RuntimeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:107:0')
+    body = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:77:0",
+    )
+    exit_halt = RaiseEffect.for_builtin(
+        "RuntimeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:107:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(ExitSet.halted(exit_halt), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(exit_halt)
 
 
 def test_and_exit_never_suppresses_restores_body_halt():
-    body = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:64:0')
+    body = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:64:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(ExitSet.completed(False), disposition=NeverSuppresses())
     assert after.collapse() == Incomplete(body)
@@ -180,8 +219,8 @@ def test_and_exit_proven_contract_consumes_named_halt():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     _, mro = _builtin_exception_identity("ValueError")
-    body = RaiseEffect.for_builtin("ValueError",
-        
+    body = RaiseEffect.for_builtin(
+        "ValueError",
         exception_type_mro=mro,
         occurrence="exit_set.py:2:0",
     )
@@ -194,7 +233,10 @@ def test_and_exit_proven_contract_consumes_named_halt():
 
 
 def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
-    body = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:36:0')
+    body = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:36:0",
+    )
     incoming = ExitSet.halted(body)
     after = incoming.and_exit(
         ExitSet.completed(True),
@@ -205,7 +247,10 @@ def test_and_exit_runtime_selected_leaves_open_residual_not_guessed():
 
 def test_and_exit_fans_exitset_across_conditional_faces():
     condition = _guard("condition")
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:29:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set.py:29:0",
+    )
     incoming = ExitSet.conditional_halt(condition, effect, "state")
     exit_es = ExitSet.completed(False)
     after = incoming.and_exit(exit_es, disposition=NeverSuppresses())
@@ -218,8 +263,8 @@ def test_and_exit_proven_contract_suppresses_only_matching_face():
 
     condition = _guard("condition")
     _, mro = _builtin_exception_identity("ValueError")
-    effect = RaiseEffect.for_builtin("ValueError",
-        
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
         exception_type_mro=mro,
         occurrence="exit_set.py:3:0",
     )
@@ -235,8 +280,8 @@ def test_and_exit_membrane_suppresses_matcher_authority():
     from sugar_lift_py_tests.floor.ground_exit import _builtin_exception_identity
 
     _, mro = _builtin_exception_identity("KeyError")
-    body = RaiseEffect.for_builtin("KeyError",
-        
+    body = RaiseEffect.for_builtin(
+        "KeyError",
         exception_type_mro=mro,
         occurrence="exit_set.py:1:0",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py
@@ -46,7 +46,10 @@ def _guard(name: str):
 
 
 def _effect(name: str = "ValueError"):
-    return RaiseEffect.for_builtin(name, occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py:49:0')
+    return RaiseEffect.for_builtin(
+        name,
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set_arm_census.py:49:0",
+    )
 
 
 def _value():

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py
@@ -69,7 +69,10 @@ def _guard(index: int):
 
 
 def _effect(name: str) -> RaiseEffect:
-    return RaiseEffect.for_builtin(name, occurrence='implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py:72:0')
+    return RaiseEffect.for_builtin(
+        name,
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_exit_set_normalize_identity.py:72:0",
+    )
 
 
 def _random_exits(rng: random.Random, count: int, distinct: int) -> tuple:

--- a/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_exit_set_partition_testimony.py
@@ -151,9 +151,7 @@ def test_guarded_stamps_the_face_it_is_given_and_nothing_else():
     plain = ExitSet.completed("v").guarded(condition)
     assert plain.exits[0].faces == frozenset()
 
-    joined = faced.union(
-        ExitSet.completed("w").guarded(not_(condition), else_face)
-    )
+    joined = faced.union(ExitSet.completed("w").guarded(not_(condition), else_face))
     # The join is factorable because the producer testified, not because the
     # guards happen to be spelled as negations of each other.
     factored = joined.factor_completed()

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_nested_exit_faces.py
@@ -148,7 +148,15 @@ def _raise(
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner=producer_node_owner or 'NestedBody.desugar'),
+        RaiseEffect(
+            exception_type_coordinate=_identity(name),
+            occurrence=AuthenticatedRaiseLocus.of(occ),
+            exception_name=name,
+            blame=occ,
+            exception_type_mro=(_identity(name),),
+            raised_value=raised_value,
+            producer_node_owner=producer_node_owner or "NestedBody.desugar",
+        ),
         _state(marker),
     )
 
@@ -181,7 +189,11 @@ def _nested_body_faces(
         _Atomic("body-returned", ()),
         _state("returned-no-raise", ReturnValue(TermValue("early-return"))),
     )
-    return ExitSet((completed, returned, matching, mismatching)), matching.effect, mismatching.effect
+    return (
+        ExitSet((completed, returned, matching, mismatching)),
+        matching.effect,
+        mismatching.effect,
+    )
 
 
 def _observed_binding(face):
@@ -249,9 +261,7 @@ def _factored_boundary(
         manager=manager,
         body=(Fixed(body),),
         semantics=None,
-        contract_ref=SimpleNamespace(
-            import_signature=ImportSignatureV2(parameters)
-        ),
+        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(parameters)),
         context_manager_edge=None,
         boundary_faces=_factored_boundary_faces(),
         observation_slot_id=observation_slot_id,
@@ -340,7 +350,9 @@ def test_matching_raise_under_pattern_face_binds_held_not_complement():
     """Pattern face retains message obligation; bind only held; halt unbound."""
     # Symbolic pattern keeps the message predicate open → held + complement.
     pattern = SymbolicValue(make_var("open_msg_pattern"))
-    body, matching_effect, _ = _nested_body_faces(matching_message=StringValue("needle"))
+    body, matching_effect, _ = _nested_body_faces(
+        matching_message=StringValue("needle")
+    )
     sugar, _ = _factored_boundary(body, pattern=pattern)
     routed = sugar.desugar()
 
@@ -378,9 +390,7 @@ def test_mismatching_raise_remains_halted_and_unbound_under_both_faces():
     routed = sugar.desugar()
 
     mismatch_faces = [
-        face
-        for face in routed.exits
-        if "body-mismatch-raise" in str(face.guard)
+        face for face in routed.exits if "body-mismatch-raise" in str(face.guard)
     ]
     assert mismatch_faces, routed.exits
     assert all(isinstance(face, Halted) for face in mismatch_faces), mismatch_faces
@@ -403,7 +413,9 @@ def test_pattern_obligation_survives_only_on_pattern_face():
 
     face_ids = {guard.name for guard, _ in sugar._guarded_semantics()}
     assert face_ids == {"match-none-face", "match-pattern-face"}
-    operands = {semantics.message_pattern_operand for _, semantics in sugar._guarded_semantics()}
+    operands = {
+        semantics.message_pattern_operand for _, semantics in sugar._guarded_semantics()
+    }
     assert operands == {
         NoMessagePatternV1(),
         OptionalFormalArgumentProjectionV1(1),
@@ -460,7 +472,9 @@ def test_twin_none_vs_pattern_face_identities_never_recombine():
     guarded = sugar._guarded_semantics()
     assert len(guarded) == 2
     by_name = {guard.name: semantics for guard, semantics in guarded}
-    assert isinstance(by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1)
+    assert isinstance(
+        by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1
+    )
     assert isinstance(
         by_name["match-pattern-face"].message_pattern_operand,
         OptionalFormalArgumentProjectionV1,
@@ -480,11 +494,7 @@ def test_twin_return_vs_raise_under_factored_faces():
     sugar, _ = _factored_boundary(body)
     routed = sugar.desugar()
 
-    returned = [
-        face
-        for face in routed.exits
-        if "body-returned" in str(face.guard)
-    ]
+    returned = [face for face in routed.exits if "body-returned" in str(face.guard)]
     assert returned
     assert all(isinstance(face, Halted) for face in returned)
     assert all(isinstance(face.effect, ExpectationNotMetEffect) for face in returned)
@@ -521,15 +531,15 @@ def test_twin_consumed_vs_unmatched_binding():
     for face in routed.exits:
         if isinstance(face, Halted) and face.effect is mismatch_effect:
             assert _observed_binding(face) is None
-        if isinstance(face, Halted) and isinstance(face.effect, ExpectationNotMetEffect):
+        if isinstance(face, Halted) and isinstance(
+            face.effect, ExpectationNotMetEffect
+        ):
             assert _observed_binding(face) is None
 
 
 def test_ground_pattern_decides_matching_message_under_nested_body():
     """Ground pattern: matching message consumes under pattern face; miss stays halt."""
-    body_hit, hit_effect, _ = _nested_body_faces(
-        matching_message=StringValue("needle")
-    )
+    body_hit, hit_effect, _ = _nested_body_faces(matching_message=StringValue("needle"))
     # Rebuild body so matching raise message is "other" (miss) under same guards.
     miss_matching = _raise(
         "ValueError",
@@ -576,6 +586,4 @@ def test_ground_pattern_decides_matching_message_under_nested_body():
     # Ground miss: no consumption of the raise under the pattern face.
     assert all(isinstance(face, Halted) for face in miss_pattern_for_raise)
     assert all(_observed_binding(face) is None for face in miss_pattern_for_raise)
-    assert all(
-        face.effect is miss_matching.effect for face in miss_pattern_for_raise
-    )
+    assert all(face.effect is miss_matching.effect for face in miss_pattern_for_raise)

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_source_resource_stack.py
@@ -72,9 +72,7 @@ class _Expected:
 
 
 def _state(marker: str):
-    return _ReducedBlock(
-        entries=(marker,), can_fall_through=False, fall_through=()
-    )
+    return _ReducedBlock(entries=(marker,), can_fall_through=False, fall_through=())
 
 
 class Fixed(Sugar):
@@ -118,12 +116,8 @@ class _RecordingProtocol:
 
 
 def _protocol_calls(slot: str, face_id: str):
-    enter_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "e" * 128, 1, 0, 1, 1
-    )
-    exit_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "x" * 128, 2, 0, 2, 1
-    )
+    enter_definition = SourceFragmentCoordinateV1("blake3-512:" + "e" * 128, 1, 0, 1, 1)
+    exit_definition = SourceFragmentCoordinateV1("blake3-512:" + "x" * 128, 2, 0, 2, 1)
     enter = MethodCallSugar(
         receiver=ManagerRefSugar(slot_id=slot, site=None),
         name="__enter__",
@@ -145,7 +139,9 @@ def _protocol_calls(slot: str, face_id: str):
     return enter, exit_, enter_definition, exit_definition
 
 
-def _source_resource(*, protocol, summary, body, slot="resource-slot", face_id="res-exit"):
+def _source_resource(
+    *, protocol, summary, body, slot="resource-slot", face_id="res-exit"
+):
     enter, exit_, enter_def, exit_def = _protocol_calls(slot, face_id)
     return WithSourceResourceSugar(
         manager=Fixed(Complete(TermValue(1))),
@@ -234,9 +230,7 @@ def _factored_boundary(body: ExitSet, *, pattern=None, observation_slot_id="exci
         manager=Fixed(Complete(manager_value)),
         body=(Fixed(body),),
         semantics=None,
-        contract_ref=SimpleNamespace(
-            import_signature=ImportSignatureV2(parameters)
-        ),
+        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(parameters)),
         context_manager_edge=None,
         boundary_faces=_factored_boundary_faces(),
         observation_slot_id=observation_slot_id,
@@ -257,7 +251,15 @@ def _raise(name: str, marker: str, *, message=None, occurrence=None):
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='StackBody.desugar'),
+        RaiseEffect(
+            exception_type_coordinate=_identity(name),
+            occurrence=AuthenticatedRaiseLocus.of(occ),
+            exception_name=name,
+            blame=occ,
+            exception_type_mro=(_identity(name),),
+            raised_value=raised_value,
+            producer_node_owner="StackBody.desugar",
+        ),
         _state(marker),
     )
 
@@ -332,7 +334,8 @@ def test_resource_outer_assertion_inner_enter_exit_source_order():
 
     # Assertion authority: matching consumed with binding; mismatch restored.
     assert any(
-        isinstance(face, Completed) and _observed_binding(face) is not None
+        isinstance(face, Completed)
+        and _observed_binding(face) is not None
         and _observed_binding(face).effect is matching_effect
         for face in exits.exits
     )
@@ -391,9 +394,7 @@ def test_assertion_outer_resource_inner_enter_exit_source_order():
         manager=Fixed(Complete(manager_value)),
         body=(resource,),
         semantics=None,
-        contract_ref=SimpleNamespace(
-            import_signature=ImportSignatureV2(parameters)
-        ),
+        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(parameters)),
         context_manager_edge=None,
         boundary_faces=_factored_boundary_faces(),
         observation_slot_id="excinfo",
@@ -436,9 +437,7 @@ def test_each_outgoing_face_keeps_both_manager_identities():
     # Every face still carries a factored message-face guard.
     for face in exits.exits:
         text = str(face.guard)
-        assert (
-            "match-none-face" in text or "match-pattern-face" in text
-        ), text
+        assert "match-none-face" in text or "match-pattern-face" in text, text
 
 
 def test_suppression_authorities_remain_separate():
@@ -547,9 +546,7 @@ def test_twin_source_order_swaps_outer_type():
         manager=Fixed(Complete(manager_value)),
         body=(resource_inner,),
         semantics=None,
-        contract_ref=SimpleNamespace(
-            import_signature=ImportSignatureV2(parameters)
-        ),
+        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(parameters)),
         context_manager_edge=None,
         boundary_faces=_factored_boundary_faces(),
         observation_slot_id="excinfo",
@@ -583,6 +580,4 @@ def test_excinfo_only_on_consumed_occurrence_through_stack():
     }
     assert matching_effect in bound
     assert mismatch_effect not in bound
-    assert all(
-        e.occurrence_id == "body.py:10:8:matching" for e in bound
-    )
+    assert all(e.occurrence_id == "body.py:10:8:matching" for e in bound)

--- a/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factored_boundary_try_finally.py
@@ -128,7 +128,15 @@ def _raise(
         )
     return Halted(
         _Atomic(f"body-{marker}", ()),
-        RaiseEffect(exception_type_coordinate=_identity(name), occurrence=AuthenticatedRaiseLocus.of(occ), exception_name=name, blame=occ, exception_type_mro=(_identity(name),), raised_value=raised_value, producer_node_owner='TryFinallyBody.desugar'),
+        RaiseEffect(
+            exception_type_coordinate=_identity(name),
+            occurrence=AuthenticatedRaiseLocus.of(occ),
+            exception_name=name,
+            blame=occ,
+            exception_type_mro=(_identity(name),),
+            raised_value=raised_value,
+            producer_node_owner="TryFinallyBody.desugar",
+        ),
         _state(marker),
     )
 
@@ -209,9 +217,7 @@ def _factored_boundary(body: ExitSet, *, pattern=None, observation_slot_id="exci
         manager=Fixed(Complete(manager_value)),
         body=(Fixed(body),),
         semantics=None,
-        contract_ref=SimpleNamespace(
-            import_signature=ImportSignatureV2(parameters)
-        ),
+        contract_ref=SimpleNamespace(import_signature=ImportSignatureV2(parameters)),
         context_manager_edge=None,
         boundary_faces=_factored_boundary_faces(),
         observation_slot_id=observation_slot_id,
@@ -281,9 +287,7 @@ def test_finally_runs_on_consumed_unmet_and_retained_halt_paths():
         and _observed_binding(face) is not None
     ]
     assert consumed, routed.exits
-    assert all(
-        _observed_binding(face).effect is matching_effect for face in consumed
-    )
+    assert all(_observed_binding(face).effect is matching_effect for face in consumed)
 
     unmet = [
         face
@@ -412,15 +416,15 @@ def test_twin_none_vs_pattern_faces_survive_try_finally():
         "match-pattern-face",
     }
     by_name = {g.name: s for g, s in guarded}
-    assert isinstance(by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1)
+    assert isinstance(
+        by_name["match-none-face"].message_pattern_operand, NoMessagePatternV1
+    )
     assert isinstance(
         by_name["match-pattern-face"].message_pattern_operand,
         OptionalFormalArgumentProjectionV1,
     )
 
-    routed, _ = _join_try_finally(
-        boundary.desugar(), ExitSet.completed("cleanup-done")
-    )
+    routed, _ = _join_try_finally(boundary.desugar(), ExitSet.completed("cleanup-done"))
     text = " ".join(str(face.guard) for face in routed.exits)
     assert "match-none-face" in text and "match-pattern-face" in text
     for face in routed.exits:

--- a/implementations/python/sugar-lift-py-tests/tests/test_factoring_gap_kind.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factoring_gap_kind.py
@@ -63,9 +63,7 @@ def test_one_silent_arm_is_partly_stamped_not_unstamped():
     left = _arm(_guard("a"), "one", frozenset({face}))
     right = _arm(_guard("b"), "two")
 
-    assert (
-        classify_factoring_gap(left, right).kind is FactoringGapKind.PARTLY_STAMPED
-    )
+    assert classify_factoring_gap(left, right).kind is FactoringGapKind.PARTLY_STAMPED
 
 
 def test_shared_partition_same_side_is_stamped_not_separating():
@@ -94,9 +92,7 @@ def test_unrelated_partitions_are_stamped_disjoint():
     left = _arm(_guard("a"), "one", frozenset({left_face}))
     right = _arm(_guard("b"), "two", frozenset({right_face}))
 
-    assert (
-        classify_factoring_gap(left, right).kind is FactoringGapKind.STAMPED_DISJOINT
-    )
+    assert classify_factoring_gap(left, right).kind is FactoringGapKind.STAMPED_DISJOINT
 
 
 def test_opposed_faces_never_reach_a_gap_at_all():
@@ -159,7 +155,9 @@ def test_the_flag_reads_either_arm():
     """
     merged = and_([_guard("p"), or_([_guard("a"), _guard("x")])])
 
-    assert classify_factoring_gap(_arm(_guard("b"), "two"), _arm(merged, "one")).merged_arm
+    assert classify_factoring_gap(
+        _arm(_guard("b"), "two"), _arm(merged, "one")
+    ).merged_arm
 
 
 # --------------------------------------------------------------------------
@@ -190,9 +188,7 @@ def test_the_refusal_carries_its_arms_so_a_census_never_parses_the_message():
     starts depending on message formatting.
     """
     with pytest.raises(ExitSetFactoringGap) as raised:
-        ExitSet(
-            (_arm(_guard("a"), "one"), _arm(_guard("b"), "two"))
-        ).factor_completed()
+        ExitSet((_arm(_guard("a"), "one"), _arm(_guard("b"), "two"))).factor_completed()
 
     gap = raised.value
     assert gap.left is not None and gap.right is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_factory_build_context_retirement_ontology.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_factory_build_context_retirement_ontology.py
@@ -13,7 +13,6 @@ import tokenize
 
 import pytest
 
-
 _PACKAGE_MARKER = Path(
     "implementations/python/sugar-lift-py-tests/src/"
     "sugar_lift_py_tests/context/reduce_context.py"
@@ -24,7 +23,9 @@ def _discover_repo() -> Path:
     candidates: set[Path] = set()
     artifact = Path(__file__).resolve()
     spec = importlib.util.find_spec("sugar_lift_py_tests")
-    installed = None if spec is None or spec.origin is None else Path(spec.origin).resolve()
+    installed = (
+        None if spec is None or spec.origin is None else Path(spec.origin).resolve()
+    )
     if installed is not None:
         for candidate in installed.parents:
             package_root = candidate / "implementations/python/sugar-lift-py-tests/src"
@@ -129,7 +130,9 @@ Environment = dict[str, frozenset[ReachingDefinition]]
 
 @dataclass(frozen=True)
 class ReachingIndex:
-    before: dict[tuple[str, tuple[tuple[str, str, int, int], ...], str, Span], Environment]
+    before: dict[
+        tuple[str, tuple[tuple[str, str, int, int], ...], str, Span], Environment
+    ]
     module_exit: Environment
 
 
@@ -151,10 +154,24 @@ def _node_occurrence(
     lexical: list[tuple[str, str, int, int]] = []
     parent = facts.parents.get(node)
     while parent is not None:
-        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)) and _has_span(parent):
-            lexical.append((type(parent).__name__, getattr(parent, "name", "<lambda>"), parent.lineno, parent.col_offset))
+        if isinstance(
+            parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ) and _has_span(parent):
+            lexical.append(
+                (
+                    type(parent).__name__,
+                    getattr(parent, "name", "<lambda>"),
+                    parent.lineno,
+                    parent.col_offset,
+                )
+            )
         parent = facts.parents.get(parent)
-    return (facts.module, tuple(reversed(lexical)), type(node).__name__, _node_span(node))
+    return (
+        facts.module,
+        tuple(reversed(lexical)),
+        type(node).__name__,
+        _node_span(node),
+    )
 
 
 def _before_environment(facts: ModuleFacts, node: ast.AST) -> Environment:
@@ -165,20 +182,24 @@ def _before_environment(facts: ModuleFacts, node: ast.AST) -> Environment:
 
 
 def _production_files() -> tuple[Path, ...]:
-    return tuple(sorted(
-        path
-        for root in PRODUCTION_ROOTS
-        for path in root.rglob("*.py")
-        if "tests" not in path.parts and not path.name.startswith("test_")
-    ))
+    return tuple(
+        sorted(
+            path
+            for root in PRODUCTION_ROOTS
+            for path in root.rglob("*.py")
+            if "tests" not in path.parts and not path.name.startswith("test_")
+        )
+    )
 
 
 def _test_files() -> tuple[Path, ...]:
-    return tuple(sorted(
-        path
-        for path in PYTHON.rglob("*.py")
-        if "tests" in path.parts or path.name.startswith("test_")
-    ))
+    return tuple(
+        sorted(
+            path
+            for path in PYTHON.rglob("*.py")
+            if "tests" in path.parts or path.name.startswith("test_")
+        )
+    )
 
 
 def _production_module(path: Path) -> str:
@@ -206,12 +227,16 @@ def _node_span(node: ast.AST) -> Span:
 
 
 def _has_span(node: ast.AST) -> bool:
-    return all(getattr(node, field, None) is not None for field in ("lineno", "col_offset", "end_lineno", "end_col_offset"))
+    return all(
+        getattr(node, field, None) is not None
+        for field in ("lineno", "col_offset", "end_lineno", "end_col_offset")
+    )
 
 
 def _contains(outer: Span, inner: Span) -> bool:
     return (outer.line, outer.column) <= (inner.line, inner.column) and (
-        inner.end_line, inner.end_column
+        inner.end_line,
+        inner.end_column,
     ) <= (outer.end_line, outer.end_column)
 
 
@@ -225,7 +250,11 @@ def _relative_module(module: str, package: str, level: int) -> str:
 
 def _facts(path: Path, *, module: str) -> ModuleFacts:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    parents = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
     package = module if path.name == "__init__.py" else module.rpartition(".")[0]
     return ModuleFacts(path, module, package, tree, parents)
 
@@ -233,20 +262,28 @@ def _facts(path: Path, *, module: str) -> ModuleFacts:
 def _merge_environments(*environments: Environment) -> Environment:
     names = set().union(*(environment for environment in environments))
     return {
-        name: frozenset().union(*(environment.get(name, frozenset()) for environment in environments))
+        name: frozenset().union(
+            *(environment.get(name, frozenset()) for environment in environments)
+        )
         for name in names
     }
 
 
-def _with_definition(environment: Environment, definition: ReachingDefinition) -> Environment:
+def _with_definition(
+    environment: Environment, definition: ReachingDefinition
+) -> Environment:
     updated = dict(environment)
     updated[definition.name] = frozenset((definition,))
     return updated
 
 
-def _add_definition(environment: Environment, definition: ReachingDefinition) -> Environment:
+def _add_definition(
+    environment: Environment, definition: ReachingDefinition
+) -> Environment:
     updated = dict(environment)
-    updated[definition.name] = updated.get(definition.name, frozenset()) | frozenset((definition,))
+    updated[definition.name] = updated.get(definition.name, frozenset()) | frozenset(
+        (definition,)
+    )
     return updated
 
 
@@ -259,13 +296,19 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
     cached = _REACHING_CACHE.get(cache_key)
     if cached is not None:
         return cached
-    before: dict[tuple[str, tuple[tuple[str, str, int, int], ...], str, Span], Environment] = {}
+    before: dict[
+        tuple[str, tuple[tuple[str, str, int, int], ...], str, Span], Environment
+    ] = {}
 
     def store_before(node: ast.AST, environment: Environment) -> None:
         if not _has_span(node):
             return
         key = _node_occurrence(facts, node)
-        before[key] = _merge_environments(before[key], environment) if key in before else dict(environment)
+        before[key] = (
+            _merge_environments(before[key], environment)
+            if key in before
+            else dict(environment)
+        )
 
     def target_names(target: ast.AST) -> tuple[str, ...]:
         if isinstance(target, ast.Name):
@@ -273,7 +316,9 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
         if isinstance(target, ast.Starred):
             return target_names(target.value)
         if isinstance(target, (ast.Tuple, ast.List)):
-            return tuple(name for element in target.elts for name in target_names(element))
+            return tuple(
+                name for element in target.elts for name in target_names(element)
+            )
         return ()
 
     def pattern_names(pattern: ast.pattern) -> tuple[str, ...]:
@@ -284,31 +329,43 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
         if isinstance(pattern, ast.MatchStar):
             return (pattern.name,) if pattern.name else ()
         if isinstance(pattern, ast.MatchMapping):
-            return tuple(name for child in pattern.patterns for name in pattern_names(child)) + (
-                (pattern.rest,) if pattern.rest else ()
-            )
+            return tuple(
+                name for child in pattern.patterns for name in pattern_names(child)
+            ) + ((pattern.rest,) if pattern.rest else ())
         if isinstance(pattern, ast.MatchSequence):
-            return tuple(name for child in pattern.patterns for name in pattern_names(child))
+            return tuple(
+                name for child in pattern.patterns for name in pattern_names(child)
+            )
         if isinstance(pattern, ast.MatchClass):
             return tuple(
-                name for child in (*pattern.patterns, *pattern.kwd_patterns) for name in pattern_names(child)
+                name
+                for child in (*pattern.patterns, *pattern.kwd_patterns)
+                for name in pattern_names(child)
             )
         if isinstance(pattern, ast.MatchOr):
-            alternatives = tuple(frozenset(pattern_names(child)) for child in pattern.patterns)
+            alternatives = tuple(
+                frozenset(pattern_names(child)) for child in pattern.patterns
+            )
             if alternatives and len(set(alternatives)) != 1:
-                raise AssertionError(f"match alternatives bind different names at {facts.path}:{pattern.lineno}")
+                raise AssertionError(
+                    f"match alternatives bind different names at {facts.path}:{pattern.lineno}"
+                )
             return tuple(sorted(next(iter(alternatives), frozenset())))
         return ()
 
     def owned_nodes(node: ast.AST):
         """Walk one lexical scope, pruning nested definition-time scopes."""
         yield node
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)):
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
             return
         for child in ast.iter_child_nodes(node):
             yield from owned_nodes(child)
 
-    def declarations(statements: list[ast.stmt]) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
+    def declarations(
+        statements: list[ast.stmt],
+    ) -> tuple[frozenset[str], frozenset[str], frozenset[str]]:
         globals_: set[str] = set()
         nonlocals: set[str] = set()
         locals_: set[str] = set()
@@ -318,14 +375,22 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                     globals_.update(node.names)
                 elif isinstance(node, ast.Nonlocal):
                     nonlocals.update(node.names)
-                elif isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.NamedExpr)):
-                    targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
-                    locals_.update(name for target in targets for name in target_names(target))
+                elif isinstance(
+                    node, (ast.Assign, ast.AnnAssign, ast.AugAssign, ast.NamedExpr)
+                ):
+                    targets = (
+                        node.targets if isinstance(node, ast.Assign) else (node.target,)
+                    )
+                    locals_.update(
+                        name for target in targets for name in target_names(target)
+                    )
                 elif isinstance(node, (ast.For, ast.AsyncFor)):
                     locals_.update(target_names(node.target))
                 elif isinstance(node, (ast.With, ast.AsyncWith)):
                     locals_.update(
-                        name for item in node.items if item.optional_vars is not None
+                        name
+                        for item in node.items
+                        if item.optional_vars is not None
                         for name in target_names(item.optional_vars)
                     )
                 elif isinstance(node, ast.ExceptHandler) and node.name:
@@ -334,15 +399,29 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                     locals_.update(pattern_names(node.pattern))
                 elif isinstance(node, (ast.Import, ast.ImportFrom)):
                     locals_.update(
-                        alias.asname or (alias.name.split(".")[0] if isinstance(node, ast.Import) else alias.name)
-                        for alias in node.names if alias.name != "*"
+                        alias.asname
+                        or (
+                            alias.name.split(".")[0]
+                            if isinstance(node, ast.Import)
+                            else alias.name
+                        )
+                        for alias in node.names
+                        if alias.name != "*"
                     )
-                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                elif isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                ):
                     locals_.add(node.name)
         overlap = globals_ & nonlocals
         if overlap:
-            raise AssertionError(f"global/nonlocal overlap at {facts.path}: {sorted(overlap)!r}")
-        return frozenset(globals_), frozenset(nonlocals), frozenset(locals_ - globals_ - nonlocals)
+            raise AssertionError(
+                f"global/nonlocal overlap at {facts.path}: {sorted(overlap)!r}"
+            )
+        return (
+            frozenset(globals_),
+            frozenset(nonlocals),
+            frozenset(locals_ - globals_ - nonlocals),
+        )
 
     def record(
         node: ast.AST | None,
@@ -357,18 +436,30 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
             environment = record(node.value, environment, walrus_exports=walrus_exports)
             environment = bind_target(node.target, node.value, environment)
             if walrus_exports is not None and isinstance(node.target, ast.Name):
-                walrus_exports.append(ReachingDefinition(node.target.id, node.target, expression=node.value))
+                walrus_exports.append(
+                    ReachingDefinition(
+                        node.target.id, node.target, expression=node.value
+                    )
+                )
             store_before(node.target, environment)
             return environment
         if isinstance(node, ast.Lambda):
             for default in (*node.args.defaults, *node.args.kw_defaults):
                 environment = record(default, environment)
             local = dict(environment)
-            for argument in (*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs):
-                local = _with_definition(local, ReachingDefinition(argument.arg, argument))
+            for argument in (
+                *node.args.posonlyargs,
+                *node.args.args,
+                *node.args.kwonlyargs,
+            ):
+                local = _with_definition(
+                    local, ReachingDefinition(argument.arg, argument)
+                )
             record(node.body, local, walrus_exports=None)
             return environment
-        if isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)):
+        if isinstance(
+            node, (ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp)
+        ):
             local = dict(environment)
             exports: list[ReachingDefinition] = []
             for generator in node.generators:
@@ -398,27 +489,41 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
         nonlocal_names: frozenset[str] = frozenset(),
     ) -> Environment:
         if isinstance(target, ast.Name):
-            owner = "module" if target.id in global_names else "nonlocal" if target.id in nonlocal_names else "local"
+            owner = (
+                "module"
+                if target.id in global_names
+                else "nonlocal" if target.id in nonlocal_names else "local"
+            )
             return _with_definition(
                 environment,
-                ReachingDefinition(target.id, target, expression=value, scope_owner=owner),
+                ReachingDefinition(
+                    target.id, target, expression=value, scope_owner=owner
+                ),
             )
         if isinstance(target, (ast.Tuple, ast.List)):
             result = environment
             for element in target.elts:
-                result = bind_target(element, None, result, global_names, nonlocal_names)
+                result = bind_target(
+                    element, None, result, global_names, nonlocal_names
+                )
             return result
         if isinstance(target, ast.Starred):
-            return bind_target(target.value, value, environment, global_names, nonlocal_names)
+            return bind_target(
+                target.value, value, environment, global_names, nonlocal_names
+            )
         if isinstance(target, ast.Attribute):
             return _add_definition(
                 environment,
-                ReachingDefinition(f"@attribute:{target.attr}", target, expression=value),
+                ReachingDefinition(
+                    f"@attribute:{target.attr}", target, expression=value
+                ),
             )
         return environment
 
     def join_normal(*environments: Environment | None) -> Environment | None:
-        present = tuple(environment for environment in environments if environment is not None)
+        present = tuple(
+            environment for environment in environments if environment is not None
+        )
         return _merge_environments(*present) if present else None
 
     def combine(*faces: FlowFaces) -> FlowFaces:
@@ -446,31 +551,49 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                 break
             store_before(statement, environment)
             if isinstance(statement, ast.ImportFrom):
-                provider = _relative_module(statement.module or "", facts.package, statement.level)
+                provider = _relative_module(
+                    statement.module or "", facts.package, statement.level
+                )
                 for imported in statement.names:
                     if imported.name == "*":
                         environment = _add_definition(
                             environment,
-                            ReachingDefinition("@star", imported, symbol=Symbol(provider, "*")),
+                            ReachingDefinition(
+                                "@star", imported, symbol=Symbol(provider, "*")
+                            ),
                         )
                     else:
-                        environment = _with_definition(environment, ReachingDefinition(
-                            imported.asname or imported.name,
-                            imported,
-                            symbol=Symbol(provider, imported.name),
-                        ))
+                        environment = _with_definition(
+                            environment,
+                            ReachingDefinition(
+                                imported.asname or imported.name,
+                                imported,
+                                symbol=Symbol(provider, imported.name),
+                            ),
+                        )
                 record(statement, environment)
             elif isinstance(statement, ast.Import):
                 for imported in statement.names:
                     local = imported.asname or imported.name.split(".")[0]
-                    environment = _with_definition(environment, ReachingDefinition(local, imported, symbol=Symbol(imported.name, "")))
+                    environment = _with_definition(
+                        environment,
+                        ReachingDefinition(
+                            local, imported, symbol=Symbol(imported.name, "")
+                        ),
+                    )
                 record(statement, environment)
             elif isinstance(statement, (ast.Assign, ast.AnnAssign)):
                 value = statement.value
                 environment = record(value, environment)
-                targets = statement.targets if isinstance(statement, ast.Assign) else (statement.target,)
+                targets = (
+                    statement.targets
+                    if isinstance(statement, ast.Assign)
+                    else (statement.target,)
+                )
                 for target in targets:
-                    environment = bind_target(target, value, environment, global_names, nonlocal_names)
+                    environment = bind_target(
+                        target, value, environment, global_names, nonlocal_names
+                    )
                     record(target, environment)
             elif isinstance(statement, ast.AugAssign):
                 environment = record(statement.target, environment)
@@ -479,61 +602,111 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                     statement.target, None, environment, global_names, nonlocal_names
                 )
             elif isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                for expression in (*statement.decorator_list, *statement.args.defaults, *statement.args.kw_defaults, statement.returns):
+                for expression in (
+                    *statement.decorator_list,
+                    *statement.args.defaults,
+                    *statement.args.kw_defaults,
+                    statement.returns,
+                ):
                     environment = record(expression, environment)
-                environment = _with_definition(environment, ReachingDefinition(statement.name, statement))
+                environment = _with_definition(
+                    environment, ReachingDefinition(statement.name, statement)
+                )
                 local = dict(environment)
-                for argument in (*statement.args.posonlyargs, *statement.args.args, *statement.args.kwonlyargs):
-                    local = _with_definition(local, ReachingDefinition(argument.arg, argument))
+                for argument in (
+                    *statement.args.posonlyargs,
+                    *statement.args.args,
+                    *statement.args.kwonlyargs,
+                ):
+                    local = _with_definition(
+                        local, ReachingDefinition(argument.arg, argument)
+                    )
                     record(argument.annotation, environment)
                 if statement.args.vararg is not None:
-                    local = _with_definition(local, ReachingDefinition(statement.args.vararg.arg, statement.args.vararg))
+                    local = _with_definition(
+                        local,
+                        ReachingDefinition(
+                            statement.args.vararg.arg, statement.args.vararg
+                        ),
+                    )
                 if statement.args.kwarg is not None:
-                    local = _with_definition(local, ReachingDefinition(statement.args.kwarg.arg, statement.args.kwarg))
+                    local = _with_definition(
+                        local,
+                        ReachingDefinition(
+                            statement.args.kwarg.arg, statement.args.kwarg
+                        ),
+                    )
                 global_names, nonlocal_names, local_names = declarations(statement.body)
                 # Python decides the whole function's locals at definition time.
                 for name in local_names:
                     local = _with_definition(
-                        local, ReachingDefinition(name, statement, scope_owner="predeclared")
+                        local,
+                        ReachingDefinition(name, statement, scope_owner="predeclared"),
                     )
                 flow_block(statement.body, local, global_names, nonlocal_names)
             elif isinstance(statement, ast.ClassDef):
-                for expression in (*statement.decorator_list, *statement.bases, *(keyword.value for keyword in statement.keywords)):
+                for expression in (
+                    *statement.decorator_list,
+                    *statement.bases,
+                    *(keyword.value for keyword in statement.keywords),
+                ):
                     record(expression, environment)
-                environment = _with_definition(environment, ReachingDefinition(statement.name, statement))
+                environment = _with_definition(
+                    environment, ReachingDefinition(statement.name, statement)
+                )
                 flow_block(statement.body, dict(environment))
             elif isinstance(statement, ast.If):
                 environment = record(statement.test, environment)
                 branches = combine(
-                    flow_block(statement.body, dict(environment), global_names, nonlocal_names),
-                    flow_block(statement.orelse, dict(environment), global_names, nonlocal_names),
+                    flow_block(
+                        statement.body, dict(environment), global_names, nonlocal_names
+                    ),
+                    flow_block(
+                        statement.orelse,
+                        dict(environment),
+                        global_names,
+                        nonlocal_names,
+                    ),
                 )
                 environment = branches.normal
-                returned.extend(branches.returned); raised.extend(branches.raised)
-                broken.extend(branches.broken); continued.extend(branches.continued)
+                returned.extend(branches.returned)
+                raised.extend(branches.raised)
+                broken.extend(branches.broken)
+                continued.extend(branches.continued)
             elif isinstance(statement, (ast.For, ast.AsyncFor)):
                 environment = record(statement.iter, environment)
-                loop_environment = bind_target(statement.target, None, environment, global_names, nonlocal_names)
+                loop_environment = bind_target(
+                    statement.target, None, environment, global_names, nonlocal_names
+                )
                 while True:
-                    body = flow_block(statement.body, loop_environment, global_names, nonlocal_names)
+                    body = flow_block(
+                        statement.body, loop_environment, global_names, nonlocal_names
+                    )
                     recurrence = join_normal(body.normal, *body.continued)
-                    next_environment = join_normal(environment, loop_environment, recurrence)
+                    next_environment = join_normal(
+                        environment, loop_environment, recurrence
+                    )
                     assert next_environment is not None
                     if next_environment == loop_environment:
                         break
                     loop_environment = next_environment
                 else_in = join_normal(environment, body.normal)
                 assert else_in is not None
-                else_face = flow_block(statement.orelse, else_in, global_names, nonlocal_names)
+                else_face = flow_block(
+                    statement.orelse, else_in, global_names, nonlocal_names
+                )
                 environment = join_normal(else_face.normal, *body.broken)
                 returned.extend((*body.returned, *else_face.returned))
                 raised.extend((*body.raised, *else_face.raised))
-                continued.extend(else_face.continued); broken.extend(else_face.broken)
+                continued.extend(else_face.continued)
+                broken.extend(else_face.broken)
             elif isinstance(statement, ast.While):
                 environment = record(statement.test, environment)
                 loop_environment = dict(environment)
                 while True:
-                    body = flow_block(statement.body, loop_environment, global_names, nonlocal_names)
+                    body = flow_block(
+                        statement.body, loop_environment, global_names, nonlocal_names
+                    )
                     recurrence = join_normal(body.normal, *body.continued)
                     next_environment = join_normal(environment, recurrence)
                     assert next_environment is not None
@@ -543,13 +716,18 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                     loop_environment = next_environment
                 else_in = join_normal(environment, body.normal)
                 assert else_in is not None
-                else_face = flow_block(statement.orelse, else_in, global_names, nonlocal_names)
+                else_face = flow_block(
+                    statement.orelse, else_in, global_names, nonlocal_names
+                )
                 environment = join_normal(else_face.normal, *body.broken)
                 returned.extend((*body.returned, *else_face.returned))
                 raised.extend((*body.raised, *else_face.raised))
-                continued.extend(else_face.continued); broken.extend(else_face.broken)
+                continued.extend(else_face.continued)
+                broken.extend(else_face.broken)
             elif isinstance(statement, (ast.Try, ast.TryStar)):
-                body_face = flow_block(statement.body, dict(environment), global_names, nonlocal_names)
+                body_face = flow_block(
+                    statement.body, dict(environment), global_names, nonlocal_names
+                )
                 handler_faces = []
                 for handler in statement.handlers:
                     raised_inputs = body_face.raised or (dict(environment),)
@@ -558,47 +736,103 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                         record(handler.type, handler_environment)
                         if handler.name:
                             handler_environment = _with_definition(
-                                handler_environment, ReachingDefinition(handler.name, handler)
+                                handler_environment,
+                                ReachingDefinition(handler.name, handler),
                             )
                         handler_faces.append(
-                            flow_block(handler.body, handler_environment, global_names, nonlocal_names)
+                            flow_block(
+                                handler.body,
+                                handler_environment,
+                                global_names,
+                                nonlocal_names,
+                            )
                         )
-                else_face = flow_block(statement.orelse, body_face.normal, global_names, nonlocal_names) if body_face.normal is not None else FlowFaces(None)
-                pre_final = combine(else_face, *handler_faces, FlowFaces(
-                    None, body_face.returned, (), body_face.broken, body_face.continued
-                ))
+                else_face = (
+                    flow_block(
+                        statement.orelse, body_face.normal, global_names, nonlocal_names
+                    )
+                    if body_face.normal is not None
+                    else FlowFaces(None)
+                )
+                pre_final = combine(
+                    else_face,
+                    *handler_faces,
+                    FlowFaces(
+                        None,
+                        body_face.returned,
+                        (),
+                        body_face.broken,
+                        body_face.continued,
+                    ),
+                )
                 if statement.finalbody:
                     final_outputs: list[FlowFaces] = []
                     for face_name, inputs in (
-                        ("normal", (() if pre_final.normal is None else (pre_final.normal,))),
-                        ("returned", pre_final.returned), ("raised", pre_final.raised),
-                        ("broken", pre_final.broken), ("continued", pre_final.continued),
+                        (
+                            "normal",
+                            (() if pre_final.normal is None else (pre_final.normal,)),
+                        ),
+                        ("returned", pre_final.returned),
+                        ("raised", pre_final.raised),
+                        ("broken", pre_final.broken),
+                        ("continued", pre_final.continued),
                     ):
                         for input_environment in inputs:
-                            final = flow_block(statement.finalbody, input_environment, global_names, nonlocal_names)
+                            final = flow_block(
+                                statement.finalbody,
+                                input_environment,
+                                global_names,
+                                nonlocal_names,
+                            )
                             if final.normal is not None:
                                 final = FlowFaces(
                                     final.normal if face_name == "normal" else None,
-                                    final.returned + ((final.normal,) if face_name == "returned" else ()),
-                                    final.raised + ((final.normal,) if face_name == "raised" else ()),
-                                    final.broken + ((final.normal,) if face_name == "broken" else ()),
-                                    final.continued + ((final.normal,) if face_name == "continued" else ()),
+                                    final.returned
+                                    + (
+                                        (final.normal,)
+                                        if face_name == "returned"
+                                        else ()
+                                    ),
+                                    final.raised
+                                    + (
+                                        (final.normal,) if face_name == "raised" else ()
+                                    ),
+                                    final.broken
+                                    + (
+                                        (final.normal,) if face_name == "broken" else ()
+                                    ),
+                                    final.continued
+                                    + (
+                                        (final.normal,)
+                                        if face_name == "continued"
+                                        else ()
+                                    ),
                                 )
                             final_outputs.append(final)
                     pre_final = combine(*final_outputs)
                 environment = pre_final.normal
-                returned.extend(pre_final.returned); raised.extend(pre_final.raised)
-                broken.extend(pre_final.broken); continued.extend(pre_final.continued)
+                returned.extend(pre_final.returned)
+                raised.extend(pre_final.raised)
+                broken.extend(pre_final.broken)
+                continued.extend(pre_final.continued)
             elif isinstance(statement, (ast.With, ast.AsyncWith)):
                 local = dict(environment)
                 for item in statement.items:
                     local = record(item.context_expr, local)
                     if item.optional_vars is not None:
-                        local = bind_target(item.optional_vars, item.context_expr, local, global_names, nonlocal_names)
+                        local = bind_target(
+                            item.optional_vars,
+                            item.context_expr,
+                            local,
+                            global_names,
+                            nonlocal_names,
+                        )
                 face = flow_block(statement.body, local, global_names, nonlocal_names)
                 environment = face.normal
-                returned.extend(face.returned); raised.extend(face.raised)
-                broken.extend(face.broken); continued.extend(face.continued)
+                returned.extend(face.returned)
+                raised.extend(face.raised)
+                broken.extend(face.broken)
+                continued.extend(face.continued)
             elif isinstance(statement, ast.Match):
                 environment = record(statement.subject, environment)
                 exits = []
@@ -607,36 +841,58 @@ def _reaching_index(facts: ModuleFacts) -> ReachingIndex:
                     record(case.guard, environment)
                     case_environment = dict(environment)
                     for name in pattern_names(case.pattern):
-                        owner = "module" if name in global_names else "nonlocal" if name in nonlocal_names else "local"
-                        case_environment = _with_definition(
-                            case_environment, ReachingDefinition(name, case.pattern, scope_owner=owner)
+                        owner = (
+                            "module"
+                            if name in global_names
+                            else "nonlocal" if name in nonlocal_names else "local"
                         )
-                    exits.append(flow_block(case.body, case_environment, global_names, nonlocal_names))
+                        case_environment = _with_definition(
+                            case_environment,
+                            ReachingDefinition(name, case.pattern, scope_owner=owner),
+                        )
+                    exits.append(
+                        flow_block(
+                            case.body, case_environment, global_names, nonlocal_names
+                        )
+                    )
                 matched = combine(*exits)
                 environment = join_normal(environment, matched.normal)
-                returned.extend(matched.returned); raised.extend(matched.raised)
-                broken.extend(matched.broken); continued.extend(matched.continued)
+                returned.extend(matched.returned)
+                raised.extend(matched.raised)
+                broken.extend(matched.broken)
+                continued.extend(matched.continued)
             elif isinstance(statement, ast.Delete):
                 for target in statement.targets:
                     if isinstance(target, ast.Name):
-                        environment = _with_definition(environment, ReachingDefinition(target.id, target, deleted=True))
+                        environment = _with_definition(
+                            environment,
+                            ReachingDefinition(target.id, target, deleted=True),
+                        )
                     elif isinstance(target, ast.Attribute):
                         environment = _add_definition(
                             environment,
-                            ReachingDefinition(f"@attribute:{target.attr}", target, deleted=True),
+                            ReachingDefinition(
+                                f"@attribute:{target.attr}", target, deleted=True
+                            ),
                         )
                 record(statement, environment)
             else:
                 environment = record(statement, environment)
                 if isinstance(statement, ast.Return):
-                    returned.append(environment); environment = None
+                    returned.append(environment)
+                    environment = None
                 elif isinstance(statement, ast.Raise):
-                    raised.append(environment); environment = None
+                    raised.append(environment)
+                    environment = None
                 elif isinstance(statement, ast.Break):
-                    broken.append(environment); environment = None
+                    broken.append(environment)
+                    environment = None
                 elif isinstance(statement, ast.Continue):
-                    continued.append(environment); environment = None
-        return FlowFaces(environment, tuple(returned), tuple(raised), tuple(broken), tuple(continued))
+                    continued.append(environment)
+                    environment = None
+        return FlowFaces(
+            environment, tuple(returned), tuple(raised), tuple(broken), tuple(continued)
+        )
 
     module_face = flow_block(facts.tree.body, {})
     module_exit = module_face.normal or {}
@@ -658,15 +914,24 @@ def _attribute_parts(node: ast.AST) -> tuple[str, ...] | None:
 def _declared_exports(facts: ModuleFacts) -> frozenset[str] | None:
     for statement in facts.tree.body:
         if isinstance(statement, (ast.Assign, ast.AnnAssign)):
-            targets = statement.targets if isinstance(statement, ast.Assign) else (statement.target,)
-            if any(isinstance(target, ast.Name) and target.id == "__all__" for target in targets):
+            targets = (
+                statement.targets
+                if isinstance(statement, ast.Assign)
+                else (statement.target,)
+            )
+            if any(
+                isinstance(target, ast.Name) and target.id == "__all__"
+                for target in targets
+            ):
                 value = statement.value
                 if isinstance(value, (ast.List, ast.Tuple, ast.Set)) and all(
                     isinstance(element, ast.Constant) and isinstance(element.value, str)
                     for element in value.elts
                 ):
                     return frozenset(element.value for element in value.elts)
-                raise AssertionError(f"dynamic __all__ is outside retirement resolver: {facts.path}:{statement.lineno}")
+                raise AssertionError(
+                    f"dynamic __all__ is outside retirement resolver: {facts.path}:{statement.lineno}"
+                )
     return None
 
 
@@ -677,10 +942,22 @@ def _resolve_definition(
     seen: frozenset[tuple[str, str, int, int, int, int]],
 ) -> Symbol | None:
     span = _node_span(definition.node)
-    key = (facts.module, definition.name, span.line, span.column, span.end_line, span.end_column)
+    key = (
+        facts.module,
+        definition.name,
+        span.line,
+        span.column,
+        span.end_line,
+        span.end_column,
+    )
     if key in seen:
-        if any(module == TARGET_MODULE or name == TARGET_NAME for module, name, *_ in seen | {key}):
-            raise AssertionError(f"target resolved-definition cycle at {facts.path}:{getattr(definition.node, 'lineno', '?')}")
+        if any(
+            module == TARGET_MODULE or name == TARGET_NAME
+            for module, name, *_ in seen | {key}
+        ):
+            raise AssertionError(
+                f"target resolved-definition cycle at {facts.path}:{getattr(definition.node, 'lineno', '?')}"
+            )
         return None
     if definition.deleted:
         return None
@@ -712,12 +989,17 @@ def _resolve_export(
     star: bool,
 ) -> Symbol | None:
     exports = _declared_exports(provider)
-    if star and ((exports is not None and name not in exports) or (exports is None and name.startswith("_"))):
+    if star and (
+        (exports is not None and name not in exports)
+        or (exports is None and name.startswith("_"))
+    ):
         return None
     definitions = _reaching_index(provider).module_exit.get(name, frozenset())
     resolved = {
-        symbol for definition in definitions
-        if (symbol := _resolve_definition(definition, provider, graph, seen)) is not None
+        symbol
+        for definition in definitions
+        if (symbol := _resolve_definition(definition, provider, graph, seen))
+        is not None
     }
     star_resolved = set()
     for definition in _reaching_index(provider).module_exit.get("@star", frozenset()):
@@ -729,7 +1011,9 @@ def _resolve_export(
                 star_resolved.add(symbol)
     resolved |= star_resolved
     if len(resolved) > 1 and Symbol(TARGET_MODULE, TARGET_NAME) in resolved:
-        raise AssertionError(f"ambiguous export {provider.module}.{name}: {sorted(resolved, key=lambda item: (item.module, item.name))!r}")
+        raise AssertionError(
+            f"ambiguous export {provider.module}.{name}: {sorted(resolved, key=lambda item: (item.module, item.name))!r}"
+        )
     if len(resolved) > 1:
         return None
     return next(iter(resolved), None)
@@ -753,31 +1037,48 @@ def _resolve(
         )
         resolved = {symbol for symbol in resolutions if symbol is not None}
         target_symbol = Symbol(TARGET_MODULE, TARGET_NAME)
-        if target_symbol in resolved and (len(resolved) > 1 or any(symbol is None for symbol in resolutions)):
-            raise AssertionError(f"ambiguous reaching definitions for {facts.path}:{node.lineno}:{node.col_offset} {node.id}: {definitions!r}")
+        if target_symbol in resolved and (
+            len(resolved) > 1 or any(symbol is None for symbol in resolutions)
+        ):
+            raise AssertionError(
+                f"ambiguous reaching definitions for {facts.path}:{node.lineno}:{node.col_offset} {node.id}: {definitions!r}"
+            )
         if len(resolved) > 1:
             return None
         if resolved:
             return next(iter(resolved))
         star_resolutions: list[Symbol | None] = []
         for definition in environment.get("@star", frozenset()):
-            provider_name = definition.symbol.module if definition.symbol is not None else ""
+            provider_name = (
+                definition.symbol.module if definition.symbol is not None else ""
+            )
             provider = graph.get(provider_name)
             if provider is not None:
                 symbol = _resolve_export(node.id, provider, graph, seen, star=True)
                 star_resolutions.append(symbol)
         star_resolved = {symbol for symbol in star_resolutions if symbol is not None}
-        if len(star_resolved) > 1 and Symbol(TARGET_MODULE, TARGET_NAME) in star_resolved:
-            raise AssertionError(f"ambiguous star binding {facts.path}:{node.lineno} {node.id}: {star_resolved!r}")
+        if (
+            len(star_resolved) > 1
+            and Symbol(TARGET_MODULE, TARGET_NAME) in star_resolved
+        ):
+            raise AssertionError(
+                f"ambiguous star binding {facts.path}:{node.lineno} {node.id}: {star_resolved!r}"
+            )
         if Symbol(TARGET_MODULE, TARGET_NAME) in star_resolved and any(
             symbol is None for symbol in star_resolutions
         ):
-            raise AssertionError(f"target star binding has unresolved sibling {facts.path}:{node.lineno} {node.id}")
+            raise AssertionError(
+                f"target star binding has unresolved sibling {facts.path}:{node.lineno} {node.id}"
+            )
         if len(star_resolved) > 1:
             return None
         if star_resolved:
             return next(iter(star_resolved))
-        if not definitions and not environment.get("@star") and node.id in {"isinstance", "issubclass", "getattr", "hasattr"}:
+        if (
+            not definitions
+            and not environment.get("@star")
+            and node.id in {"isinstance", "issubclass", "getattr", "hasattr"}
+        ):
             return Symbol("builtins", node.id)
         return None
     parts = _attribute_parts(node)
@@ -789,13 +1090,19 @@ def _resolve(
     root_symbol = _resolve(root_node, facts, graph, seen, environment_override)
     if root_symbol is None:
         return None
-    module = root_symbol.module if root_symbol.name == "" else ".".join((root_symbol.module, root_symbol.name))
+    module = (
+        root_symbol.module
+        if root_symbol.name == ""
+        else ".".join((root_symbol.module, root_symbol.name))
+    )
     if len(parts) == 1:
         return root_symbol
     projected = Symbol(".".join((module, *parts[1:-1])), parts[-1])
     projected_provider = graph.get(projected.module)
     if projected_provider is not None:
-        exported = _resolve_export(projected.name, projected_provider, graph, seen, star=False)
+        exported = _resolve_export(
+            projected.name, projected_provider, graph, seen, star=False
+        )
         if exported is not None:
             projected = exported
     # Attribute assignments are keyed by the resolved base symbol and field,
@@ -810,15 +1117,23 @@ def _resolve(
             resolutions.append(_resolve_definition(definition, facts, graph, seen))
     candidates = {symbol for symbol in resolutions if symbol is not None}
     if len(candidates) > 1 and Symbol(TARGET_MODULE, TARGET_NAME) in candidates:
-        raise AssertionError(f"ambiguous attribute provenance {facts.path}:{node.lineno}: {candidates!r}")
+        raise AssertionError(
+            f"ambiguous attribute provenance {facts.path}:{node.lineno}: {candidates!r}"
+        )
     if len(candidates) > 1:
         return None
-    if Symbol(TARGET_MODULE, TARGET_NAME) in candidates and any(symbol is None for symbol in resolutions):
-        raise AssertionError(f"target attribute provenance has unresolved sibling {facts.path}:{node.lineno}")
+    if Symbol(TARGET_MODULE, TARGET_NAME) in candidates and any(
+        symbol is None for symbol in resolutions
+    ):
+        raise AssertionError(
+            f"target attribute provenance has unresolved sibling {facts.path}:{node.lineno}"
+        )
     return next(iter(candidates), projected)
 
 
-def _is_target(node: ast.AST, facts: ModuleFacts, graph: dict[str, ModuleFacts]) -> bool:
+def _is_target(
+    node: ast.AST, facts: ModuleFacts, graph: dict[str, ModuleFacts]
+) -> bool:
     return _resolve(node, facts, graph) == Symbol(TARGET_MODULE, TARGET_NAME)
 
 
@@ -839,18 +1154,22 @@ def _raw_rows(files: tuple[Path, ...]) -> tuple[RawRow, ...]:
                             match.start() + (token.start[1] if offset == 0 else 0),
                         )
                         if position in token_kinds:
-                            raise AssertionError(f"overlapping tokenizer ownership at {relative}:{position}")
+                            raise AssertionError(
+                                f"overlapping tokenizer ownership at {relative}:{position}"
+                            )
                         token_kinds[position] = tokenize.tok_name[token.type]
         for line_number, line in enumerate(source.splitlines(), 1):
             for match in pattern.finditer(line):
                 column = match.start()
                 token_kind = token_kinds.get((line_number, column))
-                rows.append(RawRow(
-                    relative,
-                    Span(line_number, column, line_number, match.end()),
-                    token_kind or "UNMAPPED",
-                    line.strip(),
-                ))
+                rows.append(
+                    RawRow(
+                        relative,
+                        Span(line_number, column, line_number, match.end()),
+                        token_kind or "UNMAPPED",
+                        line.strip(),
+                    )
+                )
     return tuple(sorted(rows))
 
 
@@ -859,16 +1178,25 @@ def _annotation_roots(tree: ast.Module) -> tuple[tuple[ast.AST, str], ...]:
     for node in ast.walk(tree):
         if isinstance(node, ast.arg) and node.annotation is not None:
             roots.append((node.annotation, "annotation_leaf"))
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.returns is not None:
+        elif (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.returns is not None
+        ):
             roots.append((node.returns, "annotation_leaf"))
         elif isinstance(node, ast.AnnAssign):
             roots.append((node.annotation, "annotation_leaf"))
-            if isinstance(node.annotation, ast.Name) and node.annotation.id == "TypeAlias" and node.value is not None:
+            if (
+                isinstance(node.annotation, ast.Name)
+                and node.annotation.id == "TypeAlias"
+                and node.value is not None
+            ):
                 roots.append((node.value, "type_alias_site"))
     return tuple(roots)
 
 
-def _annotation_resolves(root: ast.AST, facts: ModuleFacts, graph: dict[str, ModuleFacts]) -> bool:
+def _annotation_resolves(
+    root: ast.AST, facts: ModuleFacts, graph: dict[str, ModuleFacts]
+) -> bool:
     expression = root
     containing_environment = _before_environment(facts, root)
     if isinstance(root, ast.Constant) and isinstance(root.value, str):
@@ -896,9 +1224,15 @@ def _inside_type_checking(
     )
 
 
-def _classification_candidates(raw: RawRow, facts: ModuleFacts, graph: dict[str, ModuleFacts]) -> tuple[SemanticRow, ...]:
+def _classification_candidates(
+    raw: RawRow, facts: ModuleFacts, graph: dict[str, ModuleFacts]
+) -> tuple[SemanticRow, ...]:
     candidates: list[SemanticRow] = []
-    containing = [node for node in ast.walk(facts.tree) if _has_span(node) and _contains(_node_span(node), raw.span)]
+    containing = [
+        node
+        for node in ast.walk(facts.tree)
+        if _has_span(node) and _contains(_node_span(node), raw.span)
+    ]
     for node in containing:
         if (
             isinstance(node, ast.ClassDef)
@@ -907,27 +1241,54 @@ def _classification_candidates(raw: RawRow, facts: ModuleFacts, graph: dict[str,
             and raw.token_kind == "NAME"
             and raw.span.line == node.lineno
         ):
-            candidates.append(SemanticRow(raw, "definition", f"{facts.module}:{node.lineno}"))
+            candidates.append(
+                SemanticRow(raw, "definition", f"{facts.module}:{node.lineno}")
+            )
     for node in containing:
         if isinstance(node, ast.ImportFrom):
             for imported in node.names:
-                if imported.name == TARGET_NAME and _contains(_node_span(imported), raw.span):
-                    symbol = Symbol(_relative_module(node.module or "", facts.package, node.level), imported.name)
+                if imported.name == TARGET_NAME and _contains(
+                    _node_span(imported), raw.span
+                ):
+                    symbol = Symbol(
+                        _relative_module(node.module or "", facts.package, node.level),
+                        imported.name,
+                    )
                     provider = graph.get(symbol.module)
                     resolved = provider is not None and _resolve_export(
                         symbol.name, provider, graph, frozenset(), star=False
                     ) == Symbol(TARGET_MODULE, TARGET_NAME)
                     if resolved:
-                        category = "type_checking_import" if _inside_type_checking(raw, facts, graph) else (
-                            "runtime_reexport" if facts.path.name == "__init__.py" else "runtime_import"
+                        category = (
+                            "type_checking_import"
+                            if _inside_type_checking(raw, facts, graph)
+                            else (
+                                "runtime_reexport"
+                                if facts.path.name == "__init__.py"
+                                else "runtime_import"
+                            )
                         )
-                        candidates.append(SemanticRow(raw, category, f"{symbol.module}.{symbol.name}"))
+                        candidates.append(
+                            SemanticRow(raw, category, f"{symbol.module}.{symbol.name}")
+                        )
     for root, category in _annotation_roots(facts.tree):
-        if _contains(_node_span(root), raw.span) and _annotation_resolves(root, facts, graph):
-            candidates.append(SemanticRow(raw, category, ast.dump(root, include_attributes=False)))
+        if _contains(_node_span(root), raw.span) and _annotation_resolves(
+            root, facts, graph
+        ):
+            candidates.append(
+                SemanticRow(raw, category, ast.dump(root, include_attributes=False))
+            )
     for node in containing:
-        if isinstance(node, ast.Call) and _contains(_node_span(node.func), raw.span) and _is_target(node.func, facts, graph):
-            candidates.append(SemanticRow(raw, "constructor", ast.dump(node.func, include_attributes=False)))
+        if (
+            isinstance(node, ast.Call)
+            and _contains(_node_span(node.func), raw.span)
+            and _is_target(node.func, facts, graph)
+        ):
+            candidates.append(
+                SemanticRow(
+                    raw, "constructor", ast.dump(node.func, include_attributes=False)
+                )
+            )
     for node in containing:
         if (
             isinstance(node, ast.Constant)
@@ -935,37 +1296,69 @@ def _classification_candidates(raw: RawRow, facts: ModuleFacts, graph: dict[str,
             and isinstance(facts.parents.get(node), (ast.List, ast.Tuple, ast.Set))
             and any(
                 isinstance(parent, ast.Assign)
-                and any(isinstance(target, ast.Name) and target.id == "__all__" for target in parent.targets)
+                and any(
+                    isinstance(target, ast.Name) and target.id == "__all__"
+                    for target in parent.targets
+                )
                 for parent in ast.walk(facts.tree)
-                if hasattr(parent, "lineno") and _contains(_node_span(parent), _node_span(node))
+                if hasattr(parent, "lineno")
+                and _contains(_node_span(parent), _node_span(node))
             )
         ):
-            candidates.append(SemanticRow(raw, "export_literal", "resolved __all__ export"))
+            candidates.append(
+                SemanticRow(raw, "export_literal", "resolved __all__ export")
+            )
     # Non-code occurrences are explicit terminal semantic categories. There is
     # deliberately no generic prose fallback.
     if raw.token_kind == "COMMENT":
         candidates.append(SemanticRow(raw, "source_comment", "tokenize.COMMENT"))
-    string_nodes = [node for node in containing if isinstance(node, ast.Constant) and isinstance(node.value, str)]
-    if string_nodes and not any(row.category in {"annotation_leaf", "type_alias_site", "export_literal"} for row in candidates):
+    string_nodes = [
+        node
+        for node in containing
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+    if string_nodes and not any(
+        row.category in {"annotation_leaf", "type_alias_site", "export_literal"}
+        for row in candidates
+    ):
         calls = [node for node in containing if isinstance(node, ast.Call)]
         if calls:
-            call = min(calls, key=lambda node: (node.end_lineno - node.lineno, node.end_col_offset - node.col_offset))
-            candidates.append(SemanticRow(raw, "diagnostic_literal", ast.dump(call.func, include_attributes=False)))
+            call = min(
+                calls,
+                key=lambda node: (
+                    node.end_lineno - node.lineno,
+                    node.end_col_offset - node.col_offset,
+                ),
+            )
+            candidates.append(
+                SemanticRow(
+                    raw,
+                    "diagnostic_literal",
+                    ast.dump(call.func, include_attributes=False),
+                )
+            )
         else:
-            candidates.append(SemanticRow(raw, "documentation_literal", "AST string literal"))
+            candidates.append(
+                SemanticRow(raw, "documentation_literal", "AST string literal")
+            )
     return tuple(candidates)
 
 
-def _semantic_rows(raw: tuple[RawRow, ...], facts: dict[str, ModuleFacts]) -> tuple[SemanticRow, ...]:
+def _semantic_rows(
+    raw: tuple[RawRow, ...], facts: dict[str, ModuleFacts]
+) -> tuple[SemanticRow, ...]:
     by_path = {_path_identity(module.path): module for module in facts.values()}
     unmapped = tuple(row for row in raw if row.token_kind == "UNMAPPED")
     assert not unmapped, f"unmapped tokenizer spans: {unmapped!r}"
     candidate_rows = tuple(
-        (row, _classification_candidates(row, by_path[row.path], facts))
-        for row in raw
+        (row, _classification_candidates(row, by_path[row.path], facts)) for row in raw
     )
-    wrong_cardinality = tuple((row, candidates) for row, candidates in candidate_rows if len(candidates) != 1)
-    assert not wrong_cardinality, f"exact semantic ownership cardinality != 1: {wrong_cardinality!r}"
+    wrong_cardinality = tuple(
+        (row, candidates) for row, candidates in candidate_rows if len(candidates) != 1
+    )
+    assert (
+        not wrong_cardinality
+    ), f"exact semantic ownership cardinality != 1: {wrong_cardinality!r}"
     rows = tuple(candidates[0] for _, candidates in candidate_rows)
     assert len(rows) == len(raw)
     assert {row.raw for row in rows} == set(raw)
@@ -973,7 +1366,9 @@ def _semantic_rows(raw: tuple[RawRow, ...], facts: dict[str, ModuleFacts]) -> tu
     return rows
 
 
-def _semantic_ontology_impacts(facts: dict[str, ModuleFacts]) -> tuple[OntologyImpact, ...]:
+def _semantic_ontology_impacts(
+    facts: dict[str, ModuleFacts],
+) -> tuple[OntologyImpact, ...]:
     """Discover ontology reachability from resolved testimony, never token spelling."""
     target = Symbol(TARGET_MODULE, TARGET_NAME)
     impacts: list[OntologyImpact] = []
@@ -981,38 +1376,88 @@ def _semantic_ontology_impacts(facts: dict[str, ModuleFacts]) -> tuple[OntologyI
         relative = _path_identity(module.path)
         annotation_roots = tuple(root for root, _ in _annotation_roots(module.tree))
         for node in ast.walk(module.tree):
-            if isinstance(node, ast.ClassDef) and Symbol(module.module, node.name) == target:
-                impacts.append(OntologyImpact(relative, _node_span(node), "definition", target))
-            elif isinstance(node, (ast.Name, ast.Attribute)) and isinstance(
-                getattr(node, "ctx", ast.Load()), ast.Load
-            ) and not (
-                isinstance(module.parents.get(node), ast.Call)
-                and module.parents[node].func is node
-            ) and not any(
-                _contains(_node_span(root), _node_span(node)) for root in annotation_roots
-            ) and _resolve(node, module, facts) == target:
-                impacts.append(OntologyImpact(relative, _node_span(node), "resolved_use", target))
-            elif isinstance(node, ast.Call) and _resolve(node.func, module, facts) == target:
-                impacts.append(OntologyImpact(relative, _node_span(node.func), "constructor", target))
+            if (
+                isinstance(node, ast.ClassDef)
+                and Symbol(module.module, node.name) == target
+            ):
+                impacts.append(
+                    OntologyImpact(relative, _node_span(node), "definition", target)
+                )
+            elif (
+                isinstance(node, (ast.Name, ast.Attribute))
+                and isinstance(getattr(node, "ctx", ast.Load()), ast.Load)
+                and not (
+                    isinstance(module.parents.get(node), ast.Call)
+                    and module.parents[node].func is node
+                )
+                and not any(
+                    _contains(_node_span(root), _node_span(node))
+                    for root in annotation_roots
+                )
+                and _resolve(node, module, facts) == target
+            ):
+                impacts.append(
+                    OntologyImpact(relative, _node_span(node), "resolved_use", target)
+                )
+            elif (
+                isinstance(node, ast.Call)
+                and _resolve(node.func, module, facts) == target
+            ):
+                impacts.append(
+                    OntologyImpact(
+                        relative, _node_span(node.func), "constructor", target
+                    )
+                )
             elif isinstance(node, ast.ImportFrom):
-                provider_name = _relative_module(node.module or "", module.package, node.level)
+                provider_name = _relative_module(
+                    node.module or "", module.package, node.level
+                )
                 provider = facts.get(provider_name)
                 if provider is not None:
                     for alias in node.names:
-                        if alias.name != "*" and _resolve_export(
-                            alias.name, provider, facts, frozenset(), star=False
-                        ) == target:
-                            impacts.append(OntologyImpact(relative, _node_span(alias), "resolved_import", target))
+                        if (
+                            alias.name != "*"
+                            and _resolve_export(
+                                alias.name, provider, facts, frozenset(), star=False
+                            )
+                            == target
+                        ):
+                            impacts.append(
+                                OntologyImpact(
+                                    relative,
+                                    _node_span(alias),
+                                    "resolved_import",
+                                    target,
+                                )
+                            )
         for root in annotation_roots:
             if _annotation_resolves(root, module, facts):
-                impacts.append(OntologyImpact(relative, _node_span(root), "annotation_contract", target))
+                impacts.append(
+                    OntologyImpact(
+                        relative, _node_span(root), "annotation_contract", target
+                    )
+                )
         exports = _declared_exports(module)
         if exports is not None:
             for name in exports:
-                if _resolve_export(name, module, facts, frozenset(), star=False) == target:
+                if (
+                    _resolve_export(name, module, facts, frozenset(), star=False)
+                    == target
+                ):
                     for node in ast.walk(module.tree):
-                        if isinstance(node, ast.Constant) and node.value == name and _has_span(node):
-                            impacts.append(OntologyImpact(relative, _node_span(node), "resolved_reexport", target))
+                        if (
+                            isinstance(node, ast.Constant)
+                            and node.value == name
+                            and _has_span(node)
+                        ):
+                            impacts.append(
+                                OntologyImpact(
+                                    relative,
+                                    _node_span(node),
+                                    "resolved_reexport",
+                                    target,
+                                )
+                            )
     duplicates = tuple(row for row in impacts if impacts.count(row) > 1)
     assert not duplicates, f"duplicate semantic ontology impacts: {duplicates!r}"
     return tuple(sorted(impacts))
@@ -1040,14 +1485,18 @@ class MigrationManifestRow:
     caller: str
 
 
-def _reduce_context_sites(production: dict[str, ModuleFacts]) -> dict[str, tuple[str, Span]]:
+def _reduce_context_sites(
+    production: dict[str, ModuleFacts],
+) -> dict[str, tuple[str, Span]]:
     facts = production["sugar_lift_py_tests.context.reduce_context"]
     path = _path_identity(facts.path)
     sites: dict[str, tuple[str, Span]] = {}
     for node in ast.walk(facts.tree):
         if isinstance(node, ast.ClassDef) and node.name == "ReduceContext":
             sites["type"] = (path, _node_span(node))
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in {"root", "derived"}:
+        elif isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef)
+        ) and node.name in {"root", "derived"}:
             sites[node.name] = (path, _node_span(node))
     assert set(sites) == {"type", "root", "derived"}, sites
     return sites
@@ -1069,10 +1518,16 @@ def _definition_origins(
     if definition.symbol is not None and definition.symbol.name:
         provider = graph.get(definition.symbol.module)
         if provider is not None:
-            for upstream in _reaching_index(provider).module_exit.get(definition.symbol.name, frozenset()):
-                origins.update(_definition_origins(upstream, provider, graph, seen | {origin}))
+            for upstream in _reaching_index(provider).module_exit.get(
+                definition.symbol.name, frozenset()
+            ):
+                origins.update(
+                    _definition_origins(upstream, provider, graph, seen | {origin})
+                )
     if definition.expression is not None:
-        origins.update(_expression_origins(definition.expression, facts, graph, seen | {origin}))
+        origins.update(
+            _expression_origins(definition.expression, facts, graph, seen | {origin})
+        )
     return frozenset(origins)
 
 
@@ -1097,8 +1552,12 @@ def _expression_origins(
                     origins.update(_definition_origins(definition, facts, graph, seen))
             provider = graph.get(TARGET_MODULE)
             if provider is not None:
-                for definition in _reaching_index(provider).module_exit.get(TARGET_NAME, frozenset()):
-                    origins.update(_definition_origins(definition, provider, graph, seen))
+                for definition in _reaching_index(provider).module_exit.get(
+                    TARGET_NAME, frozenset()
+                ):
+                    origins.update(
+                        _definition_origins(definition, provider, graph, seen)
+                    )
             continue
         if not isinstance(node, ast.Name):
             continue
@@ -1116,12 +1575,18 @@ def _resolved_use_edges(
     for facts in graph.values():
         path = _path_identity(facts.path)
         candidates: list[tuple[ast.AST, Environment | None, Span, str]] = [
-            (node, None, _node_span(node), type(node).__name__) for node in ast.walk(facts.tree)
-            if isinstance(node, (ast.Name, ast.Attribute)) and _has_span(node)
+            (node, None, _node_span(node), type(node).__name__)
+            for node in ast.walk(facts.tree)
+            if isinstance(node, (ast.Name, ast.Attribute))
+            and _has_span(node)
             and _resolve(node, facts, graph) == target
         ]
         for root, _ in _annotation_roots(facts.tree):
-            if isinstance(root, ast.Constant) and isinstance(root.value, str) and _annotation_resolves(root, facts, graph):
+            if (
+                isinstance(root, ast.Constant)
+                and isinstance(root.value, str)
+                and _annotation_resolves(root, facts, graph)
+            ):
                 parsed = ast.parse(root.value, mode="eval").body
                 candidates.extend(
                     (
@@ -1130,10 +1595,13 @@ def _resolved_use_edges(
                         _node_span(root),
                         f"forward:{_node_span(node)!r}:{ast.dump(node, include_attributes=False)}",
                     )
-                    for node in ast.walk(parsed) if isinstance(node, ast.Name)
+                    for node in ast.walk(parsed)
+                    if isinstance(node, ast.Name)
                 )
         for node, environment, use_span, use_kind in candidates:
-            origins = _expression_origins(node, facts, graph, environment_override=environment)
+            origins = _expression_origins(
+                node, facts, graph, environment_override=environment
+            )
             use = (path, use_span, use_kind)
             edges.extend((origin, use) for origin in origins)
     duplicates = tuple(edge for edge in edges if edges.count(edge) > 1)
@@ -1147,40 +1615,54 @@ def _migration_rows(
     impacts: tuple[OntologyImpact, ...] = (),
 ) -> tuple[MigrationRow, ...]:
     sites = _reduce_context_sites(production)
-    facts_by_path = {
-        _path_identity(facts.path): facts for facts in production.values()
-    }
+    facts_by_path = {_path_identity(facts.path): facts for facts in production.values()}
     dataflow_edges = _resolved_use_edges(production)
     rows: list[MigrationRow] = []
     for row in semantic:
         facts = facts_by_path[row.raw.path]
         containing = [
-            node for node in ast.walk(facts.tree)
+            node
+            for node in ast.walk(facts.tree)
             if _has_span(node) and _contains(_node_span(node), row.raw.span)
         ]
         semantic_owners: list[ast.AST] = []
         semantic_owners.extend(
-            alias for node in containing if isinstance(node, (ast.Import, ast.ImportFrom))
-            for alias in node.names if _has_span(alias) and _contains(_node_span(alias), row.raw.span)
+            alias
+            for node in containing
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+            if _has_span(alias) and _contains(_node_span(alias), row.raw.span)
         )
         semantic_owners.extend(
-            root for root, _ in _annotation_roots(facts.tree) if _contains(_node_span(root), row.raw.span)
+            root
+            for root, _ in _annotation_roots(facts.tree)
+            if _contains(_node_span(root), row.raw.span)
         )
         semantic_owners.extend(
-            node for node in containing
-            if isinstance(node, ast.Call) and _contains(_node_span(node.func), row.raw.span)
+            node
+            for node in containing
+            if isinstance(node, ast.Call)
+            and _contains(_node_span(node.func), row.raw.span)
             and _is_target(node.func, facts, production)
         )
         semantic_owners.extend(
-            node for node in containing if isinstance(node, ast.ClassDef)
-            and facts.module == TARGET_MODULE and node.name == TARGET_NAME
-            and row.raw.span.line == node.lineno and row.raw.token_kind == "NAME"
+            node
+            for node in containing
+            if isinstance(node, ast.ClassDef)
+            and facts.module == TARGET_MODULE
+            and node.name == TARGET_NAME
+            and row.raw.span.line == node.lineno
+            and row.raw.token_kind == "NAME"
         )
         if not semantic_owners and row.category in {
-            "export_literal", "documentation_literal", "diagnostic_literal"
+            "export_literal",
+            "documentation_literal",
+            "diagnostic_literal",
         }:
             semantic_owners.extend(
-                node for node in containing if isinstance(node, ast.Constant) and isinstance(node.value, str)
+                node
+                for node in containing
+                if isinstance(node, ast.Constant) and isinstance(node.value, str)
             )
         if row.category == "source_comment":
             semantic_owner = None
@@ -1200,107 +1682,157 @@ def _migration_rows(
             if _has_span(caller)
             else Span(1, 0, len(facts.path.read_text(encoding="utf-8").splitlines()), 0)
         )
-        annotation_owner = semantic_owner if any(
-            semantic_owner is root for root, _ in _annotation_roots(facts.tree)
-        ) else None
-        constructor_owner = semantic_owner if isinstance(semantic_owner, ast.Call) else None
+        annotation_owner = (
+            semantic_owner
+            if any(semantic_owner is root for root, _ in _annotation_roots(facts.tree))
+            else None
+        )
+        constructor_owner = (
+            semantic_owner if isinstance(semantic_owner, ast.Call) else None
+        )
         if annotation_owner is not None:
             replacement_path, replacement_span = sites["type"]
             action = "replace exact caller annotation contract with typed ReduceContext"
         elif constructor_owner is not None:
             replacement_path, replacement_span = sites["derived"]
-            action = "replace self reconstruction with authenticated ReduceContext.derived"
+            action = (
+                "replace self reconstruction with authenticated ReduceContext.derived"
+            )
         else:
             replacement_path, replacement_span = row.raw.path, row.raw.span
             action = "delete ontology definition/export/documentation occurrence"
         consumers: list[tuple[str, Span, str]] = []
         if semantic_owner is not None:
             owner_origin = (facts.module, _node_occurrence(facts, semantic_owner))
-            consumers.extend(use for origin, use in dataflow_edges if origin == owner_origin)
+            consumers.extend(
+                use for origin, use in dataflow_edges if origin == owner_origin
+            )
             if annotation_owner is not None:
-                consumers.append((row.raw.path, _node_span(annotation_owner), "annotation contract"))
+                consumers.append(
+                    (row.raw.path, _node_span(annotation_owner), "annotation contract")
+                )
             if constructor_owner is not None:
-                consumers.append((row.raw.path, _node_span(constructor_owner), "constructor call"))
+                consumers.append(
+                    (row.raw.path, _node_span(constructor_owner), "constructor call")
+                )
         terminal = row.category in {
-            "source_comment", "documentation_literal", "diagnostic_literal", "export_literal"
+            "source_comment",
+            "documentation_literal",
+            "diagnostic_literal",
+            "export_literal",
         }
         if not consumers and terminal:
             consumers.append((row.raw.path, row.raw.span, "terminal deletion site"))
-        assert consumers, f"executable semantic site has no resolved migration consumer: {row!r}"
-        assert len(consumers) == len(set(consumers)), f"duplicate migration consumer edges: {row.raw!r} {consumers!r}"
-        rows.append(MigrationRow(
-            row.raw,
-            row.raw.path,
-            caller_span,
-            f"{type(caller).__name__}:{getattr(caller, 'name', facts.module)}:{_node_span(semantic_owner) if semantic_owner is not None else row.raw.span}",
-            replacement_path,
-            replacement_span,
-            action,
-            tuple(sorted(consumers)),
-        ))
+        assert (
+            consumers
+        ), f"executable semantic site has no resolved migration consumer: {row!r}"
+        assert len(consumers) == len(
+            set(consumers)
+        ), f"duplicate migration consumer edges: {row.raw!r} {consumers!r}"
+        rows.append(
+            MigrationRow(
+                row.raw,
+                row.raw.path,
+                caller_span,
+                f"{type(caller).__name__}:{getattr(caller, 'name', facts.module)}:{_node_span(semantic_owner) if semantic_owner is not None else row.raw.span}",
+                replacement_path,
+                replacement_span,
+                action,
+                tuple(sorted(consumers)),
+            )
+        )
     assert len(rows) == len(semantic)
     alias_only = tuple(
-        impact for impact in impacts
+        impact
+        for impact in impacts
         if not any(
             row.raw.path == impact.path
-            and (_contains(impact.span, row.raw.span) or _contains(row.raw.span, impact.span))
+            and (
+                _contains(impact.span, row.raw.span)
+                or _contains(row.raw.span, impact.span)
+            )
             for row in semantic
         )
     )
     for impact in alias_only:
         facts = facts_by_path[impact.path]
         containing = [
-            node for node in ast.walk(facts.tree)
+            node
+            for node in ast.walk(facts.tree)
             if _has_span(node) and _node_span(node) == impact.span
         ]
         if impact.kind == "annotation_contract":
             owner_candidates = [
-                root for root, _ in _annotation_roots(facts.tree) if _node_span(root) == impact.span
+                root
+                for root, _ in _annotation_roots(facts.tree)
+                if _node_span(root) == impact.span
             ]
         elif impact.kind == "constructor":
             owner_candidates = [
-                node.func for node in ast.walk(facts.tree) if isinstance(node, ast.Call)
-                and _has_span(node.func) and _node_span(node.func) == impact.span
+                node.func
+                for node in ast.walk(facts.tree)
+                if isinstance(node, ast.Call)
+                and _has_span(node.func)
+                and _node_span(node.func) == impact.span
             ]
         else:
             owner_candidates = [
-                node for node in containing
+                node
+                for node in containing
                 if isinstance(node, (ast.Name, ast.Attribute, ast.alias, ast.Constant))
             ]
-        assert len(owner_candidates) == 1, (
-            f"alias-only migration owner cardinality != 1: {impact!r} {owner_candidates!r}"
-        )
+        assert (
+            len(owner_candidates) == 1
+        ), f"alias-only migration owner cardinality != 1: {impact!r} {owner_candidates!r}"
         owner = owner_candidates[0]
         origin = (facts.module, _node_occurrence(facts, owner))
-        consumers = tuple(use for edge_origin, use in dataflow_edges if edge_origin == origin)
-        resolved_owner = (
-            isinstance(owner, (ast.Name, ast.Attribute))
-            and _resolve(owner, facts, production) == Symbol(TARGET_MODULE, TARGET_NAME)
+        consumers = tuple(
+            use for edge_origin, use in dataflow_edges if edge_origin == origin
         )
+        resolved_owner = isinstance(owner, (ast.Name, ast.Attribute)) and _resolve(
+            owner, facts, production
+        ) == Symbol(TARGET_MODULE, TARGET_NAME)
         parent = facts.parents.get(owner)
-        if not consumers and resolved_owner and parent is not None and _has_span(parent):
-            consumers = ((
-                impact.path,
-                _node_span(parent),
-                f"resolved {type(parent).__name__} consumer",
-            ),)
+        if (
+            not consumers
+            and resolved_owner
+            and parent is not None
+            and _has_span(parent)
+        ):
+            consumers = (
+                (
+                    impact.path,
+                    _node_span(parent),
+                    f"resolved {type(parent).__name__} consumer",
+                ),
+            )
         if not consumers and impact.kind == "resolved_reexport":
             consumers = ((impact.path, impact.span, "authenticated export deletion"),)
         assert consumers, f"alias-only impact has no transitive consumer: {impact!r}"
-        rows.append(MigrationRow(
-            impact,
-            impact.path,
-            impact.span,
-            f"{type(owner).__name__}:{impact.kind}",
-            impact.path,
-            impact.span,
-            "migrate alias-only resolved capability to ReduceContext",
-            tuple(sorted(consumers)),
-        ))
+        rows.append(
+            MigrationRow(
+                impact,
+                impact.path,
+                impact.span,
+                f"{type(owner).__name__}:{impact.kind}",
+                impact.path,
+                impact.span,
+                "migrate alias-only resolved capability to ReduceContext",
+                tuple(sorted(consumers)),
+            )
+        )
     assert len({row.source for row in rows}) == len(rows)
-    return tuple(sorted(rows, key=lambda row: (
-        row.caller_path, row.caller_span, type(row.source).__name__, repr(row.source)
-    )))
+    return tuple(
+        sorted(
+            rows,
+            key=lambda row: (
+                row.caller_path,
+                row.caller_span,
+                type(row.source).__name__,
+                repr(row.source),
+            ),
+        )
+    )
 
 
 def _migration_manifest(
@@ -1314,70 +1846,113 @@ def _migration_manifest(
         facts = facts_by_path[impact.path]
         if impact.kind == "constructor":
             owners = [
-                node for node in ast.walk(facts.tree) if isinstance(node, ast.Call)
-                and _has_span(node.func) and _node_span(node.func) == impact.span
+                node
+                for node in ast.walk(facts.tree)
+                if isinstance(node, ast.Call)
+                and _has_span(node.func)
+                and _node_span(node.func) == impact.span
             ]
             action = "replace construction capability with ReduceContext.root/derived"
         elif impact.kind == "resolved_import":
             owners = [
-                node for node in ast.walk(facts.tree) if isinstance(node, ast.alias)
-                and _has_span(node) and _node_span(node) == impact.span
+                node
+                for node in ast.walk(facts.tree)
+                if isinstance(node, ast.alias)
+                and _has_span(node)
+                and _node_span(node) == impact.span
             ]
             action = "delete import after all resolved consumers migrate"
         elif impact.kind == "annotation_contract":
-            owners = [root for root, _ in _annotation_roots(facts.tree) if _node_span(root) == impact.span]
+            owners = [
+                root
+                for root, _ in _annotation_roots(facts.tree)
+                if _node_span(root) == impact.span
+            ]
             action = "replace exact annotation capability with ReduceContext"
         elif impact.kind == "resolved_reexport":
             owners = [
-                node for node in ast.walk(facts.tree) if isinstance(node, ast.Constant)
-                and _has_span(node) and _node_span(node) == impact.span
+                node
+                for node in ast.walk(facts.tree)
+                if isinstance(node, ast.Constant)
+                and _has_span(node)
+                and _node_span(node) == impact.span
             ]
             action = "delete authenticated export edge"
         elif impact.kind == "definition":
             owners = [
-                node for node in ast.walk(facts.tree) if isinstance(node, ast.ClassDef)
-                and _node_span(node) == impact.span
+                node
+                for node in ast.walk(facts.tree)
+                if isinstance(node, ast.ClassDef) and _node_span(node) == impact.span
             ]
             action = "delete unowned ontology definition"
         else:
             owners = [
-                node for node in ast.walk(facts.tree) if isinstance(node, (ast.Name, ast.Attribute))
-                and _has_span(node) and _node_span(node) == impact.span
+                node
+                for node in ast.walk(facts.tree)
+                if isinstance(node, (ast.Name, ast.Attribute))
+                and _has_span(node)
+                and _node_span(node) == impact.span
                 and _resolve(node, facts, graph) == impact.authority
             ]
             action = "migrate resolved capability use to ReduceContext"
-        assert len(owners) == 1, f"migration manifest owner cardinality != 1: {impact!r} {owners!r}"
+        assert (
+            len(owners) == 1
+        ), f"migration manifest owner cardinality != 1: {impact!r} {owners!r}"
         owner = owners[0]
         caller = owner
-        while caller in facts.parents and not isinstance(caller, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        while caller in facts.parents and not isinstance(
+            caller, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
             caller = facts.parents[caller]
-        rows.append(MigrationManifestRow(
-            impact.path,
-            impact.span,
-            impact.kind,
-            f"{type(owner).__name__}:{_node_span(owner)}",
-            action,
-            f"{type(caller).__name__}:{getattr(caller, 'name', facts.module)}",
-        ))
+        rows.append(
+            MigrationManifestRow(
+                impact.path,
+                impact.span,
+                impact.kind,
+                f"{type(owner).__name__}:{_node_span(owner)}",
+                action,
+                f"{type(caller).__name__}:{getattr(caller, 'name', facts.module)}",
+            )
+        )
     for row in semantic:
-        if row.category not in {"source_comment", "documentation_literal", "diagnostic_literal"}:
+        if row.category not in {
+            "source_comment",
+            "documentation_literal",
+            "diagnostic_literal",
+        }:
             continue
-        rows.append(MigrationManifestRow(
-            row.raw.path, row.raw.span, row.category, row.authority,
-            "delete explicitly terminal prose testimony", f"token:{row.raw.token_kind}",
-        ))
+        rows.append(
+            MigrationManifestRow(
+                row.raw.path,
+                row.raw.span,
+                row.category,
+                row.authority,
+                "delete explicitly terminal prose testimony",
+                f"token:{row.raw.token_kind}",
+            )
+        )
     ontology = graph[TARGET_MODULE]
     ontology_path = _path_identity(ontology.path)
     line_count = len(ontology.path.read_text(encoding="utf-8").splitlines())
-    rows.append(MigrationManifestRow(
-        ontology_path, Span(1, 0, line_count, 0), "ontology_file", ontology.module,
-        "delete file after every semantic edge migrates", "module owner",
-    ))
-    assert len(rows) == len(set(rows)), "migration manifest contains duplicate site-owner-action rows"
+    rows.append(
+        MigrationManifestRow(
+            ontology_path,
+            Span(1, 0, line_count, 0),
+            "ontology_file",
+            ontology.module,
+            "delete file after every semantic edge migrates",
+            "module owner",
+        )
+    )
+    assert len(rows) == len(
+        set(rows)
+    ), "migration manifest contains duplicate site-owner-action rows"
     return tuple(sorted(rows))
 
 
-def _bounded_runtime_discriminators(facts: dict[str, ModuleFacts]) -> tuple[tuple[str, Span, str], ...]:
+def _bounded_runtime_discriminators(
+    facts: dict[str, ModuleFacts],
+) -> tuple[tuple[str, Span, str], ...]:
     """Resolve the bounded admission grammar: semantic builtin calls,
     identity/equality comparisons, and match subject/class/pattern/guards.
 
@@ -1386,8 +1961,10 @@ def _bounded_runtime_discriminators(facts: dict[str, ModuleFacts]) -> tuple[tupl
     """
     rows: list[tuple[str, Span, str]] = []
     discriminator_symbols = {
-        Symbol("builtins", "isinstance"), Symbol("builtins", "issubclass"),
-        Symbol("builtins", "getattr"), Symbol("builtins", "hasattr"),
+        Symbol("builtins", "isinstance"),
+        Symbol("builtins", "issubclass"),
+        Symbol("builtins", "getattr"),
+        Symbol("builtins", "hasattr"),
     }
 
     def string_values(node: ast.AST, module: ModuleFacts) -> frozenset[str]:
@@ -1406,37 +1983,60 @@ def _bounded_runtime_discriminators(facts: dict[str, ModuleFacts]) -> tuple[tupl
         relative = _path_identity(module.path)
         for node in ast.walk(module.tree):
             candidates: tuple[ast.AST, ...] = ()
-            if isinstance(node, ast.Call) and _resolve(node.func, module, facts) in discriminator_symbols:
+            if (
+                isinstance(node, ast.Call)
+                and _resolve(node.func, module, facts) in discriminator_symbols
+            ):
                 callee = _resolve(node.func, module, facts)
-                if callee in {Symbol("builtins", "getattr"), Symbol("builtins", "hasattr")}:
+                if callee in {
+                    Symbol("builtins", "getattr"),
+                    Symbol("builtins", "hasattr"),
+                }:
                     if len(node.args) >= 2 and string_values(node.args[1], module):
                         candidates = (node.args[0],)
                 else:
                     candidates = tuple(node.args[1:])
-            elif isinstance(node, ast.Compare) and any(isinstance(op, (ast.Is, ast.IsNot, ast.Eq, ast.NotEq)) for op in node.ops):
+            elif isinstance(node, ast.Compare) and any(
+                isinstance(op, (ast.Is, ast.IsNot, ast.Eq, ast.NotEq))
+                for op in node.ops
+            ):
                 candidates = (node.left, *node.comparators)
             elif isinstance(node, ast.Match):
                 candidates = (node.subject,)
             elif isinstance(node, ast.MatchClass):
                 candidates = (node.cls,)
             elif isinstance(node, ast.match_case):
-                candidates = tuple(candidate for candidate in (node.pattern, node.guard) if candidate is not None)
+                candidates = tuple(
+                    candidate
+                    for candidate in (node.pattern, node.guard)
+                    if candidate is not None
+                )
             if candidates and any(
-                isinstance(ref, (ast.Name, ast.Attribute)) and _is_target(ref, module, facts)
-                for candidate in candidates for ref in ast.walk(candidate)
+                isinstance(ref, (ast.Name, ast.Attribute))
+                and _is_target(ref, module, facts)
+                for candidate in candidates
+                for ref in ast.walk(candidate)
             ):
                 anchor = node if hasattr(node, "lineno") else candidates[0]
-                rows.append((relative, _node_span(anchor), ast.dump(node, include_attributes=False)))
+                rows.append(
+                    (
+                        relative,
+                        _node_span(anchor),
+                        ast.dump(node, include_attributes=False),
+                    )
+                )
     return tuple(sorted(rows))
 
 
 def _constructor_rows(facts: dict[str, ModuleFacts]) -> tuple[tuple[str, Span], ...]:
-    return tuple(sorted(
-        (_path_identity(module.path), _node_span(node.func))
-        for module in facts.values()
-        for node in ast.walk(module.tree)
-        if isinstance(node, ast.Call) and _is_target(node.func, module, facts)
-    ))
+    return tuple(
+        sorted(
+            (_path_identity(module.path), _node_span(node.func))
+            for module in facts.values()
+            for node in ast.walk(module.tree)
+            if isinstance(node, ast.Call) and _is_target(node.func, module, facts)
+        )
+    )
 
 
 def _report():
@@ -1445,14 +2045,29 @@ def _report():
     # stable occurrence keys govern reuse only within this report.
     _REACHING_CACHE.clear()
     production_files = _production_files()
-    production = {_production_module(path): _facts(path, module=_production_module(path)) for path in production_files}
+    production = {
+        _production_module(path): _facts(path, module=_production_module(path))
+        for path in production_files
+    }
     raw = _raw_rows(production_files)
     semantic = _semantic_rows(raw, production)
-    test_facts = {_test_module(path): _facts(path, module=_test_module(path)) for path in _test_files()}
+    test_facts = {
+        _test_module(path): _facts(path, module=_test_module(path))
+        for path in _test_files()
+    }
     # Tests resolve against production providers without sharing module identity.
     test_graph = {**production, **test_facts}
     impacts = _semantic_ontology_impacts(test_graph)
-    return production_files, raw, semantic, impacts, production, test_facts, _constructor_rows(test_graph), _bounded_runtime_discriminators(production)
+    return (
+        production_files,
+        raw,
+        semantic,
+        impacts,
+        production,
+        test_facts,
+        _constructor_rows(test_graph),
+        _bounded_runtime_discriminators(production),
+    )
 
 
 def _universe_identity() -> str:
@@ -1497,10 +2112,21 @@ def test_independent_exact_span_audits_reconcile_every_live_row(ontology_snapsho
         f"source_sha256={ontology_snapshot.source_sha256}",
         f"universe_sha256={ontology_snapshot.universe_sha256}",
     )
-    _, raw, semantic, impacts, production, test_facts, constructors, discriminators = ontology_snapshot.report
-    discovered_by_file = {path: sum(row.path == path for row in raw) for path in {row.path for row in raw}}
-    annotations = tuple(row for row in semantic if row.category in {"annotation_leaf", "type_alias_site"})
-    categories = {category: sum(row.category == category for row in semantic) for category in {row.category for row in semantic}}
+    _, raw, semantic, impacts, production, test_facts, constructors, discriminators = (
+        ontology_snapshot.report
+    )
+    discovered_by_file = {
+        path: sum(row.path == path for row in raw) for path in {row.path for row in raw}
+    }
+    annotations = tuple(
+        row
+        for row in semantic
+        if row.category in {"annotation_leaf", "type_alias_site"}
+    )
+    categories = {
+        category: sum(row.category == category for row in semantic)
+        for category in {row.category for row in semantic}
+    }
     if not raw:
         assert semantic == ()
         assert impacts == ()
@@ -1512,35 +2138,53 @@ def test_independent_exact_span_audits_reconcile_every_live_row(ontology_snapsho
     migrations = _migration_rows(semantic, {**production, **test_facts}, impacts)
     manifest = _migration_manifest(semantic, impacts, {**production, **test_facts})
     executable_semantic = tuple(
-        row for row in semantic
-        if row.category not in {"source_comment", "documentation_literal", "diagnostic_literal"}
+        row
+        for row in semantic
+        if row.category
+        not in {"source_comment", "documentation_literal", "diagnostic_literal"}
     )
     missing_semantic_impacts = tuple(
-        row for row in executable_semantic
+        row
+        for row in executable_semantic
         if not any(
             impact.path == row.raw.path
-            and (_contains(impact.span, row.raw.span) or _contains(row.raw.span, impact.span))
+            and (
+                _contains(impact.span, row.raw.span)
+                or _contains(row.raw.span, impact.span)
+            )
             for impact in impacts
         )
     )
     assert not missing_semantic_impacts, missing_semantic_impacts
-    assert all(impact.authority == Symbol(TARGET_MODULE, TARGET_NAME) for impact in impacts)
+    assert all(
+        impact.authority == Symbol(TARGET_MODULE, TARGET_NAME) for impact in impacts
+    )
     assert any(
         not any(
             row.raw.path == impact.path
-            and (_contains(impact.span, row.raw.span) or _contains(row.raw.span, impact.span))
+            and (
+                _contains(impact.span, row.raw.span)
+                or _contains(row.raw.span, impact.span)
+            )
             for row in semantic
         )
         for impact in impacts
     ), "semantic door must independently retain alias-only impact rows"
-    manifest_sites = {(row.path, row.span) for row in manifest if row.site_kind != "ontology_file"}
-    assert len(manifest_sites) == len(tuple(row for row in manifest if row.site_kind != "ontology_file"))
+    manifest_sites = {
+        (row.path, row.span) for row in manifest if row.site_kind != "ontology_file"
+    }
+    assert len(manifest_sites) == len(
+        tuple(row for row in manifest if row.site_kind != "ontology_file")
+    )
     assert sum(row.site_kind == "constructor" for row in manifest) == 9
     assert sum(row.site_kind == "ontology_file" for row in manifest) == 1
     assert all(
         any(
             manifest_row.path == row.raw.path
-            and (_contains(manifest_row.span, row.raw.span) or _contains(row.raw.span, manifest_row.span))
+            and (
+                _contains(manifest_row.span, row.raw.span)
+                or _contains(row.raw.span, manifest_row.span)
+            )
             for manifest_row in manifest
         )
         for row in semantic
@@ -1560,21 +2204,35 @@ def test_independent_exact_span_audits_reconcile_every_live_row(ontology_snapsho
     assert categories["source_comment"] == 3
     assert categories["documentation_literal"] == 2
     assert categories["diagnostic_literal"] == 1
-    assert {row.source for row in migrations if isinstance(row.source, RawRow)} == set(raw)
+    assert {row.source for row in migrations if isinstance(row.source, RawRow)} == set(
+        raw
+    )
     assert {
         row.source for row in migrations if isinstance(row.source, OntologyImpact)
     } == {
-        impact for impact in impacts
+        impact
+        for impact in impacts
         if not any(
             row.raw.path == impact.path
-            and (_contains(impact.span, row.raw.span) or _contains(row.raw.span, impact.span))
+            and (
+                _contains(impact.span, row.raw.span)
+                or _contains(row.raw.span, impact.span)
+            )
             for row in semantic
         )
     }
     assert len(constructors) == 9  # one production self-reconstruction + eight tests
-    assert sum(path in {_path_identity(facts.path) for facts in test_facts.values()} for path, _ in constructors) == 8
+    assert (
+        sum(
+            path in {_path_identity(facts.path) for facts in test_facts.values()}
+            for path, _ in constructors
+        )
+        == 8
+    )
     assert discriminators == ()
-    assert len(production) > len(EXPECTED_RAW_BY_FILE)  # repository-wide discovery denominator is non-empty and independent
+    assert len(production) > len(
+        EXPECTED_RAW_BY_FILE
+    )  # repository-wide discovery denominator is non-empty and independent
 
 
 def test_reaching_definition_authority_truthful_and_lying_twins(tmp_path):
@@ -1610,7 +2268,9 @@ def test_reaching_definition_authority_truthful_and_lying_twins(tmp_path):
         for node in target.tree.body
         if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name)
     }
-    assert _resolve(assignments["before"], target, graph) == Symbol(TARGET_MODULE, TARGET_NAME)
+    assert _resolve(assignments["before"], target, graph) == Symbol(
+        TARGET_MODULE, TARGET_NAME
+    )
     assert _resolve(assignments["after"], target, graph) is None
 
     discriminators = _bounded_runtime_discriminators(graph)
@@ -1631,7 +2291,9 @@ def test_reaching_definition_authority_truthful_and_lying_twins(tmp_path):
 def test_immutable_artifact_discovers_authenticated_repo_without_caller_root(tmp_path):
     artifact = tmp_path / "immutable_ontology_instrument.py"
     artifact.write_bytes(Path(__file__).read_bytes())
-    spec = importlib.util.spec_from_file_location("immutable_ontology_instrument", artifact)
+    spec = importlib.util.spec_from_file_location(
+        "immutable_ontology_instrument", artifact
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -1660,7 +2322,8 @@ def test_alias_only_impact_without_resolved_origin_edge_is_loud(tmp_path):
     )
     orphan_facts = _facts(orphan_path, module="fixture.orphan")
     hidden = next(
-        node for node in ast.walk(orphan_facts.tree)
+        node
+        for node in ast.walk(orphan_facts.tree)
         if isinstance(node, ast.Name) and node.id == "Hidden"
     )
     impact = OntologyImpact(
@@ -1752,11 +2415,31 @@ def test_scope_control_flow_and_spelling_free_discovery_twins(tmp_path):
     assert _resolve(assignments["after_return"], scope, graph) == target_symbol
     assert _resolve(assignments["after_walrus"], scope, graph) == target_symbol
     assert _resolve(assignments["condition_truth_after"], scope, graph) == target_symbol
-    with __import__("pytest").raises(AssertionError, match="ambiguous reaching definitions"):
+    with __import__("pytest").raises(
+        AssertionError, match="ambiguous reaching definitions"
+    ):
         _resolve(assignments["condition_lie_after"], scope, graph)
     index = _reaching_index(scope)
-    assert next(iter(index.before[_node_occurrence(scope, assignments["global_use"])].get("global_slot", ()))).scope_owner == "module"
-    assert next(iter(index.before[_node_occurrence(scope, assignments["nonlocal_use"])].get("nonlocal_slot", ()))).scope_owner == "nonlocal"
+    assert (
+        next(
+            iter(
+                index.before[_node_occurrence(scope, assignments["global_use"])].get(
+                    "global_slot", ()
+                )
+            )
+        ).scope_owner
+        == "module"
+    )
+    assert (
+        next(
+            iter(
+                index.before[_node_occurrence(scope, assignments["nonlocal_use"])].get(
+                    "nonlocal_slot", ()
+                )
+            )
+        ).scope_owner
+        == "nonlocal"
+    )
 
     bridge_path = tmp_path / "bridge.py"
     bridge_path.write_text(
@@ -1764,11 +2447,15 @@ def test_scope_control_flow_and_spelling_free_discovery_twins(tmp_path):
         encoding="utf-8",
     )
     consumer_path = tmp_path / "consumer_without_target_spelling.py"
-    consumer_path.write_text("from fixture.bridge import *\nconstructed = Hidden()\n", encoding="utf-8")
+    consumer_path.write_text(
+        "from fixture.bridge import *\nconstructed = Hidden()\n", encoding="utf-8"
+    )
     bridge = _facts(bridge_path, module="fixture.bridge")
     consumer = _facts(consumer_path, module="fixture.consumer_without_spelling")
     expanded_graph = {**graph, bridge.module: bridge, consumer.module: consumer}
-    assert _constructor_rows(expanded_graph) == (("__fixture__/consumer_without_target_spelling.py", Span(2, 14, 2, 20)),)
+    assert _constructor_rows(expanded_graph) == (
+        ("__fixture__/consumer_without_target_spelling.py", Span(2, 14, 2, 20)),
+    )
 
 
 def test_control_transfer_shadow_ambiguity_and_multiplicity_twins(tmp_path):
@@ -1825,7 +2512,9 @@ def test_control_transfer_shadow_ambiguity_and_multiplicity_twins(tmp_path):
     assert _resolve(assignments["final_truth"], flow, graph) == target_symbol
     assert _resolve(assignments["caught_lie"], flow, graph) is None
     assert _resolve(assignments["final_override"], flow, graph) == target_symbol
-    with __import__("pytest").raises(AssertionError, match="ambiguous reaching definitions"):
+    with __import__("pytest").raises(
+        AssertionError, match="ambiguous reaching definitions"
+    ):
         _resolve(assignments["after_loop"], flow, graph)
     lambdas = [node for node in ast.walk(flow.tree) if isinstance(node, ast.Lambda)]
     assert _resolve(lambdas[0].body, flow, graph) == target_symbol
@@ -1846,10 +2535,17 @@ def test_control_transfer_shadow_ambiguity_and_multiplicity_twins(tmp_path):
     )
     holder = _facts(holder_path, module="fixture.holder")
     attribute = _facts(attribute_path, module="fixture.attribute_ambiguity")
-    attribute_graph = {target.module: target, holder.module: holder, attribute.module: attribute}
+    attribute_graph = {
+        target.module: target,
+        holder.module: holder,
+        attribute.module: attribute,
+    }
     use = next(
-        node.value for node in attribute.tree.body
-        if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name) and node.targets[0].id == "use"
+        node.value
+        for node in attribute.tree.body
+        if isinstance(node, ast.Assign)
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == "use"
     )
     with __import__("pytest").raises(AssertionError, match="attribute provenance"):
         _resolve(use, attribute, attribute_graph)
@@ -1869,29 +2565,54 @@ def test_control_transfer_shadow_ambiguity_and_multiplicity_twins(tmp_path):
     bridge = _facts(bridge_path, module="fixture.truth_bridge")
     lie = _facts(lie_path, module="fixture.lie_bridge")
     star = _facts(star_path, module="fixture.star_ambiguity")
-    star_graph = {target.module: target, bridge.module: bridge, lie.module: lie, star.module: star}
-    star_use = next(node.value for node in star.tree.body if isinstance(node, ast.Assign))
+    star_graph = {
+        target.module: target,
+        bridge.module: bridge,
+        lie.module: lie,
+        star.module: star,
+    }
+    star_use = next(
+        node.value for node in star.tree.body if isinstance(node, ast.Assign)
+    )
     with __import__("pytest").raises(AssertionError, match="star binding"):
         _resolve(star_use, star, star_graph)
 
     prose_path = tmp_path / "prose_collision.py"
-    prose_path.write_text('"FactoryBuildContext FactoryBuildContext"\n', encoding="utf-8")
+    prose_path.write_text(
+        '"FactoryBuildContext FactoryBuildContext"\n', encoding="utf-8"
+    )
     prose = _facts(prose_path, module="fixture.prose_collision")
     raw = _raw_rows((prose_path,))
     assert len(raw) == 2 and len({row.span for row in raw}) == 2
     semantic = _semantic_rows(raw, {prose.module: prose})
-    assert [row.category for row in semantic] == ["documentation_literal", "documentation_literal"]
+    assert [row.category for row in semantic] == [
+        "documentation_literal",
+        "documentation_literal",
+    ]
 
 
 def test_measured_retirement_postcondition_has_no_surviving_ontology(ontology_snapshot):
-    assert ontology_snapshot.source_sha256 == hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+    assert (
+        ontology_snapshot.source_sha256
+        == hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+    )
     assert ontology_snapshot.universe_sha256 == _universe_identity()
-    files, raw, semantic, _, _, test_facts, constructors, discriminators = ontology_snapshot.report
-    exports = tuple(row for row in semantic if row.category in {"runtime_reexport", "export_literal"})
-    ontology_files = tuple(path for path in files if path.name == "factory_build_context.py")
+    files, raw, semantic, _, _, test_facts, constructors, discriminators = (
+        ontology_snapshot.report
+    )
+    exports = tuple(
+        row
+        for row in semantic
+        if row.category in {"runtime_reexport", "export_literal"}
+    )
+    ontology_files = tuple(
+        path for path in files if path.name == "factory_build_context.py"
+    )
     test_paths = {_path_identity(facts.path) for facts in test_facts.values()}
     test_constructors = tuple(row for row in constructors if row[0] in test_paths)
-    production_constructors = tuple(row for row in constructors if row[0] not in test_paths)
+    production_constructors = tuple(
+        row for row in constructors if row[0] not in test_paths
+    )
 
     vector = {
         "R_symbol": (len(raw), raw),
@@ -1902,4 +2623,6 @@ def test_measured_retirement_postcondition_has_no_surviving_ontology(ontology_sn
         "R_test_constructors": (len(test_constructors), test_constructors),
     }
     offenders = {axis: rows for axis, (count, rows) in vector.items() if count}
-    assert not offenders, f"retirement_vector={{{', '.join(f'{axis}: {len(rows)}' for axis, rows in offenders.items())}}} rows={offenders!r}"
+    assert (
+        not offenders
+    ), f"retirement_vector={{{', '.join(f'{axis}: {len(rows)}' for axis, rows in offenders.items())}}} rows={offenders!r}"

--- a/implementations/python/sugar-lift-py-tests/tests/test_finally_swallows_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finally_swallows_control.py
@@ -229,9 +229,9 @@ def test_twin_finally_raise_after_body_raise_must_keep_context():
         )
     )
     assert effect.exception_name == "RuntimeError"
-    assert effect.context_effect is not None, (
-        "MISSING: finally raise after body raise must carry body as context_effect"
-    )
+    assert (
+        effect.context_effect is not None
+    ), "MISSING: finally raise after body raise must carry body as context_effect"
     assert effect.context_effect.exception_name == "ValueError"
     # Refuse swapped primary/context.
     assert not (

--- a/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_fixture_supplied_resource_obligation.py
@@ -153,9 +153,7 @@ def test_fixture_resource_is_discharged_at_authenticated_formal_binding():
         cid_of_json({"kind": "external-resource", "state": "ready"}),
     )
     bound = frame.bind_node_actuals((actual,), (), (testimony,))
-    obligation = FixtureSuppliedResourceObligationV1.mint(
-        bound.formal_coordinates[0]
-    )
+    obligation = FixtureSuppliedResourceObligationV1.mint(bound.formal_coordinates[0])
 
     discharge = obligation.discharge(bound.runtime_entries[0])
 
@@ -169,9 +167,7 @@ def test_fixture_resource_without_binding_testimony_is_a_named_refusal():
     function, actual = _function_and_actual()
     frame = function.source_visible_call_frame()
     bound = frame.bind_node_actuals((actual,), ())
-    obligation = FixtureSuppliedResourceObligationV1.mint(
-        bound.formal_coordinates[0]
-    )
+    obligation = FixtureSuppliedResourceObligationV1.mint(bound.formal_coordinates[0])
 
     with pytest.raises(FixtureResourceBindingRefusal) as caught:
         obligation.discharge(bound.runtime_entries[0])
@@ -228,7 +224,11 @@ def test_population_outcomes_require_a_positive_authenticated_exceptional_exit()
 
     obligation, entry = _authenticated_obligation_and_entry()
     positive = classify_fixture_resource_outcome(
-        obligation, entry, lambda: Incomplete(RaiseEffect.for_builtin("ValueError", blame="site", occurrence="site"))
+        obligation,
+        entry,
+        lambda: Incomplete(
+            RaiseEffect.for_builtin("ValueError", blame="site", occurrence="site")
+        ),
     )
     absent = classify_fixture_resource_outcome(
         obligation, entry, lambda: Complete("ordinary completion")

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -14,7 +14,6 @@ import json
 import sys
 from pathlib import Path
 
-
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 _SCRIPT = _SCRIPTS / "compose_control_effect_board.py"
 
@@ -119,9 +118,10 @@ def _runtime_identity_object(*, suffix: str = "a"):
 
 
 def _require_runtime_parameter(module) -> None:
-    assert "runtime_attestation" in inspect.signature(
-        module.compose_k1_from_rows
-    ).parameters, "compose can still mint a width without runtimeIdentity/v1"
+    assert (
+        "runtime_attestation"
+        in inspect.signature(module.compose_k1_from_rows).parameters
+    ), "compose can still mint a width without runtimeIdentity/v1"
 
 
 def _compose(module, row, *, runtime_attestation=None):
@@ -308,9 +308,7 @@ def test_valid_but_disagreeing_shard_runtime_cids_refuse() -> None:
         module.mint_partial(
             plan=plan,
             shard_index=1,
-            terminal_rows=[
-                ("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))
-            ],
+            terminal_rows=[("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))],
             runtime_attestation=right,
         ),
     ]
@@ -352,9 +350,10 @@ def test_well_formed_shard_runtime_wrong_for_compose_authority_refuses() -> None
     )
     assert status == "unmeasured"
     _assert_only_unmeasured(body)
-    assert "runtimeCid mismatches authenticated compose runtime" in body[
-        "unmeasuredReasons"
-    ]["s00"]
+    assert (
+        "runtimeCid mismatches authenticated compose runtime"
+        in body["unmeasuredReasons"]["s00"]
+    )
 
 
 def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
@@ -388,9 +387,7 @@ def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
         module.mint_partial(
             plan=plan,
             shard_index=1,
-            terminal_rows=[
-                ("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))
-            ],
+            terminal_rows=[("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))],
             runtime_attestation=mutually_agreeing_wrong_runtime,
         ),
     ]
@@ -407,7 +404,9 @@ def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
     )
 
 
-def test_runtime_identity_is_inside_body_cid_but_paths_are_outside_runtime_cid() -> None:
+def test_runtime_identity_is_inside_body_cid_but_paths_are_outside_runtime_cid() -> (
+    None
+):
     module = _load()
     _require_runtime_parameter(module)
     first = _runtime_attestation(invoked="/venv-a/bin/python")
@@ -415,18 +414,15 @@ def test_runtime_identity_is_inside_body_cid_but_paths_are_outside_runtime_cid()
     moved["runtimeIdentity"]["invokedExecutable"] = "/venv-b/bin/python"
     assert moved["runtimeCid"] == first["runtimeCid"]
 
-    left_status, left = _compose(
-        module, _row(module), runtime_attestation=first
-    )
-    right_status, right = _compose(
-        module, _row(module), runtime_attestation=moved
-    )
+    left_status, left = _compose(module, _row(module), runtime_attestation=first)
+    right_status, right = _compose(module, _row(module), runtime_attestation=moved)
 
     assert left_status == right_status == "sealed"
     assert left["runtimeCid"] == right["runtimeCid"]
-    assert left["runtimeIdentity"]["invokedExecutable"] != right["runtimeIdentity"][
-        "invokedExecutable"
-    ]
+    assert (
+        left["runtimeIdentity"]["invokedExecutable"]
+        != right["runtimeIdentity"]["invokedExecutable"]
+    )
     assert left["bodyCid"] != right["bodyCid"]
 
 
@@ -486,23 +482,20 @@ def test_missing_stage_testimony_refuses() -> None:
     status, body = _compose(module, row)
     assert status == "unmeasured"
     _assert_only_unmeasured(body)
-    assert any(
-        "stageId" in str(f.get("reason")) for f in body["instrumentFailures"]
-    )
+    assert any("stageId" in str(f.get("reason")) for f in body["instrumentFailures"])
 
 
 def test_claimed_key_cid_mismatch_refuses() -> None:
     module = _load()
     row = _row(module)
-    row["edgeWitnesses"][module.EDGE_ENUMERATE_FILE]["inputKeyCid"] = (
-        "sha256:" + ("0" * 64)
+    row["edgeWitnesses"][module.EDGE_ENUMERATE_FILE]["inputKeyCid"] = "sha256:" + (
+        "0" * 64
     )
     status, body = _compose(module, row)
     assert status == "unmeasured"
     _assert_only_unmeasured(body)
     assert any(
-        f.get("reason") == "inputKeyCid mismatch"
-        for f in body["instrumentFailures"]
+        f.get("reason") == "inputKeyCid mismatch" for f in body["instrumentFailures"]
     )
 
 
@@ -518,9 +511,7 @@ def test_duplicate_key_rows_refuse_even_when_both_sides_match() -> None:
     status, body = _compose(module, row)
     assert status == "unmeasured"
     _assert_only_unmeasured(body)
-    assert any(
-        f.get("duplicateKeys") for f in body["instrumentFailures"]
-    )
+    assert any(f.get("duplicateKeys") for f in body["instrumentFailures"])
 
 
 def test_explicit_instrument_exception_refuses() -> None:
@@ -576,9 +567,7 @@ def test_construction_panic_without_required_payload_refuses() -> None:
         {
             "category": "panic",
             "terminalKind": "construction-panic",
-            "observedEventType": (
-                "sugar_lift_py_tests.gap.panic.ConstructionPanic"
-            ),
+            "observedEventType": ("sugar_lift_py_tests.gap.panic.ConstructionPanic"),
             "blocking_terminal_count": 1,
             "final_terminal": "construction-panic",
             "panic": {"owner": "WithSugar", "coordinate": "pandas/a.py:1:0"},
@@ -625,9 +614,7 @@ def test_truthful_attested_row_seals_and_carries_recomputable_manifests() -> Non
     for edge in attestation["edges"].values():
         assert edge["inputKeyCount"] == len(edge["inputKeyManifest"])
         assert edge["outputKeyCount"] == len(edge["outputKeyManifest"])
-        assert edge["inputKeyCid"] == module.key_manifest_cid(
-            edge["inputKeyManifest"]
-        )
+        assert edge["inputKeyCid"] == module.key_manifest_cid(edge["inputKeyManifest"])
         assert edge["outputKeyCid"] == module.key_manifest_cid(
             edge["outputKeyManifest"]
         )
@@ -681,9 +668,7 @@ def test_aggregate_panic_magnitude_cannot_disagree_with_attested_keys() -> None:
     aggregate["construction_panics"].append(
         {"owner": "LyingAggregate", "coordinate": "pandas/a.py:99:0"}
     )
-    attestation, failures = module.attest_frontier_rows(
-        [("pandas/a.py", row)]
-    )
+    attestation, failures = module.attest_frontier_rows([("pandas/a.py", row)])
     assert failures == []
     body = module.seal_board_from_aggregate(
         aggregate,

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_binding.py
@@ -58,7 +58,10 @@ def _assert_named_halt(outcome) -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_function_formal_native_operation_projection.py
@@ -73,7 +73,10 @@ def test_ordinary_function_call_discharge_can_halt_with_named_identity() -> None
     )
     assert halted.effect.exception_type_coordinate == type_error
     assert halted.effect.exception_name == "TypeError"
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_guard_context_binding.py
@@ -118,15 +118,11 @@ def _production_generator_call(source: str):
         (source, "prod_guard.py", blake3_512_of(source.encode("utf-8"))),
         construction_context=construction,
     )
-    function = next(
-        node for node in tree.nodes() if isinstance(node, FunctionDef)
-    )
+    function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
     call = next(node for node in tree.nodes() if isinstance(node, Call))
     frame = function.source_visible_call_frame().bind_node_actuals(
         call.args,
-        tuple(
-            (kw.arg, kw.value) for kw in call.keywords if kw.arg is not None
-        ),
+        tuple((kw.arg, kw.value) for kw in call.keywords if kw.arg is not None),
     )
     construction.source_call_frames[_call_coordinate(call)] = frame
     return tree, function, call, frame, construction
@@ -213,9 +209,12 @@ def test_production_positional_bind_actuals_floor_reaches_guard_by_identity() ->
         == frame.formal_coordinates[0].cid
     )
     # Guard table holds binder identity.
-    assert machine._guard_evaluation_context().temporal.value_if_bound(
-        frame.formal_coordinates[0].cid
-    ) is true_arg
+    assert (
+        machine._guard_evaluation_context().temporal.value_if_bound(
+            frame.formal_coordinates[0].cid
+        )
+        is true_arg
+    )
     # Guard resolves and splices then-branch.
     result = machine.resume()
     assert isinstance(result, YieldEffect)
@@ -244,23 +243,23 @@ def test_production_keyword_and_default_bind_actuals_floor_by_identity() -> None
         site=call.fragment,
         source_call_frame=frame,
     )
-    outcome = sugar.desugar(
-        ReduceContext.root(owner="production-keyword-guard")
-    )
+    outcome = sugar.desugar(ReduceContext.root(owner="production-keyword-guard"))
     assert isinstance(outcome, Complete)
     machine = outcome.value
     assert isinstance(machine, GeneratorConstructionV1)
     assert len(machine.formal_floor_bindings) == 2
     by_cid = {
-        item.coordinate_cid: item.floor_value
-        for item in machine.formal_floor_bindings
+        item.coordinate_cid: item.floor_value for item in machine.formal_floor_bindings
     }
     assert by_cid[frame.formal_coordinates[0].cid] is enabled_floor
     # Default formal is the exact object bind_actuals returned.
     assert by_cid[frame.formal_coordinates[1].cid] is bound.actuals[1]
-    assert machine._guard_evaluation_context().temporal.value_if_bound(
-        frame.formal_coordinates[0].cid
-    ) is enabled_floor
+    assert (
+        machine._guard_evaluation_context().temporal.value_if_bound(
+            frame.formal_coordinates[0].cid
+        )
+        is enabled_floor
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -281,9 +280,7 @@ def test_caller_context_requires_with_temporal_surface() -> None:
             frame_coordinate="frame:probe",
             binding_state=(entry,),
             steps=(ReturnStepV1(),),
-            formal_floor_bindings=(
-                FormalFloorBindingV1(entry.coordinate.cid, floor),
-            ),
+            formal_floor_bindings=(FormalFloorBindingV1(entry.coordinate.cid, floor),),
             reduction_context=_NoWithTemporal(),
         )
 
@@ -311,9 +308,12 @@ def test_binder_floor_reaches_guard_by_identity() -> None:
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
     assert isinstance(machine.resume(), YieldEffect)
-    assert machine._guard_evaluation_context().temporal.value_if_bound(
-        entry.coordinate.cid
-    ) is floor
+    assert (
+        machine._guard_evaluation_context().temporal.value_if_bound(
+            entry.coordinate.cid
+        )
+        is floor
+    )
 
 
 def test_binder_false_floor_splices_else_branch() -> None:
@@ -345,9 +345,12 @@ def test_renamed_formal_uses_coordinate_not_spelling() -> None:
     floor = TrueBoolLiteralSugar(site=param.fragment)
     machine = _machine(entry=entry, floor=floor)
     assert isinstance(machine.resume(), YieldEffect)
-    assert machine._guard_evaluation_context().temporal.value_if_bound(
-        entry.coordinate.cid
-    ) is floor
+    assert (
+        machine._guard_evaluation_context().temporal.value_if_bound(
+            entry.coordinate.cid
+        )
+        is floor
+    )
 
 
 def test_wrong_coordinate_guard_refuses_when_roster_is_honest() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_guard_outcome_sequencing.py
@@ -311,7 +311,8 @@ def test_nonlinear_guard_gap_transition_is_exact_typed_refusal() -> None:
 
 
 def test_guard_carrier_composes_prefix_and_runs_projection_and_transition_once(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ) -> None:
     path = tmp_path / "guard_carrier.py"
     path.write_text("def f(left, right):\n    return left == right\n", encoding="utf-8")
@@ -358,7 +359,8 @@ def test_guard_carrier_composes_prefix_and_runs_projection_and_transition_once(
 
 
 def test_projected_truth_exitset_composes_a_branch_carrier_without_duplication(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ) -> None:
     path = tmp_path / "projected_truth_carrier.py"
     path.write_text("def f(left, right):\n    return left == right\n", encoding="utf-8")

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_if_step.py
@@ -133,9 +133,7 @@ def test_an_if_without_a_suspension_is_pre_yield_guarded_setup() -> None:
 
 
 def test_pre_yield_if_assign_is_nameable_guarded_setup() -> None:
-    steps = _steps(
-        "def g(c):\n    if c:\n        prior = None\n    yield 1\n"
-    )
+    steps = _steps("def g(c):\n    if c:\n        prior = None\n    yield 1\n")
     assert isinstance(steps[0], IfStepV1)
     from sugar_lift_py_tests.generator_construction import AssignStepV1
 
@@ -158,10 +156,7 @@ def test_pre_yield_if_with_raise_is_raise_step_inside_if() -> None:
 
 def test_raise_step_has_canonical_generator_construction_testimony() -> None:
     steps = _steps(
-        "def g(c):\n"
-        "    if c:\n"
-        "        raise ValueError('boom')\n"
-        "    yield 1\n"
+        "def g(c):\n" "    if c:\n" "        raise ValueError('boom')\n" "    yield 1\n"
     )
 
     preimage = _machine(steps).construction_term_preimage()

--- a/implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_generator_value_exitset_sequencing.py
@@ -225,7 +225,8 @@ def test_assign_sequences_one_completed_face_and_bypasses_two_halted_faces(
 
 @pytest.mark.parametrize("consumer", ("return", "yield"))
 def test_return_and_yield_sequence_one_completed_face_and_two_halts(
-    monkeypatch, consumer: str,
+    monkeypatch,
+    consumer: str,
 ) -> None:
     exits, original = _mixed_faces()
     reductions: list[str] = []
@@ -314,13 +315,17 @@ def test_synthetic_all_halted_assign_is_unchanged_and_runs_no_continuation(
     assert isinstance(outcome, ExitSet)
     assert outcome.exits == arms
     assert all(actual is expected for actual, expected in zip(outcome.exits, arms))
-    assert all(face.state is expected.state for face, expected in zip(outcome.exits, arms))
+    assert all(
+        face.state is expected.state for face, expected in zip(outcome.exits, arms)
+    )
     assert machine.cursor == 0
     assert not machine.binding_state
 
 
 @pytest.mark.parametrize("consumer", ("assign", "return", "yield"))
-def test_incomplete_value_becomes_one_halted_face_without_advancing(consumer: str) -> None:
+def test_incomplete_value_becomes_one_halted_face_without_advancing(
+    consumer: str,
+) -> None:
     effect = RaiseEffect.for_builtin("ValueError", occurrence="incomplete:value")
     reductions: list[str] = []
     value = _OutcomeValue(Incomplete(effect), reductions)
@@ -506,7 +511,9 @@ def test_native_exit_carrier_preserves_identity_and_appends_one_continuation(
 
 @pytest.mark.parametrize("consumer", ("assign", "return", "yield"))
 def test_native_exit_carrier_gap_callback_raises_exact_transition_refusal(
-    tmp_path, monkeypatch, consumer: str,
+    tmp_path,
+    monkeypatch,
+    consumer: str,
 ) -> None:
     carrier, _, _, _, _, _ = _carrier(tmp_path)
     reductions: list[str] = []

--- a/implementations/python/sugar-lift-py-tests/tests/test_global_nonlocal_declaration.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_global_nonlocal_declaration.py
@@ -282,9 +282,7 @@ def test_source_global_then_assign_statement_kinds() -> None:
     """Source ``global x; x = 1; return x``: Global is InertSugar; Assign separate."""
     source = "def f():\n    global x\n    x = 1\n    return x\n"
     function = next(
-        n
-        for n in _tree(source).nodes()
-        if isinstance(n, FunctionDef) and n.name == "f"
+        n for n in _tree(source).nodes() if isinstance(n, FunctionDef) and n.name == "f"
     )
     sugar = function.sugar()
     kinds = [type(s).__name__ for s in sugar.statements]
@@ -329,11 +327,7 @@ def test_nonlocal_route_then_read_via_reduce_block() -> None:
     assert isinstance(exits, ExitSet)
     completed = [e for e in exits.exits if isinstance(e, Completed)]
     assert len(completed) == 1, exits.exits
-    rets = [
-        e
-        for e in completed[0].value.entries
-        if isinstance(e, ReturnValue)
-    ]
+    rets = [e for e in completed[0].value.entries if isinstance(e, ReturnValue)]
     assert rets and rets[0].value == TermValue(7), completed[0].value.entries
     # nonlocal_names enrolled on continuing context when present
     cont = completed[0].value.context

--- a/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_workspace_locus.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_ground_exit_workspace_locus.py
@@ -96,9 +96,9 @@ def _raise_effects(root: Path) -> dict[str, RaiseEffect]:
     effects: dict[str, RaiseEffect] = {}
     for function in source_file.functions():
         outcome = function.sugar().desugar(None)
-        assert isinstance(outcome, Complete), (
-            f"{function.name} did not construct: {outcome!r}"
-        )
+        assert isinstance(
+            outcome, Complete
+        ), f"{function.name} did not construct: {outcome!r}"
         raises = [
             statement
             for statement in outcome.value.record.statements
@@ -130,12 +130,12 @@ def test_ground_exit_blame_is_workspace_relative(corpus: Path) -> None:
         # The blame renders the fragment, which names the file it cites. That
         # name must be the workspace-relative one -- an absolute spelling is
         # the address no other checkout can resolve.
-        assert "'ground_exits.py'" in blame, (
-            f"{name} blame `{blame}` does not name the workspace-relative locus"
-        )
-        assert str(corpus) not in blame, (
-            f"{name} blame `{blame}` leaks the absolute workspace path"
-        )
+        assert (
+            "'ground_exits.py'" in blame
+        ), f"{name} blame `{blame}` does not name the workspace-relative locus"
+        assert (
+            str(corpus) not in blame
+        ), f"{name} blame `{blame}` leaks the absolute workspace path"
 
 
 def test_ground_exit_cites_the_source_it_locates(corpus: Path) -> None:
@@ -165,9 +165,7 @@ def test_absolute_locus_still_refuses_to_construct_a_ground_exit(
 
     path = corpus / "ground_exits.py"
     source_file = SourceFile(path_source(str(path)))
-    function = next(
-        fn for fn in source_file.functions() if fn.name == "ground_index"
-    )
+    function = next(fn for fn in source_file.functions() if fn.name == "ground_index")
     with pytest.raises(ConstructionPanic) as raised:
         function.sugar().desugar(None)
     message = str(raised.value)

--- a/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_grouped_raise_effect.py
@@ -23,7 +23,12 @@ def _leaf(identity, occurrence: str, *mro, raised_value=None):
 
     if raised_value is None:
         raised_value = _typed_value(identity, *(tuple(mro) or (identity,)))
-    return RaiseEffect(exception_type_coordinate=identity, occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_type_mro=tuple(mro) or (identity,), raised_value=raised_value)
+    return RaiseEffect(
+        exception_type_coordinate=identity,
+        occurrence=AuthenticatedRaiseLocus.of(occurrence),
+        exception_type_mro=tuple(mro) or (identity,),
+        raised_value=raised_value,
+    )
 
 
 def test_nested_group_partition_preserves_tree_and_leaf_identities():
@@ -118,7 +123,11 @@ def test_except_star_partition_and_issubclass_share_class_value_floor(monkeypatc
     issubclass.callable_application_with(
         CallableApplication((leaf_class, base_class), (), "issubclass-site"), None
     )
-    leaf = RaiseEffect(exception_type_coordinate=leaf_identity, occurrence=AuthenticatedRaiseLocus.of('leaf:truthful'), raised_value=leaf_type)
+    leaf = RaiseEffect(
+        exception_type_coordinate=leaf_identity,
+        occurrence=AuthenticatedRaiseLocus.of("leaf:truthful"),
+        raised_value=leaf_type,
+    )
     partition = GroupedRaiseEffect("group:root", "root", (leaf,)).partition(
         base_type, "except-star-site"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_floor_value_law.py
@@ -21,7 +21,6 @@ from sugar_lift_py_tests.ir import atomic, ctor, implies
 from sugar_lift_py_tests.sugar.false_bool_literal_sugar import FalseBoolLiteralSugar
 from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
 
-
 GUARD = atomic("renamed_guard", [])
 
 
@@ -37,9 +36,7 @@ GUARD = atomic("renamed_guard", [])
             "blake3-512:renamed-class-definition",
             (),
             None,
-            SourceFragmentCoordinateV1(
-                "blake3-512:renamed-source", 1, 6, 1, 18
-            ),
+            SourceFragmentCoordinateV1("blake3-512:renamed-source", 1, 6, 1, 18),
         ),
         ComprehensionValue(ctor("renamed-comprehension", [])),
         GuardedValue(

--- a/implementations/python/sugar-lift-py-tests/tests/test_guarded_law_from_source.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_guarded_law_from_source.py
@@ -37,7 +37,7 @@ from sugar_lift_py_tests.floor.inv_value import InvValue
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.outcome import Complete
 
-CORPUS = '''\
+CORPUS = """\
 def bare_string(flag):
     if flag:
         "a string statement"
@@ -80,7 +80,7 @@ def guarded_obligation(flag, claim):
     if flag:
         assert claim
     return 7
-'''
+"""
 
 # Each function names the Floor category its guarded entry rides as. The six
 # categories are exactly the non-BlockValue owners the ledger records.
@@ -187,9 +187,9 @@ def test_the_guard_is_not_dropped_by_the_stable_category(corpus: Path) -> None:
         for statement in outcome.value.record.statements
         if isinstance(statement, InvValue)
     ]
-    assert len(obligations) == 1, (
-        f"expected exactly one obligation, saw {len(obligations)}"
-    )
+    assert (
+        len(obligations) == 1
+    ), f"expected exactly one obligation, saw {len(obligations)}"
     formula = obligations[0].formula
     assert getattr(formula, "kind", None) == "implies", (
         f"the guarded obligation is `{formula}`, not an implication -- the "

--- a/implementations/python/sugar-lift-py-tests/tests/test_halted_face_pairing_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_halted_face_pairing_instrument.py
@@ -16,7 +16,6 @@ from sugar_lift_py_tests.effect.grouped_raise_effect import GroupedRaiseEffect
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
 from sugar_lift_py_tests.sugar.function_universe_sugar import reduce_block_to_exitset
 
-
 DEPENDENT_AXIS_STATUS = {
     "migration_direct43_indirect20": "UNMEASURED: paired lineage door",
     "effect_change_same_event": "UNMEASURED: paired lineage door",
@@ -30,7 +29,9 @@ DEPENDENT_AXIS_STATUS = {
 
 def _paired_gate(axis: str, tmp_path: Path | None = None):
     if tmp_path is not None:
-        source, function, exits = _reduced(tmp_path, f"gate_{axis}", "def target():\n    raise ValueError('gate')\n")
+        source, function, exits = _reduced(
+            tmp_path, f"gate_{axis}", "def target():\n    raise ValueError('gate')\n"
+        )
         (face,) = exits.exits
         lineage = owner._read_halt_lineage(face)
         assert type(lineage) is owner._PairedRaiseFaceV1
@@ -79,7 +80,9 @@ def test_paired_lineage_owner_and_all_downstream_teeth(tmp_path: Path):
 
     (guarded,) = owner.ExitSet((face,)).guarded(face.guard).exits
     (normalized,) = owner.ExitSet((face,)).normalize().exits
-    sequenced = owner.ExitSet((face,)).sequence(lambda value: owner.ExitSet.completed(value))
+    sequenced = owner.ExitSet((face,)).sequence(
+        lambda value: owner.ExitSet.completed(value)
+    )
     assert _read(guarded) is lineage
     assert _read(normalized) is lineage
     (sequenced_face,) = sequenced.exits
@@ -95,7 +98,6 @@ def test_paired_lineage_owner_and_all_downstream_teeth(tmp_path: Path):
         owner.ExitSet((face, distinct)).normalize()
     assert conflict.value.left_lineage is lineage
     assert conflict.value.right_lineage is _read(distinct)
-
 
     # Closed construction/refusal and public capability closure auto-activate
     # with the owner product; no test-only replay/mutation API is introduced.
@@ -113,7 +115,6 @@ def test_paired_lineage_owner_and_all_downstream_teeth(tmp_path: Path):
         assert refusal.value.source is source.unit
         assert refusal.value.occurrence == face.effect.occurrence_id
 
-
     # Real TryStar path: partition lineage retains distinct authenticated
     # original/matched/residual occurrence objects.
     star_source, _, star_exits = _reduced(
@@ -125,7 +126,9 @@ def test_paired_lineage_owner_and_all_downstream_teeth(tmp_path: Path):
         "    except* ValueError:\n"
         "        raise RuntimeError('handler')\n",
     )
-    grouped = tuple(face for face in star_exits.exits if isinstance(face.effect, GroupedRaiseEffect))
+    grouped = tuple(
+        face for face in star_exits.exits if isinstance(face.effect, GroupedRaiseEffect)
+    )
     (grouped_face,) = grouped
     partition = _read(grouped_face).partition_lineage
     assert partition.source_identity is star_source.unit
@@ -140,7 +143,7 @@ def test_authenticated_nonraise_producer_and_cross_variant_refusal(tmp_path: Pat
     variant_name = "_AuthenticatedNonRaiseHaltV1"
     if variant_name not in owner.__dict__:
         pytest.fail(
-        "R_missing_authenticated_nonraise_producer=1: no canonical ordinary "
+            "R_missing_authenticated_nonraise_producer=1: no canonical ordinary "
             "authenticated nonraise producer is available; do not fabricate one",
             pytrace=False,
         )
@@ -188,7 +191,9 @@ def test_handler_matching_binding_has_external_work_counters(tmp_path: Path):
     if not _paired_gate("handler_match_bind_counters", tmp_path):
         return
     source, function, exits = _reduced(
-        tmp_path, "handler", "def target():\n    try:\n        raise ValueError('x')\n    except ValueError as error:\n        raise RuntimeError(str(error))\n    finally:\n        pass\n"
+        tmp_path,
+        "handler",
+        "def target():\n    try:\n        raise ValueError('x')\n    except ValueError as error:\n        raise RuntimeError(str(error))\n    finally:\n        pass\n",
     )
     (face,) = exits.exits
     assert face.effect is not None
@@ -199,7 +204,9 @@ def test_trystar_partition_refusal_is_typed_and_observed(tmp_path: Path):
     if not _paired_gate("trystar_partition_substitution", tmp_path):
         return
     source, _, exits = _reduced(
-        tmp_path, "partition", "def target():\n    try:\n        raise ExceptionGroup('g', [ValueError('v'), TypeError('t')])\n    except* ValueError:\n        raise RuntimeError('handled')\n"
+        tmp_path,
+        "partition",
+        "def target():\n    try:\n        raise ExceptionGroup('g', [ValueError('v'), TypeError('t')])\n    except* ValueError:\n        raise RuntimeError('handled')\n",
     )
     grouped = tuple(f for f in exits.exits if isinstance(f.effect, GroupedRaiseEffect))
     (face,) = grouped

--- a/implementations/python/sugar-lift-py-tests/tests/test_halted_lineage_owner_prerequisite_instrument.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_halted_lineage_owner_prerequisite_instrument.py
@@ -33,11 +33,14 @@ def _reduce(tmp_path: Path, stem: str, text: str):
 
 def test_raise_owner_seats_exact_paired_lineage(tmp_path: Path, monkeypatch):
     from sugar_lift_py_tests.sugar import exit_set_routing
+
     seen = []
     original = exit_set_routing.promote_raise_halts
+
     def observe(exits):
         seen.append(exits)
         return original(exits)
+
     monkeypatch.setattr(exit_set_routing, "promote_raise_halts", observe)
     with pytest.raises(owner._HaltLineageProducerMissingV1):
         _reduce(tmp_path, "raise", "def target():\n    raise ValueError('x')\n")
@@ -45,23 +48,34 @@ def test_raise_owner_seats_exact_paired_lineage(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.parametrize("statement", ["break", "continue"])
-def test_loop_control_owner_seats_authenticated_nonraise(tmp_path: Path, statement: str, monkeypatch):
+def test_loop_control_owner_seats_authenticated_nonraise(
+    tmp_path: Path, statement: str, monkeypatch
+):
     from sugar_lift_py_tests.sugar.loop_control_sugar import LoopControlSugar
+
     seen = []
     original = LoopControlSugar.desugar
+
     def observe(self, ctx=None):
         seen.append((self, ctx))
         return original(self, ctx)
+
     monkeypatch.setattr(LoopControlSugar, "desugar", observe)
     with pytest.raises(owner._HaltLineageProducerMissingV1):
-        _reduce(tmp_path, statement, f"def target(xs):\n    for x in xs:\n        {statement}\n")
+        _reduce(
+            tmp_path,
+            statement,
+            f"def target(xs):\n    for x in xs:\n        {statement}\n",
+        )
     assert len(seen) == 1
     assert seen[0][0].target_cid != seen[0][0].occurrence_cid
 
 
 def test_legacy_and_forged_faces_refuse_with_external_zero_work(tmp_path: Path):
     pytest.importorskip("sugar_lift_py_tests.outcome.exit_set")
-    source, _, exits = _reduce(tmp_path, "plain", "def target():\n    raise ValueError('x')\n")
+    source, _, exits = _reduce(
+        tmp_path, "plain", "def target():\n    raise ValueError('x')\n"
+    )
     (face,) = exits.exits
     refusal_type = owner._HaltLineageRefusalV1
     for operation in (
@@ -81,7 +95,9 @@ def test_legacy_and_forged_faces_refuse_with_external_zero_work(tmp_path: Path):
 
 
 def test_transforms_preserve_identity_and_cross_variant_refuses(tmp_path: Path):
-    _, _, exits = _reduce(tmp_path, "transform", "def target():\n    raise ValueError('x')\n")
+    _, _, exits = _reduce(
+        tmp_path, "transform", "def target():\n    raise ValueError('x')\n"
+    )
     (face,) = exits.exits
     lineage = owner._read_halt_lineage(face)
     (guarded,) = owner.ExitSet((face,)).guarded(face.guard).exits

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_branch_result_slot.py
@@ -99,7 +99,9 @@ def test_undecidable_if_elif_else_retains_complementary_faces() -> None:
         TermValue(10),
         TermValue(30),
     }
-    first_guard = next(entry.guards[0] for entry in returns if entry.value == TermValue(10))
+    first_guard = next(
+        entry.guards[0] for entry in returns if entry.value == TermValue(10)
+    )
     assert any(
         guard == not_(first_guard)
         for entry in returns
@@ -118,9 +120,7 @@ def test_condition_halt_bypasses_every_if_elif_else_body() -> None:
     )
     tree = _tree(f"{source}\nchoose(None)\n")
     (outcome,) = tuple(
-        node.sugar().desugar(None)
-        for node in tree.nodes()
-        if isinstance(node, Call)
+        node.sugar().desugar(None) for node in tree.nodes() if isinstance(node, Call)
     )
 
     halted = _only(outcome, Halted)
@@ -131,12 +131,7 @@ def test_condition_halt_bypasses_every_if_elif_else_body() -> None:
 
 
 def _two_source_ifs() -> tuple[If, If]:
-    tree = _tree(
-        "if left:\n"
-        "    x = 1\n"
-        "if right:\n"
-        "    y = 2\n"
-    )
+    tree = _tree("if left:\n" "    x = 1\n" "if right:\n" "    y = 2\n")
     branches = tuple(node for node in tree.nodes() if isinstance(node, If))
     assert len(branches) == 2
     return branches
@@ -151,7 +146,9 @@ def test_raw_source_if_routes_through_its_exact_slot_at_the_if_occurrence() -> N
     assert sugar.site.seal().cid == branch.fragment.seal().cid
 
 
-def test_truthful_stored_slot_constructs_but_slot_swap_panics_at_its_occurrence() -> None:
+def test_truthful_stored_slot_constructs_but_slot_swap_panics_at_its_occurrence() -> (
+    None
+):
     truthful, unrelated = _two_source_ifs()
     truthful_slot = branch_result_slot(truthful.test)
     unrelated_slot = branch_result_slot(unrelated.test)

--- a/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_if_construct_sugar_slot_producer.py
@@ -152,7 +152,10 @@ def test_condition_halt_bypasses_both_if_bodies() -> None:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -173,9 +176,7 @@ def test_condition_halt_emits_no_occurrence_from_toxic_body_twins() -> None:
     comparisons = tuple(node for node in tree.nodes() if isinstance(node, Compare))
     assert len(comparisons) == 3
     (outcome,) = tuple(
-        node.sugar().desugar(None)
-        for node in tree.nodes()
-        if isinstance(node, Call)
+        node.sugar().desugar(None) for node in tree.nodes() if isinstance(node, Call)
     )
 
     assert isinstance(outcome, ExitSet)
@@ -247,9 +248,7 @@ def test_identical_condition_spellings_at_distinct_ifs_do_not_share_slots() -> N
         for branch, slot in zip(rewritten, slots, strict=True)
     )
     assert expected_guards[0] != expected_guards[1]
-    for outcome, slot, expected in zip(
-        outcomes, slots, expected_guards, strict=True
-    ):
+    for outcome, slot, expected in zip(outcomes, slots, expected_guards, strict=True):
         assert isinstance(outcome, Complete)
         guarded = outcome.value
         assert guarded.guard == expected

--- a/implementations/python/sugar-lift-py-tests/tests/test_immutable_attribute_delete.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_immutable_attribute_delete.py
@@ -13,7 +13,9 @@ from sugar_source_tree.tree import SourceFile
 def _site(tmp_path):
     path = tmp_path / "attr_delete.py"
     path.write_text("def f(obj):\n    del obj.attr\n")
-    function = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions())
+    function = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    )
     return function.body[0].fragment
 
 
@@ -32,9 +34,14 @@ class _Receiver(Sugar):
 
 @pytest.mark.parametrize(
     ("receiver", "owner"),
-    ((StringValue("abc"), "StringValue.delattr"), (BytesValue(b"abc"), "BytesValue.delattr")),
+    (
+        (StringValue("abc"), "StringValue.delattr"),
+        (BytesValue(b"abc"), "BytesValue.delattr"),
+    ),
 )
-def test_immutable_scalar_attribute_delete_has_exact_owner_occurrence(tmp_path, receiver, owner):
+def test_immutable_scalar_attribute_delete_has_exact_owner_occurrence(
+    tmp_path, receiver, owner
+):
     site = _site(tmp_path)
     outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", site).desugar()
     assert isinstance(outcome, Incomplete)
@@ -44,6 +51,10 @@ def test_immutable_scalar_attribute_delete_has_exact_owner_occurrence(tmp_path, 
 
 
 @pytest.mark.parametrize("receiver", (StringValue("abc"), BytesValue(b"abc")))
-def test_immutable_scalar_attribute_delete_cannot_fabricate_completion(tmp_path, receiver):
-    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", _site(tmp_path)).desugar()
+def test_immutable_scalar_attribute_delete_cannot_fabricate_completion(
+    tmp_path, receiver
+):
+    outcome = AttributeDeleteEffectSugar(
+        _Receiver(receiver), "attr", _site(tmp_path)
+    ).desugar()
     assert not isinstance(outcome, Complete)

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_bound_callee_is_closed.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_bound_callee_is_closed.py
@@ -41,9 +41,7 @@ def _post(source: str):
 def _scoped(post, formals: tuple[str, ...]) -> ScopedFormula:
     sort = UnknownSort(reason="lift is sort-silent; the compiler decides")
     allowed = {name: sort for name in (*formals, "out")}
-    return ScopedFormula(
-        formula_from_ir(post, var_sorts=allowed), allowed_vars=allowed
-    )
+    return ScopedFormula(formula_from_ir(post, var_sorts=allowed), allowed_vars=allowed)
 
 
 def test_module_alias_call_head_projects_a_closed_coordinate() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_use_source_cid_pairing.py
@@ -29,12 +29,16 @@ def test_lying_mismatched_source_cid_is_refused_at_import_use_mint(
     lying_cid = "blake3-512:" + "0" * 128
     assert lying_cid != honest_cid
 
-    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+    with pytest.raises(
+        ValueError, match="authenticated import-use source CID is stale"
+    ):
         authenticated_import_uses(
             tmp_path, path, source, lying_cid, module_identities={}
         )
 
-    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+    with pytest.raises(
+        ValueError, match="authenticated import-use source CID is stale"
+    ):
         authenticated_import_use_receipts(
             tmp_path, path, source, lying_cid, module_identities={}
         )
@@ -49,7 +53,9 @@ def test_dual_door_crlf_claim_is_refused_not_repaired(tmp_path: Path) -> None:
     claimed = blake3_512_of(path.read_bytes())
     assert blake3_512_of(source.encode("utf-8")) != claimed
 
-    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+    with pytest.raises(
+        ValueError, match="authenticated import-use source CID is stale"
+    ):
         authenticated_import_use_receipts(
             tmp_path, path, source, claimed, module_identities={}
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_value_use_receipts.py
@@ -59,8 +59,7 @@ def test_value_use_receipt_changes_when_source_moves(tmp_path: Path) -> None:
     assert early_f[0].use["useSite"] != late_f[0].use["useSite"]
     assert early_f[0].use["cid"] != late_f[0].use["cid"]
     assert (
-        early_f[0].use["useSite"]["startLine"]
-        != late_f[0].use["useSite"]["startLine"]
+        early_f[0].use["useSite"]["startLine"] != late_f[0].use["useSite"]["startLine"]
     )
 
 
@@ -97,9 +96,7 @@ def test_package_relative_member_receipts_refuse_cross_package_substitution(
         package = tmp_path / package_name
         package.mkdir()
         path = package / "__init__.py"
-        source, source_cid = _write(
-            path, "from . import helper\nvalue = helper.FLAG\n"
-        )
+        source, source_cid = _write(path, "from . import helper\nvalue = helper.FLAG\n")
         rows, _ = authenticated_import_value_use_receipts(
             tmp_path, path, source, source_cid, module_identities={}
         )
@@ -120,9 +117,7 @@ def test_non_init_module_relative_import_keeps_parent_package(
     package = tmp_path / "sibling_control"
     package.mkdir()
     path = package / "consumer.py"
-    source, source_cid = _write(
-        path, "from . import helper\nvalue = helper.FLAG\n"
-    )
+    source, source_cid = _write(path, "from . import helper\nvalue = helper.FLAG\n")
 
     rows, _ = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
@@ -150,7 +145,9 @@ def test_tampered_source_cid_refuses_value_use_receipts(tmp_path: Path) -> None:
     source, honest_cid = _write(path, "from pkg import f\nx = f\n")
     lying = "blake3-512:" + "0" * 128
     assert lying != honest_cid
-    with pytest.raises(ValueError, match="authenticated import-use source CID is stale"):
+    with pytest.raises(
+        ValueError, match="authenticated import-use source CID is stale"
+    ):
         authenticated_import_value_use_receipts(
             tmp_path, path, source, lying, module_identities={}
         )
@@ -161,9 +158,7 @@ def test_same_name_shadowing_does_not_authorize_value_use(tmp_path: Path) -> Non
     path = tmp_path / "shadow.py"
     source, source_cid = _write(
         path,
-        "from pkg import f\n"
-        "f = 1\n"
-        "x = f\n",
+        "from pkg import f\n" "f = 1\n" "x = f\n",
     )
     receipts, _ = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
@@ -195,8 +190,7 @@ def test_wildcard_import_does_not_authorize_value_use(tmp_path: Path) -> None:
     path = tmp_path / "star.py"
     source, source_cid = _write(
         path,
-        "from pkg import *\n"
-        "x = f\n",
+        "from pkg import *\n" "x = f\n",
     )
     receipts, outcomes = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
@@ -212,8 +206,7 @@ def test_chained_attribute_coordinates_without_spelling_resolution(
     path = tmp_path / "chain.py"
     source, source_cid = _write(
         path,
-        "import os\n"
-        "x = os.path.join\n",
+        "import os\n" "x = os.path.join\n",
     )
     receipts, _ = authenticated_import_value_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
@@ -313,8 +306,7 @@ def test_nearby_call_receipt_does_not_authorize_value_use(tmp_path: Path) -> Non
     path = tmp_path / "call_only.py"
     source, source_cid = _write(
         path,
-        "from pkg import f\n"
-        "f(1)\n",
+        "from pkg import f\n" "f(1)\n",
     )
     call_receipts, call_outcomes = authenticated_import_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
@@ -535,7 +527,9 @@ def test_forged_value_role_on_call_shape_is_refused_at_mint(tmp_path: Path) -> N
     forged_demand = dict(call.demand)
     forged_demand["authenticatedImportUse"] = forged_use_cid
     forged_demand["role"] = "value-use"
-    with pytest.raises(ValueError, match="cannot carry value-use role|cannot carry a use role"):
+    with pytest.raises(
+        ValueError, match="cannot carry value-use role|cannot carry a use role"
+    ):
         AuthenticatedImportUseV1(
             import_binding=call.import_binding,
             target_symbol=call.target_symbol,

--- a/implementations/python/sugar-lift-py-tests/tests/test_importorskip_binding_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_importorskip_binding_state.py
@@ -59,9 +59,7 @@ def test_truthful_from_import_importorskip_mints_module(tmp_path: Path) -> None:
 def test_lying_local_def_importorskip_does_not_mint(tmp_path: Path) -> None:
     state = _final_state(
         tmp_path,
-        "def importorskip(m):\n"
-        "    return m\n"
-        'np = importorskip("numpy")\n',
+        "def importorskip(m):\n" "    return m\n" 'np = importorskip("numpy")\n',
     )
     assert state["np"] == [_NON_IMPORT]
     assert not any(

--- a/implementations/python/sugar-lift-py-tests/tests/test_isinstance_len_tuple_builtins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_isinstance_len_tuple_builtins.py
@@ -78,9 +78,7 @@ def test_tuple_construct_from_tuple_value_is_identity():
 def test_dict_items_then_dict_construct_preserves_exact_entries():
     temporal = builtin_name_temporal()
     source = DictValue(((StringValue("key"), TermValue(3)),))
-    items = source.call_method_value(
-        "items", (), owner="test", blame="site"
-    )
+    items = source.call_method_value("items", (), owner="test", blame="site")
     assert isinstance(items, Complete)
 
     dict_fn = temporal.value_if_bound("dict")

--- a/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_iterator_floor_surface.py
@@ -190,7 +190,11 @@ def test_string_site_cannot_mint_stop_iteration() -> None:
     with pytest.raises(ConstructionPanic) as caught:
         project_next(ListIteratorValue((), index=0), "iterator-surface-site")
     text = str(caught.value)
-    assert "fragment" in text.lower() or "locus" in text.lower() or "source" in text.lower()
+    assert (
+        "fragment" in text.lower()
+        or "locus" in text.lower()
+        or "source" in text.lower()
+    )
     assert "StopIteration" not in text or "no source fragment" in text
     # Lying twin: claiming string blame yields a greened Incomplete StopIteration.
     with pytest.raises(ConstructionPanic):

--- a/implementations/python/sugar-lift-py-tests/tests/test_list_iterator_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_list_iterator_attribute_mutation.py
@@ -6,10 +6,19 @@ from sugar_source_tree.tree import SourceFile
 def _outcomes(tmp_path):
     path = tmp_path / "list_iterator_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     store_site, delete_site = body[0].fragment, body[1].fragment
     value = ListIteratorValue((TermValue(1),))
-    return ((value.setattr("attr", TermValue(7), store_site), "ListIteratorValue.setattr", store_site), (value.delattr("attr", delete_site), "ListIteratorValue.delattr", delete_site))
+    return (
+        (
+            value.setattr("attr", TermValue(7), store_site),
+            "ListIteratorValue.setattr",
+            store_site,
+        ),
+        (value.delattr("attr", delete_site), "ListIteratorValue.delattr", delete_site),
+    )
 
 
 def test_list_iterator_attribute_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_list_iterator_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_list_iterator_subscript_mutation.py
@@ -6,14 +6,27 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "list_iterator_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     value = ListIteratorValue((TermValue(1),))
-    return ((value.setitem(TermValue(0), TermValue(7), store_site), "ListIteratorValue.setitem", store_site), (value.delitem(TermValue(0), delete_site), "ListIteratorValue.delitem", delete_site))
+    return (
+        (
+            value.setitem(TermValue(0), TermValue(7), store_site),
+            "ListIteratorValue.setitem",
+            store_site,
+        ),
+        (
+            value.delitem(TermValue(0), delete_site),
+            "ListIteratorValue.delitem",
+            delete_site,
+        ),
+    )
 
 
 def test_list_iterator_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_exit_partition_carrier.py
@@ -150,7 +150,10 @@ def test_guarded_loop_read_is_a_constructed_term_with_exact_coordinates():
     projection = LoopGuardedProjection(
         (
             LoopGuardedCompletedFace(
-                "BreakExit", atomic("break_guard", []), IntLiteralSugar(1, value_site), 2
+                "BreakExit",
+                atomic("break_guard", []),
+                IntLiteralSugar(1, value_site),
+                2,
             ),
             LoopGuardedCompletedFace(
                 "NormalExhaustion",
@@ -180,12 +183,18 @@ def test_guarded_loop_read_is_a_constructed_term_with_exact_coordinates():
         _TermSite("blake3-512:" + "44" * 32),
     )
 
-    assert _term_content_cid(
-        foreign_target.to_term(owner="guarded-loop-read-foreign-target")
-    ) != authentic_cid
-    assert _term_content_cid(
-        foreign_occurrence.to_term(owner="guarded-loop-read-foreign-occurrence")
-    ) != authentic_cid
+    assert (
+        _term_content_cid(
+            foreign_target.to_term(owner="guarded-loop-read-foreign-target")
+        )
+        != authentic_cid
+    )
+    assert (
+        _term_content_cid(
+            foreign_occurrence.to_term(owner="guarded-loop-read-foreign-occurrence")
+        )
+        != authentic_cid
+    )
 
     missing_target = GuardedBindingReadSugar(
         "value",
@@ -275,9 +284,7 @@ def test_delete_uses_the_same_authenticated_loop_exit_family():
     site = _Site()
     projection = _projection(
         [
-            LoopGuardedCompletedFace(
-                "BreakExit", atomic("b", []), _BoundState(), 2
-            ),
+            LoopGuardedCompletedFace("BreakExit", atomic("b", []), _BoundState(), 2),
             LoopGuardedCompletedFace(
                 "NormalExhaustion",
                 atomic("n", []),
@@ -603,9 +610,7 @@ def test_the_loop_family_stays_linear_as_factors_are_appended(tmp_path):
     family = ExitSet(
         (
             Completed(guard("broke"), "a", frozenset({faces["BreakExit"]})),
-            Completed(
-                guard("exhausted"), "b", frozenset({faces["NormalExhaustion"]})
-            ),
+            Completed(guard("exhausted"), "b", frozenset({faces["NormalExhaustion"]})),
         )
     ).factor_completed()
 
@@ -613,7 +618,9 @@ def test_the_loop_family_stays_linear_as_factors_are_appended(tmp_path):
     for step_count in (1, 2, 3, 4, 5, 6, 7, 8):
         exits = family
         for index in range(step_count):
-            exits = exits.sequence(lambda value, _i=index: ExitSet.completed((value, _i)))
+            exits = exits.sequence(
+                lambda value, _i=index: ExitSet.completed((value, _i))
+            )
         series.append(len([e for e in exits.exits if isinstance(e, Completed)]))
 
     assert series == [1] * 8, (

--- a/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_loop_stop_iteration_coordinate.py
@@ -28,8 +28,8 @@ def _stop_identity():
 
 def test_truthful_stop_iteration_coordinate_is_exhaustion() -> None:
     identity, mro = _stop_identity()
-    effect = RaiseEffect.for_builtin("StopIteration",
-        
+    effect = RaiseEffect.for_builtin(
+        "StopIteration",
         exception_type_mro=mro,
         occurrence="loop.py:1:0",
         producer_node_owner="project_next",
@@ -40,8 +40,8 @@ def test_truthful_stop_iteration_coordinate_is_exhaustion() -> None:
 
 def test_lying_twin_same_spelling_foreign_coordinate_is_not_exhaustion() -> None:
     identity, mro = _stop_identity()
-    truthful = RaiseEffect.for_builtin("StopIteration",
-        
+    truthful = RaiseEffect.for_builtin(
+        "StopIteration",
         exception_type_mro=mro,
         occurrence="loop.py:1:0",
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_decided_one_matcher_law.py
@@ -94,7 +94,13 @@ def _fabricated_decided_miss_sites(path: Path) -> list[tuple[Path, int, str]]:
     for node in ast.walk(tree):
         if _is_match_decided_false(node):
             line = getattr(node, "lineno", 0)
-            sites.append((path, line, ast.get_source_segment(source, node) or "MatchDecided(False)"))
+            sites.append(
+                (
+                    path,
+                    line,
+                    ast.get_source_segment(source, node) or "MatchDecided(False)",
+                )
+            )
     return sites
 
 
@@ -131,7 +137,9 @@ def test_one_matcher_is_the_sole_match_decided_false_owner() -> None:
     )
 
 
-def test_sourcefile_construction_door_auditor_is_blind_to_fabricated_match_decided() -> None:
+def test_sourcefile_construction_door_auditor_is_blind_to_fabricated_match_decided() -> (
+    None
+):
     """LOUD: repository SOURCEFILE_CONSTRUCTION_DOOR auditor does not cover this sin class.
 
     ``tests/sourcefile_construction_door_auditor.py`` closes SourceFile construction, privacy, and
@@ -164,9 +172,5 @@ def test_planted_fabricated_miss_is_detected() -> None:
         "        return MatchDecided(False)\n"
         "    return MatchDecided(True)\n"
     )
-    hits = [
-        node
-        for node in ast.walk(planted)
-        if _is_match_decided_false(node)
-    ]
+    hits = [node for node in ast.walk(planted) if _is_match_decided_false(node)]
     assert len(hits) == 1

--- a/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_match_guard_binding_rollback.py
@@ -107,9 +107,7 @@ def _block_entries(outcome):
     if isinstance(outcome, Complete):
         block = outcome.value
         return tuple(
-            getattr(block, "statements", None)
-            or getattr(block, "entries", None)
-            or ()
+            getattr(block, "statements", None) or getattr(block, "entries", None) or ()
         )
     if isinstance(outcome, ExitSet):
         entries = []
@@ -117,9 +115,7 @@ def _block_entries(outcome):
             if isinstance(face, Completed):
                 v = face.value
                 entries.extend(
-                    getattr(v, "statements", None)
-                    or getattr(v, "entries", None)
-                    or ()
+                    getattr(v, "statements", None) or getattr(v, "entries", None) or ()
                 )
         return tuple(entries)
     return ()
@@ -137,6 +133,7 @@ def _block_return_values(outcome) -> list:
         if isinstance(inner, ReturnValue):
             found.append(inner.value)
     return found
+
 
 # ===========================================================================
 # Subject evaluates once
@@ -230,9 +227,9 @@ def test_false_guard_rolls_back_before_next_case() -> None:
     outcome = sugar.desugar(ReduceContext.root(owner="guard-false-rollback"))
     values = _block_return_values(outcome)
     # Second case wins under ground truth; first body must not be the sole answer.
-    assert any(v == TermValue(2) or getattr(v, "value", None) == 2 for v in values), (
-        values
-    )
+    assert any(
+        v == TermValue(2) or getattr(v, "value", None) == 2 for v in values
+    ), values
     # First case body return 1 is not selected under sat selection for subject 5.
     # (May appear under unsat guard formula — if present must be guarded unsat.)
 
@@ -259,9 +256,9 @@ def test_false_guard_does_not_leave_capture_for_later_case_scope() -> None:
     )
     outcome = sugar.desugar(ReduceContext.root(owner="fresh-capture"))
     values = _block_return_values(outcome)
-    assert any(v == TermValue(3) or getattr(v, "value", None) == 3 for v in values), (
-        values
-    )
+    assert any(
+        v == TermValue(3) or getattr(v, "value", None) == 3 for v in values
+    ), values
 
 
 # ===========================================================================
@@ -281,8 +278,8 @@ class _HaltingGuard(Sugar):
 
     def desugar(self, ctx=None):
         return Incomplete(
-            RaiseEffect.for_builtin("ValueError",
-                
+            RaiseEffect.for_builtin(
+                "ValueError",
                 blame=str(self.site),
                 occurrence=str(self.site),
                 producer_node_owner="MatchGuard",
@@ -329,6 +326,7 @@ def test_guard_halt_bypasses_later_cases() -> None:
     assert incompletes, entries
     assert incompletes[0].effect.exception_name == "ValueError"
 
+
 # ===========================================================================
 # Case order and wildcard fall-through distinct
 # ===========================================================================
@@ -339,7 +337,9 @@ def test_case_order_first_match_wins() -> None:
     sugar = _match(
         _int(1),
         MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(10)),)),
-        MatchCaseSpec(alternatives=(_int(1),), body=(_ret(_int(20)),)),  # same pattern later
+        MatchCaseSpec(
+            alternatives=(_int(1),), body=(_ret(_int(20)),)
+        ),  # same pattern later
         MatchCaseSpec(alternatives=(), body=(_ret(_int(0)),)),
     )
     outcome = sugar.desugar(ReduceContext.root(owner="order"))

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_defining_class_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_defining_class_transport.py
@@ -34,7 +34,9 @@ def test_receiver_and_inherited_method_retain_distinct_class_owners() -> None:
     _context, base, derived = _constructed_pair()
 
     receiver = derived.construct_receiver_state_from_block(None, "receiver")
-    (owner_method,) = tuple(method for method in receiver.methods if method.name == "owner")
+    (owner_method,) = tuple(
+        method for method in receiver.methods if method.name == "owner"
+    )
 
     assert receiver.defining_class is derived
     assert owner_method.defining_class is base
@@ -58,11 +60,7 @@ def test_inherited_method_binds_lexical_class_not_runtime_receiver_class() -> No
 
 def test_overriding_method_uses_derived_defining_class() -> None:
     base, _ = _definitions()
-    source = (
-        "class Derived:\n"
-        "    def owner(self):\n"
-        "        return __class__\n"
-    )
+    source = "class Derived:\n" "    def owner(self):\n" "        return __class__\n"
     tree = SourceFile((source, "derived_owner.py", blake3_512_of(source.encode())))
     (derived,) = tuple(node for node in tree.root.body if isinstance(node, ClassDef))
     context = ReduceContext.root(owner="test")

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_raise_transport.py
@@ -139,11 +139,7 @@ def _route_try(exits: ExitSet, expected: str) -> ExitSet:
 
 
 def _raise_body(exception: str = "ValueError") -> str:
-    return (
-        "class Raiser:\n"
-        f"    def boom(self):\n"
-        f"        raise {exception}\n"
-    )
+    return "class Raiser:\n" f"    def boom(self):\n" f"        raise {exception}\n"
 
 
 # ===========================================================================
@@ -160,8 +156,7 @@ def test_bound_method_raise_publishes_named_halt_at_call() -> None:
     assert halted.effect.exception_name == "ValueError"
     assert halted.effect.exception_type_coordinate == _identity("ValueError")
     assert (
-        halted.effect.occurrence_id is not None
-        or halted.effect.occurrence is not None
+        halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
     ), f"{CODEX3}: halt missing occurrence"
     # Call boundary re-owns the published edge.
     assert halted.effect.producer_node_owner == "Call"
@@ -224,9 +219,9 @@ def test_prior_store_survives_in_pre_effect_state_across_method_call() -> None:
     halted = _method_halt(source)
     assert halted.state is not None, f"{CODEX1}: halt dropped pre-effect state"
     lists = [e for e in halted.state.entries if isinstance(e, ListValue)]
-    assert lists == [ListValue((TermValue(9),))], (
-        f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
-    )
+    assert lists == [
+        ListValue((TermValue(9),))
+    ], f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
 
 
 # ===========================================================================
@@ -295,12 +290,12 @@ def test_method_raise_under_guard_keeps_guard_on_halt_face() -> None:
     halt = halted[0]
     assert halt.effect.exception_name == "ValueError"
     guard_s = str(halt.guard)
-    assert "py.truthy" in guard_s or "truthy" in guard_s or "branch" in guard_s, (
-        f"{CODEX3}: guard dropped on method raise face: {halt.guard!r}"
+    assert (
+        "py.truthy" in guard_s or "truthy" in guard_s or "branch" in guard_s
+    ), f"{CODEX3}: guard dropped on method raise face: {halt.guard!r}"
+    assert "not" in str(completed[0].guard).lower() or str(completed[0].guard) != str(
+        halt.guard
     )
-    assert "not" in str(completed[0].guard).lower() or str(
-        completed[0].guard
-    ) != str(halt.guard)
 
 
 def test_method_raise_under_true_guard_collapses_to_sole_halt() -> None:
@@ -389,8 +384,8 @@ def test_wrong_exception_observation_is_not_the_method_effect() -> None:
     """Bite: foreign RaiseEffect is not the transported method edge."""
     source = _raise_body() + "\nRaiser().boom()\n"
     halted = _method_halt(source)
-    foreign = RaiseEffect.for_builtin("ValueError",
-        
+    foreign = RaiseEffect.for_builtin(
+        "ValueError",
         blame="foreign.py:1:0",
         occurrence="foreign.py:1:0",
         exception_type_mro=(_identity("ValueError"),),
@@ -415,14 +410,14 @@ def test_fabricated_empty_state_is_not_pre_effect_when_store_preceded_raise() ->
     halted = _method_halt(source)
     fabricated = _ReducedBlock((), True, ())
     assert halted.state is not None, f"{CODEX1}: missing pre-effect state"
-    assert halted.state != fabricated or halted.state.entries, (
-        f"{CODEX1}: state collapsed to empty fabricated block"
-    )
+    assert (
+        halted.state != fabricated or halted.state.entries
+    ), f"{CODEX1}: state collapsed to empty fabricated block"
     with pytest.raises(AssertionError):
         assert halted.state is fabricated
-    assert any(isinstance(e, ListValue) for e in halted.state.entries), (
-        f"{CODEX1}: prior store absent from entries={halted.state.entries!r}"
-    )
+    assert any(
+        isinstance(e, ListValue) for e in halted.state.entries
+    ), f"{CODEX1}: prior store absent from entries={halted.state.entries!r}"
 
 
 def test_handler_value_is_not_fabricated_fresh_block_twin() -> None:
@@ -483,8 +478,8 @@ def test_bound_method_raise_is_sole_exceptional_edge() -> None:
     source = _raise_body() + "\nRaiser().boom()\n"
     outcome = _method_outcome(source)
     assert isinstance(outcome, ExitSet)
-    assert sum(isinstance(e, Halted) for e in outcome.exits) == 1, (
-        f"{CODEX3}: expected sole Halted edge, got {outcome.exits!r}"
-    )
+    assert (
+        sum(isinstance(e, Halted) for e in outcome.exits) == 1
+    ), f"{CODEX3}: expected sole Halted edge, got {outcome.exits!r}"
     with pytest.raises(AssertionError):
         assert all(isinstance(e, Completed) for e in outcome.exits)

--- a/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_method_return_as_actual.py
@@ -61,18 +61,12 @@ CODEX3_GENERAL_PRODUCER = (
     "not BlockValue body, not unreduced CallSiteValue)"
 )
 
-FACTORY_MAKE_41 = (
-    "class Factory:\n"
-    "    def make(self):\n"
-    "        return 41\n"
-)
+FACTORY_MAKE_41 = "class Factory:\n" "    def make(self):\n" "        return 41\n"
 
 STORE_DEF = "def store(obj, key, value):\n    obj[key] = value\n"
 
 RAISING_FACTORY = (
-    "class Factory:\n"
-    "    def make(self):\n"
-    "        raise ValueError()\n"
+    "class Factory:\n" "    def make(self):\n" "        raise ValueError()\n"
 )
 
 CHAIN_SOURCE = (
@@ -143,9 +137,7 @@ def _attr_call_outcome(source: str, attr: str):
     calls = tuple(
         n
         for n in tree.nodes()
-        if isinstance(n, Call)
-        and isinstance(n.func, Attribute)
-        and n.func.attr == attr
+        if isinstance(n, Call) and isinstance(n.func, Attribute) and n.func.attr == attr
     )
     assert calls, (attr, source)
     return _desugar_or_name_codex3(
@@ -310,7 +302,9 @@ def test_method_return_feeds_compare_isomorphic_to_direct_value() -> None:
     """
     direct = _compare_outcome("41 < 50\n")
     method = _compare_outcome(FACTORY_MAKE_41 + "\nFactory().make() < 50\n")
-    assert _completed_compare_is_true(method) is _completed_compare_is_true(direct) is True, (
+    assert (
+        _completed_compare_is_true(method) is _completed_compare_is_true(direct) is True
+    ), (
         f"{CODEX3_GENERAL_PRODUCER} — Compare method-return face not isomorphic "
         f"to direct 41<50: method={type(method).__name__} direct={type(direct).__name__}"
     )
@@ -484,10 +478,7 @@ def test_swapped_receiver_is_not_the_returned_value() -> None:
     assert dug == TermValue(41)
     assert dug != receiver
     # A swapped lying map that treats self as the returned actual fails.
-    assert not (
-        isinstance(dug, ObjectValue)
-        and dug.class_name == "Factory"
-    )
+    assert not (isinstance(dug, ObjectValue) and dug.class_name == "Factory")
 
 
 def test_discrimination_list_literal_is_not_make_return() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_moved_dispatch_targets.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_moved_dispatch_targets.py
@@ -94,13 +94,13 @@ def test_dynamic_isinstance_projects_the_value_through_its_owned_term_door() -> 
 
 def test_dynamic_isinstance_keeps_a_value_owned_term_refusal_loud() -> None:
     source = "subject\n"
-    tree = SourceFile((source, "dynamic-isinstance-lie.py", blake3_512_of(source.encode())))
+    tree = SourceFile(
+        (source, "dynamic-isinstance-lie.py", blake3_512_of(source.encode()))
+    )
     site = next(node for node in tree.nodes() if isinstance(node, Name)).fragment
 
     with pytest.raises(ConstructionPanic):
-        SymbolicValue(make_var("RuntimeType")).test_python_type(
-            FloorValue(), site
-        )
+        SymbolicValue(make_var("RuntimeType")).test_python_type(FloorValue(), site)
 
 
 # -- sugar.for_sugar cap -> floor/sequence_repetition.py --------------------

--- a/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_membership.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_membership.py
@@ -22,8 +22,7 @@ def _source(tmp_path: Path, name: str, *, suffix: str = ""):
     path.write_text(
         "OPTIONS = {}\n"
         "def has_option(key):\n"
-        "    return key in OPTIONS\n"
-        + suffix,
+        "    return key in OPTIONS\n" + suffix,
         encoding="utf-8",
     )
     tree = SourceFile.from_path(path)
@@ -39,9 +38,7 @@ def _source(tmp_path: Path, name: str, *, suffix: str = ""):
 
 
 def _context(binding, *, kind: str):
-    value = MutableGlobalValue(
-        "OPTIONS", kind, binding.source_cid, binding.seal()
-    )
+    value = MutableGlobalValue("OPTIONS", kind, binding.source_cid, binding.seal())
     ctx = ReduceContext.root(owner="mutable-global-membership")
     return value, ctx.with_temporal(ctx.temporal.bind_value("OPTIONS", value))
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_mutable_global_value.py
@@ -9,6 +9,7 @@ from sugar_source_tree.nodes import Name, Subscript
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+
 def _identity(name: str):
     from sugar_lift_py_tests.floor.ground_exit import (
         _builtin_exception_identity,
@@ -16,7 +17,6 @@ def _identity(name: str):
 
     identity, _mro = _builtin_exception_identity(name)
     return identity
-
 
 
 def _sites(tmp_path, source: str, filename: str):
@@ -32,15 +32,14 @@ def _sites(tmp_path, source: str, filename: str):
     return binding, lookup
 
 
-def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_faces(tmp_path, monkeypatch):
+def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_faces(
+    tmp_path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     binding, site = _sites(
-        tmp_path,
-        "OPTIONS = {}\nvalue = OPTIONS[key]\n", "mutable_global_truth.py"
+        tmp_path, "OPTIONS = {}\nvalue = OPTIONS[key]\n", "mutable_global_truth.py"
     )
-    value = MutableGlobalValue(
-        "OPTIONS", "dict", binding.source_cid, binding.seal()
-    )
+    value = MutableGlobalValue("OPTIONS", "dict", binding.source_cid, binding.seal())
     term = value.to_term(owner="test")
 
     exits = value.subscript(StringValue("display.max_rows"), site)
@@ -66,19 +65,19 @@ def test_mutable_dict_global_lookup_preserves_complementary_value_and_keyerror_f
     assert next(iter(halted.faces)).partition == next(iter(completed.faces)).partition
 
 
-def test_mutable_dict_global_lookup_refuses_foreign_source_coordinate(tmp_path, monkeypatch):
+def test_mutable_dict_global_lookup_refuses_foreign_source_coordinate(
+    tmp_path, monkeypatch
+):
     monkeypatch.chdir(tmp_path)
     binding, truthful = _sites(
-        tmp_path,
-        "OPTIONS = {}\nvalue = OPTIONS[key]\n", "mutable_global_truth.py"
+        tmp_path, "OPTIONS = {}\nvalue = OPTIONS[key]\n", "mutable_global_truth.py"
     )
     _foreign_binding, foreign = _sites(
         tmp_path,
-        "OPTIONS = {}\nvalue = OPTIONS[other_key]\n", "mutable_global_foreign.py"
+        "OPTIONS = {}\nvalue = OPTIONS[other_key]\n",
+        "mutable_global_foreign.py",
     )
-    value = MutableGlobalValue(
-        "OPTIONS", "dict", binding.source_cid, binding.seal()
-    )
+    value = MutableGlobalValue("OPTIONS", "dict", binding.source_cid, binding.seal())
 
     assert truthful is not binding
     assert len(value.subscript(StringValue("display.max_rows"), truthful).exits) == 2

--- a/implementations/python/sugar-lift-py-tests/tests/test_name_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_name_augassign_formal_caller.py
@@ -323,9 +323,7 @@ def test_halt_blocks_tail_read_of_partial_update() -> None:
     """Through reduce_block: iadd halt leaves temporal unbound for the name."""
     from sugar_lift_py_tests.context import ReduceContext
 
-    face = Incomplete(
-        CoverageGapEffect(boundary="iadd", reason="halt before rebind")
-    )
+    face = Incomplete(CoverageGapEffect(boundary="iadd", reason="halt before rebind"))
 
     class _Halt(FloorValue):
         def inplace_binary_operator_with(self, operation, ctx):
@@ -424,12 +422,9 @@ def test_authenticated_formal_discharge_updates_binding() -> None:
     assert isinstance(pending, NativeOperationExitCarrierV1)
     assert pending.demand.operator == "iadd"
     coords = {
-        c.declared_name: c.coordinate_cid
-        for c in function.sugar().formal_coordinates
+        c.declared_name: c.coordinate_cid for c in function.sugar().formal_coordinates
     }
-    exits = pending.discharge(
-        {coords["x"]: TermValue(3), coords["rhs"]: TermValue(4)}
-    )
+    exits = pending.discharge({coords["x"]: TermValue(3), coords["rhs"]: TermValue(4)})
     assert isinstance(exits, ExitSet)
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Completed)
@@ -461,9 +456,7 @@ def test_arithmetic_halt_is_not_completed_return_of_prior_binding() -> None:
     assert isinstance(outcome, ExitSet)
     halted = [e for e in outcome.exits if isinstance(e, Halted)]
     assert halted, outcome.exits
-    assert any(
-        getattr(e.effect, "exception_name", None) == "TypeError" for e in halted
-    )
+    assert any(getattr(e.effect, "exception_name", None) == "TypeError" for e in halted)
     for face in (e for e in outcome.exits if isinstance(e, Completed)):
         from sugar_lift_py_tests.floor.return_value import ReturnValue
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_named_expression_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_named_expression_subscript_mutation.py
@@ -12,7 +12,9 @@ def _sites(tmp_path):
         "    (bound := None)[0] = value\n"
         "    del (bound := None)[0]\n"
     )
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -20,17 +22,30 @@ def _value():
     return NamedExpressionValue("bound", NoneValue())
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "NoneValue.setitem", 0), ("delitem", "NoneValue.delitem", 1)))
-def test_named_expression_subscript_mutations_dispatch_to_exact_presented_owner(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = _value()
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (("setitem", "NoneValue.setitem", 0), ("delitem", "NoneValue.delitem", 1)),
+)
+def test_named_expression_subscript_mutations_dispatch_to_exact_presented_owner(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = _value()
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_named_expression_subscript_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = _value()
-    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = _value()
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_exit_carrier.py
@@ -99,9 +99,7 @@ def test_short_circuit_truthful_second_leg_joins_untouched_stopping_face():
     continuing_guard = atomic("test:first-leg-truth", [])
     continuing_face, stopped_face = partition("test:carrier-short-circuit")
     stopped_value = TermValue(41)
-    stopped = ExitSet.completed(
-        stopped_value, complement_guard(continuing_guard)
-    )
+    stopped = ExitSet.completed(stopped_value, complement_guard(continuing_guard))
 
     exits = carrier.short_circuit(
         continuing_guard=continuing_guard,
@@ -137,9 +135,7 @@ def test_short_circuit_lying_second_leg_retains_its_authentic_halt_occurrence():
     carrier, left, right = _carrier(operator="less_than")
     continuing_guard = atomic("test:first-leg-truth", [])
     continuing_face, stopped_face = partition("test:carrier-short-circuit-halt")
-    stopped = ExitSet.completed(
-        TermValue(42), complement_guard(continuing_guard)
-    )
+    stopped = ExitSet.completed(TermValue(42), complement_guard(continuing_guard))
 
     raw = carrier.discharge(
         {
@@ -180,7 +176,9 @@ def test_short_circuit_preserves_first_leg_halt_without_stopping_face():
             first_right.coordinate_cid: TermValue(2),
         }
     )
-    first_halt = next(exit_ for exit_ in first_result.exits if isinstance(exit_, Halted))
+    first_halt = next(
+        exit_ for exit_ in first_result.exits if isinstance(exit_, Halted)
+    )
 
     second, second_left, second_right = _carrier(operator="less_than")
     continuing_guard = atomic("test:first-leg-completed-truthy", [])
@@ -189,9 +187,9 @@ def test_short_circuit_preserves_first_leg_halt_without_stopping_face():
     stopped = ExitSet(
         (
             first_halt,
-            ExitSet.completed(
-                stopped_value, complement_guard(continuing_guard)
-            ).exits[0],
+            ExitSet.completed(stopped_value, complement_guard(continuing_guard)).exits[
+                0
+            ],
         )
     )
 
@@ -235,9 +233,7 @@ def test_short_circuit_exception_keeps_actual_map_and_exact_temporal_state():
 
     exits = carrier.short_circuit(
         continuing_guard=continuing_guard,
-        stopped=ExitSet.completed(
-            TermValue(0), complement_guard(continuing_guard)
-        ),
+        stopped=ExitSet.completed(TermValue(0), complement_guard(continuing_guard)),
         continuing_face=continuing_face,
         stopped_face=stopped_face,
     ).discharge(actuals)
@@ -257,9 +253,7 @@ def test_short_circuit_missing_second_leg_actual_remains_explicitly_undischarged
     continuing_face, stopped_face = partition("test:short-circuit-undischarged")
     composed = carrier.short_circuit(
         continuing_guard=continuing_guard,
-        stopped=ExitSet.completed(
-            TermValue(0), complement_guard(continuing_guard)
-        ),
+        stopped=ExitSet.completed(TermValue(0), complement_guard(continuing_guard)),
         continuing_face=continuing_face,
         stopped_face=stopped_face,
     )
@@ -519,10 +513,12 @@ def test_complementary_guard_tooth_rejects_same_guard_mutation():
 
 def test_multiple_guards_are_explicitly_conjoined():
     carrier, left, right = _carrier()
-    exits = carrier.guarded(atomic("outer", [])).guarded(
-        atomic("inner", [])
-    ).discharge(
-        {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+    exits = (
+        carrier.guarded(atomic("outer", []))
+        .guarded(atomic("inner", []))
+        .discharge(
+            {left.coordinate_cid: TermValue(1), right.coordinate_cid: TermValue(2)}
+        )
     )
     assert exits.exits[0].guard.kind == "and"
     assert len(exits.exits[0].guard.operands) == 2
@@ -583,7 +579,9 @@ def test_same_native_operation_demand_can_halt_for_authenticated_actuals():
     assert isinstance(halted, Halted)
     assert halted.effect.exception_name is None
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
-    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+    assert (
+        isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence!r}"
     )
@@ -888,7 +886,9 @@ def test_setitem_discharges_and_halts_with_named_exception_identity():
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("IndexError").identity
-    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+    assert (
+        isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence!r}"
     )
@@ -1060,12 +1060,10 @@ def test_production_minted_operators_equal_projector_table_exactly():
     missing_projectors = production - projectors
     orphan_projectors = projectors - production
     assert missing_projectors == frozenset(), (
-        "production mints operators with no projector: "
-        f"{sorted(missing_projectors)}"
+        "production mints operators with no projector: " f"{sorted(missing_projectors)}"
     )
     assert orphan_projectors == frozenset(), (
-        "projectors with no production mint path: "
-        f"{sorted(orphan_projectors)}"
+        "projectors with no production mint path: " f"{sorted(orphan_projectors)}"
     )
     assert "subscript" in projectors
     assert "setitem" in projectors
@@ -1099,9 +1097,7 @@ def test_symbolic_formal_subscript_discharges_completed_through_projector():
 
     exits = outcome.discharge(
         {
-            receiver_coordinate.coordinate_cid: ListValue(
-                (TermValue(7), TermValue(8))
-            ),
+            receiver_coordinate.coordinate_cid: ListValue((TermValue(7), TermValue(8))),
         }
     )
     assert len(exits.exits) == 1
@@ -1123,14 +1119,14 @@ def test_symbolic_formal_subscript_discharges_authenticated_exceptional_through_
     assert isinstance(outcome, NativeOperationExitCarrierV1)
     assert outcome.demand.operator == "subscript"
 
-    exits = outcome.discharge(
-        {receiver_coordinate.coordinate_cid: NoneValue()}
-    )
+    exits = outcome.discharge({receiver_coordinate.coordinate_cid: NoneValue()})
     assert len(exits.exits) == 1
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _Expected("TypeError").identity
-    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+    assert (
+        isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_pre_effect_state.py
@@ -26,7 +26,6 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import ClassDef, FunctionDef
 from sugar_source_tree.tree import SourceFile
 
-
 SOURCE = (
     "class Widget:\n"
     "    @property\n"
@@ -100,7 +99,10 @@ def test_setattr_exception_and_boundary_share_exact_pre_effect_state() -> None:
     assert halted.state is testimony.state
     assert halted.effect.exception_name == "AttributeError"
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_operation_prefix_carrier.py
@@ -89,7 +89,9 @@ def test_completed_prefix_arms_stay_deferred_and_retain_all_testimony() -> None:
     first_obligation = _Pending("first", (_Demand("first-demand"),))
     second_obligation = _Pending("second", (_Demand("second-demand"),))
     stopped_state = object()
-    stopped_effect = UndeterminedRaiseEffect(blame="prefix-halt", occurrence="prefix-halt")
+    stopped_effect = UndeterminedRaiseEffect(
+        blame="prefix-halt", occurrence="prefix-halt"
+    )
     prefix = ExitSet(
         (
             Completed(
@@ -152,7 +154,9 @@ def test_incompatible_prefix_carrier_demands_refuse_loudly() -> None:
         )
     )
 
-    with pytest.raises(ConstructionPanic, match="incompatible native-operation demands"):
+    with pytest.raises(
+        ConstructionPanic, match="incompatible native-operation demands"
+    ):
         NativeOperationExitCarrierV1.compose_prefix(
             prefix,
             lambda value: first if value == TermValue(1) else second,

--- a/implementations/python/sugar-lift-py-tests/tests/test_native_protocol_definition_refs.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_native_protocol_definition_refs.py
@@ -27,7 +27,10 @@ def test_native_protocol_slots_share_one_authenticated_definition_door():
         {},
         {(receiver, NativeProtocolSlot.CONTEXT_EXIT): definition},
     )
-    assert refs.require_native_definition(receiver, NativeProtocolSlot.CONTEXT_EXIT) == definition
+    assert (
+        refs.require_native_definition(receiver, NativeProtocolSlot.CONTEXT_EXIT)
+        == definition
+    )
     gap = refs.require_native_definition(receiver, NativeProtocolSlot.TRUTH)
     assert isinstance(gap, NativeDefinitionCoordinateGapV1)
     assert gap.reason.startswith("authenticated source definition")

--- a/implementations/python/sugar-lift-py-tests/tests/test_nested_source_return_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_nested_source_return_projection.py
@@ -85,12 +85,7 @@ def _calls_named(tree, name: str) -> list[Call]:
     ]
 
 
-NESTED = (
-    "def inner():\n"
-    "    return 3\n"
-    "def outer():\n"
-    "    return inner()\n"
-)
+NESTED = "def inner():\n" "    return 3\n" "def outer():\n" "    return inner()\n"
 
 
 # ---------------------------------------------------------------------------
@@ -99,9 +94,7 @@ NESTED = (
 
 
 def test_inner_alone_projects_return_floor() -> None:
-    tree, context, functions = _tree(
-        NESTED + "\ninner()\n", bind=frozenset({"inner"})
-    )
+    tree, context, functions = _tree(NESTED + "\ninner()\n", bind=frozenset({"inner"}))
     call = _calls_named(tree, "inner")[0]
     frame = context.source_call_frames[_coordinate(call)]
     outcome = call.sugar().desugar(None)
@@ -110,18 +103,14 @@ def test_inner_alone_projects_return_floor() -> None:
     assert outcome.value.body is not None
     # Authenticated source call: coordinate is frame CID, not bare spelling.
     assert outcome.value.source_call_frame_cid == frame.frame_cid
-    floor = outcome.value.force_floor(
-        None, owner="inner-alone", project_callsite=False
-    )
+    floor = outcome.value.force_floor(None, owner="inner-alone", project_callsite=False)
     assert isinstance(floor.statements[0], ReturnValue)
     assert floor.statements[0].value == TermValue(3)
     del functions
 
 
 def test_outer_alone_carries_inner_call_in_body() -> None:
-    tree, context, _ = _tree(
-        NESTED + "\nouter()\n", bind=frozenset({"outer", "inner"})
-    )
+    tree, context, _ = _tree(NESTED + "\nouter()\n", bind=frozenset({"outer", "inner"}))
     call = _calls_named(tree, "outer")[0]
     frame = context.source_call_frames[_coordinate(call)]
     outcome = call.sugar().desugar(None)
@@ -134,9 +123,12 @@ def test_outer_alone_carries_inner_call_in_body() -> None:
     assert dug is not None
     # Occurrence of outer is this call site's enrolled frame, not inner's.
     assert outcome.value.site is not None
-    assert outcome.value.source_call_frame_cid != context.source_call_frames[
-        _coordinate(_calls_named(tree, "inner")[0])
-    ].frame_cid
+    assert (
+        outcome.value.source_call_frame_cid
+        != context.source_call_frames[
+            _coordinate(_calls_named(tree, "inner")[0])
+        ].frame_cid
+    )
 
 
 def test_both_call_occurrences_are_distinct_coordinates() -> None:
@@ -180,9 +172,7 @@ def test_swapped_inner_outer_frame_testimony_is_not_truthful() -> None:
         (source, "swap.py", blake3_512_of(source.encode())),
         construction_context=context,
     )
-    functions = {
-        n.name: n for n in tree.nodes() if isinstance(n, FunctionDef)
-    }
+    functions = {n.name: n for n in tree.nodes() if isinstance(n, FunctionDef)}
     outer_call = _calls_named(tree, "outer")[0]
     inner_call = _calls_named(tree, "inner")[0]
     outer_frame = functions["outer"].source_visible_call_frame()
@@ -197,9 +187,7 @@ def test_swapped_inner_outer_frame_testimony_is_not_truthful() -> None:
         (source, "truth.py", blake3_512_of(source.encode())),
         construction_context=truth_ctx,
     )
-    truth_fns = {
-        n.name: n for n in truth_tree.nodes() if isinstance(n, FunctionDef)
-    }
+    truth_fns = {n.name: n for n in truth_tree.nodes() if isinstance(n, FunctionDef)}
     truth_outer = _calls_named(truth_tree, "outer")[0]
     truth_inner = _calls_named(truth_tree, "inner")[0]
     truth_ctx.source_call_frames[_coordinate(truth_outer)] = truth_fns[
@@ -216,14 +204,12 @@ def test_swapped_inner_outer_frame_testimony_is_not_truthful() -> None:
     # without the inner() call hop — not isomorphic to truthful outer.
     assert swapped.value.body != truthful.value.body or (
         swapped.value.parameters != truthful.value.parameters
-        or swapped.value.source_call_frame_cid
-        != truthful.value.source_call_frame_cid
+        or swapped.value.source_call_frame_cid != truthful.value.source_call_frame_cid
     )
     # Frame CIDs on the CallSiteValue must not match the truthful outer frame
     # when testimony was swapped.
     assert (
-        swapped.value.source_call_frame_cid
-        != truthful.value.source_call_frame_cid
+        swapped.value.source_call_frame_cid != truthful.value.source_call_frame_cid
         or swapped.value.body != truthful.value.body
     )
 
@@ -249,12 +235,14 @@ def test_recursion_by_name_is_not_the_transport() -> None:
     a = alpha_call.sugar().desugar(None).value
     b = beta_call.sugar().desugar(None).value
     # Frame CIDs distinguish alpha vs beta — not target_name spelling.
-    assert a.source_call_frame_cid == context.source_call_frames[
-        _coordinate(alpha_call)
-    ].frame_cid
-    assert b.source_call_frame_cid == context.source_call_frames[
-        _coordinate(beta_call)
-    ].frame_cid
+    assert (
+        a.source_call_frame_cid
+        == context.source_call_frames[_coordinate(alpha_call)].frame_cid
+    )
+    assert (
+        b.source_call_frame_cid
+        == context.source_call_frames[_coordinate(beta_call)].frame_cid
+    )
     assert a.source_call_frame_cid != b.source_call_frame_cid
     af = a.force_floor(None, owner="alpha", project_callsite=False)
     bf = b.force_floor(None, owner="beta", project_callsite=False)
@@ -277,20 +265,24 @@ def test_two_hop_return_feeds_binop_through_both_frames() -> None:
     direct_src = "3 + 1\n"
     helper_tree, _, _ = _tree(helper_src, bind=frozenset({"outer", "inner"}))
     direct_tree, _, _ = _tree(direct_src, bind=frozenset())
-    direct = next(n for n in direct_tree.nodes() if isinstance(n, BinOp)).sugar().desugar(
-        None
+    direct = (
+        next(n for n in direct_tree.nodes() if isinstance(n, BinOp))
+        .sugar()
+        .desugar(None)
     )
 
     try:
-        helper = next(
-            n for n in helper_tree.nodes() if isinstance(n, BinOp)
-        ).sugar().desugar(None)
+        helper = (
+            next(n for n in helper_tree.nodes() if isinstance(n, BinOp))
+            .sugar()
+            .desugar(None)
+        )
     except (ConstructionPanic, SugarNotWritten) as exc:
         pytest.fail(f"{CODEX3_OWNER} two-hop binop: {exc}")
 
-    assert isinstance(helper, (Complete, ExitSet)), (
-        f"{CODEX3_OWNER} outcome={type(helper).__name__}"
-    )
+    assert isinstance(
+        helper, (Complete, ExitSet)
+    ), f"{CODEX3_OWNER} outcome={type(helper).__name__}"
 
     def _val(outcome):
         if isinstance(outcome, Complete):
@@ -300,9 +292,9 @@ def test_two_hop_return_feeds_binop_through_both_frames() -> None:
         return completed[0].value
 
     hv, dv = _val(helper), _val(direct)
-    assert hv == dv or getattr(hv, "value", hv) == getattr(dv, "value", dv), (
-        f"{CODEX3_OWNER} helper={hv!r} direct={dv!r}"
-    )
+    assert hv == dv or getattr(hv, "value", hv) == getattr(
+        dv, "value", dv
+    ), f"{CODEX3_OWNER} helper={hv!r} direct={dv!r}"
 
 
 def test_two_hop_preserves_outer_and_inner_occurrences_on_dig_path() -> None:
@@ -321,9 +313,10 @@ def test_two_hop_preserves_outer_and_inner_occurrences_on_dig_path() -> None:
     inner_call = _calls_named(tree, "inner")[0]
     outer_cs = outer_call.sugar().desugar(None).value
     assert outer_cs.source_call_frame_cid is not None
-    assert outer_cs.source_call_frame_cid == context.source_call_frames[
-        _coordinate(outer_call)
-    ].frame_cid
+    assert (
+        outer_cs.source_call_frame_cid
+        == context.source_call_frames[_coordinate(outer_call)].frame_cid
+    )
     # Inner frame remains enrolled under its own coordinate after outer desugar.
     inner_frame = context.source_call_frames[_coordinate(inner_call)]
     assert inner_frame.frame_cid != outer_cs.source_call_frame_cid

--- a/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_no_call_body_attribution.py
@@ -41,7 +41,10 @@ def _probe(family: ProducerFamily, evaluator) -> BodyProbe:
 def _raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(exception_type_coordinate=str_const('TypeError'), occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'))
+            RaiseEffect(
+                exception_type_coordinate=str_const("TypeError"),
+                occurrence=AuthenticatedRaiseLocus.of("pandas/example.py:1:4"),
+            )
         )
     )
 
@@ -82,7 +85,11 @@ def _nameless_raise_value():
 def _call_owned_raise_value():
     return Complete(
         RaiseValue(
-            RaiseEffect(exception_type_coordinate=str_const('TypeError'), occurrence=AuthenticatedRaiseLocus.of('pandas/example.py:1:4'), producer_node_owner='Call')
+            RaiseEffect(
+                exception_type_coordinate=str_const("TypeError"),
+                occurrence=AuthenticatedRaiseLocus.of("pandas/example.py:1:4"),
+                producer_node_owner="Call",
+            )
         )
     )
 
@@ -718,6 +725,7 @@ def test_selected_family_denominator_remains_fixed() -> None:
 
 def test_attribute_family_denominator_is_native_root_inventory() -> None:
     assert FAMILY_DENOMINATORS[ProducerFamily.ATTRIBUTE] == 53
+
 
 def test_discovery_has_no_last_named_exclusions_side_channel() -> None:
     """Lying twin: the side-channel shell must not reappear.

--- a/implementations/python/sugar-lift-py-tests/tests/test_none_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_none_subscript_mutation.py
@@ -14,7 +14,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "none_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -33,9 +35,16 @@ class _Value(Sugar):
 
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
-    store = SubscriptStoreEffectSugar(_Value(NoneValue()), _Value(TermValue(0)), _Value(TermValue(7)), store_site).desugar()
-    delete = SubscriptDeleteEffectSugar(_Value(NoneValue()), _Value(TermValue(0)), delete_site).desugar()
-    return ((store, "NoneValue.setitem", store_site), (delete, "NoneValue.delitem", delete_site))
+    store = SubscriptStoreEffectSugar(
+        _Value(NoneValue()), _Value(TermValue(0)), _Value(TermValue(7)), store_site
+    ).desugar()
+    delete = SubscriptDeleteEffectSugar(
+        _Value(NoneValue()), _Value(TermValue(0)), delete_site
+    ).desugar()
+    return (
+        (store, "NoneValue.setitem", store_site),
+        (delete, "NoneValue.delitem", delete_site),
+    )
 
 
 def test_none_subscript_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_method_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_method_attribute_mutation.py
@@ -9,11 +9,11 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "object_method_attribute_mutation.py"
     path.write_text(
-        "def mutate_method(method):\n"
-        "    method.attr = 7\n"
-        "    del method.attr\n"
+        "def mutate_method(method):\n" "    method.attr = 7\n" "    del method.attr\n"
     )
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -21,17 +21,33 @@ def _value(site):
     return ObjectMethodValue("method", ("self",), TrueBoolLiteralSugar(site=site))
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "ObjectMethodValue.setattr", 0), ("delattr", "ObjectMethodValue.delattr", 1)))
-def test_object_method_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = _value(site)
-    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "ObjectMethodValue.setattr", 0),
+        ("delattr", "ObjectMethodValue.delattr", 1),
+    ),
+)
+def test_object_method_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = _value(site)
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
     assert outcome.value.effect.exception_name == "AttributeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_object_method_attribute_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = _value(store_site)
-    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = _value(store_site)
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_object_method_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_object_method_subscript_mutation.py
@@ -9,9 +9,7 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "object_method_subscript_mutation.py"
     path.write_text(
-        "def mutate_method(method):\n"
-        "    method[0] = 7\n"
-        "    del method[0]\n"
+        "def mutate_method(method):\n" "    method[0] = 7\n" "    del method[0]\n"
     )
     body = next(
         SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()

--- a/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_one_authoritative_scoreboard.py
@@ -81,7 +81,8 @@ def test_every_module_that_emits_an_r_quantity_declares_its_authority() -> None:
     producers = _board_producers()
     assert producers, "recognizer found no R-emitting module — it walked the wrong tree"
     undeclared = sorted(
-        str(path.relative_to(KIT)) for path, declared in producers.items()
+        str(path.relative_to(KIT))
+        for path, declared in producers.items()
         if declared is None
     )
     assert not undeclared, (

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_caller_twins.py
@@ -425,9 +425,7 @@ def test_authenticated_box_expected_actual_names_type_error_edge(
         if isinstance(node, SourceBinOp)
         and node.line_col_span().start_line == pair.operation.lineno
     )
-    produced = actual_return.value.add(
-        StringValue("a"), helper_operation.fragment
-    )
+    produced = actual_return.value.add(StringValue("a"), helper_operation.fragment)
     raised = produced.value
     assert raised.effect.exception_type_coordinate == ctor(
         "python:exception_type_identity",
@@ -505,8 +503,10 @@ def test_installed_box_expected_source_call_has_an_authenticated_frame(
         context.source_call_resolutions[coordinate],
         SourceCallPreconstructionRefV1,
     )
-    result = call.sugar().desugar(None).value._dig_floor_or_none(
-        None, owner="installed box_expected return"
+    result = (
+        call.sugar()
+        .desugar(None)
+        .value._dig_floor_or_none(None, owner="installed box_expected return")
     )
     assert result is not None
     assert not isinstance(result, CallSiteValue)

--- a/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pandas_binary_operation_exception_floor.py
@@ -46,6 +46,7 @@ class _ValueSugar(ConstructedTermSugar):
             symbol_kind="coordinate",
         )
 
+
 # Content manifest (relative path + per-file BLAKE3-512). Path-shape
 # sha256:a223… is historical negative testimony only — never identity.
 PANDAS_MANIFEST_CID = (

--- a/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_parameter_contract_resume_twins.py
@@ -74,7 +74,9 @@ def _resolution(
 
 
 def _good_set(unit, cand, owned):
-    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(
+        cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid
+    )
     return (
         ParameterContractResolutionSetV1.mint(
             link_unit_cid=unit.link_unit_cid, resolutions=(res,)
@@ -101,7 +103,9 @@ def test_twin_missing_resolution_panics():
 
 def test_twin_duplicate_resolution_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(
+        cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid
+    )
     rset = ParameterContractResolutionSetV1.mint(
         link_unit_cid=unit.link_unit_cid, resolutions=(res, res)
     )
@@ -111,7 +115,9 @@ def test_twin_duplicate_resolution_panics():
 
 def test_twin_stale_resolution_cid_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(
+        cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid
+    )
     res["resolutionCid"] = "blake3-512:" + "0" * 128
     rset = ParameterContractResolutionSetV1.mint(
         link_unit_cid=unit.link_unit_cid, resolutions=(res,)
@@ -146,7 +152,9 @@ def test_twin_wrong_candidate_panics():
 
 def test_twin_lost_continuation_panics():
     unit, cand, owned = _link_unit()
-    res = _resolution(cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid)
+    res = _resolution(
+        cand.sole_demand().demand_cid, cand.candidate_cid, owned.contract_cid
+    )
     # a set minted for a DIFFERENT continuation key
     foreign = ParameterContractResolutionSetV1.mint(
         link_unit_cid="blake3-512:" + "9" * 128, resolutions=(res,)

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py
@@ -61,7 +61,6 @@ from sugar_lift_py_tests.outcome.exit_set import (
 )
 from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
 
-
 OPERAND_COUNTS = (1, 2, 3, 4, 5, 6, 7, 8)
 
 
@@ -80,7 +79,14 @@ def _partitioning_arm(name: str):
     return ExitSet(
         (
             Completed(condition, f"{name}-value"),
-            Halted(not_(condition), RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:163:0'), None),
+            Halted(
+                not_(condition),
+                RaiseEffect.for_builtin(
+                    "ValueError",
+                    occurrence="implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:163:0",
+                ),
+                None,
+            ),
         )
     )
 
@@ -160,7 +166,10 @@ def test_the_halted_arm_survives_the_factoring():
     halted = [exit_ for exit_ in exits.exits if isinstance(exit_, Halted)]
 
     assert len(halted) == 1
-    assert halted[0].effect == RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:83:0')
+    assert halted[0].effect == RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_partition_arm_growth.py:83:0",
+    )
 
 
 def test_both_faces_values_survive_inside_the_guarded_chain():

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_demand_conservation.py
@@ -80,7 +80,7 @@ def test_every_face_of_a_partition_carries_the_demand() -> None:
             Completed(ctor("g_true", []), TermValue(7), (), ()),
             Halted(
                 ctor("g_false", []),
-                RaiseEffect.for_builtin('ValueError', blame=BLAME, occurrence=BLAME),
+                RaiseEffect.for_builtin("ValueError", blame=BLAME, occurrence=BLAME),
                 None,
                 (),
                 (),

--- a/implementations/python/sugar-lift-py-tests/tests/test_partition_family_admission.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partition_family_admission.py
@@ -290,9 +290,7 @@ def test_the_loops_exit_partition_is_two_faced_and_excludes_the_latch():
     carried, and it claims nothing. That is the honest state for an edge that
     is not an exit.
     """
-    brk, done = partition_family(
-        "loop@target", ("BreakExit", "NormalExhaustion")
-    )
+    brk, done = partition_family("loop@target", ("BreakExit", "NormalExhaustion"))
 
     assert brk.arity == done.arity == 2
     factored = ExitSet(

--- a/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_pending_contract_partition_arm.py
@@ -81,7 +81,10 @@ def test_partition_join_puts_the_obligation_on_every_face():
     partitioned = ExitSet(
         (
             Completed(_guard("hot"), "then-value"),
-            Halted(_guard("cold"), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")),
+            Halted(
+                _guard("cold"),
+                RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
+            ),
         )
     )
 
@@ -103,7 +106,10 @@ def test_partition_join_does_not_pick_one_face():
     partitioned = ExitSet(
         (
             Completed(_guard("hot"), "then-value"),
-            Halted(_guard("cold"), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom")),
+            Halted(
+                _guard("cold"),
+                RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
+            ),
         )
     )
 
@@ -123,9 +129,7 @@ def test_partition_join_conserves_an_obligation_the_face_already_owed():
     one: two distinct constructions, two carriers, nothing conjoined."""
     already = _carrier("other", ordinal=1, line=7)
     pending = _carrier()
-    partitioned = ExitSet(
-        (Completed(true_guard(), "v", frozenset(), (already,)),)
-    )
+    partitioned = ExitSet((Completed(true_guard(), "v", frozenset(), (already,)),))
 
     joined = rewrap_pending(
         pending, partitioned, owner="test", blame=pending.source_node
@@ -133,9 +137,7 @@ def test_partition_join_conserves_an_obligation_the_face_already_owed():
 
     (arm,) = joined.exits
     assert len(arm.pending_contracts) == 2
-    assert _cids(arm.pending_contracts) == sorted(
-        _cids((already,)) + _cids((pending,))
-    )
+    assert _cids(arm.pending_contracts) == sorted(_cids((already,)) + _cids((pending,)))
 
 
 def test_partition_join_is_idempotent_on_the_same_construction():
@@ -143,9 +145,7 @@ def test_partition_join_is_idempotent_on_the_same_construction():
     outcome DAG is ONE obligation -- `F and F` IS `F`. Exact cardinality: `!= 1`
     would be satisfied by the 2 this is meant to exclude."""
     pending = _carrier()
-    partitioned = ExitSet(
-        (Completed(true_guard(), "v", frozenset(), (pending,)),)
-    )
+    partitioned = ExitSet((Completed(true_guard(), "v", frozenset(), (pending,)),))
 
     joined = rewrap_pending(
         pending, partitioned, owner="test", blame=pending.source_node
@@ -164,9 +164,7 @@ def test_an_unknown_outcome_kind_is_still_loud():
 
     pending = _carrier()
     with pytest.raises(ConstructionPanic):
-        rewrap_pending(
-            pending, object(), owner="test", blame=pending.source_node
-        )
+        rewrap_pending(pending, object(), owner="test", blame=pending.source_node)
 
 
 # ------------------------------------------------------ conservation laws ----
@@ -205,7 +203,10 @@ def test_sequence_carries_the_prefix_obligation_onto_every_tail_exit():
         return ExitSet(
             (
                 Completed(_guard("ok"), "tail"),
-                Halted(_guard("bad"), RaiseEffect.for_builtin("KeyError", blame="k", occurrence="k")),
+                Halted(
+                    _guard("bad"),
+                    RaiseEffect.for_builtin("KeyError", blame="k", occurrence="k"),
+                ),
             )
         )
 
@@ -229,9 +230,7 @@ def test_factoring_unions_obligations_rather_than_intersecting_them():
         (
             Completed(g, "a", frozenset(), (left,)),
             Completed(
-                __import__(
-                    "sugar_lift_py_tests.ir", fromlist=["not_"]
-                ).not_(g),
+                __import__("sugar_lift_py_tests.ir", fromlist=["not_"]).not_(g),
                 "b",
                 frozenset(),
                 (right,),
@@ -242,9 +241,7 @@ def test_factoring_unions_obligations_rather_than_intersecting_them():
     after = before.factor_completed()
 
     (arm,) = [e for e in after.exits if isinstance(e, Completed)]
-    assert _cids(arm.pending_contracts) == sorted(
-        _cids((left,)) + _cids((right,))
-    )
+    assert _cids(arm.pending_contracts) == sorted(_cids((left,)) + _cids((right,)))
 
 
 def test_arms_owing_different_things_do_not_merge():
@@ -339,7 +336,10 @@ def test_sole_completed_outcome_refuses_two_distinct_constructions():
                 true_guard(),
                 "v",
                 frozenset(),
-                (_carrier("left", ordinal=0, line=3), _carrier("right", ordinal=1, line=4)),
+                (
+                    _carrier("left", ordinal=0, line=3),
+                    _carrier("right", ordinal=1, line=4),
+                ),
             ),
         )
     )
@@ -434,7 +434,9 @@ def test_the_nested_statement_splice_conserves_faces_and_obligations():
             (
                 Halted(
                     _guard("h"),
-                    RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
+                    RaiseEffect.for_builtin(
+                        "ValueError", blame="boom", occurrence="boom"
+                    ),
                     inner,
                     frozenset({face}),
                     (pending,),
@@ -501,7 +503,15 @@ def test_an_arm_owing_nothing_never_reaches_the_refusal():
         _enrol_exit_obligations,
     )
 
-    clean = ExitSet((Halted(true_guard(), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"), None),))
+    clean = ExitSet(
+        (
+            Halted(
+                true_guard(),
+                RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
+                None,
+            ),
+        )
+    )
 
     assert _enrol_exit_obligations(clean) is clean
 
@@ -542,6 +552,10 @@ def test_a_stateless_halt_that_owes_nothing_keeps_its_state():
         _halt_state,
     )
 
-    clean = Halted(true_guard(), RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"), None)
+    clean = Halted(
+        true_guard(),
+        RaiseEffect.for_builtin("ValueError", blame="boom", occurrence="boom"),
+        None,
+    )
 
     assert _halt_state(_ReducedBlock(("earlier-entry",), True, ()), clean) is None

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -30,6 +30,7 @@ _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
+
 def _tiny_corpus(root: Path) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     (root / "a.py").write_text("x = 1\n", encoding="utf-8")
@@ -97,7 +98,9 @@ def test_mint_content_cid_stable_for_same_rows(tmp_path: Path) -> None:
 def test_mint_carries_distinct_storage_and_semantic_identities(tmp_path: Path) -> None:
     first_corpus = _tiny_corpus(tmp_path / "first")
     second_corpus = _tiny_corpus(tmp_path / "second")
-    (second_corpus / "b.py").write_text("def different():\n    return 2\n", encoding="utf-8")
+    (second_corpus / "b.py").write_text(
+        "def different():\n    return 2\n", encoding="utf-8"
+    )
     first = mint_prebuilt_demand_table(_authenticated(first_corpus))
     second = mint_prebuilt_demand_table(_authenticated(second_corpus))
     assert first.semantic_identity.content_key != second.semantic_identity.content_key
@@ -118,7 +121,9 @@ def test_validator_refuses_table_for_different_corpus(tmp_path: Path) -> None:
     other = _tiny_corpus(tmp_path / "other")
     (other / "b.py").write_text("def different():\n    return 2\n", encoding="utf-8")
     table = mint_prebuilt_demand_table(_authenticated(corpus))
-    with pytest.raises(DemandTableSemanticIdentityMismatch, match="semantic identity mismatch"):
+    with pytest.raises(
+        DemandTableSemanticIdentityMismatch, match="semantic identity mismatch"
+    ):
         validate_prebuilt_demand_table(table, _authenticated(other))
 
 
@@ -197,9 +202,7 @@ def test_load_refuses_tampered_content_cid(tmp_path: Path) -> None:
     bad = raw.replace(table.content_cid[-4:], "ffff", 1)
     artifact.write_text(bad, encoding="utf-8")
     with pytest.raises(DemandTableArtifactRefusal, match="contentCid mismatch"):
-        load_prebuilt_demand_table(
-            artifact, expected_corpus_pin=_expected_pin(corpus)
-        )
+        load_prebuilt_demand_table(artifact, expected_corpus_pin=_expected_pin(corpus))
 
 
 def test_load_refuses_plan_cid_mismatch(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_predicate_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_predicate_attribute_mutation.py
@@ -7,14 +7,23 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "predicate_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     value = PredicateValue(atomic("p", []))
-    return ((value.setattr("attr", TermValue(7), store_site), "PredicateValue.setattr", store_site), (value.delattr("attr", delete_site), "PredicateValue.delattr", delete_site))
+    return (
+        (
+            value.setattr("attr", TermValue(7), store_site),
+            "PredicateValue.setattr",
+            store_site,
+        ),
+        (value.delattr("attr", delete_site), "PredicateValue.delattr", delete_site),
+    )
 
 
 def test_predicate_attribute_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_predicate_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_predicate_subscript_mutation.py
@@ -7,14 +7,27 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "predicate_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     value = PredicateValue(atomic("p", []))
-    return ((value.setitem(TermValue(0), TermValue(7), store_site), "PredicateValue.setitem", store_site), (value.delitem(TermValue(0), delete_site), "PredicateValue.delitem", delete_site))
+    return (
+        (
+            value.setitem(TermValue(0), TermValue(7), store_site),
+            "PredicateValue.setitem",
+            store_site,
+        ),
+        (
+            value.delitem(TermValue(0), delete_site),
+            "PredicateValue.delitem",
+            delete_site,
+        ),
+    )
 
 
 def test_predicate_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_presealed_target_pattern_receipt.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_presealed_target_pattern_receipt.py
@@ -34,14 +34,10 @@ def _products(helper: str = "sink", *, suffix: str = ""):
         construction_context=context,
     )
     calls = tuple(node for node in tree.nodes() if isinstance(node, Call))
-    comprehensions = tuple(
-        node for node in tree.nodes() if isinstance(node, ListComp)
-    )
+    comprehensions = tuple(node for node in tree.nodes() if isinstance(node, ListComp))
     assert len(calls) == len(comprehensions) == 2
     sugars = tuple(call._construct_sugar() for call in calls)
-    patterns = tuple(
-        sugar.args[0].generators[0].target_pattern for sugar in sugars
-    )
+    patterns = tuple(sugar.args[0].generators[0].target_pattern for sugar in sugars)
     assert all(type(pattern) is TargetPatternV1 for pattern in patterns)
     return tree, comprehensions, sugars, patterns
 
@@ -167,4 +163,3 @@ def test_generic_mutable_dataclass_remains_loud() -> None:
     with pytest.raises(ConstructedValueCategoryGap) as gap:
         constructed_value_cid_v2(_UnrelatedMutableDataclass(1))
     assert "MUTABLE dataclass" in str(gap.value)
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py
@@ -15,7 +15,10 @@ from sugar_lift_py_tests.sugar.function_universe_sugar import _ReducedBlock
 
 def test_terminal_raise_with_prior_state_promotes_to_halt_only():
     marker = object()
-    effect = RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:39:0')
+    effect = RaiseEffect.for_builtin(
+        "OSError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:39:0",
+    )
     exits = ExitSet(
         (
             Completed(
@@ -36,7 +39,10 @@ def test_terminal_raise_with_prior_state_promotes_to_halt_only():
 def test_guarded_raise_keeps_its_complementary_completed_arm():
     marker = object()
     condition = make_var("condition")
-    effect = RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:18:0')
+    effect = RaiseEffect.for_builtin(
+        "OSError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_promote_terminal_raise_halts.py:18:0",
+    )
     exits = ExitSet(
         (
             Completed(

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_from_try_composition.py
@@ -120,7 +120,9 @@ def test_raise_outer_from_handler_binding_keeps_distinct_type_and_occurrence():
     cause_effect = effect.cause_value.effect
     assert isinstance(cause_effect, RaiseEffect)
     assert cause_effect.exception_name == "ValueError"
-    assert isinstance(cause_effect.occurrence, str) and ":" in cause_effect.occurrence, (
+    assert (
+        isinstance(cause_effect.occurrence, str) and ":" in cause_effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {cause_effect.occurrence!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_raise_matcher_subject_is_a_value.py
@@ -71,8 +71,8 @@ class _TermBearingHandler:
 
 def _valueless_effect() -> RaiseEffect:
     """The measured shape: a raise with no value and no authenticated type."""
-    return RaiseEffect.for_builtin("NameError",
-        
+    return RaiseEffect.for_builtin(
+        "NameError",
         blame=OCCURRENCE,
         occurrence=OCCURRENCE,
     )
@@ -160,8 +160,8 @@ def test_a_real_value_term_still_retains_the_question() -> None:
     as a refusal. A guard that refused everything would pass every test above
     and destroy the mechanism.
     """
-    effect = RaiseEffect.for_builtin("ValueError",
-        
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
         blame=OCCURRENCE,
         occurrence=OCCURRENCE,
         raised_value=TermValue(7),
@@ -179,16 +179,14 @@ def test_a_real_value_term_still_retains_the_question() -> None:
 def test_matching_halt_without_message_operand_retains_message_obligation() -> None:
     """Truthful twin: the raised VALUE exists, but its rendered message is open."""
     raised_value = TermValue(7)
-    effect = RaiseEffect.for_builtin("ValueError",
-        
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence=OCCURRENCE,
         raised_value=raised_value,
     )
     expected = _AuthenticatedHandler(effect.exception_type_coordinate)
 
-    verdict = raise_effect_message_verdict(
-        effect, expected, StringValue("boom")
-    )
+    verdict = raise_effect_message_verdict(effect, expected, StringValue("boom"))
 
     assert isinstance(verdict, MatchRetained)
     assert verdict.obligation.name == "py.re_search"
@@ -200,8 +198,8 @@ def test_matching_halt_without_message_operand_retains_message_obligation() -> N
 
 def test_valueless_halt_cannot_use_occurrence_as_message_evidence() -> None:
     """Lying twin: a source coordinate is not a rendered-message operand."""
-    effect = RaiseEffect.for_builtin("ValueError",
-        
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence=OCCURRENCE,
         raised_value=None,
     )
@@ -246,9 +244,7 @@ def test_written_empty_message_regex_rejects_a_nonempty_message() -> None:
     """Lying twin: treating written ``^$`` as absent would consume this halt."""
     effect, expected = _effect_with_message("boom")
 
-    constrained = raise_effect_message_verdict(
-        effect, expected, StringValue("^$")
-    )
+    constrained = raise_effect_message_verdict(effect, expected, StringValue("^$"))
     absent = raise_effect_message_verdict(effect, expected, None)
 
     assert constrained == MatchDecided(False)

--- a/implementations/python/sugar-lift-py-tests/tests/test_real_literal_constructed_term.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_real_literal_constructed_term.py
@@ -43,9 +43,7 @@ def test_real_literal_term_seals_value_sort_and_exact_occurrence() -> None:
     second = _unary("\n~3.5\n", "second.py").operand.sugar()
     integer_node = next(
         node
-        for node in SourceFile(
-            ("~3\n", "integer.py", blake3_512_of(b"~3\n"))
-        ).nodes()
+        for node in SourceFile(("~3\n", "integer.py", blake3_512_of(b"~3\n"))).nodes()
         if isinstance(node, Constant)
     )
     integer = integer_node.sugar()

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -76,8 +76,9 @@ def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():
     receiver = ObjectValue("Renamed", (), identity="receiver-1")
     stored = TermValue(17)
     context = ReduceContext.root(owner="receiver-field-store").with_temporal(
-        ReduceContext.root(owner="receiver-field-store-seed")
-        .temporal.bind_value("self", receiver)
+        ReduceContext.root(owner="receiver-field-store-seed").temporal.bind_value(
+            "self", receiver
+        )
     )
 
     exits = reduce_block_to_exitset(
@@ -109,9 +110,7 @@ def test_returned_alias_observes_updated_mapping_receiver_identity():
 
     assert len(exits) == 1
     returned = next(
-        entry
-        for entry in exits[0].value.entries
-        if isinstance(entry, ReturnValue)
+        entry for entry in exits[0].value.entries if isinstance(entry, ReturnValue)
     ).value
     assert isinstance(returned, MappingObjectValue)
     assert returned.identity == receiver.identity
@@ -133,9 +132,7 @@ def test_same_class_different_receiver_identity_is_not_rewritten():
     ).exits
 
     returned = next(
-        entry
-        for entry in exits[0].value.entries
-        if isinstance(entry, ReturnValue)
+        entry for entry in exits[0].value.entries if isinstance(entry, ReturnValue)
     ).value
     assert returned is distinct
     assert returned.identity == "receiver-2"

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_owned_mapping_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_owned_mapping_mutation.py
@@ -36,24 +36,34 @@ def test_builtin_super_setitem_carries_receiver_transition_and_none_separately()
 
     assert isinstance(outcome, Complete)
     assert isinstance(outcome.value, ReceiverOwnedMutationResult)
-    assert isinstance(outcome.value.project_operation_receiver(None, owner="test"), NoneValue)
+    assert isinstance(
+        outcome.value.project_operation_receiver(None, owner="test"), NoneValue
+    )
     assert outcome.value.receiver_before is receiver
     assert outcome.value.receiver_after.identity == receiver.identity
-    assert outcome.value.receiver_after.entries == ((StringValue("member"), TermValue(7)),)
+    assert outcome.value.receiver_after.entries == (
+        (StringValue("member"), TermValue(7)),
+    )
 
 
 def test_receiver_transition_updates_every_exact_identity_alias_only():
     definition, receiver = _definition_and_receiver()
     distinct = MappingObjectValue("Mapping", (), identity="other")
-    result = BuiltinSuperValue(definition, receiver).call_method_value(
-        "__setitem__",
-        (StringValue("member"), TermValue(7)),
-        owner="test",
-        blame="site",
-    ).value
+    result = (
+        BuiltinSuperValue(definition, receiver)
+        .call_method_value(
+            "__setitem__",
+            (StringValue("member"), TermValue(7)),
+            owner="test",
+            blame="site",
+        )
+        .value
+    )
     ctx = ReduceContext.root(owner="test")
     ctx = ctx.with_temporal(ctx.temporal.bind_value("left", receiver))
-    ctx = ctx.with_temporal(ctx.temporal.bind_value("alias", receiver.mapping_with_entries(())))
+    ctx = ctx.with_temporal(
+        ctx.temporal.bind_value("alias", receiver.mapping_with_entries(()))
+    )
     ctx = ctx.with_temporal(ctx.temporal.bind_value("distinct", distinct))
 
     updated = result.extend_scope(ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_bounded_run_equivalence.py
@@ -69,9 +69,7 @@ def _invoke(argv: list[str], capsys=None) -> Completed:
         from sugar_lift_py_tests.corpus_pin import pin_corpus
 
         root = Path(argv[argv.index("--corpus-root") + 1]).resolve()
-        observed = pin_corpus(
-            root, distribution=root.name, version="test-pin"
-        )
+        observed = pin_corpus(root, distribution=root.name, version="test-pin")
         module._PANDAS_3_0_3_AGGREGATE_HASH = observed.aggregate_hash
         module._PANDAS_3_0_3_MANIFEST_SHAPE_CID = corpus_cid(list(observed.paths))
     saved = sys.argv

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_denominator_complete_schema.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_denominator_complete_schema.py
@@ -6,7 +6,6 @@ import importlib.util
 import sys
 from pathlib import Path
 
-
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 _SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_preflight.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_runtime_preflight.py
@@ -11,7 +11,6 @@ import pytest
 
 import sugar_lift_py_tests.authenticated_pytest as runtime_authority
 
-
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 _SCRIPT = _SCRIPTS / "control_effect_recensus.py"
 
@@ -80,7 +79,9 @@ def test_wrong_runtime_refuses_before_even_missing_corpus_selection(
     )
     receipt = tmp_path / "wrong-runtime.json"
 
-    assert _invoke(module, corpus=tmp_path / "corpus-does-not-exist", receipt=receipt) == 2
+    assert (
+        _invoke(module, corpus=tmp_path / "corpus-does-not-exist", receipt=receipt) == 2
+    )
     body = json.loads(receipt.read_text(encoding="utf-8"))
     assert body["kind"] == "control-effect-recensus-unmeasured/v1"
     assert body["status"] == "unmeasured"
@@ -113,7 +114,9 @@ def test_runtime_hash_failure_is_separate_and_never_fabricates_identity(
     )
     receipt = tmp_path / "identity-failure.json"
 
-    assert _invoke(module, corpus=tmp_path / "corpus-does-not-exist", receipt=receipt) == 2
+    assert (
+        _invoke(module, corpus=tmp_path / "corpus-does-not-exist", receipt=receipt) == 2
+    )
     body = json.loads(receipt.read_text(encoding="utf-8"))
     assert body["status"] == "unmeasured"
     assert body["requiredRuntime"] == "cpython-3.12.13"

--- a/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py
@@ -7,7 +7,10 @@ from sugar_lift_py_tests.sugar import function_universe_sugar
 
 
 def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
-    effect = RaiseEffect.for_builtin('AttributeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:26:0')
+    effect = RaiseEffect.for_builtin(
+        "AttributeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:26:0",
+    )
     pre_effect_state = object()
     exits = ExitSet((Halted(true_guard(), effect, pre_effect_state),))
     monkeypatch.setattr(
@@ -23,7 +26,10 @@ def test_reduce_body_retains_one_unconditional_stateful_halt(monkeypatch):
 
 
 def test_reduce_body_still_collapses_one_unconditional_stateless_halt(monkeypatch):
-    effect = RaiseEffect.for_builtin('AttributeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:10:0')
+    effect = RaiseEffect.for_builtin(
+        "AttributeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_reduce_body_stateful_halt.py:10:0",
+    )
     exits = ExitSet((Halted(true_guard(), effect),))
     monkeypatch.setattr(
         function_universe_sugar,
@@ -34,4 +40,3 @@ def test_reduce_body_still_collapses_one_unconditional_stateless_halt(monkeypatc
     reduced = function_universe_sugar.reduce_body(())
 
     assert reduced == Incomplete(effect)
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py
@@ -57,7 +57,6 @@ from sugar_lift_py_tests.floor.raise_value import (
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 from sugar_lift_py_tests.ir import ctor, str_const
 
-
 _SHA = "a" * 64
 _LOCUS = "pkg/mod.py:12:4"
 
@@ -77,7 +76,10 @@ def _named_cited_effect(**overrides) -> RaiseEffect:
         occurrence=_LOCUS,
     )
     fields.update(overrides)
-    return RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:79:0')
+    return RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:79:0",
+    )
 
 
 def _coordinate_cited_effect(**overrides) -> RaiseEffect:
@@ -92,7 +94,11 @@ def _coordinate_cited_effect(**overrides) -> RaiseEffect:
         occurrence=_LOCUS,
     )
     fields.update(overrides)
-    return RaiseEffect(occurrence=AuthenticatedRaiseLocus.of('implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:94:0'))
+    return RaiseEffect(
+        occurrence=AuthenticatedRaiseLocus.of(
+            "implementations/python/sugar-lift-py-tests/tests/test_render_edge_exceptional_exit_citation.py:94:0"
+        )
+    )
 
 
 def _is_fabricated_constant(node: ast.AST) -> str | None:
@@ -156,8 +162,16 @@ def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
     is the signal the stronger substrate arrived and this note can retire.
     There is no hard-coded R=1; the probe is the absence of those markers.
     """
-    auditor = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_auditor.py"
-    evidence = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_evidence.py"
+    auditor = (
+        Path(__file__).resolve().parents[4]
+        / "tests"
+        / "sourcefile_construction_door_auditor.py"
+    )
+    evidence = (
+        Path(__file__).resolve().parents[4]
+        / "tests"
+        / "sourcefile_construction_door_evidence.py"
+    )
     assert auditor.is_file(), auditor
     assert evidence.is_file(), evidence
 
@@ -170,7 +184,7 @@ def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
         "render-edge fabrication and retire this module's blind-spot claim"
     )
     assert "exceptional_exit" not in auditor_text
-    assert "or \"reraise\"" not in auditor_text
+    assert 'or "reraise"' not in auditor_text
     assert "source-sha256" not in auditor_text
     assert "RenderEdge" not in evidence_text
     assert "exceptional_exit" not in evidence_text
@@ -185,13 +199,13 @@ def test_law_of_one_auditor_cannot_see_render_edge_fabrication() -> None:
 
 def test_ast_tooth_lying_twin_or_reraise_is_visible() -> None:
     """Planted BoolOp ``or`` second mechanism must be recognized."""
-    planted = '''
+    planted = """
 def _exceptional_exit_term(effect):
     name = effect.exception_name or "reraise"
     cite = effect.source_sha256 or "unavailable"
     locus = effect.blame or "<unknown raise locus>"
     return name, cite, locus
-'''
+"""
     offenders = fabricated_meaning_offenders(planted, path="planted.py")
     assert len(offenders) == 3, offenders
     assert any("reraise" in row for row in offenders)
@@ -205,13 +219,13 @@ def test_ast_tooth_lying_twin_ifexp_reraise_is_visible() -> None:
     The historical AST tooth only saw BoolOp ``or``. Reintroduction via
     ``x if c else "reraise"`` is the same second mechanism in different clothes.
     """
-    planted = '''
+    planted = """
 def _exceptional_exit_term(effect):
     name = effect.exception_name if effect.exception_name is not None else "reraise"
     cite = "unavailable" if effect.source_sha256 is None else effect.source_sha256
     locus = effect.blame if effect.blame is not None else "<unknown raise locus>"
     return name, cite, locus
-'''
+"""
     offenders = fabricated_meaning_offenders(planted, path="planted_ifexp.py")
     assert len(offenders) == 3, offenders
     assert any("reraise" in row for row in offenders)
@@ -222,9 +236,7 @@ def _exceptional_exit_term(effect):
 def test_ast_tooth_truthful_raise_value_has_zero_fabricated_meaning_defaults() -> None:
     """Production emission door: R=0 for fabricated-meaning default shapes."""
     source = _RAISE_VALUE_PATH.read_text(encoding="utf-8")
-    offenders = fabricated_meaning_offenders(
-        source, path=str(_RAISE_VALUE_PATH)
-    )
+    offenders = fabricated_meaning_offenders(source, path=str(_RAISE_VALUE_PATH))
     assert offenders == [], (
         "render-edge emission invents meaning via default literal; "
         "Law of One: identity comes from the tree only. Offenders:\n"
@@ -234,21 +246,21 @@ def test_ast_tooth_truthful_raise_value_has_zero_fabricated_meaning_defaults() -
 
 def test_ast_tooth_does_not_flag_boolean_existence_ors() -> None:
     """``name is not None or coord is not None`` is existence, not meaning."""
-    clean = '''
+    clean = """
 def has_identity(effect):
     return (
         effect.exception_name is not None
         or effect.exception_type_coordinate is not None
     )
-'''
+"""
     assert fabricated_meaning_offenders(clean) == []
 
 
 def test_ast_tooth_does_not_flag_ifexp_without_fabricated_literal() -> None:
-    clean = '''
+    clean = """
 def pick(a, b, c):
     return a if c else b
-'''
+"""
     assert fabricated_meaning_offenders(clean) == []
 
 
@@ -324,7 +336,9 @@ def test_nameless_raise_value_post_contribution_stays_loud() -> None:
 
 def test_name_without_source_sha_cannot_cite_unavailable() -> None:
     """Placeholder ``#source-sha256=unavailable`` is absent evidence, not a cite."""
-    effect = RaiseEffect.for_builtin('ValueError', blame=_LOCUS, source_sha256=None, occurrence=_LOCUS)
+    effect = RaiseEffect.for_builtin(
+        "ValueError", blame=_LOCUS, source_sha256=None, occurrence=_LOCUS
+    )
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -337,7 +351,9 @@ def test_name_without_source_sha_cannot_cite_unavailable() -> None:
 
 def test_name_without_blame_cannot_cite_unknown_locus() -> None:
     """Placeholder ``<unknown raise locus>`` is not a re-readable citation."""
-    effect = RaiseEffect.for_builtin('ValueError', blame=None, source_sha256=_SHA, occurrence=None)
+    effect = RaiseEffect.for_builtin(
+        "ValueError", blame=None, source_sha256=_SHA, occurrence=None
+    )
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -368,7 +384,9 @@ def test_exception_name_reraise_placeholder_cannot_reach_fol() -> None:
     citable exit after the first refuse-placeholders shot. Fabricated
     identity is not authenticated identity.
     """
-    effect = RaiseEffect.for_builtin('reraise', blame=_LOCUS, source_sha256=_SHA, occurrence=_LOCUS)
+    effect = RaiseEffect.for_builtin(
+        "reraise", blame=_LOCUS, source_sha256=_SHA, occurrence=_LOCUS
+    )
 
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
@@ -385,7 +403,12 @@ def test_exception_name_reraise_placeholder_cannot_reach_fol() -> None:
 )
 def test_every_fabricated_meaning_literal_as_name_is_loud(placeholder: str) -> None:
     """Every denylist member as exception_name is an offender class, not a name."""
-    effect = RaiseEffect(occurrence=AuthenticatedRaiseLocus.of(_LOCUS), exception_name=placeholder, blame=_LOCUS, source_sha256=_SHA)
+    effect = RaiseEffect(
+        occurrence=AuthenticatedRaiseLocus.of(_LOCUS),
+        exception_name=placeholder,
+        blame=_LOCUS,
+        source_sha256=_SHA,
+    )
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
     assert placeholder in raised.value.info.observed
@@ -394,7 +417,9 @@ def test_every_fabricated_meaning_literal_as_name_is_loud(placeholder: str) -> N
 
 def test_empty_exception_name_cannot_reach_fol() -> None:
     """Empty spelling is not tree-authenticated identity."""
-    effect = RaiseEffect.for_builtin('', blame=_LOCUS, source_sha256=_SHA, occurrence=_LOCUS)
+    effect = RaiseEffect.for_builtin(
+        "", blame=_LOCUS, source_sha256=_SHA, occurrence=_LOCUS
+    )
     with pytest.raises(ConstructionPanic) as raised:
         _exceptional_exit_term(effect)
     assert "empty" in raised.value.info.observed

--- a/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_repo_root_door.py
@@ -32,18 +32,18 @@ def _write_marker(repo: Path) -> Path:
     repo.mkdir(parents=True, exist_ok=True)
     marker = repo / MARKER
     marker.write_text(
-        textwrap.dedent(
-            """\
+        textwrap.dedent("""\
             [tools]
             python = "3.12.13"
-            """
-        ),
+            """),
         encoding="utf-8",
     )
     return marker
 
 
-def test_resolves_by_walking_from_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolves_by_walking_from_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo = tmp_path / "checkout"
     _write_marker(repo)
     nested = repo / "implementations" / "python" / "sugar-lift-py-tests"
@@ -76,7 +76,9 @@ def test_site_packages_layout_resolves_via_github_workspace(
         / "sugar_lift_py_tests"
     )
     site_pkg.mkdir(parents=True)
-    (site_pkg / "authenticated_pytest.py").write_text("# fake install\n", encoding="utf-8")
+    (site_pkg / "authenticated_pytest.py").write_text(
+        "# fake install\n", encoding="utf-8"
+    )
     # Cwd is the temp env (wrong for parents[N]); env names the checkout.
     monkeypatch.chdir(tmp_path / "sugar-python-test-environment")
     monkeypatch.delenv("SUGAR_REPO_ROOT", raising=False)

--- a/implementations/python/sugar-lift-py-tests/tests/test_runtime_identity_v1.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_runtime_identity_v1.py
@@ -13,9 +13,9 @@ import sugar_lift_py_tests.authenticated_pytest as authority
 
 
 def _require_v1_api() -> None:
-    assert hasattr(authority, "RuntimeIdentityV1"), (
-        "runtimeIdentity/v1 is not implemented at the authenticated interpreter door"
-    )
+    assert hasattr(
+        authority, "RuntimeIdentityV1"
+    ), "runtimeIdentity/v1 is not implemented at the authenticated interpreter door"
     assert hasattr(authority, "observe_runtime_identity_v1")
     assert hasattr(authority, "runtime_cid_for_identity")
     assert hasattr(authority, "authenticate_runtime_identity_v1")
@@ -74,9 +74,9 @@ def test_changed_runtime_bytes_change_hash_and_runtime_cid(
     right = _observe_with_base(monkeypatch, invoked=second, base=second)
 
     assert left.executable_sha256 != right.executable_sha256
-    assert authority.runtime_cid_for_identity(left) != authority.runtime_cid_for_identity(
-        right
-    )
+    assert authority.runtime_cid_for_identity(
+        left
+    ) != authority.runtime_cid_for_identity(right)
 
 
 def test_runtime_identity_wire_matches_observed_v1_shape(

--- a/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_self_sealing_instrument_law.py
@@ -23,8 +23,7 @@ def _classes(source: str) -> set[str]:
 
 def test_each_reject_class_has_a_structural_planted_twin() -> None:
     """Lying twin: each subclass is recognized when planted."""
-    assert _classes(
-        """
+    assert _classes("""
 def audit():
     projection_calls = []
     if not projection_calls:
@@ -32,29 +31,22 @@ def audit():
             EvidenceSite(Path(__file__).resolve(), 1, (), audit.__name__)
         ]
     assert projection_calls
-"""
-    ) == {"SYNTHESIZED-EVIDENCE"}
+""") == {"SYNTHESIZED-EVIDENCE"}
 
-    assert _classes(
-        """
+    assert _classes("""
 def test_conserves():
     enrolled = 1
     assert enrolled == enrolled
-"""
-    ) == {"TAUTOLOGICAL-ASSERT"}
+""") == {"TAUTOLOGICAL-ASSERT"}
 
-    assert _classes(
-        """
+    assert _classes("""
 def test_halt_identity():
     assert halted.effect.exception_type_coordinate is not None
-"""
-    ) == {"PRESENCE-ONLY-IDENTITY"}
+""") == {"PRESENCE-ONLY-IDENTITY"}
 
-    assert _classes(
-        """
+    assert _classes("""
 def test_occurrence():
-"""
-    ) == {"PRESENCE-ONLY-IDENTITY"}
+""") == {"PRESENCE-ONLY-IDENTITY"}
 
 
 def test_discrimination_negatives_do_not_false_positive() -> None:
@@ -115,7 +107,9 @@ def test_sourcefile_construction_door_live_self_seed_is_drained() -> None:
     auditor = repo / "tests" / "sourcefile_construction_door_auditor.py"
     assert auditor.is_file(), auditor
     source = auditor.read_text(encoding="utf-8")
-    findings = LAW.scan_python_source(source, "tests/sourcefile_construction_door_auditor.py")
+    findings = LAW.scan_python_source(
+        source, "tests/sourcefile_construction_door_auditor.py"
+    )
     synthesized = [f for f in findings if f.violation_class == "SYNTHESIZED-EVIDENCE"]
     assert synthesized == [], (
         "R_synthesized_evidence regression on sourcefile_construction_door_auditor: "

--- a/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sequence_membership_floor.py
@@ -102,9 +102,7 @@ def test_nested_list_membership_is_decided_from_constructed_members():
     needle = ListValue((TermValue(1),))
     missing = ListValue((TermValue(3),))
     assert isinstance(container.contains(needle, "site").value, TrueBoolLiteralSugar)
-    assert isinstance(
-        container.contains(missing, "site").value, FalseBoolLiteralSugar
-    )
+    assert isinstance(container.contains(missing, "site").value, FalseBoolLiteralSugar)
 
 
 def test_nested_tuple_membership_is_decided_from_constructed_members():
@@ -121,9 +119,7 @@ def test_nested_tuple_membership_is_decided_from_constructed_members():
     needle = TupleValue((TermValue(1),))
     missing = TupleValue((TermValue(9),))
     assert isinstance(container.contains(needle, "site").value, TrueBoolLiteralSugar)
-    assert isinstance(
-        container.contains(missing, "site").value, FalseBoolLiteralSugar
-    )
+    assert isinstance(container.contains(missing, "site").value, FalseBoolLiteralSugar)
 
 
 def test_string_substring_membership_is_decided():

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_attribute_mutation.py
@@ -12,7 +12,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "set_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -32,9 +34,14 @@ class _Value(Sugar):
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     receiver = SetValue((TermValue(1),))
-    store = AttributeStoreEffectSugar(_Value(receiver), _Value(TermValue(7)), "attr", store_site).desugar()
+    store = AttributeStoreEffectSugar(
+        _Value(receiver), _Value(TermValue(7)), "attr", store_site
+    ).desugar()
     delete = AttributeDeleteEffectSugar(_Value(receiver), "attr", delete_site).desugar()
-    return ((store, "SetValue.setattr", store_site), (delete, "SetValue.delattr", delete_site))
+    return (
+        (store, "SetValue.setattr", store_site),
+        (delete, "SetValue.delattr", delete_site),
+    )
 
 
 def test_set_attribute_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_literal_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_literal_attribute_mutation.py
@@ -8,17 +8,33 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "set_literal_attribute_mutation.py"
-    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "SetLiteralValue.setattr", 0), ("delattr", "SetLiteralValue.delattr", 1)))
-def test_set_literal_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "SetLiteralValue.setattr", 0),
+        ("delattr", "SetLiteralValue.delattr", 1),
+    ),
+)
+def test_set_literal_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
     sites = _sites(tmp_path)
     site = sites[site_index]
     value = SetLiteralValue((num(1),))
-    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
     assert outcome.value.effect.exception_name == "AttributeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_literal_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_literal_subscript_mutation.py
@@ -8,17 +8,33 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "set_literal_subscript_mutation.py"
-    path.write_text("def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "SetLiteralValue.setitem", 0), ("delitem", "SetLiteralValue.delitem", 1)))
-def test_set_literal_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "SetLiteralValue.setitem", 0),
+        ("delitem", "SetLiteralValue.delitem", 1),
+    ),
+)
+def test_set_literal_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
     sites = _sites(tmp_path)
     site = sites[site_index]
     value = SetLiteralValue((num(1),))
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_set_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_set_subscript_mutation.py
@@ -12,7 +12,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "set_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -32,9 +34,16 @@ class _Value(Sugar):
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
     receiver = SetValue((TermValue(1),))
-    store = SubscriptStoreEffectSugar(_Value(receiver), _Value(TermValue(0)), _Value(TermValue(7)), store_site).desugar()
-    delete = SubscriptDeleteEffectSugar(_Value(receiver), _Value(TermValue(0)), delete_site).desugar()
-    return ((store, "SetValue.setitem", store_site), (delete, "SetValue.delitem", delete_site))
+    store = SubscriptStoreEffectSugar(
+        _Value(receiver), _Value(TermValue(0)), _Value(TermValue(7)), store_site
+    ).desugar()
+    delete = SubscriptDeleteEffectSugar(
+        _Value(receiver), _Value(TermValue(0)), delete_site
+    ).desugar()
+    return (
+        (store, "SetValue.setitem", store_site),
+        (delete, "SetValue.delitem", delete_site),
+    )
 
 
 def test_set_subscript_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_method_caller.py
@@ -53,9 +53,7 @@ from sugar_source_tree.nodes import Attribute, Call, ClassDef, FunctionDef
 from sugar_source_tree.tree import SourceFile
 
 METHOD_BODY = (
-    "class Writer:\n"
-    "    def store(self, obj, value):\n"
-    "        obj.field = value\n"
+    "class Writer:\n" "    def store(self, obj, value):\n" "        obj.field = value\n"
 )
 
 METHOD_DEFAULTS = (
@@ -69,10 +67,7 @@ TARGET_CLASS = "class Target:\n    pass\n"
 
 # Property getter without setter — store path must AttributeError.
 PROPERTY_TARGET = (
-    "class Target:\n"
-    "    @property\n"
-    "    def field(self):\n"
-    "        return 1\n"
+    "class Target:\n" "    @property\n" "    def field(self):\n" "        return 1\n"
 )
 
 
@@ -155,8 +150,11 @@ def _assert_named_halt(outcome, *, require_pre_effect_state: bool = True) -> Hal
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("AttributeError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -245,11 +243,7 @@ def _floor_target_arg(arg) -> ObjectValue:
 
 def test_bound_self_does_not_shift_obj_value_coordinates() -> None:
     """Positional method call binds self, then obj/value in declaration order."""
-    source = (
-        TARGET_CLASS
-        + METHOD_BODY
-        + "\nWriter().store(Target(), 7)\n"
-    )
+    source = TARGET_CLASS + METHOD_BODY + "\nWriter().store(Target(), 7)\n"
     callsite = _method_callsite(source)
     _assert_bound_self_first(callsite)
     target = _floor_target_arg(callsite.arg_values[1])
@@ -300,9 +294,7 @@ def test_positional_keyword_and_default_method_calls_discharge() -> None:
             TARGET_CLASS + METHOD_BODY + "\nWriter().store(Target(), 7)\n"
         ),
         _method_callsite(
-            TARGET_CLASS
-            + METHOD_BODY
-            + "\nWriter().store(obj=Target(), value=7)\n"
+            TARGET_CLASS + METHOD_BODY + "\nWriter().store(obj=Target(), value=7)\n"
         ),
         _method_callsite(
             TARGET_CLASS + METHOD_DEFAULTS + "\nWriter().store(Target())\n"
@@ -419,11 +411,7 @@ def test_getter_only_property_method_call_binds_and_floor_refuses_store() -> Non
     pre-effect state identity; producer_outcome over an undug constructor arg
     is not the discharge instrument.
     """
-    source = (
-        PROPERTY_TARGET
-        + METHOD_BODY
-        + "\nWriter().store(Target(), 7)\n"
-    )
+    source = PROPERTY_TARGET + METHOD_BODY + "\nWriter().store(Target(), 7)\n"
     site = _method_callsite(source)
     _assert_bound_self_first(site)
     target = _floor_target_arg(site.arg_values[1])

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_formal_caller.py
@@ -96,8 +96,11 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("AttributeError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -228,7 +231,7 @@ def test_source_defined_property_without_setter_named_attribute_error() -> None:
     exits = pending.discharge({obj_cid: receiver, value_cid: TermValue(7)})
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
+    assert halted.effect.exception_type_coordinate == _identity("AttributeError")
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
     assert halted.effect.occurrence_id == str(site)
 
@@ -288,7 +291,10 @@ def test_source_defined_wrong_boundary_type_leaves_halt_unconsumed() -> None:
         if isinstance(face, Halted) and face.effect is original.effect
     ]
     assert remaining == [original]
-    assert isinstance(remaining[0].effect.occurrence_id, str) and ":" in remaining[0].effect.occurrence_id, (
+    assert (
+        isinstance(remaining[0].effect.occurrence_id, str)
+        and ":" in remaining[0].effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {remaining[0].effect.occurrence_id!r}"
     )
@@ -370,7 +376,7 @@ def test_positional_caller_completes_field_store_via_setattr() -> None:
 def test_positional_caller_halts_with_named_identity_from_setattr() -> None:
     halted = _assert_named_halt(_call_outcome("obj, value", "1, 2"))
     # Origin is store dispatch, not a fabricated boundary type alone.
-    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
+    assert halted.effect.exception_type_coordinate == _identity("AttributeError")
     # Source call presentation may name the Call producer for the edge; the
     # type coordinate is still from setattr floor discharge, not pytest.raises.
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
@@ -394,7 +400,7 @@ def test_tuple_receiver_store_halts_from_setattr_not_boundary() -> None:
     )
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('AttributeError')
+    assert halted.effect.exception_type_coordinate == _identity("AttributeError")
     assert halted.effect.occurrence_id == str(site)
     assert "AttributeError" in repr(halted.effect.exception_type_coordinate)
     # Direct setattr owner is proven on the incomplete path before carrier
@@ -543,7 +549,10 @@ def test_wrong_expected_type_leaves_exceptional_edge_unconsumed() -> None:
     assert produced_type != wrong
     # The exceptional edge is still present (unconsumed by a wrong boundary).
     assert isinstance(halted, Halted)
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setattr_named_variadic_binding.py
@@ -185,9 +185,7 @@ def test_empty_star_stores_honest_empty_tuple() -> None:
     assert isinstance(exits.exits[0], Completed)
     record = exits.exits[0].value.record
     assert any(
-        isinstance(s, ObjectValue)
-        and s.fields
-        and s.fields[-1].value == TupleValue(())
+        isinstance(s, ObjectValue) and s.fields and s.fields[-1].value == TupleValue(())
         for s in record.statements
     )
 
@@ -262,7 +260,10 @@ def test_getter_only_property_named_attributeerror_with_star_pack() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("AttributeError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_formal_caller.py
@@ -72,8 +72,11 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('TypeError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("TypeError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -309,7 +312,10 @@ def test_invalid_index_halts_with_named_indexerror() -> None:
     halted = exits.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_method_caller.py
@@ -140,8 +140,11 @@ def _assert_named_halt(outcome) -> Halted:
     assert len(outcome.exits) == 1
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
-    assert halted.effect.exception_type_coordinate == _identity('IndexError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("IndexError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -232,9 +235,7 @@ def test_discrimination_self_is_not_the_setitem_receiver_slot() -> None:
 def test_positional_keyword_and_default_method_calls_discharge() -> None:
     sites = (
         _method_callsite(METHOD_BODY + "\nHolder().store([0], 0, 9)\n"),
-        _method_callsite(
-            METHOD_BODY + "\nHolder().store(obj=[0], key=0, value=9)\n"
-        ),
+        _method_callsite(METHOD_BODY + "\nHolder().store(obj=[0], key=0, value=9)\n"),
         _method_callsite(METHOD_DEFAULTS + "\nHolder().store([0])\n"),
     )
     for site in sites:

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_parameter_kinds.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_parameter_kinds.py
@@ -208,7 +208,10 @@ def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_setitem_variadic_binding.py
@@ -266,7 +266,10 @@ def test_invalid_index_named_indexerror_with_exact_pre_effect_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_silent_zero_tolerance.py
@@ -119,9 +119,7 @@ def test_register_only_matches_discharge_silent_offenders(tmp_path: Path) -> Non
         path.write_text(source, encoding="utf-8")
         _, reg = _SCANNER._audit_file(path, rel=name)
         _, dis = _SCANNER._audit_file_discharge(path, rel=name)
-        assert reg == dis, (
-            f"{name}: register-only {reg!r} != discharge {dis!r}"
-        )
+        assert reg == dis, f"{name}: register-only {reg!r} != discharge {dis!r}"
 
 
 def test_register_only_matches_discharge_on_small_kit_file() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_2_ordering_floor.py
@@ -72,7 +72,9 @@ def _floor_value_path() -> Path:
     )
 
 
-def test_sourcefile_construction_door_auditor_cannot_see_ordering_floor_meaning_sin() -> None:
+def test_sourcefile_construction_door_auditor_cannot_see_ordering_floor_meaning_sin() -> (
+    None
+):
     """LOUD: repository SOURCEFILE_CONSTRUCTION_DOOR auditor is SourceFile-owner scoped only.
 
     It does not AST-walk floor ordering doors for Complete(PredicateValue).
@@ -80,7 +82,11 @@ def test_sourcefile_construction_door_auditor_cannot_see_ordering_floor_meaning_
     gains a floor-meaning denominator — do not pretend the shared auditor
     closed this sin.
     """
-    auditor = Path(__file__).resolve().parents[4] / "tests" / "sourcefile_construction_door_auditor.py"
+    auditor = (
+        Path(__file__).resolve().parents[4]
+        / "tests"
+        / "sourcefile_construction_door_auditor.py"
+    )
     assert auditor.is_file(), "sourcefile_construction_door_auditor.py must exist"
     text = auditor.read_text(encoding="utf-8")
     assert "less_than_from_left" not in text
@@ -104,8 +110,13 @@ def test_floor_value_ordering_defaults_never_mint_predicate_complete() -> None:
             if item.name not in _ORDERING_METHODS:
                 continue
             for child in ast.walk(item):
-                if isinstance(child, ast.Name) and child.id == "resolve_comparison_atom":
-                    offenders.append(f"{item.name}:{child.lineno}:resolve_comparison_atom")
+                if (
+                    isinstance(child, ast.Name)
+                    and child.id == "resolve_comparison_atom"
+                ):
+                    offenders.append(
+                        f"{item.name}:{child.lineno}:resolve_comparison_atom"
+                    )
                 if isinstance(child, ast.Call):
                     func = child.func
                     if isinstance(func, ast.Name) and func.id == "Complete":
@@ -114,8 +125,13 @@ def test_floor_value_ordering_defaults_never_mint_predicate_complete() -> None:
                         # on the default doors (ground arms live on subclasses).
                         offenders.append(f"{item.name}:{child.lineno}:Complete(...)")
                     if isinstance(func, ast.Name) and func.id == "PredicateValue":
-                        offenders.append(f"{item.name}:{child.lineno}:PredicateValue(...)")
-                    if isinstance(func, ast.Attribute) and func.attr == "PredicateValue":
+                        offenders.append(
+                            f"{item.name}:{child.lineno}:PredicateValue(...)"
+                        )
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and func.attr == "PredicateValue"
+                    ):
                         offenders.append(
                             f"{item.name}:{child.lineno}:…PredicateValue(...)"
                         )
@@ -141,9 +157,10 @@ def test_undecided_ordering_operand_throws_named_never_complete(method: str) -> 
     with pytest.raises(SugarNotWritten) as raised:
         getattr(left, method)(right, SITE)
     assert "undecided" in raised.value.observed.lower()
-    assert "ordering" in raised.value.observed.lower() or "ordering" in (
-        raised.value.requested or ""
-    ).lower()
+    assert (
+        "ordering" in raised.value.observed.lower()
+        or "ordering" in (raised.value.requested or "").lower()
+    )
 
 
 @pytest.mark.parametrize(
@@ -272,9 +289,7 @@ def test_lying_residual_ordering_predicate_mint_panics_at_publisher() -> None:
         )
     )
     with pytest.raises(ConstructionPanic) as raised:
-        outcome = publish_undecided_ordering_edges(
-            left, right, SITE, "Lt", forged
-        )
+        outcome = publish_undecided_ordering_edges(left, right, SITE, "Lt", forged)
         if isinstance(outcome, ExitSet):
             raise AssertionError(
                 "residual ordering PredicateValue dual-edged — SIN reintroduced"
@@ -332,9 +347,10 @@ def test_lying_dual_edge_is_not_undecided_binary_answer() -> None:
         outcome = _symbolic().subtract(TermValue(1), SITE)
         if isinstance(outcome, ExitSet):
             for face in outcome.exits:
-                if isinstance(face, Halted) and getattr(
-                    face.effect, "exception_name", "missing"
-                ) is None:
+                if (
+                    isinstance(face, Halted)
+                    and getattr(face.effect, "exception_name", "missing") is None
+                ):
                     raise AssertionError(
                         "nameless binary halt is the SIN: TypeError boundary "
                         "can never match it"
@@ -357,9 +373,10 @@ def test_undecided_contains_is_named_refusal_not_complete_or_panic() -> None:
 
     with pytest.raises(SugarNotWritten) as raised:
         _symbolic().contains(TermValue(1), SITE)
-    assert "membership" in (raised.value.requested or "").lower() or "contain" in (
-        raised.value.observed or ""
-    ).lower()
+    assert (
+        "membership" in (raised.value.requested or "").lower()
+        or "contain" in (raised.value.observed or "").lower()
+    )
     # Not a construction panic harness failure.
     assert not isinstance(raised.value, ConstructionPanic)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_6_enumeration_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_sin_cluster_6_enumeration_door.py
@@ -220,10 +220,7 @@ def test_resolve_function_for_call_by_coordinate() -> None:
 
 
 def test_resolve_function_for_call_miss_throws_named() -> None:
-    source = (
-        "def test_a():\n"
-        "    assert unknown_callee(1) == 1\n"
-    )
+    source = "def test_a():\n" "    assert unknown_callee(1) == 1\n"
     tree = _tree(source)
     list(tree.functions())
     call = next(

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_subscript_store_formal_caller.py
@@ -338,9 +338,7 @@ def test_dict_rhs_projects_authenticated_insertion_order_keys() -> None:
     rhs = DictValue(
         ((StringValue("a"), TermValue(1)), (StringValue("b"), TermValue(2)))
     )
-    out = ListValue((TermValue(0),)).setitem(
-        SliceValue(None, None, None), rhs, site
-    )
+    out = ListValue((TermValue(0),)).setitem(SliceValue(None, None, None), rhs, site)
     assert out == Complete(ListValue((StringValue("a"), StringValue("b"))))
 
 
@@ -349,9 +347,7 @@ def test_dict_rhs_is_not_values_or_typeerror() -> None:
     rhs = DictValue(
         ((StringValue("a"), TermValue(1)), (StringValue("b"), TermValue(2)))
     )
-    out = ListValue((TermValue(0),)).setitem(
-        SliceValue(None, None, None), rhs, site
-    )
+    out = ListValue((TermValue(0),)).setitem(SliceValue(None, None, None), rhs, site)
     assert out != Complete(ListValue((TermValue(1), TermValue(2))))
     from sugar_lift_py_tests.floor import RaiseValue
 
@@ -413,7 +409,9 @@ def test_production_store_sugar_with_slice_index_completes() -> None:
             return ()
 
     sugar = SubscriptStoreEffectSugar(
-        receiver=_Obs("receiver", ListValue((TermValue(0), TermValue(1), TermValue(2)))),
+        receiver=_Obs(
+            "receiver", ListValue((TermValue(0), TermValue(1), TermValue(2)))
+        ),
         index=SliceSugar(
             IntLiteralSugar(0, site=site),
             IntLiteralSugar(2, site=site),
@@ -462,9 +460,7 @@ def test_positional_caller_completes_slice_store() -> None:
         "[0, 1, 2, 3], [9, 9]",
     )
     stored = _stored_list(outcome)
-    assert stored == ListValue(
-        (TermValue(0), TermValue(9), TermValue(9), TermValue(3))
-    )
+    assert stored == ListValue((TermValue(0), TermValue(9), TermValue(9), TermValue(3)))
 
 
 def test_keyword_caller_completes_slice_store() -> None:
@@ -484,9 +480,7 @@ def test_default_caller_completes_slice_store() -> None:
         "[0, 1, 2, 3]",
     )
     stored = _stored_list(outcome)
-    assert stored == ListValue(
-        (TermValue(0), TermValue(7), TermValue(7), TermValue(3))
-    )
+    assert stored == ListValue((TermValue(0), TermValue(7), TermValue(7), TermValue(3)))
 
 
 def test_full_slice_caller_replaces_entire_list() -> None:
@@ -615,9 +609,7 @@ def test_formal_bound_demand_gap_is_executable_red_law() -> None:
     """
     from sugar_lift_py_tests.outcome import Incomplete
 
-    function, pending = _helper(
-        "def helper(obj, lo, value):\n    obj[lo:3] = value\n"
-    )
+    function, pending = _helper("def helper(obj, lo, value):\n    obj[lo:3] = value\n")
     # Whatever shell production chooses today must not be a fabricated Complete
     # list store — formal lower bound is still open work.
     if isinstance(pending, NativeOperationExitCarrierV1):

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_value_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_value_attribute_mutation.py
@@ -7,7 +7,9 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "slice_value_attribute_mutation.py"
-    path.write_text("def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n")
+    path.write_text(
+        "def f(value, replacement):\n    value.attr = replacement\n    del value.attr\n"
+    )
     body = next(
         SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
     ).body

--- a/implementations/python/sugar-lift-py-tests/tests/test_slice_value_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_slice_value_subscript_mutation.py
@@ -7,17 +7,30 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "slice_value_subscript_mutation.py"
-    path.write_text("def f(value, replacement):\n    value[0] = replacement\n    del value[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(value, replacement):\n    value[0] = replacement\n    del value[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "SliceValue.setitem", 0), ("delitem", "SliceValue.delitem", 1)))
-def test_slice_value_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (("setitem", "SliceValue.setitem", 0), ("delitem", "SliceValue.delitem", 1)),
+)
+def test_slice_value_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
     sites = _sites(tmp_path)
     site = sites[site_index]
     value = SliceValue(None, None, None)
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_identity_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_identity_law.py
@@ -120,15 +120,9 @@ def test_ledger_tooth_status_only_sum_is_not_sufficient() -> None:
 def test_ledger_tooth_quiet_when_partition_honest() -> None:
     from sugar_lift_py_tests.tree_enumerate import assert_source_audit_ledger
 
-    assert_source_audit_ledger(
-        warranted=1, unresolved=1, source_loci=2, report_R=1
-    )
-    assert_source_audit_ledger(
-        warranted=2, unresolved=0, source_loci=2, report_R=0
-    )
-    assert_source_audit_ledger(
-        warranted=0, unresolved=2, source_loci=2, report_R=2
-    )
+    assert_source_audit_ledger(warranted=1, unresolved=1, source_loci=2, report_R=1)
+    assert_source_audit_ledger(warranted=2, unresolved=0, source_loci=2, report_R=0)
+    assert_source_audit_ledger(warranted=0, unresolved=2, source_loci=2, report_R=2)
 
 
 def test_lift_rpc_calls_the_one_door_not_cid_alone() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
@@ -252,4 +252,3 @@ def test_truthful_twin_roll_call_path_conserves_on_real_source(tmp_path: Path) -
     _assert_conserved(audit, report_R=report.R)
     assert audit["totals"]["source_unresolved"] == report.R
     assert audit["totals"]["source_loci"] == len(report.roster)
-

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -143,7 +143,10 @@ def test_binder_refuses_corrupt_formal_coordinate_roster(variant: str) -> None:
     elif variant == "reordered":
         corrupt = tuple(reversed(coordinates))
     else:
-        corrupt = (replace(coordinates[0], scope_owner_cid="blake3-512:" + "00" * 64), coordinates[1])
+        corrupt = (
+            replace(coordinates[0], scope_owner_cid="blake3-512:" + "00" * 64),
+            coordinates[1],
+        )
 
     with pytest.raises(SourceCallBindingGap, match="formal coordinate roster"):
         replace(frame, formal_coordinates=corrupt).bind_actuals(
@@ -195,9 +198,9 @@ def test_binder_refuses_stale_binding_coordinate_cid() -> None:
     stale = replace(frame.formal_coordinates[0], cid="blake3-512:" + "00" * 64)
 
     with pytest.raises(SourceCallBindingGap, match="CID"):
-        replace(frame, formal_coordinates=(stale, frame.formal_coordinates[1])).bind_actuals(
-            (TermValue(1), TermValue(2)), ()
-        )
+        replace(
+            frame, formal_coordinates=(stale, frame.formal_coordinates[1])
+        ).bind_actuals((TermValue(1), TermValue(2)), ())
 
 
 def test_binder_refuses_same_signature_foreign_native_roster() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_raise_transport.py
@@ -157,7 +157,9 @@ def test_authenticated_raise_helper_publishes_named_halt_at_call() -> None:
     halted = _call_halt(tree, "raiser")
     assert halted.effect.exception_name == "ValueError"
     assert halted.effect.exception_type_coordinate == _identity("ValueError")
-    assert halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
+    assert (
+        halted.effect.occurrence_id is not None or halted.effect.occurrence is not None
+    )
     # Call boundary re-owns the published edge.
     assert halted.effect.producer_node_owner == "Call"
     assert halted.state is not None
@@ -172,7 +174,9 @@ def test_store_indexerror_raise_helper_carries_named_type_and_occurrence() -> No
     halted = _call_halt(tree, "raiser")
     assert halted.effect.exception_name == "IndexError"
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence, (
+    assert (
+        isinstance(halted.effect.occurrence, str) and ":" in halted.effect.occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence!r}"
     )
@@ -217,9 +221,9 @@ def test_prior_store_survives_in_pre_effect_state_across_call_boundary() -> None
     halted = _call_halt(tree, "raiser")
     assert halted.state is not None, f"{CODEX1}: halt dropped pre-effect state"
     lists = [e for e in halted.state.entries if isinstance(e, ListValue)]
-    assert lists == [ListValue((TermValue(9),))], (
-        f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
-    )
+    assert lists == [
+        ListValue((TermValue(9),))
+    ], f"{CODEX1}: earlier store not in halt state entries={halted.state.entries!r}"
 
 
 # ===========================================================================
@@ -287,9 +291,9 @@ def test_helper_raise_under_guard_keeps_guard_on_halt_face() -> None:
     )
     call = _calls_named(tree, "maybe")[0]
     outcome = call.sugar().desugar(None)
-    assert isinstance(outcome, ExitSet), (
-        f"{CODEX3}: guarded raise expected ExitSet, got {type(outcome).__name__}"
-    )
+    assert isinstance(
+        outcome, ExitSet
+    ), f"{CODEX3}: guarded raise expected ExitSet, got {type(outcome).__name__}"
     halted = [e for e in outcome.exits if isinstance(e, Halted)]
     completed = [e for e in outcome.exits if isinstance(e, Completed)]
     assert len(halted) == 1, f"{CODEX3}: need one halt arm, got {outcome.exits!r}"
@@ -298,13 +302,13 @@ def test_helper_raise_under_guard_keeps_guard_on_halt_face() -> None:
     assert halt.effect.exception_name == "ValueError"
     # Guard is non-trivial (not bare True / empty and).
     guard_s = str(halt.guard)
-    assert "py.truthy" in guard_s or "truthy" in guard_s or "branch" in guard_s, (
-        f"{CODEX3}: guard dropped on raise face: {halt.guard!r}"
-    )
+    assert (
+        "py.truthy" in guard_s or "truthy" in guard_s or "branch" in guard_s
+    ), f"{CODEX3}: guard dropped on raise face: {halt.guard!r}"
     # Completed arm is the complementary not(guard).
-    assert "not" in str(completed[0].guard).lower() or str(
-        completed[0].guard
-    ) != str(halt.guard)
+    assert "not" in str(completed[0].guard).lower() or str(completed[0].guard) != str(
+        halt.guard
+    )
 
 
 def test_helper_raise_under_true_guard_collapses_to_sole_halt() -> None:
@@ -429,9 +433,9 @@ def test_fabricated_empty_state_is_not_pre_effect_when_store_preceded_raise() ->
     halted = _call_halt(tree, "raiser")
     fabricated = _ReducedBlock((), True, ())
     assert halted.state is not None
-    assert halted.state != fabricated or halted.state.entries, (
-        f"{CODEX1}: state collapsed to empty fabricated block"
-    )
+    assert (
+        halted.state != fabricated or halted.state.entries
+    ), f"{CODEX1}: state collapsed to empty fabricated block"
     with pytest.raises(AssertionError):
         assert halted.state is fabricated
     # Positive: prior store present.

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_compare_control.py
@@ -9,12 +9,16 @@ from sugar_lift_py_tests.context_manager_resolution import (
     SourceFragmentCoordinateV1,
     TreeConstructionContextV1,
 )
-from sugar_lift_py_tests.floor import CallSiteValue, GuardedReturn, ReturnValue, TermValue
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    GuardedReturn,
+    ReturnValue,
+    TermValue,
+)
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
-
 
 SOURCE = (
     "def lower():\n"
@@ -145,7 +149,10 @@ def test_named_exceptional_source_return_bypasses_both_bodies_with_state() -> No
 
     halted = _only_exit(call.sugar().desugar(None), Halted)
     assert halted.effect.exception_type_coordinate == _type_error_identity()
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -205,7 +212,9 @@ def test_wrong_return_frame_cannot_claim_the_truthful_branch() -> None:
 def test_wrong_occurrence_frame_cannot_claim_the_authentic_return() -> None:
     tree, context, _ = _tree("choose(2)\n")
     lower_calls = tuple(
-        call for call in _calls(tree, "lower") if call.line_col_span().start_line in (8, 10)
+        call
+        for call in _calls(tree, "lower")
+        if call.line_col_span().start_line in (8, 10)
     )
     assert len(lower_calls) == 2
     first_coordinate = _coordinate(lower_calls[0])

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py
@@ -81,9 +81,7 @@ def _tree(source: str, *, bind: frozenset[str] | None = None, name: str = "sr.py
         construction_context=context,
     )
     functions = {
-        node.name: node
-        for node in tree.nodes()
-        if isinstance(node, FunctionDef)
+        node.name: node for node in tree.nodes() if isinstance(node, FunctionDef)
     }
     for call in tree.nodes():
         if not isinstance(call, Call):
@@ -132,12 +130,25 @@ CODEX3_OWNER = (
 @pytest.mark.parametrize(
     "competing_exit",
     (
-        RaiseValue(RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:140:0')),
+        RaiseValue(
+            RaiseEffect.for_builtin(
+                "TypeError",
+                occurrence="implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:140:0",
+            )
+        ),
         GuardedRaise(
             (TermValue(True).to_term(owner="guard"),),
-            RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:138:0'),
+            RaiseEffect.for_builtin(
+                "TypeError",
+                occurrence="implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:138:0",
+            ),
         ),
-        Incomplete(RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:135:0')),
+        Incomplete(
+            RaiseEffect.for_builtin(
+                "TypeError",
+                occurrence="implementations/python/sugar-lift-py-tests/tests/test_source_return_operation_generalization.py:135:0",
+            )
+        ),
         LoopControlValue("break", "helper.py:3"),
     ),
 )
@@ -189,8 +200,10 @@ def test_tuple_helper_authenticated_call_projects_container_return() -> None:
         bind=frozenset({"pack_probe"}),
     )
     call = _first(tree, Call)
-    floor = call.sugar().desugar(None).value.force_floor(
-        None, owner="tuple-return-floor", project_callsite=False
+    floor = (
+        call.sugar()
+        .desugar(None)
+        .value.force_floor(None, owner="tuple-return-floor", project_callsite=False)
     )
     assert isinstance(floor.statements[0], ReturnValue)
     assert floor.statements[0].value == TupleValue(
@@ -204,8 +217,10 @@ def test_symbolic_helper_authenticated_call_projects_formal_return() -> None:
         bind=frozenset({"identity_probe"}),
     )
     call = _first(tree, Call)
-    floor = call.sugar().desugar(None).value.force_floor(
-        None, owner="symbolic-return-floor", project_callsite=False
+    floor = (
+        call.sugar()
+        .desugar(None)
+        .value.force_floor(None, owner="symbolic-return-floor", project_callsite=False)
     )
     assert isinstance(floor.statements[0], ReturnValue)
     # Bound formal projects the actual TermValue(7).
@@ -270,8 +285,10 @@ def test_tampered_wrong_body_is_not_the_authenticated_return() -> None:
     context.source_call_frames[_coordinate(call)] = functions[
         "decoy"
     ].source_visible_call_frame()
-    floor = call.sugar().desugar(None).value.force_floor(
-        None, owner="tamper-probe", project_callsite=False
+    floor = (
+        call.sugar()
+        .desugar(None)
+        .value.force_floor(None, owner="tamper-probe", project_callsite=False)
     )
     assert floor.statements[0].value == TermValue(99)
     with pytest.raises(AssertionError):
@@ -297,16 +314,14 @@ def test_scalar_helper_feeds_binop_isomorphic_to_direct() -> None:
     try:
         helper = _first(helper_tree, BinOp).sugar().desugar(None)
     except ConstructionPanic as exc:
-        pytest.fail(
-            f"{CODEX3_OWNER} observed ConstructionPanic on scalar()+2: {exc}"
-        )
+        pytest.fail(f"{CODEX3_OWNER} observed ConstructionPanic on scalar()+2: {exc}")
     except SugarNotWritten as exc:
         pytest.fail(f"{CODEX3_OWNER} observed SugarNotWritten on scalar()+2: {exc}")
 
     # Both complete (or both factored with a completed arm).
-    assert isinstance(helper, (Complete, ExitSet)), (
-        f"{CODEX3_OWNER} helper outcome={type(helper).__name__}"
-    )
+    assert isinstance(
+        helper, (Complete, ExitSet)
+    ), f"{CODEX3_OWNER} helper outcome={type(helper).__name__}"
     hv = _completed_value(helper)
     dv = _completed_value(direct)
     # Outcome-isomorphic: same TermValue (or equal numeric floor).
@@ -351,9 +366,9 @@ def test_scalar_helper_feeds_subscript_index() -> None:
     except (ConstructionPanic, SugarNotWritten) as exc:
         pytest.fail(f"{CODEX3_OWNER} subscript index: {exc}")
     value = _completed_value(outcome)
-    assert value == TermValue(10) or getattr(value, "value", None) == 10, (
-        f"{CODEX3_OWNER} expected TermValue(10), got {value!r}"
-    )
+    assert (
+        value == TermValue(10) or getattr(value, "value", None) == 10
+    ), f"{CODEX3_OWNER} expected TermValue(10), got {value!r}"
 
 
 def test_tuple_helper_feeds_subscript_receiver() -> None:
@@ -366,9 +381,9 @@ def test_tuple_helper_feeds_subscript_receiver() -> None:
     except (ConstructionPanic, SugarNotWritten) as exc:
         pytest.fail(f"{CODEX3_OWNER} tuple subscript: {exc}")
     value = _completed_value(outcome)
-    assert value == TermValue(2) or getattr(value, "value", None) == 2, (
-        f"{CODEX3_OWNER} expected TermValue(2), got {value!r}"
-    )
+    assert (
+        value == TermValue(2) or getattr(value, "value", None) == 2
+    ), f"{CODEX3_OWNER} expected TermValue(2), got {value!r}"
 
 
 def test_scalar_helper_feeds_store_index() -> None:
@@ -389,9 +404,9 @@ def test_scalar_helper_feeds_store_index() -> None:
         pytest.fail(f"{CODEX3_OWNER} store index: {exc}")
     assert isinstance(outcome, (Complete, ExitSet)), CODEX3_OWNER
     if isinstance(outcome, ExitSet):
-        assert any(isinstance(e, Completed) for e in outcome.exits), (
-            f"{CODEX3_OWNER} store did not complete: {outcome.exits!r}"
-        )
+        assert any(
+            isinstance(e, Completed) for e in outcome.exits
+        ), f"{CODEX3_OWNER} store did not complete: {outcome.exits!r}"
 
 
 def test_symbolic_helper_feeds_binop() -> None:
@@ -404,9 +419,9 @@ def test_symbolic_helper_feeds_binop() -> None:
     except (ConstructionPanic, SugarNotWritten) as exc:
         pytest.fail(f"{CODEX3_OWNER} symbolic binop: {exc}")
     value = _completed_value(outcome)
-    assert value == TermValue(5) or getattr(value, "value", None) == 5, (
-        f"{CODEX3_OWNER} expected 5, got {value!r}"
-    )
+    assert (
+        value == TermValue(5) or getattr(value, "value", None) == 5
+    ), f"{CODEX3_OWNER} expected 5, got {value!r}"
 
 
 def test_guarded_helper_return_retains_guards_into_binop() -> None:
@@ -437,9 +452,9 @@ def test_guarded_helper_return_retains_guards_into_binop() -> None:
         assert completed, f"{CODEX3_OWNER} no completed arm: {outcome.exits!r}"
     else:
         value = outcome.value
-        assert value == TermValue(2) or getattr(value, "value", None) == 2, (
-            f"{CODEX3_OWNER} guarded return lost value: {value!r}"
-        )
+        assert (
+            value == TermValue(2) or getattr(value, "value", None) == 2
+        ), f"{CODEX3_OWNER} guarded return lost value: {value!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -501,7 +516,9 @@ def test_keyword_binding_does_not_accept_an_unknown_formal() -> None:
         if isinstance(node, BinOp) and isinstance(node.left, Call)
     )
 
-    with pytest.raises(SourceCallBindingGap, match="missing required formal|unconsumed"):
+    with pytest.raises(
+        SourceCallBindingGap, match="missing required formal|unconsumed"
+    ):
         outer.sugar().desugar(None)
 
 
@@ -532,8 +549,10 @@ def test_authenticated_lambda_return_flows_into_binop() -> None:
         bind=frozenset({"consume"}),
     )
     call = _calls_named(tree, "consume")[0]
-    value = call.sugar().desugar(None).value._dig_floor_or_none(
-        None, owner="authenticated-lambda-return"
+    value = (
+        call.sugar()
+        .desugar(None)
+        .value._dig_floor_or_none(None, owner="authenticated-lambda-return")
     )
 
     assert value == TermValue(6)
@@ -547,8 +566,10 @@ def test_renamed_keyword_lambda_return_flows_into_binop() -> None:
         bind=frozenset({"consume"}),
     )
     call = _calls_named(tree, "consume")[0]
-    value = call.sugar().desugar(None).value._dig_floor_or_none(
-        None, owner="renamed-keyword-lambda-return"
+    value = (
+        call.sugar()
+        .desugar(None)
+        .value._dig_floor_or_none(None, owner="renamed-keyword-lambda-return")
     )
 
     assert value == TermValue(6)
@@ -595,8 +616,10 @@ def test_nested_function_source_return_projects_into_outer_caller() -> None:
         bind=frozenset({"outer", "inner"}),
     )
     call = _calls_named(tree, "outer")[0]
-    value = call.sugar().desugar(None).value._dig_floor_or_none(
-        None, owner="nested-function-return"
+    value = (
+        call.sugar()
+        .desugar(None)
+        .value._dig_floor_or_none(None, owner="nested-function-return")
     )
 
     assert value == TermValue(6)
@@ -632,7 +655,11 @@ def test_nested_shadowed_function_does_not_cross_wire_outer_same_name() -> None:
         bind=frozenset({"outer", "inner"}),
     )
     call = _calls_named(tree, "outer")[0]
-    nested = [node for node in tree.nodes() if isinstance(node, FunctionDef) and node.name == "inner"]
+    nested = [
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "inner"
+    ]
     assert len(nested) == 2
     # Deliberately seat the outer same-name frame at the nested call: the
     # authenticated coordinate must reject this cross-wired testimony.
@@ -641,7 +668,9 @@ def test_nested_shadowed_function_does_not_cross_wire_outer_same_name() -> None:
         for node in tree.nodes()
         if isinstance(node, Call) and getattr(node.func, "id", None) == "inner"
     )
-    context.source_call_frames[_coordinate(nested_call)] = nested[0].source_visible_call_frame()
+    context.source_call_frames[_coordinate(nested_call)] = nested[
+        0
+    ].source_visible_call_frame()
 
     with pytest.raises((AssertionError, ConstructionPanic, SugarNotWritten)):
         call.sugar().desugar(None).value._dig_floor_or_none(
@@ -751,7 +780,9 @@ def test_foreign_same_signature_nested_frame_refuses_loudly(
     )
     tree, context, definitions, calls = _nested_definition_and_call(source)
     outer_call = max(calls, key=lambda node: node.line_col_span().start_line)
-    module_definition = min(definitions, key=lambda node: node.line_col_span().start_line)
+    module_definition = min(
+        definitions, key=lambda node: node.line_col_span().start_line
+    )
     wrong_scope_definition = sorted(
         definitions, key=lambda node: node.line_col_span().start_line
     )[1]

--- a/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py
@@ -69,7 +69,10 @@ class _TwoFacedElement:
         self.index = index
         self.guard = _atom(f"g{index}")
         self.halt_guard = _atom(f"h{index}")
-        self.effect = RaiseEffect.for_builtin(f'E{index}', occurrence='implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py:72:0')
+        self.effect = RaiseEffect.for_builtin(
+            f"E{index}",
+            occurrence="implementations/python/sugar-lift-py-tests/tests/test_spread_exit_factoring.py:72:0",
+        )
 
     def desugar(self, ctx=None):
         del ctx
@@ -210,7 +213,11 @@ def _resolve_term(term, assignment: dict):
                 else when_false
             )
             return _resolve_term(chosen, assignment)
-        return ("ctor", term.name, tuple(_resolve_term(a, assignment) for a in term.args))
+        return (
+            "ctor",
+            term.name,
+            tuple(_resolve_term(a, assignment) for a in term.args),
+        )
     if isinstance(term, _Var):
         return ("var", term.name)
     if isinstance(term, _ConstStr):
@@ -355,9 +362,7 @@ def test_arm_population_grows_linearly_with_spread_arity(kind: str) -> None:
 def test_stored_representation_grows_linearly_with_spread_arity(kind: str) -> None:
     """The storage law: the factored value may not hide an exponential either."""
     sizes = {
-        arity: _stored_nodes(
-            _spread([_TwoFacedElement(i) for i in range(arity)], kind)
-        )
+        arity: _stored_nodes(_spread([_TwoFacedElement(i) for i in range(arity)], kind))
         for arity in _GROWTH_ARITIES
     }
     _assert_at_most_linear(sizes, f"{kind}: retained DAG nodes")

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_target_store_formal_caller.py
@@ -146,9 +146,7 @@ def test_attribute_and_subscript_production_construction() -> None:
 
 
 def test_name_store_name_interleaved_constructs() -> None:
-    function, _ = _helper(
-        "def helper(obj, xs):\n    a, obj.x, b = xs\n    return a\n"
-    )
+    function, _ = _helper("def helper(obj, xs):\n    a, obj.x, b = xs\n    return a\n")
     stmt = next(
         s
         for s in function.sugar().statements
@@ -174,9 +172,7 @@ def test_ground_star_store_rest_and_field() -> None:
         ),
         site=site,
     )
-    exits = reduce_block_to_exitset(
-        (sugar,), ReduceContext.root(owner="ground_star")
-    )
+    exits = reduce_block_to_exitset((sugar,), ReduceContext.root(owner="ground_star"))
     assert isinstance(exits.exits[0], Completed)
     state = exits.exits[0].value
     assert state.context.temporal.value_if_bound("rest") == ListValue(
@@ -205,9 +201,7 @@ def test_interleaved_name_store_name_order() -> None:
 
     receiver = ObjectValue("W", (), (), (), "w1")
     sugar = DynamicUnpackStoreAssignSugar(
-        value=_FloorSugar(
-            ListValue((TermValue(1), TermValue(2), TermValue(3)))
-        ),
+        value=_FloorSugar(ListValue((TermValue(1), TermValue(2), TermValue(3)))),
         targets=(
             _OrderName("a"),
             _OrderAttr(_FloorSugar(receiver), "x", site),
@@ -373,10 +367,7 @@ def test_exact_arity_valueerror_identity() -> None:
     effect = _arity_mismatch_effect(sugar.desugar(None))
     assert effect.exception_name == "ValueError"
     assert effect.exception_type_coordinate == _valueerror_type_identity()
-    assert (
-        effect.producer_node_owner
-        == "DynamicUnpackStoreAssignSugar.arity_mismatch"
-    )
+    assert effect.producer_node_owner == "DynamicUnpackStoreAssignSugar.arity_mismatch"
     # Operation occurrence cites the unpack site — not a foreign boundary.
     assert effect.occurrence == str(site) or effect.occurrence_id == str(site)
     assert effect.occurrence_id == str(site)
@@ -511,14 +502,18 @@ def test_missing_wrong_positional_coordinate_is_loud() -> None:
     with pytest.raises(AssertionError):
         assert lying.demand.operand_coordinate_cids == cids
     # Missing formals → typed undischarged refusal, never Complete.
-    with pytest.raises(SugarNotWritten, match="authenticated caller actual absent") as missing:
+    with pytest.raises(
+        SugarNotWritten, match="authenticated caller actual absent"
+    ) as missing:
         projected.discharge({})
     assert "cid:a" in str(missing.value)
     # Lying twin: claiming missing actuals greened a Complete is impossible.
     with pytest.raises(SugarNotWritten, match="authenticated caller actual absent"):
         out = projected.discharge({})
         assert isinstance(out, Complete)
-    with pytest.raises(SugarNotWritten, match="authenticated caller actual absent") as partial:
+    with pytest.raises(
+        SugarNotWritten, match="authenticated caller actual absent"
+    ) as partial:
         projected.discharge({"cid:a": ListValue((TermValue(0),))})
     assert "cid:i" in str(partial.value)
     with pytest.raises(SugarNotWritten, match="authenticated caller actual absent"):

--- a/implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py
@@ -153,8 +153,13 @@ def test_too_few_members_named_valueerror(tmp_path: Path) -> None:
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 
     assert isinstance(outcome.effect, RaiseEffect)
-    expected = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py:156:0')
-    assert outcome.effect.exception_type_coordinate == expected.exception_type_coordinate
+    expected = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py:156:0",
+    )
+    assert (
+        outcome.effect.exception_type_coordinate == expected.exception_type_coordinate
+    )
 
 
 def test_too_few_discrimination_is_not_completed_bind(tmp_path: Path) -> None:
@@ -245,7 +250,10 @@ def test_later_store_halt_preserves_earlier_star_bindings(tmp_path: Path) -> Non
     from sugar_lift_py_tests.effect.raise_effect import RaiseEffect
 
     assert isinstance(halted[0].effect, RaiseEffect)
-    expected = RaiseEffect.for_builtin('TypeError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py:248:0')
+    expected = RaiseEffect.for_builtin(
+        "TypeError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_starred_unpack_projection.py:248:0",
+    )
     assert (
         halted[0].effect.exception_type_coordinate == expected.exception_type_coordinate
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_state_survival_matrix.py
@@ -150,7 +150,10 @@ def _unpack_store_halt() -> tuple[NativeOperationExitCarrierV1, Halted]:
     assert isinstance(halted, Halted)
     assert halted.state is pending.pre_effect_state.state
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -423,9 +426,7 @@ def test_d_unpack_name_binding_survives_later_store_halt() -> None:
     assert isinstance(success, Completed)
     assert isinstance(success.value, UniverseValue)
     returns = [
-        s
-        for s in success.value.record.statements
-        if type(s).__name__ == "ReturnValue"
+        s for s in success.value.record.statements if type(s).__name__ == "ReturnValue"
     ]
     assert len(returns) == 1
     assert returns[0].value.term.name == "p"
@@ -478,11 +479,7 @@ def test_d_free_dual_store_later_halt_retains_prior_store_in_state() -> None:
     assert halted[0].effect.producer_node_owner == "TupleValue.setitem"
     assert halted[0].state is not None
     # Prior binding / store survived: list shows first-store write.
-    lists = [
-        e
-        for e in halted[0].state.entries
-        if isinstance(e, ListValue)
-    ]
+    lists = [e for e in halted[0].state.entries if isinstance(e, ListValue)]
     assert lists == [ListValue((TermValue(2),))]
     # Not fabricated completion of the return.
     with pytest.raises(AssertionError):

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_augassign_formal_caller.py
@@ -43,7 +43,9 @@ def _tree(source: str, name: str = "subscript_augassign.py") -> SourceFile:
     )
 
 
-def _helper_definition(source: str = "def helper(obj, key, rhs):\n    obj[key] += rhs\n"):
+def _helper_definition(
+    source: str = "def helper(obj, key, rhs):\n    obj[key] += rhs\n",
+):
     tree = _tree(source, "helper_alone.py")
     function = next(node for node in tree.nodes() if isinstance(node, FunctionDef))
     return function, function.sugar().desugar(None)
@@ -88,7 +90,9 @@ def _production_sites():
     return sugar.get_site, sugar.op_site, sugar.set_site, sugar.site
 
 
-def _production_desugar(receiver, index, rhs, *, operator="iadd", projector=project_iadd):
+def _production_desugar(
+    receiver, index, rhs, *, operator="iadd", projector=project_iadd
+):
     get_site, op_site, set_site, site = _production_sites()
     sugar = SubscriptAugAssignSugar(
         receiver=_FloorSugar(receiver),
@@ -140,9 +144,10 @@ def test_op_site_ignores_same_spelling_string_in_target() -> None:
     # Index string constant span must not equal / contain the operator site.
     index_node = aug.target.slice_
     index_span = index_node.span
-    assert not (
-        op_span.start <= index_span.start and index_span.end <= op_span.end
-    ), (op_span, index_span)
+    assert not (op_span.start <= index_span.start and index_span.end <= op_span.end), (
+        op_span,
+        index_span,
+    )
     # Operator site still sits after the full target (including ['+=']).
     assert op_span.start >= aug.target.span.end
     text = sugar.op_site.unit.source[op_span.start : op_span.end]
@@ -176,7 +181,9 @@ def test_legacy_augmented_subscript_store_effect_sugar_is_deleted() -> None:
     package_root = Path(store_mod.__file__).resolve().parent.parent
     offenders = []
     for path in package_root.rglob("*.py"):
-        if "LegacyAugmentedSubscriptStoreEffectSugar" in path.read_text(encoding="utf-8"):
+        if "LegacyAugmentedSubscriptStoreEffectSugar" in path.read_text(
+            encoding="utf-8"
+        ):
             offenders.append(str(path))
     assert offenders == [], offenders
 
@@ -211,7 +218,8 @@ def test_production_inplace_set_is_independent_of_projector_table() -> None:
     assert production == frozenset(
         cls.inplace_operator
         for cls in __import__(
-            "sugar_source_tree.operators", fromlist=["AUGASSIGN_BINARY_OPERATOR_CLASSES"]
+            "sugar_source_tree.operators",
+            fromlist=["AUGASSIGN_BINARY_OPERATOR_CLASSES"],
         ).AUGASSIGN_BINARY_OPERATOR_CLASSES
     )
 
@@ -246,9 +254,7 @@ def test_projector_keys_equal_independent_production_inplace_set() -> None:
 
 def test_discrimination_circular_tooth_would_hide_missing_projector() -> None:
     """Lying: derive production set from projector table — circular, forbidden."""
-    circular = frozenset(
-        k for k in _NATIVE_OPERATION_PROJECTORS if k.startswith("i")
-    )
+    circular = frozenset(k for k in _NATIVE_OPERATION_PROJECTORS if k.startswith("i"))
     # Independent production must not be computed as circular (same object).
     independent = production_augassign_inplace_operators()
     # They currently equal when healthy — but sources differ: class attrs vs table.
@@ -599,9 +605,7 @@ def test_formal_operands_mint_iadd_not_ordinary_add() -> None:
 def test_formal_iadd_projector_is_enrolled_with_authenticated_signature() -> None:
     assert "iadd" in _NATIVE_OPERATION_PROJECTORS
     assert _NATIVE_OPERATION_PROJECTORS["iadd"] is project_iadd
-    parameters = tuple(
-        __import__("inspect").signature(project_iadd).parameters
-    )
+    parameters = tuple(__import__("inspect").signature(project_iadd).parameters)
     assert parameters == ("left", "right", "site")
 
 
@@ -627,8 +631,7 @@ def test_formal_subscript_get_carrier_missing_actuals_undischarged() -> None:
 def test_authenticated_caller_discharges_get_iadd_setitem_to_updated_list() -> None:
     function, pending = _helper_definition()
     coords = {
-        c.declared_name: c.coordinate_cid
-        for c in function.sugar().formal_coordinates
+        c.declared_name: c.coordinate_cid for c in function.sugar().formal_coordinates
     }
     exits = pending.discharge(
         {
@@ -646,8 +649,7 @@ def test_authenticated_caller_discharges_get_iadd_setitem_to_updated_list() -> N
 def test_authenticated_get_halt_blocks_store_on_formal_discharge() -> None:
     function, pending = _helper_definition()
     coords = {
-        c.declared_name: c.coordinate_cid
-        for c in function.sugar().formal_coordinates
+        c.declared_name: c.coordinate_cid for c in function.sugar().formal_coordinates
     }
     exits = pending.discharge(
         {

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_desugar.py
@@ -131,9 +131,7 @@ def test_immutable_slice_store_cannot_fabricate_mutated_receiver(
     assert outcome.effect.producer_node_owner != "TupleValue.setitem"
 
 
-@pytest.mark.parametrize(
-    "receiver", (StringValue("abc"), BytesValue(b"abc"))
-)
+@pytest.mark.parametrize("receiver", (StringValue("abc"), BytesValue(b"abc")))
 def test_immutable_slice_store_halt_preserves_exact_prior_state(tmp_path, receiver):
     from sugar_lift_py_tests.floor.block_value import BlockValue
     from sugar_lift_py_tests.outcome import Halted
@@ -185,7 +183,10 @@ def test_rhs_halt_wins_before_receiver_or_key_evaluation(tmp_path):
             log.append("value")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(exception_type_coordinate=str_const('ValueError'), occurrence=AuthenticatedRaiseLocus.of('store.py:4:12'))
+                    RaiseEffect(
+                        exception_type_coordinate=str_const("ValueError"),
+                        occurrence=AuthenticatedRaiseLocus.of("store.py:4:12"),
+                    )
                 )
             )
 
@@ -219,7 +220,10 @@ def test_receiver_halt_wins_before_key_after_rhs_completed(tmp_path):
             log.append("receiver")
             return Complete(
                 RaiseValue(
-                    RaiseEffect(exception_type_coordinate=str_const('LookupError'), occurrence=AuthenticatedRaiseLocus.of('store.py:4:4'))
+                    RaiseEffect(
+                        exception_type_coordinate=str_const("LookupError"),
+                        occurrence=AuthenticatedRaiseLocus.of("store.py:4:4"),
+                    )
                 )
             )
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_store_formal_call_projection.py
@@ -119,7 +119,10 @@ def test_immutable_receiver_reads_but_formal_store_halts_with_named_type() -> No
 
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("TypeError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_supervised_enum_supervisor.py
@@ -99,10 +99,7 @@ def test_worker_refuses_file_before_frozen_context_initialization(
     try:
         assert json.loads(worker.stdout.readline())["kind"] == "ready"
         worker.stdin.write(
-            json.dumps(
-                {"kind": "lift", "path": str(source), "rel": "clean.py"}
-            )
-            + "\n"
+            json.dumps({"kind": "lift", "path": str(source), "rel": "clean.py"}) + "\n"
         )
         worker.stdin.flush()
         refusal = json.loads(worker.stdout.readline())
@@ -266,9 +263,10 @@ def test_named_lift_error_tail_never_none_none() -> None:
     assert "(message field absent)" in _SUP._named_lift_error_tail(
         {"error_type": "RuntimeError"}
     )
-    assert _SUP._named_lift_error_tail(
-        {"error_type": "RuntimeError", "message": "boom"}
-    ) == "RuntimeError: boom"
+    assert (
+        _SUP._named_lift_error_tail({"error_type": "RuntimeError", "message": "boom"})
+        == "RuntimeError: boom"
+    )
 
 
 def test_lift_error_incomplete_payload_names_artifact(

--- a/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_swallowed_throw_second_mechanism_law.py
@@ -58,7 +58,10 @@ def seal(prefix):
 
     offenders = _SCANNER.scan_python_root(root)
     kinds = {(o.kind, o.axis) for o in offenders}
-    assert ("construction-panic-soft-continue", "R_construction_panic_soft_continue") in kinds
+    assert (
+        "construction-panic-soft-continue",
+        "R_construction_panic_soft_continue",
+    ) in kinds
 
 
 def test_lying_exception_soft_continue_is_detected(tmp_path: Path) -> None:
@@ -227,9 +230,13 @@ def test_drained_sin_cluster_4_sites_are_absent_on_live_tree() -> None:
         _PYTHON_ROOT / "sugar-source-tree/src/sugar_source_tree/nodes.py"
     ).read_text(encoding="utf-8")
     assert "return SoftUnresolvedWithSugar" not in nodes
-    assert "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes
+    assert (
+        "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes
+    )
     assert "return SoftUnresolvedTrySugar" not in nodes
-    assert "from sugar_lift_py_tests.sugar.soft_unresolved_try_sugar import" not in nodes
+    assert (
+        "from sugar_lift_py_tests.sugar.soft_unresolved_try_sugar import" not in nodes
+    )
 
     parso = (
         _PYTHON_ROOT / "sugar-source-tree/src/sugar_source_tree/parso_adapter.py"
@@ -282,11 +289,7 @@ def test_drained_sin_cluster_4_sites_are_absent_on_live_tree() -> None:
         for o in offenders
     ), _SCANNER.format_report(offenders)
     # Permanent membrane residual: multi-file corpus census only.
-    residual = [
-        o
-        for o in offenders
-        if o.kind == "exception-soft-continue"
-    ]
+    residual = [o for o in offenders if o.kind == "exception-soft-continue"]
     assert all(o.path.endswith("census.py") for o in residual), _SCANNER.format_report(
         offenders
     )
@@ -303,9 +306,9 @@ def test_live_scan_reports_named_axes_and_residual_is_nonzero_until_drained() ->
     assert counts["R_construction_panic_soft_continue"] == 0
     # Permanent open-domain membrane: multi-file census defect enumeration.
     assert counts["R_exception_soft_continue"] == 1
-    assert all(
-        o.path.endswith("census.py") for o in offenders
-    ), _SCANNER.format_report(offenders)
+    assert all(o.path.endswith("census.py") for o in offenders), _SCANNER.format_report(
+        offenders
+    )
     report = _SCANNER.format_report(offenders)
     assert "R_construction_panic_soft_continue" in report
     assert "R_exception_soft_continue" in report

--- a/implementations/python/sugar-lift-py-tests/tests/test_symbolic_value_guard_support.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_symbolic_value_guard_support.py
@@ -13,8 +13,6 @@ def test_symbolic_support_keeps_one_identity_under_a_guard() -> None:
 def test_guard_does_not_become_symbolic_value_content_identity() -> None:
     value = SymbolicValue(make_var("value"))
 
-    assert value.guarded(atomic("left", [])) is value.guarded(
-        atomic("right", [])
-    )
+    assert value.guarded(atomic("left", [])) is value.guarded(atomic("right", []))
     assert value.inv_contribution() == ()
     assert value.post_contribution() == ()

--- a/implementations/python/sugar-lift-py-tests/tests/test_term_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_term_subscript_mutation.py
@@ -12,7 +12,9 @@ from sugar_source_tree.tree import SourceFile
 def _sites(tmp_path):
     path = tmp_path / "term_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
@@ -31,9 +33,16 @@ class _Value(Sugar):
 
 def _outcomes(tmp_path):
     store_site, delete_site = _sites(tmp_path)
-    store = SubscriptStoreEffectSugar(_Value(TermValue(1)), _Value(TermValue(0)), _Value(TermValue(7)), store_site).desugar()
-    delete = SubscriptDeleteEffectSugar(_Value(TermValue(1)), _Value(TermValue(0)), delete_site).desugar()
-    return ((store, "TermValue.setitem", store_site), (delete, "TermValue.delitem", delete_site))
+    store = SubscriptStoreEffectSugar(
+        _Value(TermValue(1)), _Value(TermValue(0)), _Value(TermValue(7)), store_site
+    ).desugar()
+    delete = SubscriptDeleteEffectSugar(
+        _Value(TermValue(1)), _Value(TermValue(0)), delete_site
+    ).desugar()
+    return (
+        (store, "TermValue.setitem", store_site),
+        (delete, "TermValue.delitem", delete_site),
+    )
 
 
 def test_term_subscript_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_term_tuple_attribute_delete.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_term_tuple_attribute_delete.py
@@ -13,7 +13,13 @@ from sugar_source_tree.tree import SourceFile
 def _site(tmp_path):
     path = tmp_path / "term_tuple_attr_delete.py"
     path.write_text("def f(obj):\n    del obj.attr\n")
-    return next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body[0].fragment
+    return (
+        next(
+            SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+        )
+        .body[0]
+        .fragment
+    )
 
 
 @dataclass(frozen=True)
@@ -33,7 +39,9 @@ class _Receiver(Sugar):
     ("receiver", "owner"),
     ((TermValue(1), "TermValue.delattr"), (TupleValue(()), "TupleValue.delattr")),
 )
-def test_term_tuple_attribute_delete_has_exact_owner_occurrence(tmp_path, receiver, owner):
+def test_term_tuple_attribute_delete_has_exact_owner_occurrence(
+    tmp_path, receiver, owner
+):
     site = _site(tmp_path)
     outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", site).desugar()
     assert isinstance(outcome, Incomplete)
@@ -44,5 +52,7 @@ def test_term_tuple_attribute_delete_has_exact_owner_occurrence(tmp_path, receiv
 
 @pytest.mark.parametrize("receiver", (TermValue(1), TupleValue(())))
 def test_term_tuple_attribute_delete_cannot_fabricate_completion(tmp_path, receiver):
-    outcome = AttributeDeleteEffectSugar(_Receiver(receiver), "attr", _site(tmp_path)).desugar()
+    outcome = AttributeDeleteEffectSugar(
+        _Receiver(receiver), "attr", _site(tmp_path)
+    ).desugar()
     assert not isinstance(outcome, Complete)

--- a/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_try_native_store_carrier.py
@@ -10,7 +10,6 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Call, FunctionDef
 from sugar_source_tree.tree import SourceFile
 
-
 HELPER = (
     "def helper(a, i, q):\n"
     "    try:\n"
@@ -52,7 +51,9 @@ def _returned(outcome) -> TermValue:
     value = face.value
     if isinstance(value, CallSiteValue):
         value = value._dig_floor_or_none(None, owner="test_try_native_store_carrier")
-    returns = tuple(entry for entry in value.statements if isinstance(entry, ReturnValue))
+    returns = tuple(
+        entry for entry in value.statements if isinstance(entry, ReturnValue)
+    )
     assert len(returns) == 1
     assert isinstance(returns[0].value, TermValue)
     return returns[0].value
@@ -110,7 +111,10 @@ def test_exitset_consumer_observes_authentic_store_occurrence_and_state() -> Non
     halted = next(exit_ for exit_ in retained.exits if isinstance(exit_, Halted))
     assert pending.pre_effect_state is not None
     assert halted.state is pending.pre_effect_state.state
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_trystar_subgroup_routing.py
@@ -335,16 +335,24 @@ def test_leaf_occurrence_identities_survive_partition_and_reraise():
     type_errors = [leaf for leaf in leaves if leaf.exception_name == "TypeError"]
     assert len(value_errors) == 2
     assert len(type_errors) == 1
-    assert isinstance(value_errors[0].occurrence, str) and ":" in value_errors[0].occurrence, (
+    assert (
+        isinstance(value_errors[0].occurrence, str)
+        and ":" in value_errors[0].occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {value_errors[0].occurrence!r}"
     )
-    assert isinstance(value_errors[1].occurrence, str) and ":" in value_errors[1].occurrence, (
+    assert (
+        isinstance(value_errors[1].occurrence, str)
+        and ":" in value_errors[1].occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {value_errors[1].occurrence!r}"
     )
     assert value_errors[0].occurrence != value_errors[1].occurrence
-    assert isinstance(type_errors[0].occurrence, str) and ":" in type_errors[0].occurrence, (
+    assert (
+        isinstance(type_errors[0].occurrence, str) and ":" in type_errors[0].occurrence
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {type_errors[0].occurrence!r}"
     )
@@ -518,8 +526,7 @@ def test_grouped_raise_occurrence_is_sealed_coordinate_not_line_col_spelling():
     """Group occurrence is the sealed memento coordinate, not filename:line:col."""
     effect = _grouped_halt(
         _desugar(
-            "def f():\n"
-            "    raise ExceptionGroup('g', [ValueError()])\n",
+            "def f():\n" "    raise ExceptionGroup('g', [ValueError()])\n",
             name="sealed_occ_a.py",
         )
     )
@@ -532,8 +539,7 @@ def test_grouped_raise_occurrence_is_sealed_coordinate_not_line_col_spelling():
     assert effect.occurrence.count(":") >= 4  # file:start:end:source_cid:cid
     other = _grouped_halt(
         _desugar(
-            "def f():\n"
-            "    raise ExceptionGroup('g', [ValueError()])\n",
+            "def f():\n" "    raise ExceptionGroup('g', [ValueError()])\n",
             name="sealed_occ_b.py",
         )
     )
@@ -602,7 +608,10 @@ def test_second_handler_reads_first_handler_temporal_binding():
         raised_value=te_typed,
     )
     group = GroupedRaiseEffect(
-        "group:root", "g", (ve_leaf, te_leaf), occurrence=AuthenticatedRaiseLocus.of("group:root")
+        "group:root",
+        "g",
+        (ve_leaf, te_leaf),
+        occurrence=AuthenticatedRaiseLocus.of("group:root"),
     )
 
     class Fixed(Sugar):
@@ -725,9 +734,7 @@ def test_handler_terminal_return_face_is_retained_not_dropped():
         name="handler_return_face.py",
     )
     assert isinstance(outcome, Complete), outcome
-    returns = [
-        s for s in outcome.value.record.statements if isinstance(s, ReturnValue)
-    ]
+    returns = [s for s in outcome.value.record.statements if isinstance(s, ReturnValue)]
     assert returns and returns[0].value.value == 7
 
 
@@ -837,7 +844,9 @@ def test_guarded_handler_faces_conjoin_body_guard():
         exception_type_mro=(ve_id,),
         raised_value=ve_typed,
     )
-    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence=AuthenticatedRaiseLocus.of("group:root"))
+    group = GroupedRaiseEffect(
+        "group:root", "g", (leaf,), occurrence=AuthenticatedRaiseLocus.of("group:root")
+    )
     body_atom = atomic("body.guard", [str_const("body")])
     handler_atom = atomic("handler.guard", [str_const("handler")])
 
@@ -906,9 +915,7 @@ def test_guarded_handler_faces_conjoin_body_guard():
     if isinstance(effect, RaiseEffect):
         assert effect.exception_name == "RuntimeError"
     else:
-        assert any(
-            leaf.exception_name == "RuntimeError" for leaf in _leaves(effect)
-        )
+        assert any(leaf.exception_name == "RuntimeError" for leaf in _leaves(effect))
 
 
 def test_alternative_exceptional_faces_keep_separate_guards():
@@ -941,7 +948,9 @@ def test_alternative_exceptional_faces_keep_separate_guards():
         exception_type_mro=(ve_id,),
         raised_value=ve_typed,
     )
-    group = GroupedRaiseEffect("group:root", "g", (leaf,), occurrence=AuthenticatedRaiseLocus.of("group:root"))
+    group = GroupedRaiseEffect(
+        "group:root", "g", (leaf,), occurrence=AuthenticatedRaiseLocus.of("group:root")
+    )
     body_atom = atomic("body.guard", [str_const("body")])
     g1 = atomic("alt.one", [str_const("1")])
     g2 = atomic("alt.two", [str_const("2")])
@@ -962,12 +971,18 @@ def test_alternative_exceptional_faces_keep_separate_guards():
                 (
                     Halted(
                         g1,
-                        RaiseEffect(exception_name="KeyError", occurrence=AuthenticatedRaiseLocus.of("a1")),
+                        RaiseEffect(
+                            exception_name="KeyError",
+                            occurrence=AuthenticatedRaiseLocus.of("a1"),
+                        ),
                         None,
                     ),
                     Halted(
                         g2,
-                        RaiseEffect(exception_name="OSError", occurrence=AuthenticatedRaiseLocus.of("a2")),
+                        RaiseEffect(
+                            exception_name="OSError",
+                            occurrence=AuthenticatedRaiseLocus.of("a2"),
+                        ),
                         None,
                     ),
                 )

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_coordinate_value.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_coordinate_value.py
@@ -29,9 +29,7 @@ def _tree(tmp_path: Path, name: str) -> SourceFile:
     from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 
     path = tmp_path / name
-    path.write_text(
-        "result = tuple(item for item in unknown)[1:]\n", encoding="utf-8"
-    )
+    path.write_text("result = tuple(item for item in unknown)[1:]\n", encoding="utf-8")
     return SourceFile.from_path(
         path,
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
@@ -66,7 +64,9 @@ def _context(owner: str):
     return ReduceContext.root(owner=owner).with_temporal(builtin_name_temporal())
 
 
-def test_source_builtin_tuple_constructs_authenticated_coordinate(tmp_path: Path) -> None:
+def test_source_builtin_tuple_constructs_authenticated_coordinate(
+    tmp_path: Path,
+) -> None:
     call, _ = _nodes(_tree(tmp_path, "truth.py"))
     ctx = _context("tuple-coordinate-truth")
 
@@ -92,9 +92,7 @@ def test_source_builtin_tuple_constructs_authenticated_coordinate(tmp_path: Path
     assert isinstance(length, CallSiteValue)
     assert length.arg_values == (constructed,)
     assert length.site is use_site
-    assert length.term == ctor(
-        "call:len", (constructed.term,), symbol_kind="builtin"
-    )
+    assert length.term == ctor("call:len", (constructed.term,), symbol_kind="builtin")
 
 
 def test_source_tuple_slice_extends_receiver_coordinate_and_occurrence(
@@ -158,7 +156,8 @@ def test_tuple_coordinate_length_keeps_receiver_and_use_sites_distinct(
         receiver.call_occurrence, source_cid="blake3-512:" + "e" * 128
     )
     with pytest.raises(
-        ValueError, match="tuple coordinate call occurrence does not authenticate source"
+        ValueError,
+        match="tuple coordinate call occurrence does not authenticate source",
     ):
         replace(receiver, call_occurrence=foreign_occurrence)
     with pytest.raises(
@@ -194,7 +193,8 @@ def test_tuple_coordinate_rejects_all_reminted_testimony(tmp_path: Path) -> None
     )
 
     with pytest.raises(
-        ValueError, match="tuple coordinate call occurrence does not authenticate source"
+        ValueError,
+        match="tuple coordinate call occurrence does not authenticate source",
     ):
         replace(constructed, call_occurrence=foreign_occurrence)
     with pytest.raises(
@@ -256,7 +256,10 @@ def test_guarded_tuple_slice_preserves_exact_occurrence_in_both_arms(
     assert outcome.value.guard == guard
     assert outcome.value.when_true.use_occurrence is occurrence
     assert outcome.value.when_false.use_occurrence is occurrence
-    assert outcome.value.when_true.coordinate_cid == outcome.value.when_false.coordinate_cid
+    assert (
+        outcome.value.when_true.coordinate_cid
+        == outcome.value.when_false.coordinate_cid
+    )
 
 
 def test_guarded_subscript_preserves_foreign_occurrence_refusal(
@@ -269,14 +272,10 @@ def test_guarded_subscript_preserves_foreign_occurrence_refusal(
     foreign_occurrence = replace(
         _coordinate(subscript), source_cid="blake3-512:" + "d" * 128
     )
-    guarded = GuardedValue(
-        atomic("foreign_slice_guard", ()), receiver, receiver
-    )
+    guarded = GuardedValue(atomic("foreign_slice_guard", ()), receiver, receiver)
 
     with pytest.raises(SugarNotWritten) as raised:
-        guarded.subscript_with_occurrence(
-            index, subscript.fragment, foreign_occurrence
-        )
+        guarded.subscript_with_occurrence(index, subscript.fragment, foreign_occurrence)
 
     assert raised.value.owner == "TupleCoordinateValue.subscript"
     assert raised.value.observed == "slice use occurrence outside tuple source"

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_attribute_mutation.py
@@ -6,10 +6,19 @@ from sugar_source_tree.tree import SourceFile
 def _outcomes(tmp_path):
     path = tmp_path / "tuple_iterator_attribute_mutation.py"
     path.write_text("def f(obj, value):\n    obj.attr = value\n    del obj.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     store_site, delete_site = body[0].fragment, body[1].fragment
     value = TupleIteratorValue((TermValue(1),))
-    return ((value.setattr("attr", TermValue(7), store_site), "TupleIteratorValue.setattr", store_site), (value.delattr("attr", delete_site), "TupleIteratorValue.delattr", delete_site))
+    return (
+        (
+            value.setattr("attr", TermValue(7), store_site),
+            "TupleIteratorValue.setattr",
+            store_site,
+        ),
+        (value.delattr("attr", delete_site), "TupleIteratorValue.delattr", delete_site),
+    )
 
 
 def test_tuple_iterator_attribute_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_iterator_subscript_mutation.py
@@ -6,10 +6,23 @@ from sugar_source_tree.tree import SourceFile
 def _outcomes(tmp_path):
     path = tmp_path / "tuple_iterator_subscript_mutation.py"
     path.write_text("def f(obj, value):\n    obj[0] = value\n    del obj[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     store_site, delete_site = body[0].fragment, body[1].fragment
     value = TupleIteratorValue((TermValue(1),))
-    return ((value.setitem(TermValue(0), TermValue(7), store_site), "TupleIteratorValue.setitem", store_site), (value.delitem(TermValue(0), delete_site), "TupleIteratorValue.delitem", delete_site))
+    return (
+        (
+            value.setitem(TermValue(0), TermValue(7), store_site),
+            "TupleIteratorValue.setitem",
+            store_site,
+        ),
+        (
+            value.delitem(TermValue(0), delete_site),
+            "TupleIteratorValue.delitem",
+            delete_site,
+        ),
+    )
 
 
 def test_tuple_iterator_mutations_have_exact_owner_occurrences(tmp_path):

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_attribute_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_attribute_mutation.py
@@ -7,22 +7,42 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "tuple_literal_attribute_mutation.py"
-    path.write_text("def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target.attr = replacement\n    del target.attr\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setattr", "TupleLiteralValue.setattr", 0), ("delattr", "TupleLiteralValue.delattr", 1)))
-def test_tuple_literal_attribute_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = TupleLiteralValue((TermValue(1),))
-    outcome = value.setattr("attr", TermValue(7), site) if operation == "setattr" else value.delattr("attr", site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setattr", "TupleLiteralValue.setattr", 0),
+        ("delattr", "TupleLiteralValue.delattr", 1),
+    ),
+)
+def test_tuple_literal_attribute_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = TupleLiteralValue((TermValue(1),))
+    outcome = (
+        value.setattr("attr", TermValue(7), site)
+        if operation == "setattr"
+        else value.delattr("attr", site)
+    )
     assert outcome.value.effect.exception_name == "AttributeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_tuple_literal_attribute_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = TupleLiteralValue((TermValue(1),))
-    store = value.setattr("attr", TermValue(7), store_site); delete = value.delattr("attr", delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = TupleLiteralValue((TermValue(1),))
+    store = value.setattr("attr", TermValue(7), store_site)
+    delete = value.delattr("attr", delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_subscript_mutation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_literal_subscript_mutation.py
@@ -7,22 +7,42 @@ from sugar_source_tree.tree import SourceFile
 
 def _sites(tmp_path):
     path = tmp_path / "tuple_literal_subscript_mutation.py"
-    path.write_text("def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n")
-    body = next(SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()).body
+    path.write_text(
+        "def f(target, replacement):\n    target[0] = replacement\n    del target[0]\n"
+    )
+    body = next(
+        SourceFile(workspace_path_source(str(path), root=str(tmp_path))).functions()
+    ).body
     return body[0].fragment, body[1].fragment
 
 
-@pytest.mark.parametrize(("operation", "owner", "site_index"), (("setitem", "TupleLiteralValue.setitem", 0), ("delitem", "TupleLiteralValue.delitem", 1)))
-def test_tuple_literal_subscript_mutations_have_exact_owner_occurrences(tmp_path, operation, owner, site_index):
-    sites = _sites(tmp_path); site = sites[site_index]; value = TupleLiteralValue((TermValue(1),))
-    outcome = value.setitem(TermValue(0), TermValue(7), site) if operation == "setitem" else value.delitem(TermValue(0), site)
+@pytest.mark.parametrize(
+    ("operation", "owner", "site_index"),
+    (
+        ("setitem", "TupleLiteralValue.setitem", 0),
+        ("delitem", "TupleLiteralValue.delitem", 1),
+    ),
+)
+def test_tuple_literal_subscript_mutations_have_exact_owner_occurrences(
+    tmp_path, operation, owner, site_index
+):
+    sites = _sites(tmp_path)
+    site = sites[site_index]
+    value = TupleLiteralValue((TermValue(1),))
+    outcome = (
+        value.setitem(TermValue(0), TermValue(7), site)
+        if operation == "setitem"
+        else value.delitem(TermValue(0), site)
+    )
     assert outcome.value.effect.exception_name == "TypeError"
     assert outcome.value.effect.producer_node_owner == owner
     assert outcome.value.effect.occurrence_id == str(site)
 
 
 def test_tuple_literal_subscript_mutations_reject_wrong_site(tmp_path):
-    store_site, delete_site = _sites(tmp_path); value = TupleLiteralValue((TermValue(1),))
-    store = value.setitem(TermValue(0), TermValue(7), store_site); delete = value.delitem(TermValue(0), delete_site)
+    store_site, delete_site = _sites(tmp_path)
+    value = TupleLiteralValue((TermValue(1),))
+    store = value.setitem(TermValue(0), TermValue(7), store_site)
+    delete = value.delitem(TermValue(0), delete_site)
     assert store.value.effect.occurrence_id != str(delete_site)
     assert delete.value.effect.occurrence_id != str(store_site)

--- a/implementations/python/sugar-lift-py-tests/tests/test_tuple_value_slice_subscript.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_tuple_value_slice_subscript.py
@@ -43,8 +43,7 @@ def test_source_tuple_pandas_stride_slices_preserve_order_and_identity(
     even, odd = _subscripts(
         tmp_path,
         monkeypatch,
-        "even = (0, 1, 2, 3)[::2]\n"
-        "odd = (0, 1, 2, 3)[1::2]\n",
+        "even = (0, 1, 2, 3)[::2]\n" "odd = (0, 1, 2, 3)[1::2]\n",
     )
 
     assert _values(_desugar(even)) == (0, 2)
@@ -71,9 +70,7 @@ def test_source_tuple_negative_and_open_slice_bounds_match_python(
 def test_source_tuple_zero_slice_step_is_exact_value_error(
     tmp_path: Path, monkeypatch
 ) -> None:
-    (subscript,) = _subscripts(
-        tmp_path, monkeypatch, "result = (0, 1, 2)[::0]\n"
-    )
+    (subscript,) = _subscripts(tmp_path, monkeypatch, "result = (0, 1, 2)[::0]\n")
     sugar = subscript.sugar()
     site = sugar.site
 
@@ -89,9 +86,7 @@ def test_source_tuple_zero_slice_step_is_exact_value_error(
 def test_source_tuple_symbolic_slice_bound_stays_typed_loud(
     tmp_path: Path, monkeypatch
 ) -> None:
-    (subscript,) = _subscripts(
-        tmp_path, monkeypatch, "result = (0, 1, 2)[start:]\n"
-    )
+    (subscript,) = _subscripts(tmp_path, monkeypatch, "result = (0, 1, 2)[start:]\n")
 
     with pytest.raises(SugarNotWritten) as raised:
         _desugar(subscript)

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_formal_caller.py
@@ -122,18 +122,15 @@ def test_unary_op_sugar_constructs_for_usub() -> None:
 
 def test_ground_neg_plus_invert_fold() -> None:
     site = _site_from()
-    assert (
-        UnaryOpSugar("USub", _FloorSugar(TermValue(3)), site).desugar(None).value
-        == TermValue(-3)
-    )
-    assert (
-        UnaryOpSugar("UAdd", _FloorSugar(TermValue(3)), site).desugar(None).value
-        == TermValue(3)
-    )
-    assert (
-        UnaryOpSugar("Invert", _FloorSugar(TermValue(5)), site).desugar(None).value
-        == TermValue(~5)
-    )
+    assert UnaryOpSugar("USub", _FloorSugar(TermValue(3)), site).desugar(
+        None
+    ).value == TermValue(-3)
+    assert UnaryOpSugar("UAdd", _FloorSugar(TermValue(3)), site).desugar(
+        None
+    ).value == TermValue(3)
+    assert UnaryOpSugar("Invert", _FloorSugar(TermValue(5)), site).desugar(
+        None
+    ).value == TermValue(~5)
 
 
 def test_discrimination_neg_is_not_identity() -> None:
@@ -311,6 +308,10 @@ def test_unary_projectors_call_floor_methods_not_binary_standin() -> None:
     with pytest.raises(AssertionError):
         # Lying: unary_minus is not add-shaped (2 operands + site).
         assert (
-            len(inspect.signature(_NATIVE_OPERATION_PROJECTORS["unary_minus"]).parameters)
+            len(
+                inspect.signature(
+                    _NATIVE_OPERATION_PROJECTORS["unary_minus"]
+                ).parameters
+            )
             == 3
         )

--- a/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unary_not_bool_law.py
@@ -60,14 +60,13 @@ def _identity(name: str):
         [str_const("builtins"), str_const(name)],
     )
 
+
 MANIFEST_CID = (
     "blake3-512:6f317a5a489eb7e730064d79792f0d1656723130603309e2f2ed9cbedb604eda"
     "1c4b77a26dc90c980411292ea3994af9015da4cd850b5a307af5a4998b563530"
 )
 NA_SITE_SHA256 = "e46445908318d803ea24ac6c8f09ba2347de6fc31e12f2459555a1ba1b15e703"
-GENERIC_SITE_SHA256 = (
-    "cbc5383e8e1545537baedca85a6c62a487d3bea6942bb56e5e0c7479dd2f188d"
-)
+GENERIC_SITE_SHA256 = "cbc5383e8e1545537baedca85a6c62a487d3bea6942bb56e5e0c7479dd2f188d"
 
 
 @dataclass(frozen=True)
@@ -292,11 +291,11 @@ def test_halted_truth_is_not_negated() -> None:
 
         assert isinstance(face.value, RaiseValue)
         assert face.value.effect.exception_name == "TypeError"
-        assert face.value.effect.exception_type_coordinate == _identity('TypeError')
+        assert face.value.effect.exception_type_coordinate == _identity("TypeError")
     else:
         assert isinstance(face, Halted)
         assert face.effect.exception_name == "TypeError"
-        assert face.effect.exception_type_coordinate == _identity('TypeError')
+        assert face.effect.exception_type_coordinate == _identity("TypeError")
 
 
 def test_truthful_exceptional_face_carries_floor_type_not_boundary() -> None:
@@ -354,7 +353,10 @@ def test_formal_not_halt_bypasses_negate_continuation() -> None:
         [str_const("builtins"), str_const("TypeError")],
     )
     # Occurrence is the operation site, not a fabricated boundary locus.
-    assert isinstance(exits.exits[0].effect.occurrence_id, str) and ":" in exits.exits[0].effect.occurrence_id, (
+    assert (
+        isinstance(exits.exits[0].effect.occurrence_id, str)
+        and ":" in exits.exits[0].effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {exits.exits[0].effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_undecided_binary_operand_law.py
@@ -105,9 +105,7 @@ def test_undecided_native_bitwise_dispatch_throws_named() -> None:
         ("right_shift", ">>"),
     ),
 )
-def test_undecided_call_result_throws_named_refusal(
-    method: str, operator: str
-) -> None:
+def test_undecided_call_result_throws_named_refusal(method: str, operator: str) -> None:
     _named_refusal(_callsite(), TermValue(2), method, operator)
 
 
@@ -129,9 +127,7 @@ def test_undecided_call_result_throws_named_refusal(
         ("right_shift", ">>"),
     ),
 )
-def test_symbolic_left_operand_throws_named_refusal(
-    method: str, operator: str
-) -> None:
+def test_symbolic_left_operand_throws_named_refusal(method: str, operator: str) -> None:
     _named_refusal(_symbolic(), TermValue(2), method, operator)
 
 
@@ -256,7 +252,6 @@ def test_the_whole_function_publishes_undecided_named_refusal(
     with pytest.raises(SugarNotWritten) as raised:
         fn.sugar().desugar(None)
     assert raised.value.owner == "binary_operation_exception_floor"
-
 
 
 class _FragmentSite:

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_sequencing_law.py
@@ -56,6 +56,7 @@ from sugar_source_tree.nodes import Assign
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+
 def _identity(name: str):
     from sugar_lift_py_tests.floor.ground_exit import (
         _builtin_exception_identity,
@@ -359,7 +360,7 @@ def test_list_indexerror_store_halt_originates_in_setitem_not_boundary(
     effect = halted[0].effect
     assert effect.exception_name == "IndexError"
     assert effect.producer_node_owner == "ground_index_error"
-    assert effect.exception_type_coordinate == _identity('IndexError')
+    assert effect.exception_type_coordinate == _identity("IndexError")
     # Type name may match a boundary expectation; origin is the store producer.
     assert "pytest" not in (effect.producer_node_owner or "").lower()
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_setitem_formal_caller.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_setitem_formal_caller.py
@@ -233,7 +233,10 @@ def test_invalid_index_named_indexerror_no_statement_completion() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -254,7 +257,10 @@ def test_source_caller_invalid_index_named_indexerror() -> None:
     halted = outcome.exits[0]
     assert isinstance(halted, Halted)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_unpack_variadic_setitem_join.py
@@ -27,7 +27,13 @@ from sugar_lift_py_tests.caller_parameter_contract import (
     _NATIVE_OPERATION_PROJECTORS,
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.floor import ListValue, ReturnValue, SymbolicValue, TermValue, TupleValue
+from sugar_lift_py_tests.floor import (
+    ListValue,
+    ReturnValue,
+    SymbolicValue,
+    TermValue,
+    TupleValue,
+)
 from sugar_lift_py_tests.floor.universe_value import UniverseValue
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_python_source.canonical import blake3_512_of
@@ -209,7 +215,10 @@ def test_variadic_store_halt_preserves_earlier_name_binding_state() -> None:
     assert isinstance(halted, Halted)
     assert not isinstance(halted, Completed)
     assert halted.effect.exception_type_coordinate == _identity("IndexError")
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_walrus_operator_temporal.py
@@ -294,9 +294,9 @@ def test_left_hand_comparison_presented_owns_and_carry_binds() -> None:
 
 def test_no_string_predicate_from_left_door() -> None:
     """NamedExpressionValue must not admit comparison via operation:str."""
-    assert "predicate_from_left" not in NamedExpressionValue.__dict__, (
-        "delete string admission; use less_than_from_left etc."
-    )
+    assert (
+        "predicate_from_left" not in NamedExpressionValue.__dict__
+    ), "delete string admission; use less_than_from_left etc."
 
 
 def test_right_hand_zero_lt_walrus_reaches_typed_method() -> None:
@@ -377,9 +377,9 @@ def test_lying_operator_token_twin_refuses_same_outcome() -> None:
     truthful = ComparisonOpSugar(
         "Lt", _int(0), _walrus("n", _int(5)), site=SITE
     ).desugar(_root("op-true"))
-    lying = ComparisonOpSugar(
-        "Gt", _int(0), _walrus("n", _int(5)), site=SITE
-    ).desugar(_root("op-lie"))
+    lying = ComparisonOpSugar("Gt", _int(0), _walrus("n", _int(5)), site=SITE).desugar(
+        _root("op-lie")
+    )
     assert isinstance(truthful, Complete)
     assert isinstance(lying, Complete)
     # Ground 0 < 5 vs 0 > 5 must not be outcome-identical.

--- a/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_while_assert_condition_occurrence_identity.py
@@ -9,7 +9,6 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_source_tree.nodes import Assert, Compare, While
 from sugar_source_tree.tree import SourceFile
 
-
 SOURCE = (
     "def control(left, right):\n"
     "    while left < right:\n"
@@ -29,7 +28,10 @@ def _halt_occurrence(compare: Compare) -> str:
     assert isinstance(outcome, ExitSet)
     halted = tuple(exit_ for exit_ in outcome.exits if isinstance(exit_, Halted))
     assert len(halted) == 1
-    assert isinstance(halted[0].effect.occurrence_id, str) and ":" in halted[0].effect.occurrence_id, (
+    assert (
+        isinstance(halted[0].effect.occurrence_id, str)
+        and ":" in halted[0].effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted[0].effect.occurrence_id!r}"
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -68,9 +68,9 @@ def test_conservation_identity_is_stated_on_partition_and_refusal():
     assert ok["unaccounted"] == 0
     assert ok["accounted"] == 5
     assert ok["unconstructed"] == 3
-    assert ok["edgeWitness"]["inputKeyManifest"] == ok["edgeWitness"][
-        "outputKeyManifest"
-    ]
+    assert (
+        ok["edgeWitness"]["inputKeyManifest"] == ok["edgeWitness"]["outputKeyManifest"]
+    )
     assert ok["edgeWitness"]["missingKeys"] == []
     assert ok["edgeWitness"]["extraKeys"] == []
     assert "typed_gaps" not in ok
@@ -167,9 +167,7 @@ def test_known_constructed_with_item_shows_constructed_gt_zero(tmp_path: Path):
 
     path = tmp_path / "consumer.py"
     path.write_text(
-        "def consume(mgr):\n"
-        "    with mgr:\n"
-        "        pass\n",
+        "def consume(mgr):\n" "    with mgr:\n" "        pass\n",
         encoding="utf-8",
     )
     refs = provisional_contract_refs_from_demands(tmp_path)
@@ -198,9 +196,7 @@ def test_known_constructed_with_item_shows_constructed_gt_zero(tmp_path: Path):
         import_signature=ImportSignatureV2(()),
         protocol=_Protocol(),
     )
-    rows = module._tally_cm_resolutions(
-        ctx, source_cid=source_file.unit.source_cid
-    )
+    rows = module._tally_cm_resolutions(ctx, source_cid=source_file.unit.source_cid)
     sites = module._ast_site_prevalence(path)
     assert sites.get("site:with-item", 0) == 1
     assert sum(row["outcome"] == "constructed" for row in rows) >= 1, rows
@@ -220,9 +216,7 @@ def test_unconstructed_with_item_is_counted_not_silently_dropped(tmp_path: Path)
 
     path = tmp_path / "opaque.py"
     path.write_text(
-        "def run():\n"
-        "    with mystery():\n"
-        "        pass\n",
+        "def run():\n" "    with mystery():\n" "        pass\n",
         encoding="utf-8",
     )
     refs = provisional_contract_refs_from_demands(tmp_path)
@@ -230,9 +224,7 @@ def test_unconstructed_with_item_is_counted_not_silently_dropped(tmp_path: Path)
     source_file = open_source_file_for_construction(
         path, root=tmp_path, construction_context=ctx, populate_derived=True
     )
-    rows = module._tally_cm_resolutions(
-        ctx, source_cid=source_file.unit.source_cid
-    )
+    rows = module._tally_cm_resolutions(ctx, source_cid=source_file.unit.source_cid)
     sites = module._ast_site_prevalence(path)
     assert sites.get("site:with-item", 0) == 1
     assert sum(row["outcome"] == "unconstructed" for row in rows) == 1, rows
@@ -256,9 +248,7 @@ def test_effective_tally_includes_contract_refs_not_only_source_derived(
 
     path = tmp_path / "opaque.py"
     path.write_text(
-        "def run():\n"
-        "    with mystery():\n"
-        "        pass\n",
+        "def run():\n" "    with mystery():\n" "        pass\n",
         encoding="utf-8",
     )
     refs = provisional_contract_refs_from_demands(tmp_path)
@@ -269,9 +259,7 @@ def test_effective_tally_includes_contract_refs_not_only_source_derived(
     # Old defect shape: derived empty, provisional has the gap.
     assert len(ctx.source_derived_contract_refs) == 0
     assert len(refs.by_use_site) == 1
-    rows = module._tally_cm_resolutions(
-        ctx, source_cid=source_file.unit.source_cid
-    )
+    rows = module._tally_cm_resolutions(ctx, source_cid=source_file.unit.source_cid)
     assert len(rows) == 1, rows
 
 
@@ -289,9 +277,7 @@ def test_enumerate_with_rows_reach_partition_with_identical_keys(
 
     path = tmp_path / "opaque.py"
     path.write_text(
-        "def run():\n"
-        "    with mystery():\n"
-        "        pass\n",
+        "def run():\n" "    with mystery():\n" "        pass\n",
         encoding="utf-8",
     )
     refs = provisional_contract_refs_from_demands(tmp_path)

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_effect_boundary_warning.py
@@ -20,7 +20,11 @@ from sugar_lift_py_tests.context_manager_contract import (
     WarningEffectKindV1,
     WarningObservationBindingV1,
 )
-from sugar_lift_py_tests.effect import ExpectationNotMetEffect, RaiseEffect, WarningEffect
+from sugar_lift_py_tests.effect import (
+    ExpectationNotMetEffect,
+    RaiseEffect,
+    WarningEffect,
+)
 from sugar_lift_py_tests.floor import (
     BlockValue,
     CallSiteValue,
@@ -128,8 +132,7 @@ def test_truthful_warning_observation_completes_and_is_consumed():
     face = routed.exits[0]
     assert isinstance(face, Completed)
     assert not any(
-        isinstance(entry, WarningObservationValue)
-        for entry in face.value.entries
+        isinstance(entry, WarningObservationValue) for entry in face.value.entries
     )
 
 
@@ -150,9 +153,7 @@ def test_multi_authenticated_warning_observations_are_not_a_decided_miss():
     matcher — the lying twin of this package.
     """
     with pytest.raises(SugarNotWritten) as raised:
-        _boundary(
-            _warning("FutureWarning"), _warning("DeprecationWarning")
-        ).desugar()
+        _boundary(_warning("FutureWarning"), _warning("DeprecationWarning")).desugar()
     gap = raised.value
     assert gap.owner == "WithEffectBoundarySugar.warning_observation"
     assert "2 authenticated warning observations" in gap.observed
@@ -266,8 +267,8 @@ def _raise_with_entries(*entries):
         (
             Halted(
                 true_guard(),
-                RaiseEffect.for_builtin("TypeError",
-                    
+                RaiseEffect.for_builtin(
+                    "TypeError",
                     occurrence="body.py:3:4",
                     raised_value=raised_value,
                 ),
@@ -446,8 +447,8 @@ def _raise_after_warning(*, warning_message="deprecated operand"):
         (
             Halted(
                 true_guard(),
-                RaiseEffect.for_builtin("TypeError",
-                    
+                RaiseEffect.for_builtin(
+                    "TypeError",
                     occurrence="renamed.py:6:8",
                     raised_value=raised_value,
                 ),

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py
@@ -94,7 +94,12 @@ class _Raise(_FixedSugar):
         coordinate, mro = _builtin_exception_identity(name)
         super().__init__(
             Incomplete(
-                RaiseEffect(exception_type_coordinate=coordinate, occurrence=AuthenticatedRaiseLocus.of(occurrence), exception_name=name, exception_type_mro=mro)
+                RaiseEffect(
+                    exception_type_coordinate=coordinate,
+                    occurrence=AuthenticatedRaiseLocus.of(occurrence),
+                    exception_name=name,
+                    exception_type_mro=mro,
+                )
             ),
             probe=probe,
         )
@@ -301,7 +306,10 @@ def test_exit_face_binding_applied_per_face_without_rebuilding_exit():
 def test_enter_halt_skips_body_and_exit():
     body_ran = []
     exit_ran = []
-    enter_halt = RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:303:0')
+    enter_halt = RaiseEffect.for_builtin(
+        "OSError",
+        occurrence="implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:303:0",
+    )
     sugar = _resource(
         enter=_FixedSugar(Incomplete(enter_halt)),
         body=(_Pass(probe=body_ran),),
@@ -337,8 +345,8 @@ def test_completed_body_runs_exit_with_three_explicit_none_coordinates():
 def test_raised_body_routes_exact_face_coordinates_to_exit():
     """Face 3: type/value/traceback coordinates share the exact raised face."""
     face_id = "raised-face-17"
-    effect = RaiseEffect.for_builtin("ValueError",
-        
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
         occurrence="source.py:17:8",
     )
     exit_sugar = _parametric_exit(face_id=face_id)
@@ -635,7 +643,12 @@ def test_never_suppresses_needs_no_second_cleanup_algebra():
     faces = (
         Completed(true_guard(), _FloorValue("body")),
         Halted(
-            true_guard(), RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:637:0'), _FloorValue("pre")
+            true_guard(),
+            RaiseEffect.for_builtin(
+                "ValueError",
+                occurrence="implementations/python/sugar-lift-py-tests/tests/test_with_resource_sugar.py:637:0",
+            ),
+            _FloorValue("pre"),
         ),
     )
     for disposition in (NeverSuppresses(), NeverSuppressesDispositionV1()):
@@ -663,8 +676,8 @@ def test_lying_the_equivalence_is_specific_to_never_suppresses():
     _, mro = _builtin_exception_identity("ValueError")
     halted = Halted(
         true_guard(),
-        RaiseEffect.for_builtin("ValueError",
-            
+        RaiseEffect.for_builtin(
+            "ValueError",
             exception_type_mro=mro,
             occurrence="equiv.py:1:0",
         ),

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_source_resource_sugar.py
@@ -68,12 +68,8 @@ class _CompletedProtocol:
 
 
 def _protocol_calls():
-    enter_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "e" * 128, 1, 0, 1, 1
-    )
-    exit_definition = SourceFragmentCoordinateV1(
-        "blake3-512:" + "x" * 128, 2, 0, 2, 1
-    )
+    enter_definition = SourceFragmentCoordinateV1("blake3-512:" + "e" * 128, 1, 0, 1, 1)
+    exit_definition = SourceFragmentCoordinateV1("blake3-512:" + "x" * 128, 2, 0, 2, 1)
     enter = MethodCallSugar(
         receiver=ManagerRefSugar(slot_id="manager-slot", site=None),
         name="__enter__",
@@ -144,8 +140,8 @@ def test_summary_suppresses_disposition_consumes_matching_body_halt():
         body=(
             _FixedSugar(
                 Incomplete(
-                    RaiseEffect.for_builtin("ValueError",
-                        
+                    RaiseEffect.for_builtin(
+                        "ValueError",
                         occurrence="resource.py:4:8",
                         exception_type_mro=mro,
                     )
@@ -240,18 +236,14 @@ def test_source_exit_runs_on_early_return_face():
         ),
         (
             Complete(
-                BlockValue(
-                    (ReturnValue(TermValue("early")),), can_fall_through=False
-                )
+                BlockValue((ReturnValue(TermValue("early")),), can_fall_through=False)
             ),
             TermValue(True),
             Completed,
         ),
         (
             Incomplete(
-                RaiseEffect.for_builtin("ValueError",
-                     occurrence="resource.py:8:8"
-                )
+                RaiseEffect.for_builtin("ValueError", occurrence="resource.py:8:8")
             ),
             TermValue(False),
             Halted,

--- a/implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_worker_demand_table_gate.py
@@ -85,5 +85,9 @@ def test_worker_refuses_legacy_key_by_name(tmp_path: Path, monkeypatch):
     )
     worker._CONSTRUCTION_CONTEXT = None
     worker._CORPUS_ROOT = None
-    with pytest.raises(DemandTableArtifactRefusal, match="legacy shared demand table identity refused"):
-        worker._initialize(str(root), str(artifact), allow_local_demand_derivation=False)
+    with pytest.raises(
+        DemandTableArtifactRefusal, match="legacy shared demand table identity refused"
+    ):
+        worker._initialize(
+            str(root), str(artifact), allow_local_demand_derivation=False
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -89,9 +89,7 @@ def materialize(
     cls = ref.resolve_type()
     # Ensure the field row exists (filled lazily on first accessor). Kind
     # selects whether the control stack is part of the coordinate.
-    key = cache.key(
-        ref, reporter, ctx, unit.construction_context, kind=cls.__name__
-    )
+    key = cache.key(ref, reporter, ctx, unit.construction_context, kind=cls.__name__)
     cache.fields.setdefault(key, {})
 
     return cls(
@@ -667,7 +665,10 @@ class Backend:
         reporter: AuditReporter = NULL_REPORTER,
     ) -> _ConstructedModuleV1:
         """Construct and close one module product in one eager traversal."""
-        from .file_open_profile import _TimedModuleMaterialize, current_file_open_profile
+        from .file_open_profile import (
+            _TimedModuleMaterialize,
+            current_file_open_profile,
+        )
 
         # Profile only when a file-open instrument is active (recensus etc.).
         # L0c: key by content CID, not seat path — same module at two seats is

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -466,7 +466,10 @@ class ConstructionTestimonyReporterV1:
 
         if type(producer) is ConstructionTestimonyReporterV1:
             registered = producer._materialized_by_ref.get(node.ref)
-        elif type(producer) is CollectingReporter and getattr(node, "reporter", None) is producer:
+        elif (
+            type(producer) is CollectingReporter
+            and getattr(node, "reporter", None) is producer
+        ):
             # File-open door: CollectingReporter witnessed construction; the
             # node itself is the authenticated occurrence for this ref.
             registered = node

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -20,9 +20,7 @@ from typing import Any
 
 # Kinds whose constructed answer reads ControlConstructionContextV1.
 # Everyone else resolves identically inside or outside a loop/handler.
-CONTROL_SENSITIVE_KINDS: frozenset[str] = frozenset(
-    ("Break", "Continue", "Raise")
-)
+CONTROL_SENSITIVE_KINDS: frozenset[str] = frozenset(("Break", "Continue", "Raise"))
 
 
 def control_key_fragment(
@@ -44,6 +42,7 @@ def control_key_fragment(
     # Raise
     slots = getattr(control_context, "exception_slots", ()) or ()
     return ("exc", slots[-1] if slots else None)
+
 
 # The construction-shape CID is a CATEGORY of content-addressed work: a pure
 # function of a backend ref (fragment + subtree preimage). It is NOT unit-scoped

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -329,9 +329,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         test_guard = (
             and_([])
             if loop._ground_truth(loop.test) is True
-            else branch_result_guard(
-                branch_result_slot(loop.test), loop.test.fragment
-            )
+            else branch_result_guard(branch_result_slot(loop.test), loop.test.fragment)
         )
         exhaustion_guard = not_(test_guard)
         true_guard = test_guard
@@ -468,6 +466,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         successor_cid = binder["binderTransformCid"]
         records.extend((binder, iterator, operation))
     else:
+
         def while_test_transform(input_state_cid):
             return _record(
                 {
@@ -496,9 +495,7 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
             "operationCid",
         )
         successor_cid = recurrence_test_transform["testTransformCid"]
-        records.extend(
-            (initial_test_transform, recurrence_test_transform, operation)
-        )
+        records.extend((initial_test_transform, recurrence_test_transform, operation))
 
     body = _record(
         {

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py
@@ -51,7 +51,9 @@ class LoopProjectedBindingProductSugar(ConstructedTermSugar):
                 "loop binding product requires the producer's exact projection"
             )
         if self.projection.target_cid != self.target_cid:
-            raise BindingStateWireGap("loop binding product has a foreign loop occurrence")
+            raise BindingStateWireGap(
+                "loop binding product has a foreign loop occurrence"
+            )
         if cid_of_json(self.binding_coordinate.preimage) != self.binding_coordinate.cid:
             raise BindingStateWireGap("loop binding product has a foreign coordinate")
         expected_name = cid_of_json(
@@ -64,7 +66,9 @@ class LoopProjectedBindingProductSugar(ConstructedTermSugar):
             raise BindingStateWireGap("loop binding product has a foreign binding name")
         expected_occurrence = cid_of_json(self.site.seal().to_dict())
         if self.occurrence_cid != expected_occurrence:
-            raise BindingStateWireGap("loop binding product has a foreign read occurrence")
+            raise BindingStateWireGap(
+                "loop binding product has a foreign read occurrence"
+            )
         if (
             self.binding_coordinate.binding_site["source_cid"]
             != self.site.seal().source_cid
@@ -87,9 +91,7 @@ class LoopProjectedBindingProductSugar(ConstructedTermSugar):
             site,
             binding_coordinate,
             target_cid,
-            cid_of_json(
-                {"bindingCoordinateCid": binding_coordinate.cid, "name": name}
-            ),
+            cid_of_json({"bindingCoordinateCid": binding_coordinate.cid, "name": name}),
             cid_of_json(site.seal().to_dict()),
             _PRODUCT_MINT_AUTHORITY,
         )
@@ -195,8 +197,8 @@ def project_loop_post_binding(
             raise BindingStateWireGap(
                 f"completed face {face.cid} has {len(matches)} entries for binding coordinate"
             )
-        live_guard = None if live_guards is None else live_guards.get(
-            record["guardFormulaCid"]
+        live_guard = (
+            None if live_guards is None else live_guards.get(record["guardFormulaCid"])
         )
         if live_guards is not None:
             if live_guard is None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -159,7 +159,7 @@ class ControlConstructionContextV1:
                 observed="bare raise has no authenticated in-flight exception slot",
                 requested="an enclosing except handler effect-slot coordinate",
                 fix="construct bare raise only inside the handler that owns its effect",
-        )
+            )
         return self.exception_slots[-1]
 
 
@@ -4135,7 +4135,9 @@ class ClassDef(Statement):
                 fix="carry the parser-owned ClassDef name occurrence as binding_target",
             )
 
-    def _method_descriptor_kind(self, method: "FunctionDef | AsyncFunctionDef") -> Optional[str]:
+    def _method_descriptor_kind(
+        self, method: "FunctionDef | AsyncFunctionDef"
+    ) -> Optional[str]:
         """Authenticate one language descriptor decorator by lexical binding.
 
         The decorator spelling is only a lookup key.  A same-named module
@@ -4253,7 +4255,6 @@ class ClassDef(Statement):
         if d:
             changed["body"] = new_body
         return self if not changed else rewrite(self, **changed)
-
 
     def _construct_class_method_member(self, method):
         """Enroll one method through the FunctionDef construction door only.
@@ -6851,9 +6852,7 @@ class If(Statement):
             self, "authenticated_branch_result_slot_id", None
         )
         # Both ids are written together on first mint. Either alone is incomplete.
-        retained_slot = (
-            stored_slot_id is not None and authenticated_slot_id is not None
-        )
+        retained_slot = stored_slot_id is not None and authenticated_slot_id is not None
         if retained_slot:
             if stored_slot_id != authenticated_slot_id:
                 backend_defect(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -40,7 +40,6 @@ tree (#5940 builds the tree in isolation).
 from __future__ import annotations
 
 
-
 def _render_blame(blame: object) -> str:
     """Project a native coordinate to actionable prose only at the panic edge."""
     filename = getattr(blame, "filename", None)
@@ -239,7 +238,11 @@ def vocabulary_missing(
     *, blame: object, owner: str, observed: str, requested: str, fix: str
 ) -> "VocabularyMissing":
     raise VocabularyMissing(
-        blame=blame, owner=owner, observed=observed, requested=requested, fix=fix,
+        blame=blame,
+        owner=owner,
+        observed=observed,
+        requested=requested,
+        fix=fix,
     )
 
 
@@ -247,5 +250,9 @@ def backend_defect(
     *, blame: object, owner: str, observed: str, requested: str, fix: str
 ) -> "BackendDefect":
     raise BackendDefect(
-        blame=blame, owner=owner, observed=observed, requested=requested, fix=fix,
+        blame=blame,
+        owner=owner,
+        observed=observed,
+        requested=requested,
+        fix=fix,
     )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
@@ -206,9 +206,7 @@ def get_or_prepare_lexical_import_pass(
         _LEXICAL.move_to_end(key)
         return hit
 
-    _LEXICAL_PREPARE_COUNTS[source_cid] = (
-        _LEXICAL_PREPARE_COUNTS.get(source_cid, 0) + 1
-    )
+    _LEXICAL_PREPARE_COUNTS[source_cid] = _LEXICAL_PREPARE_COUNTS.get(source_cid, 0) + 1
     runner = _run_lexical_import_pass_on_module(
         module,
         root=root_p,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/tree.py
@@ -134,7 +134,9 @@ class SourceFile:
                 self.backend = backend if backend is not None else _default_backend()
             self.reporter = reporter
             with reduction_span(sugar="MaterializeModule", role="file", site=site):
-                constructed_module = self.backend.materialize_module(self.unit, reporter)
+                constructed_module = self.backend.materialize_module(
+                    self.unit, reporter
+                )
             self.constructed_module = constructed_module
             self.root: Module = constructed_module.root
             self.closed_roll_call = constructed_module.closed_roll_call
@@ -215,6 +217,7 @@ class SourceFile:
         down: a function yields nothing further until asked.
         """
         from sugar_lift_py_tests.engine_log import reduction_span
+
         # First full walk materializes the typed tree (field data memo).
         # Span names that cost so file-level exclusive heat is not a black box.
         with reduction_span(

--- a/implementations/python/sugar-source-tree/tests/conftest.py
+++ b/implementations/python/sugar-source-tree/tests/conftest.py
@@ -22,7 +22,7 @@ if os.path.join(_ROOT, "tests") not in sys.path:
 
 from checkout_resolution import pin_checkout  # noqa: E402
 
-pin_checkout(__file__, siblings=('sugar-lift-python-source',))
+pin_checkout(__file__, siblings=("sugar-lift-python-source",))
 
 
 def oracle_source_file(source: str, backend=None, suffix: str = ".py"):

--- a/implementations/python/sugar-source-tree/tests/declared_corpus.py
+++ b/implementations/python/sugar-source-tree/tests/declared_corpus.py
@@ -49,9 +49,7 @@ HOST_GRAMMAR = "host-grammar"
 # passing backend.
 OPTIONAL_PROVIDER = "optional-provider"
 
-OPTIONAL_LAW_CATEGORIES = frozenset(
-    {HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER}
-)
+OPTIONAL_LAW_CATEGORIES = frozenset({HEAVY_OPT_IN, HOST_GRAMMAR, OPTIONAL_PROVIDER})
 
 
 class DeclaredCorpusMissing(AssertionError):

--- a/implementations/python/sugar-source-tree/tests/fixtures/receiver_field_store_fibonacci_blowup.py
+++ b/implementations/python/sugar-source-tree/tests/fixtures/receiver_field_store_fibonacci_blowup.py
@@ -11,6 +11,7 @@
 # Twelve fib-shaped self-field stores: no numpy, no complex, no *args.
 # With DAG-correct walk (visit-once), construct is linear in statement count.
 
+
 class C:
     def setup_method(self):
         self.a0 = 1

--- a/implementations/python/sugar-source-tree/tests/test_allocation_definition_not_functiondef.py
+++ b/implementations/python/sugar-source-tree/tests/test_allocation_definition_not_functiondef.py
@@ -123,9 +123,9 @@ def test_recursive_name_call_sugar_does_not_raise_authenticated_new_shape() -> N
         try:
             call.sugar()
         except AttributeError as exc:
-            assert str(exc) != "_authenticated_new_constructor_shape", (
-                "recursive Name-call must not trip ClassDef-only method on FunctionDef"
-            )
+            assert (
+                str(exc) != "_authenticated_new_constructor_shape"
+            ), "recursive Name-call must not trip ClassDef-only method on FunctionDef"
             raise
 
 

--- a/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
+++ b/implementations/python/sugar-source-tree/tests/test_annassign_augassign.py
@@ -105,9 +105,7 @@ def test_attribute_aug_assign_formal_get_is_attribute_named_carrier():
         NativeOperationExitCarrierV1,
     )
 
-    outcome = (
-        _fn("def A(obj, y):\n    obj.a += y\n    return y\n").sugar().desugar()
-    )
+    outcome = _fn("def A(obj, y):\n    obj.a += y\n    return y\n").sugar().desugar()
     assert isinstance(outcome, NativeOperationExitCarrierV1)
     assert outcome.demand.operator == "attribute_named"
 
@@ -118,9 +116,7 @@ def test_subscript_aug_assign_formal_get_is_subscript_carrier():
         NativeOperationExitCarrierV1,
     )
 
-    outcome = (
-        _fn("def A(d, k, y):\n    d[k] += y\n    return y\n").sugar().desugar()
-    )
+    outcome = _fn("def A(d, k, y):\n    d[k] += y\n    return y\n").sugar().desugar()
     assert isinstance(outcome, NativeOperationExitCarrierV1)
     assert outcome.demand.operator == "subscript"
 

--- a/implementations/python/sugar-source-tree/tests/test_assign_nested_unpack_l3b.py
+++ b/implementations/python/sugar-source-tree/tests/test_assign_nested_unpack_l3b.py
@@ -8,7 +8,9 @@ non-display arm only.
 from __future__ import annotations
 
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
-from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import DynamicUnpackAssignSugar
+from sugar_lift_py_tests.sugar.dynamic_unpack_assign_sugar import (
+    DynamicUnpackAssignSugar,
+)
 from sugar_lift_py_tests.sugar.nested_dynamic_unpack_assign_sugar import (
     NestedDynamicUnpackAssignSugar,
 )
@@ -69,9 +71,7 @@ def _first_assign_sugar(src: str):
 
 
 def test_nested_name_only_formal_unpack_constructs_nested_dynamic_sugar():
-    sugar = _first_assign_sugar(
-        "def A(p):\n    (a, b), (c, d) = p\n    return a\n"
-    )
+    sugar = _first_assign_sugar("def A(p):\n    (a, b), (c, d) = p\n    return a\n")
     assert isinstance(sugar, NestedDynamicUnpackAssignSugar)
     assert sugar.pattern == (("a", "b"), ("c", "d"))
 
@@ -87,9 +87,7 @@ def test_flat_dynamic_unpack_still_uses_flat_sugar():
 
 
 def test_nested_display_unpack_still_constructs():
-    sugar = _fn_sugar(
-        "def A():\n    (a, b), (c, d) = (1, 2), (3, 4)\n    return a\n"
-    )
+    sugar = _fn_sugar("def A():\n    (a, b), (c, d) = (1, 2), (3, 4)\n    return a\n")
     assert sugar is not None
 
 

--- a/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
@@ -16,6 +16,7 @@ from sugar_source_tree.nodes import Attribute, With
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
+
 def _identity(name: str):
     from sugar_lift_py_tests.floor.ground_exit import (
         _builtin_exception_identity,
@@ -73,7 +74,7 @@ def test_source_property_getter_publishes_authenticated_exceptional_exit(
     effect = halted[0].effect
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "ValueError"
-    assert effect.exception_type_coordinate == _identity('ValueError')
+    assert effect.exception_type_coordinate == _identity("ValueError")
     assert isinstance(effect.occurrence_id, str) and ":" in effect.occurrence_id, (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {effect.occurrence_id!r}"
@@ -103,8 +104,11 @@ def test_property_getter_raise_keeps_imported_bare_exception_coordinate(
     halted = next(face for face in outcome.exits if isinstance(face, Halted))
     assert isinstance(halted.effect, RaiseEffect)
     assert halted.effect.exception_name == "CustomError"
-    assert halted.effect.exception_type_coordinate == _identity('CustomError')
-    assert isinstance(halted.effect.occurrence_id, str) and ":" in halted.effect.occurrence_id, (
+    assert halted.effect.exception_type_coordinate == _identity("CustomError")
+    assert (
+        isinstance(halted.effect.occurrence_id, str)
+        and ":" in halted.effect.occurrence_id
+    ), (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {halted.effect.occurrence_id!r}"
     )
@@ -181,7 +185,7 @@ def test_pandas_303_abstract_method_property_is_the_concrete_reproducer() -> Non
     effect = halted.effect
     assert isinstance(effect, RaiseEffect)
     assert effect.exception_name == "AbstractMethodError"
-    assert effect.exception_type_coordinate == _identity('AbstractMethodError')
+    assert effect.exception_type_coordinate == _identity("AbstractMethodError")
     assert isinstance(effect.occurrence_id, str) and ":" in effect.occurrence_id, (
         "authenticated raise locus must be a file:line:col occurrence id, "
         f"not presence-only; got {effect.occurrence_id!r}"

--- a/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
+++ b/implementations/python/sugar-source-tree/tests/test_binding_state_unbound.py
@@ -59,6 +59,7 @@ def _assert_unpack_arity_obligation(out, *, arity: int, names: tuple[str, ...]):
     assert isinstance(out, Incomplete), type(out).__name__
     return _assert_unpack_effect(out.effect, arity=arity, names=names)
 
+
 def _return(exit_):
     assert isinstance(exit_, Completed)
     assert isinstance(exit_.value, UniverseValue)

--- a/implementations/python/sugar-source-tree/tests/test_classdef_body_members_l1b.py
+++ b/implementations/python/sugar-source-tree/tests/test_classdef_body_members_l1b.py
@@ -29,11 +29,7 @@ def _class(src: str, name: str = "C") -> ClassDef:
 
 
 def test_l1b_simple_fields_construct() -> None:
-    sugar = _class(
-        "class C:\n"
-        "    a = 1\n"
-        "    b: int = 2\n"
-    ).sugar()
+    sugar = _class("class C:\n" "    a = 1\n" "    b: int = 2\n").sugar()
     assert isinstance(sugar, ClassDefinitionSugar)
     assert sugar.methods == ()
     assert tuple(field.name for field in sugar.fields) == ("a", "b")
@@ -42,15 +38,16 @@ def test_l1b_simple_fields_construct() -> None:
 
 def test_l1b_nested_classdef_is_a_field() -> None:
     sugar = _class(
-        "class Outer:\n"
-        "    x = 1\n"
-        "    class Inner:\n"
-        "        y = 2\n",
+        "class Outer:\n" "    x = 1\n" "    class Inner:\n" "        y = 2\n",
         name="Outer",
     ).sugar()
     assert isinstance(sugar, ClassDefinitionSugar)
     names = tuple(
-        field.name if isinstance(field, ConstructedClassFieldV1) else type(field).__name__
+        (
+            field.name
+            if isinstance(field, ConstructedClassFieldV1)
+            else type(field).__name__
+        )
         for field in sugar.fields
     )
     assert names == ("x", "Inner")
@@ -65,11 +62,7 @@ def test_l1b_nested_classdef_is_a_field() -> None:
 
 def test_l1b_conditional_fields_construct() -> None:
     sugar = _class(
-        "class C:\n"
-        "    if True:\n"
-        "        a = 1\n"
-        "    else:\n"
-        "        a = 2\n"
+        "class C:\n" "    if True:\n" "        a = 1\n" "    else:\n" "        a = 2\n"
     ).sugar()
     assert len(sugar.fields) == 1
     cond = sugar.fields[0]
@@ -101,10 +94,7 @@ def test_l1b_elif_chain_is_nested_conditional() -> None:
 def test_l1b_fields_alongside_sync_method() -> None:
     """Fields construct; method body uses FunctionDef door (not ClassDef)."""
     sugar = _class(
-        "class C:\n"
-        "    a = 1\n"
-        "    def m(self):\n"
-        "        return self.a\n"
+        "class C:\n" "    a = 1\n" "    def m(self):\n" "        return self.a\n"
     ).sugar()
     assert tuple(f.name for f in sugar.fields) == ("a",)
     assert len(sugar.methods) == 1
@@ -118,10 +108,7 @@ def test_l1b_async_method_is_method_member_not_unsupported() -> None:
 
     with pytest.raises(SugarNotWritten) as ei:
         _class(
-            "class C:\n"
-            "    a = 1\n"
-            "    async def m(self):\n"
-            "        return 1\n"
+            "class C:\n" "    a = 1\n" "    async def m(self):\n" "        return 1\n"
         ).sugar()
     err = ei.value
     assert err.owner == "ClassDef._construct_class_method_member"

--- a/implementations/python/sugar-source-tree/tests/test_classdef_chained_assignment_adapter_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_classdef_chained_assignment_adapter_testimony.py
@@ -33,9 +33,7 @@ def _available_backends():
             TreeSitterPythonBackend,
         )
 
-        cases.append(
-            pytest.param(TreeSitterPythonBackend(), id="tree-sitter-python")
-        )
+        cases.append(pytest.param(TreeSitterPythonBackend(), id="tree-sitter-python"))
     return tuple(cases)
 
 
@@ -104,9 +102,7 @@ def test_re_regexflag_chained_names_retain_targets_and_one_evaluated_floor(
     monkeypatch.setattr(AttributeSugar, "desugar", authenticated_attribute_floor)
 
     sugar = class_node.sugar()
-    fields = tuple(
-        field for field in sugar.fields if field.name in {"IGNORECASE", "I"}
-    )
+    fields = tuple(field for field in sugar.fields if field.name in {"IGNORECASE", "I"})
     assert tuple(field.name for field in fields) == ("IGNORECASE", "I")
     assert fields[0].value_sugar is fields[1].value_sugar
     debug = next(field for field in sugar.fields if field.name == "DEBUG")
@@ -165,9 +161,9 @@ def test_removing_class_chained_assign_arm_restores_exact_re_failure(
     error = excinfo.value
     assert error.owner == "ClassDef._construct_sugar"
     assert error.observed == "unsupported class member Assign"
-    assert error.blame.line_col_span == _line_assignment(
-        class_node, 145
-    ).line_col_span()
+    assert (
+        error.blame.line_col_span == _line_assignment(class_node, 145).line_col_span()
+    )
     assert error.blame.line_col_span.start_line == 145
     assert error.blame.line_col_span.start_col == 4
 

--- a/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
@@ -8,8 +8,14 @@ import tempfile
 
 import pytest
 
-from sourcefile_construction_door_evidence import SourceFileConstructionDoorEvidence, assert_test_owned_evidence
-from sourcefile_construction_door_fixture import _direct_source_file_entry, sourcefile_construction_door_evidence
+from sourcefile_construction_door_evidence import (
+    SourceFileConstructionDoorEvidence,
+    assert_test_owned_evidence,
+)
+from sourcefile_construction_door_fixture import (
+    _direct_source_file_entry,
+    sourcefile_construction_door_evidence,
+)
 from sugar_source_tree.backend import Backend
 from sugar_source_tree.nodes import SourceUnit
 from sugar_source_tree.panic import BackendDefect
@@ -50,7 +56,9 @@ def _authentic_foreign_backend_product(source: str):
             module = importlib.import_module(module_name)
         except ModuleNotFoundError:
             continue
-        products.append(_file(source, backend=getattr(module, class_name)()).constructed_module)
+        products.append(
+            _file(source, backend=getattr(module, class_name)()).constructed_module
+        )
     return products[0] if products else None
 
 
@@ -90,9 +98,15 @@ def authentic_same_preimage_axis_products(constructed_module_door):
     )
     first = _file(source).constructed_module
     same_preimage = _file(source).constructed_module
-    foreign_source = _file(source + "\n# distinct authenticated source\n").constructed_module
-    assert first.constructed_module_identity == same_preimage.constructed_module_identity
-    assert first.constructed_module_identity != foreign_source.constructed_module_identity
+    foreign_source = _file(
+        source + "\n# distinct authenticated source\n"
+    ).constructed_module
+    assert (
+        first.constructed_module_identity == same_preimage.constructed_module_identity
+    )
+    assert (
+        first.constructed_module_identity != foreign_source.constructed_module_identity
+    )
     return first, {
         "source_cid": foreign_source,
         "constructed_module_identity": foreign_source,
@@ -154,27 +168,36 @@ def authentic_leaf_axis_rows(constructed_module_door):
         if foreign_backend_product is None
         else foreign_backend_product.leaf_assertion_rows[0]
     )
-    assert first.constructed_module_identity == same_event_row.constructed_module_identity
-    assert first.construction_event_identity is not same_event_row.construction_event_identity
+    assert (
+        first.constructed_module_identity == same_event_row.constructed_module_identity
+    )
+    assert (
+        first.construction_event_identity
+        is not same_event_row.construction_event_identity
+    )
     assert first.assert_occurrence is second.assert_occurrence
     assert first.call_occurrence is not second.call_occurrence
     assert first.assert_occurrence is not foreign_frame.assert_occurrence
-    return first, second, {
-        "source_cid": foreign_source,
-        "constructed_module_identity": foreign_source,
-        "backend_fingerprint": foreign_backend,
-        "construction_event_identity": same_event_row,
-        "function_occurrence": foreign_frame,
-        "function_locus": foreign_frame,
-        "assert_occurrence": foreign_frame,
-        "assert_locus": foreign_frame,
-        "call_occurrence": second,
-        "call_locus": second,
-        "translated_atom_identity": foreign_frame,
-        "translated_atom_value": foreign_frame,
-        "translated_term_identity": second,
-        "translated_term_value": second,
-    }
+    return (
+        first,
+        second,
+        {
+            "source_cid": foreign_source,
+            "constructed_module_identity": foreign_source,
+            "backend_fingerprint": foreign_backend,
+            "construction_event_identity": same_event_row,
+            "function_occurrence": foreign_frame,
+            "function_locus": foreign_frame,
+            "assert_occurrence": foreign_frame,
+            "assert_locus": foreign_frame,
+            "call_occurrence": second,
+            "call_locus": second,
+            "translated_atom_identity": foreign_frame,
+            "translated_atom_value": foreign_frame,
+            "translated_term_identity": second,
+            "translated_term_value": second,
+        },
+    )
 
 
 class _SealCountingReporter(CollectingReporter):
@@ -213,7 +236,9 @@ def test_source_file_constructs_and_seals_inside_one_reporter_event(
     )
 
     assert source_file.root is source_file.constructed_module.root
-    assert source_file.closed_roll_call is source_file.constructed_module.closed_roll_call
+    assert (
+        source_file.closed_roll_call is source_file.constructed_module.closed_roll_call
+    )
     assert (
         source_file.provider_member_rows
         is source_file.constructed_module.provider_member_rows
@@ -330,7 +355,8 @@ def test_construction_event_receipt_constructor_and_copy_are_closed(
     ),
 )
 def test_construction_event_receipt_cross_wire_refuses_one_axis(
-    field_name, constructed_module_door,
+    field_name,
+    constructed_module_door,
 ) -> None:
     source = (
         "PROVIDER_VALUE = 3\n"
@@ -423,7 +449,9 @@ def test_filename_is_not_construction_identity_authority(
     source = "PROVIDER_VALUE = 3\n"
     first = _constructed(source, "first-name.py")
     renamed = _constructed(source, "unrelated-name.py")
-    foreign_source = _constructed(source + "# changed authenticated bytes\n", "first-name.py")
+    foreign_source = _constructed(
+        source + "# changed authenticated bytes\n", "first-name.py"
+    )
 
     assert first.source_cid == renamed.source_cid
     assert first.backend_fingerprint == renamed.backend_fingerprint
@@ -434,8 +462,7 @@ def test_filename_is_not_construction_identity_authority(
     )
     assert first.source_cid != foreign_source.source_cid
     assert (
-        first.constructed_module_identity
-        != foreign_source.constructed_module_identity
+        first.constructed_module_identity != foreign_source.constructed_module_identity
     )
     assert (
         first.construction_event_receipt.root_identity
@@ -543,9 +570,7 @@ def test_constructed_module_cross_wires_one_axis_only(
     else:
         assert getattr(first, field_name) is not getattr(foreign, field_name)
     proposed = {
-        name: (
-            getattr(foreign, name) if name == field_name else getattr(first, name)
-        )
+        name: (getattr(foreign, name) if name == field_name else getattr(first, name))
         for name in leaves
     }
     assert all(
@@ -573,7 +598,9 @@ def test_constructed_module_cross_wires_one_axis_only(
         replace(first, **{field_name: proposed[field_name]})
 
 
-def test_adapter_cannot_override_final_materialize_module(constructed_module_door) -> None:
+def test_adapter_cannot_override_final_materialize_module(
+    constructed_module_door,
+) -> None:
     with pytest.raises(TypeError, match="final Backend.materialize_module"):
 
         class _LyingBackend(Backend):
@@ -666,7 +693,9 @@ def test_later_definition_and_same_name_other_scope_do_not_authorize(
     ),
 )
 def test_forged_relation_one_axis_refuses(
-    field_name, message, authentic_relation_axis_products,
+    field_name,
+    message,
+    authentic_relation_axis_products,
 ) -> None:
     row, twins = authentic_relation_axis_products
     foreign = twins[field_name]
@@ -723,8 +752,7 @@ def test_constructed_provider_member_carries_exact_term_testimony(
     assert member.definition_occurrence is not None
     assert member.constructed_term_value.value == 3
     assert (
-        member.constructed_term_value_identity
-        == member.constructed_term_value.identity
+        member.constructed_term_value_identity == member.constructed_term_value.identity
     )
     assert member.constructed_term_sort == member.constructed_term_value.sort
     assert member.constructed_module_identity == product.constructed_module_identity
@@ -744,7 +772,9 @@ def test_constructed_provider_member_carries_exact_term_testimony(
     ),
 )
 def test_constructed_provider_member_cross_wire_refuses_one_axis(
-    field_name, message, constructed_module_door,
+    field_name,
+    message,
+    constructed_module_door,
 ) -> None:
     product = _constructed("FIRST_VALUE = 3\nSECOND_VALUE = 'three'\n")
     first, second = product.provider_member_rows
@@ -818,7 +848,10 @@ def test_constructed_provider_member_cross_wire_refuses_one_axis(
     ),
 )
 def test_constructed_provider_member_refuses_product_migration_one_axis(
-    product_kind, field_name, message, constructed_module_door,
+    product_kind,
+    field_name,
+    message,
+    constructed_module_door,
 ) -> None:
     source = "PROVIDER_VALUE = 3\n"
     first_product = _constructed(source)
@@ -914,7 +947,7 @@ def test_leaf_assertion_roster_is_distinct_ordered_same_event_testimony(
         "        return True\n"
         "    assert child() and external()\n"
     )
-    lexical, = product.lexical_call_rows
+    (lexical,) = product.lexical_call_rows
     child, external = product.leaf_assertion_rows
 
     assert product.leaf_assertion_rows is not product.lexical_call_rows

--- a/implementations/python/sugar-source-tree/tests/test_control_key_cache_converge.py
+++ b/implementations/python/sugar-source-tree/tests/test_control_key_cache_converge.py
@@ -36,8 +36,7 @@ def test_nested_breaks_sugar_targets_nearest_loop_with_shared_field_cache():
     assert len(breaks) == 2
     targets = [br.sugar().target_cid for br in breaks]
     assert targets[0] != targets[1], (
-        "inner and outer break must not share a loop target "
-        f"(got {targets!r})"
+        "inner and outer break must not share a loop target " f"(got {targets!r})"
     )
     cache = function.unit.construction_cache
     assert cache is not None

--- a/implementations/python/sugar-source-tree/tests/test_cross_unit_definition_registration.py
+++ b/implementations/python/sugar-source-tree/tests/test_cross_unit_definition_registration.py
@@ -31,7 +31,6 @@ from sugar_source_tree.panic import BackendDefect, ConstructedValueTestimonyNotW
 from sugar_source_tree.reporter import CollectingReporter
 from sugar_source_tree.tree import SourceFile
 
-
 SOURCE = (
     "def exact(value):\n"
     "    return value\n\n"
@@ -64,9 +63,7 @@ def _registered_unit(identity=None):
         collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
     )
     root = materialize(source.unit, source.root.ref, reporter)
-    definitions = tuple(
-        node for node in root.walk() if isinstance(node, FunctionDef)
-    )
+    definitions = tuple(node for node in root.walk() if isinstance(node, FunctionDef))
     calls = tuple(node for node in root.walk() if isinstance(node, Call))
     assert len(definitions) == 2
     assert len(calls) == 1
@@ -84,9 +81,7 @@ def _consumer_with_frame(frame, identity=None):
         collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
     )
     root = materialize(source.unit, source.root.ref, reporter)
-    definitions = tuple(
-        node for node in root.walk() if isinstance(node, FunctionDef)
-    )
+    definitions = tuple(node for node in root.walk() if isinstance(node, FunctionDef))
     call = next(node for node in root.walk() if isinstance(node, Call))
     return source, definitions, call, reporter, context
 
@@ -180,11 +175,11 @@ def test_same_roll_definition_registration_remains_lawful() -> None:
     context = TreeConstructionContextV1.for_source_call_construction()
     collector = CollectingReporter()
     source = SourceFile(_identity(), reporter=collector, construction_context=context)
-    definition = next(
-        node for node in source.nodes() if isinstance(node, FunctionDef)
-    )
+    definition = next(node for node in source.nodes() if isinstance(node, FunctionDef))
     call = next(node for node in source.nodes() if isinstance(node, Call))
-    context.source_call_frames[_coordinate(call)] = definition.source_visible_call_frame()
+    context.source_call_frames[_coordinate(call)] = (
+        definition.source_visible_call_frame()
+    )
     reporter = ConstructionTestimonyReporterV1(
         collector, SubstitutionTraceBuilderV1(source.unit.source_cid)
     )
@@ -216,8 +211,7 @@ def test_distinct_definition_from_empty_reporter_cannot_authorize_frame() -> Non
     with pytest.raises(BackendDefect) as gap:
         call.sugar()
     assert (
-        gap.value.owner
-        == "ConstructionTestimonyReporterV1.retain_registered_node_from"
+        gap.value.owner == "ConstructionTestimonyReporterV1.retain_registered_node_from"
     )
     assert gap.value.observed == "foreign or absent producer node registration"
     assert gap.value.blame.seal() == empty_definition.fragment.seal()

--- a/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
+++ b/implementations/python/sugar-source-tree/tests/test_desugar_defect_family_twins.py
@@ -95,7 +95,9 @@ class _BoundState(Sugar):
 
 def _demand_shape(entry):
     """The demanded formula's outermost connective, as wire vocabulary."""
-    return json.loads(encode_jcs(formula_to_value(entry.sole_demand().demanded_formula)))
+    return json.loads(
+        encode_jcs(formula_to_value(entry.sole_demand().demanded_formula))
+    )
 
 
 # --------------------------------------------------------------------------
@@ -208,7 +210,7 @@ def test_dict_display_pairs_keys_with_their_own_values() -> None:
 
 def test_fstring_over_a_partitioning_part_lifts() -> None:
     """POSITIVE. An f-string interpolation whose value partitions."""
-    out = _out("def f(d, k, v):\n return f\"x={d.setdefault(k, v)}\"\n")
+    out = _out('def f(d, k, v):\n return f"x={d.setdefault(k, v)}"\n')
     assert _statements(out)
 
 
@@ -310,9 +312,7 @@ def test_single_outcome_law_names_the_violated_law() -> None:
     from sugar_lift_py_tests.outcome import ExitSet
 
     with pytest.raises(ConstructionPanic) as raised:
-        require_single_value(
-            ExitSet(()), owner="twin", blame="twin", arm="when_true"
-        )
+        require_single_value(ExitSet(()), owner="twin", blame="twin", arm="when_true")
     assert SINGLE_OUTCOME_LAW in str(raised.value)
     assert "when_true" in str(raised.value)
 
@@ -358,9 +358,7 @@ def test_two_pending_contract_arms_join_and_conserve_both_demands() -> None:
     assert pending
 
     formals = {
-        demand.formal_coordinate_cid
-        for entry in pending
-        for demand in entry.demands
+        demand.formal_coordinate_cid for entry in pending for demand in entry.demands
     }
     assert len(formals) == 2, (
         "a join of two pending arms conserved only one formal's obligation: the "
@@ -426,9 +424,7 @@ def test_delete_over_a_loop_guarded_projection_unions_its_faces() -> None:
             # The loop ran: `y` is bound, so deleting it completes.
             LoopGuardedCompletedFace("normal", entered, _BoundState()),
             # The loop never ran: `y` was never bound, so deleting it halts.
-            LoopGuardedCompletedFace(
-                "normal", empty, UnboundProjection("y", _Site())
-            ),
+            LoopGuardedCompletedFace("normal", empty, UnboundProjection("y", _Site())),
         )
     )
     exits = delete_binding(projection, name="y", site=_Site(), ctx=None)
@@ -508,7 +504,8 @@ def test_loop_outward_face_with_a_plain_return_stays_one_completed_face() -> Non
     returns = [
         row
         for row in _statements(out)
-        if isinstance(row, ReturnValue) or isinstance(getattr(row, "value", None), ReturnValue)
+        if isinstance(row, ReturnValue)
+        or isinstance(getattr(row, "value", None), ReturnValue)
     ]
     assert len(returns) >= 1
 

--- a/implementations/python/sugar-source-tree/tests/test_formal_ref_use_site_span.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_ref_use_site_span.py
@@ -23,11 +23,7 @@ def _tree(source: str) -> SourceFile:
 
 
 def test_formal_ref_at_use_keeps_use_site_span_not_param_span() -> None:
-    source = (
-        "def f(month):\n"
-        "    assert 1 <= month <= 12\n"
-        "    return month\n"
-    )
+    source = "def f(month):\n" "    assert 1 <= month <= 12\n" "    return month\n"
     tree = _tree(source)
     fn = next(n for n in tree.nodes() if isinstance(n, FunctionDef) and n.name == "f")
     substituted = fn.substitute({})

--- a/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_for_step_v1_instrument.py
@@ -38,7 +38,6 @@ from sugar_source_tree.binding_state import mint_binding_coordinate_v1
 from sugar_source_tree.nodes import For, FunctionDef
 from sugar_source_tree.tree import SourceFile
 
-
 _OPTION_PAIR_MANAGER = (
     "def option_pair_manager(ops, undo):\n"
     "    for pat, value in ops:\n"
@@ -169,9 +168,9 @@ def test_option_pair_loops_construct_two_general_for_steps() -> None:
 
     for_steps = _for_steps(_OPTION_PAIR_MANAGER)
 
-    assert len(for_steps) == 2, (
-        "the pre-yield ops loop and finally undo loop must both remain explicit"
-    )
+    assert (
+        len(for_steps) == 2
+    ), "the pre-yield ops loop and finally undo loop must both remain explicit"
     assert all(isinstance(step.iterable, ConstructedTermSugar) for step in for_steps)
     assert all(
         len(step.body_steps) == 1 and isinstance(step.body_steps[0], term_step_type)
@@ -196,12 +195,12 @@ def test_cleanup_iterable_and_target_coordinates_are_not_reconstructed() -> None
     """Lying testimony twin: cleanup identity and both target sites stay distinct."""
     before, cleanup = _for_steps(_OPTION_PAIR_MANAGER)
 
-    assert before.iterable != cleanup.iterable, (
-        "ops and undo are distinct authenticated constructed iterables"
-    )
-    assert _target_coordinate_cids(before) != _target_coordinate_cids(cleanup), (
-        "same target spellings at different loop sites must not share identity"
-    )
+    assert (
+        before.iterable != cleanup.iterable
+    ), "ops and undo are distinct authenticated constructed iterables"
+    assert _target_coordinate_cids(before) != _target_coordinate_cids(
+        cleanup
+    ), "same target spellings at different loop sites must not share identity"
     assert before.fragment_cid != cleanup.fragment_cid
 
 
@@ -388,9 +387,7 @@ def _runtime_for_step(events: list, *, elements=None, body_term=None):
     step = replace(
         produced,
         iterable=_ValueSugar(iterable, source_for.iter.fragment),
-        body_steps=(
-            term_step_type(body_term, source_for.body[0].fragment.seal().cid),
-        ),
+        body_steps=(term_step_type(body_term, source_for.body[0].fragment.seal().cid),),
     )
     return generator_api.GeneratorConstructionV1.allocate(
         allocation_coordinate="call:renamed",
@@ -482,7 +479,9 @@ def test_swapped_authenticated_target_coordinates_swap_observed_values() -> None
     from dataclasses import replace
 
     events = []
-    machine = _runtime_for_step(events, elements=(TupleValue((TermValue(1), TermValue(2))),))
+    machine = _runtime_for_step(
+        events, elements=(TupleValue((TermValue(1), TermValue(2))),)
+    )
     step = machine.steps[0]
     swapped = replace(step, target_coordinates=tuple(reversed(step.target_coordinates)))
     machine = replace(machine, steps=(swapped, generator_api.ReturnStepV1()))
@@ -595,14 +594,10 @@ def test_first_or_second_body_halt_stops_before_the_next_recurrence(
         owner="ForStepV1-body-halt-test",
     )
     visits = []
-    halted_body = _HaltOnBodyVisit(
-        halt_at, effect, visits, events, step.iterable.site
-    )
+    halted_body = _HaltOnBodyVisit(halt_at, effect, visits, events, step.iterable.site)
     halted_step = replace(
         step,
-        body_steps=(
-            _term_step_type()(halted_body, step.body_steps[0].fragment_cid),
-        ),
+        body_steps=(_term_step_type()(halted_body, step.body_steps[0].fragment_cid),),
     )
     machine = replace(machine, steps=(halted_step, generator_api.ReturnStepV1()))
 
@@ -790,9 +785,7 @@ def test_cleanup_body_halt_supersedes_the_incoming_outgoing_face(
     halted_body = _HaltBody(cleanup_effect, events, site)
     loop = replace(
         loop,
-        body_steps=(
-            _term_step_type()(halted_body, loop.body_steps[0].fragment_cid),
-        ),
+        body_steps=(_term_step_type()(halted_body, loop.body_steps[0].fragment_cid),),
     )
     cleanup = replace(cleanup, cleanup_steps=(loop,))
     suspended = replace(

--- a/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
+++ b/implementations/python/sugar-source-tree/tests/test_generator_step_if_finally_producer.py
@@ -267,8 +267,7 @@ def test_undecidable_guard_retains_complementary_machines_same_instance() -> Non
     assert isinstance(guarded, GuardedValue)
     successors = [guarded.when_true, guarded.when_false]
     assert all(
-        isinstance(successor, GeneratorConstructionV1)
-        for successor in successors
+        isinstance(successor, GeneratorConstructionV1) for successor in successors
     )
     assert {successor.instance_coordinate for successor in successors} == {
         machine.instance_coordinate
@@ -280,17 +279,18 @@ def test_undecidable_guard_retains_complementary_machines_same_instance() -> Non
         guarded.guard,
         not_(guarded.guard),
     }
-    assert minted == [(
-        "generator.branch",
-        machine.instance_coordinate,
-        machine.steps[0].fragment_cid,
-    )]
+    assert minted == [
+        (
+            "generator.branch",
+            machine.instance_coordinate,
+            machine.steps[0].fragment_cid,
+        )
+    ]
     # Neither branch executed during guard production: both successors remain
     # seated at their own first YieldStepV1 with the exact pre-guard bindings.
     assert all(successor.cursor == machine.cursor for successor in successors)
     assert all(
-        successor.binding_state == machine.binding_state
-        for successor in successors
+        successor.binding_state == machine.binding_state for successor in successors
     )
     assert {
         successor.steps[successor.cursor].value.value for successor in successors
@@ -375,11 +375,7 @@ def test_raw_expr_statement_sugar_payload_refused_by_finally_step() -> None:
 
     with pytest.raises(TypeError, match="ConstructedTermSugar"):
         FinallyStepV1(
-            (
-                ExprStatementSugar(
-                    value=IntLiteralSugar(1, site="x"), site="s"
-                ),
-            )
+            (ExprStatementSugar(value=IntLiteralSugar(1, site="x"), site="s"),)
         )
 
 
@@ -438,7 +434,9 @@ def test_try_finally_halt_places_cleanup_before_the_raise_face() -> None:
     assert kinds[:2] == ["FinallyStepV1", "RaiseStepV1"]
 
 
-def test_return_face_runs_cleanup_and_preserves_return_when_cleanup_falls_through() -> None:
+def test_return_face_runs_cleanup_and_preserves_return_when_cleanup_falls_through() -> (
+    None
+):
     steps = _steps(
         "def manager():\n"
         "    try:\n"
@@ -531,13 +529,16 @@ def test_renamed_manager_same_if_finally_producer_shape() -> None:
     assert [type(s).__name__ for s in a] == [type(s).__name__ for s in b]
     assert isinstance(a[0], IfStepV1) and isinstance(b[0], IfStepV1)
     # Content-addressed if-text can match across renames; definition names differ.
-    assert _function(
-        "def alpha(c):\n    if c:\n        yield 1\n    try:\n        yield 2\n"
-        "    finally:\n        restore()\n"
-    ).name != _function(
-        "def beta_renamed(c):\n    if c:\n        yield 1\n    try:\n        yield 2\n"
-        "    finally:\n        restore()\n"
-    ).name
+    assert (
+        _function(
+            "def alpha(c):\n    if c:\n        yield 1\n    try:\n        yield 2\n"
+            "    finally:\n        restore()\n"
+        ).name
+        != _function(
+            "def beta_renamed(c):\n    if c:\n        yield 1\n    try:\n        yield 2\n"
+            "    finally:\n        restore()\n"
+        ).name
+    )
 
 
 def test_branch_occurrence_tamper_changes_fragment_cid() -> None:
@@ -556,10 +557,7 @@ def test_branch_occurrence_tamper_changes_fragment_cid() -> None:
 
 def test_unsupported_x_yield_in_branch_keeps_whole_if_opaque() -> None:
     steps = _steps(
-        "def manager(c):\n"
-        "    if c:\n"
-        "        x = yield 1\n"
-        "    yield 2\n"
+        "def manager(c):\n" "    if c:\n" "        x = yield 1\n" "    yield 2\n"
     )
     assert isinstance(steps[0], OpaqueStepV1)
     assert steps[0].observed == "If"
@@ -607,11 +605,7 @@ def test_cleanup_construction_invariant_failure_stays_loud() -> None:
 
 
 def test_cleanup_call_is_term_step_when_bare_expr_before_yield() -> None:
-    steps = _steps(
-        "def manager():\n"
-        "    setup()\n"
-        "    yield 1\n"
-    )
+    steps = _steps("def manager():\n" "    setup()\n" "    yield 1\n")
     assert isinstance(steps[0], TermStepV1)
     assert steps[0].fragment_cid.startswith("blake3-512:")
     assert isinstance(steps[1], YieldStepV1)
@@ -623,12 +617,8 @@ def test_cleanup_call_is_term_step_when_bare_expr_before_yield() -> None:
 
 
 def test_twin_branch_swap_changes_then_else_payloads() -> None:
-    a = _steps(
-        "def m(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n"
-    )[0]
-    b = _steps(
-        "def m(c):\n    if c:\n        yield 2\n    else:\n        yield 1\n"
-    )[0]
+    a = _steps("def m(c):\n    if c:\n        yield 1\n    else:\n        yield 2\n")[0]
+    b = _steps("def m(c):\n    if c:\n        yield 2\n    else:\n        yield 1\n")[0]
     assert isinstance(a, IfStepV1) and isinstance(b, IfStepV1)
     assert a.then_steps != b.then_steps
     assert a.else_steps != b.else_steps
@@ -666,11 +656,7 @@ def test_twin_wrong_cleanup_order_is_detectable_in_step_sequence() -> None:
         "    finally:\n"
         "        second()\n"
     )
-    term_cids = [
-        s.fragment_cid
-        for s in steps
-        if isinstance(s, TermStepV1)
-    ]
+    term_cids = [s.fragment_cid for s in steps if isinstance(s, TermStepV1)]
     finally_steps = [s for s in steps if isinstance(s, FinallyStepV1)]
     assert term_cids  # first() before yield
     assert finally_steps

--- a/implementations/python/sugar-source-tree/tests/test_guarded_binding_not_sugar_method.py
+++ b/implementations/python/sugar-source-tree/tests/test_guarded_binding_not_sugar_method.py
@@ -34,14 +34,20 @@ def test_guarded_binding_sugar_routes_to_projection_door() -> None:
     # Same door as the explicit projection path and loop prestate helper:
     assert type(_construct_binding_projection(state)).__name__ == "GuardedProjection"
     assert type(_project_binding_state_sugar(state)).__name__ == "GuardedProjection"
-    assert type(_initial_value_sugar_for_loop_prestate(state)).__name__ == "GuardedProjection"
+    assert (
+        type(_initial_value_sugar_for_loop_prestate(state)).__name__
+        == "GuardedProjection"
+    )
 
 
 def test_unbound_binding_sugar_routes_to_projection_door() -> None:
     state = UnboundBinding("x", "never-bound")
     sugar = state.sugar()
     assert type(sugar).__name__ == "UnboundProjection"
-    assert type(_initial_value_sugar_for_loop_prestate(state)).__name__ == "UnboundProjection"
+    assert (
+        type(_initial_value_sugar_for_loop_prestate(state)).__name__
+        == "UnboundProjection"
+    )
 
 
 def test_nested_guarded_binding_projects_recursively() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_if_branch_result_slot_rewrite.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_branch_result_slot_rewrite.py
@@ -22,9 +22,7 @@ def _ifs() -> tuple[If, If]:
         "else:\n"
         "    pass\n"
     )
-    source_file = SourceFile(
-        (source, "if_slot.py", blake3_512_of(source.encode()))
-    )
+    source_file = SourceFile((source, "if_slot.py", blake3_512_of(source.encode())))
     found = tuple(node for node in source_file.nodes() if isinstance(node, If))
     assert len(found) == 2
     return found
@@ -66,9 +64,7 @@ def test_duplicate_or_foreign_branch_slot_never_replaces_the_exact_slot() -> Non
             BackendDefect,
             match="the one slot authenticated for this exact If.test",
         ):
-            first._rewrite_with_slot(
-                {}, attempted, authenticated_slot=attempted
-            )
+            first._rewrite_with_slot({}, attempted, authenticated_slot=attempted)
 
     assert first.branch_result_slot_id == exact_slot.slot_id
     assert first.authenticated_branch_result_slot_id == exact_slot.slot_id

--- a/implementations/python/sugar-source-tree/tests/test_if_branch_slot_bound_name_not_foreign.py
+++ b/implementations/python/sugar-source-tree/tests/test_if_branch_slot_bound_name_not_foreign.py
@@ -53,11 +53,7 @@ def test_if_on_locally_bound_name_substitute_does_not_report_foreign_slot(
     assert rewritten is not None
     # Find the If that retained a slot (the hashable test).
     ifs = [n for n in rewritten.walk() if isinstance(n, If)]
-    slotted = [
-        n
-        for n in ifs
-        if getattr(n, "branch_result_slot_id", None) is not None
-    ]
+    slotted = [n for n in ifs if getattr(n, "branch_result_slot_id", None) is not None]
     assert slotted, "expected at least one If with a retained branch-result slot"
     target = slotted[0]
     stored = target.branch_result_slot_id

--- a/implementations/python/sugar-source-tree/tests/test_ifexp_join_both_arms_demand.py
+++ b/implementations/python/sugar-source-tree/tests/test_ifexp_join_both_arms_demand.py
@@ -227,7 +227,9 @@ def test_neither_obligation_is_weakened_twice():
     formals, same polarities, and a content address the linker's resolution
     table does not have.
     """
-    for name, (_polarity, _antecedent, consequent) in _by_formal(_out(BOTH_ARMS)).items():
+    for name, (_polarity, _antecedent, consequent) in _by_formal(
+        _out(BOTH_ARMS)
+    ).items():
         assert getattr(consequent, "kind", None) != "implies", (
             f"the {name} obligation is nested `face -> (face -> ...)`: it was "
             "weakened twice, and its demand_cid is not the one that was minted"
@@ -329,7 +331,7 @@ def test_the_same_formal_on_both_arms_owes_two_obligations_on_one_formal():
 
 def _subscripted_formal(arm) -> str:
     """The formal a `p[0]`-shaped arm value reads, off the value's own testimony."""
-    (receiver, _index) = arm.arg_values
+    receiver, _index = arm.arg_values
     return receiver.term.name
 
 

--- a/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_imported_exception_attribute_construction.py
@@ -330,9 +330,7 @@ def test_import_bound_attribute_body_does_not_invent_member_success(tmp_path):
 
     path = tmp_path / "body.py"
     path.write_text(
-        "import pandas as pd\n"
-        "def f():\n"
-        "    return pd.util.foo\n",
+        "import pandas as pd\n" "def f():\n" "    return pd.util.foo\n",
         encoding="utf-8",
     )
     tree = SourceFile(path_source(str(path)))

--- a/implementations/python/sugar-source-tree/tests/test_l0a_authenticated_constructor_shape.py
+++ b/implementations/python/sugar-source-tree/tests/test_l0a_authenticated_constructor_shape.py
@@ -40,9 +40,7 @@ def test_non_class_nodes_answer_none_for_constructor_shape() -> None:
             continue
         # Must not raise AttributeError
         shape = node._authenticated_new_constructor_shape()
-        assert shape is None, (
-            f"{type(node).__name__} must answer None, got {shape!r}"
-        )
+        assert shape is None, f"{type(node).__name__} must answer None, got {shape!r}"
 
 
 def test_classdef_with_authenticated_new_shape_constructs() -> None:

--- a/implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_live_for_destructuring_target.py
@@ -15,13 +15,20 @@ from sugar_lift_py_tests.floor.tuple_value import TupleValue
 from sugar_lift_py_tests.outcome import Complete, Completed, ExitSet, Halted
 from sugar_lift_py_tests.temporal import bind_temporal
 from sugar_source_tree.binding_state import mint_binding_coordinate_v1
-from sugar_source_tree.nodes import For, FunctionDef, TargetPatternConstructionGapV1, TargetPatternV1
+from sugar_source_tree.nodes import (
+    For,
+    FunctionDef,
+    TargetPatternConstructionGapV1,
+    TargetPatternV1,
+)
 from sugar_source_tree.tree import SourceFile
 
 
 def _function(source: str) -> FunctionDef:
     with TemporaryDirectory(dir=Path.cwd()) as directory:
-        path = Path(directory).relative_to(Path.cwd()) / "live_for_destructuring_target.py"
+        path = (
+            Path(directory).relative_to(Path.cwd()) / "live_for_destructuring_target.py"
+        )
         path.write_text(source)
         tree = SourceFile.from_path(path)
         return next(node for node in tree.nodes() if isinstance(node, FunctionDef))
@@ -182,7 +189,9 @@ def test_live_pair_target_rejects_foreign_target_and_scope_testimony() -> None:
 
     foreign_site_lie = (foreign_site, pattern.target_coordinates[1])
     with pytest.raises(TargetPatternConstructionGapV1) as site_rejected:
-        pattern.source_unit.require_target_pattern_coordinates(pattern, foreign_site_lie)
+        pattern.source_unit.require_target_pattern_coordinates(
+            pattern, foreign_site_lie
+        )
     assert site_rejected.value.reason == "foreign-target-coordinate"
     assert site_rejected.value.target_pattern is pattern
     assert site_rejected.value.expected_coordinates is pattern.coordinates
@@ -190,7 +199,9 @@ def test_live_pair_target_rejects_foreign_target_and_scope_testimony() -> None:
 
     foreign_scope_lie = (foreign_scope, pattern.target_coordinates[1])
     with pytest.raises(TargetPatternConstructionGapV1) as scope_rejected:
-        pattern.source_unit.require_target_pattern_coordinates(pattern, foreign_scope_lie)
+        pattern.source_unit.require_target_pattern_coordinates(
+            pattern, foreign_scope_lie
+        )
     assert scope_rejected.value.reason == "foreign-target-scope"
     assert scope_rejected.value.target_pattern is pattern
     assert scope_rejected.value.expected_coordinates is pattern.coordinates

--- a/implementations/python/sugar-source-tree/tests/test_loop_control_pre_exit_state.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_control_pre_exit_state.py
@@ -7,7 +7,6 @@ from sugar_lift_py_tests.effect import LoopControlEffect
 from sugar_lift_py_tests.outcome import Halted
 from sugar_source_tree.tree import SourceFile
 
-
 SOURCE = (
     "def helper(values):\n"
     "    for value in values:\n"
@@ -27,9 +26,7 @@ def _controls():
             )
         ).functions()
     )
-    return tuple(
-        node for node in function.walk() if node.kind in {"Break", "Continue"}
-    )
+    return tuple(node for node in function.walk() if node.kind in {"Break", "Continue"})
 
 
 @pytest.mark.parametrize("action", ("break", "continue"))

--- a/implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_projected_binding_product.py
@@ -22,8 +22,7 @@ def _function(source: str):
 
 
 def _product(*, function_name: str = "arbitrary", carried_name: str = "carried"):
-    constructed = _function(
-        f"""
+    constructed = _function(f"""
 def {function_name}(items):
     {carried_name} = 0
     for first in items:
@@ -31,9 +30,10 @@ def {function_name}(items):
     for second in items:
         {carried_name} = second
     return {carried_name}
-"""
-    ).sugar()
-    product = constructed.statements[2].construction.loop_runtime.initial_value_sugars[0]
+""").sugar()
+    product = constructed.statements[2].construction.loop_runtime.initial_value_sugars[
+        0
+    ]
     assert isinstance(product, LoopProjectedBindingProductSugar)
     return product
 
@@ -49,13 +49,28 @@ def test_real_source_loop_reuses_the_exact_producer_owned_product() -> None:
 @pytest.mark.parametrize(
     ("change", "message"),
     (
-        (lambda product, foreign: {"projection": foreign.projection}, "foreign loop occurrence"),
+        (
+            lambda product, foreign: {"projection": foreign.projection},
+            "foreign loop occurrence",
+        ),
         (lambda product, foreign: {"name": "same_spelling"}, "foreign binding name"),
-        (lambda product, foreign: {"binding_coordinate": foreign.binding_coordinate}, "foreign binding name"),
+        (
+            lambda product, foreign: {"binding_coordinate": foreign.binding_coordinate},
+            "foreign binding name",
+        ),
         (lambda product, foreign: {"site": foreign.site}, "foreign read occurrence"),
-        (lambda product, foreign: {"occurrence_cid": foreign.occurrence_cid}, "foreign read occurrence"),
-        (lambda product, foreign: {"target_cid": foreign.target_cid}, "foreign loop occurrence"),
-        (lambda product, foreign: {"_mint_authority": foreign.target_cid}, "authenticated projection mint"),
+        (
+            lambda product, foreign: {"occurrence_cid": foreign.occurrence_cid},
+            "foreign read occurrence",
+        ),
+        (
+            lambda product, foreign: {"target_cid": foreign.target_cid},
+            "foreign loop occurrence",
+        ),
+        (
+            lambda product, foreign: {"_mint_authority": foreign.target_cid},
+            "authenticated projection mint",
+        ),
     ),
 )
 def test_product_substitution_twins_refuse(change, message: str) -> None:
@@ -67,7 +82,9 @@ def test_product_substitution_twins_refuse(change, message: str) -> None:
 
 
 def test_side_door_zero_is_structural() -> None:
-    source = Path(__file__).parents[1] / "src/sugar_source_tree/live_loop_construction.py"
+    source = (
+        Path(__file__).parents[1] / "src/sugar_source_tree/live_loop_construction.py"
+    )
     text = source.read_text()
 
     assert "construct_live_binding_product_sugar" not in text

--- a/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
+++ b/implementations/python/sugar-source-tree/tests/test_loop_recurrence_term.py
@@ -28,12 +28,7 @@ def _loop(tmp_path: Path, source: str, name: str):
     )
 
 
-_BASE = (
-    "def exercise(xs):\n"
-    "    for item in xs:\n"
-    "        pass\n"
-    "    return xs\n"
-)
+_BASE = "def exercise(xs):\n" "    for item in xs:\n" "        pass\n" "    return xs\n"
 
 _CARRIED = (
     "def exercise(xs):\n"
@@ -83,9 +78,7 @@ def _old_loop_term(loop):
             ),
             ctor(
                 "python:loop-outward-face-testimony",
-                tuple(
-                    str_const(cid) for cid in root["outwardHaltedFaceCids"]
-                ),
+                tuple(str_const(cid) for cid in root["outwardHaltedFaceCids"]),
                 symbol_kind="coordinate",
             ),
         ),
@@ -185,9 +178,7 @@ def test_loop_recurrence_rejects_lying_iterable_occurrence(tmp_path: Path):
     truthful = _loop(tmp_path, _CARRIED, "truthful.py")
     lying = _loop(
         tmp_path,
-        _CARRIED.replace("exercise(xs)", "exercise(xs, ys)").replace(
-            "in xs", "in ys"
-        ),
+        _CARRIED.replace("exercise(xs)", "exercise(xs, ys)").replace("in xs", "in ys"),
         "lying.py",
     )
     construction = replace(

--- a/implementations/python/sugar-source-tree/tests/test_module_block_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_module_block_construction.py
@@ -29,11 +29,7 @@ def _tree(
 
 def test_module_constructs_each_child_once_in_source_order(monkeypatch) -> None:
     tree = _tree(
-        "def first():\n"
-        "    return 1\n"
-        "\n"
-        "def second():\n"
-        "    return 2\n"
+        "def first():\n" "    return 1\n" "\n" "def second():\n" "    return 2\n"
     )
     calls: list[tuple[str, int]] = []
     constructed: dict[str, object] = {}
@@ -55,7 +51,9 @@ def test_module_constructs_each_child_once_in_source_order(monkeypatch) -> None:
     assert sugar.statements[1] is constructed["second"]
 
 
-def test_module_threads_temporal_scope_before_constructing_children(monkeypatch) -> None:
+def test_module_threads_temporal_scope_before_constructing_children(
+    monkeypatch,
+) -> None:
     tree = _tree("x = 1\nassert x == 1\n")
     observed_asserts: list[Assert] = []
     original = Assert.sugar
@@ -71,19 +69,14 @@ def test_module_threads_temporal_scope_before_constructing_children(monkeypatch)
     assert type(sugar).__name__ == "ModuleBlockSugar"
     assert len(observed_asserts) == 1
     assert not any(
-        isinstance(node, Name) and node.id == "x"
-        for node in observed_asserts[0].walk()
+        isinstance(node, Name) and node.id == "x" for node in observed_asserts[0].walk()
     )
 
 
 def test_module_propagates_the_child_owner_panic_and_stops_the_tail(
     monkeypatch,
 ) -> None:
-    tree = _tree(
-        "type Alias = int\n"
-        "def never_reached():\n"
-        "    return 1\n"
-    )
+    tree = _tree("type Alias = int\n" "def never_reached():\n" "    return 1\n")
     tail_calls = 0
     original = FunctionDef.sugar
 

--- a/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_assertion_manager_composition.py
@@ -46,7 +46,6 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.source_oracle import path_source
 from sugar_source_tree.tree import SourceFile
 
-
 SOURCE = (
     "from dependency import halting, observing\n"
     "def f():\n"
@@ -65,7 +64,7 @@ STRESS_SOURCE = (
     "    if using_feature:\n"
     '        with observing(warn, match="Operation between non"):\n'
     "            with halting(\n"
-    "                pa.lib.ArrowNotImplementedError, match=\"has no kernel\"\n"
+    '                pa.lib.ArrowNotImplementedError, match="has no kernel"\n'
     "            ):\n"
     '                raise pa.lib.ArrowNotImplementedError("has no kernel")\n'
 )
@@ -174,9 +173,7 @@ def _constructed_boundaries(tmp_path, source=SOURCE, *, warning_first=False):
         )
     }
     context = TreeConstructionContextV1(
-        ResolvedContractRefsV1(
-            _cid("c"), _cid("t"), MappingProxyType(rows)
-        )
+        ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType(rows))
     )
     function = next(SourceFile(identity, construction_context=context).functions())
     sugar = function.sugar()
@@ -220,9 +217,7 @@ def test_lying_variable_patterns_do_not_alias_between_boundaries(tmp_path):
 
 def test_reverse_order_branch_constructs_both_native_boundaries(tmp_path):
     """The stress shape stays source-ordered under a branch and local import."""
-    outer, inner = _constructed_boundaries(
-        tmp_path, STRESS_SOURCE, warning_first=True
-    )
+    outer, inner = _constructed_boundaries(tmp_path, STRESS_SOURCE, warning_first=True)
     assert isinstance(outer.semantics.effect_kind, WarningEffectKindV1)
     assert isinstance(inner.semantics.effect_kind, RaiseEffectKindV1)
     assert outer.manager.desugar().value.arg_values[-1] == StringValue(
@@ -230,9 +225,7 @@ def test_reverse_order_branch_constructs_both_native_boundaries(tmp_path):
     )
     inner_call = inner.manager.desugar().value
     assert isinstance(inner_call.arg_values[0], AuthenticatedExceptionTypeValue)
-    assert inner_call.arg_values[-1] == StringValue(
-        "has no kernel"
-    )
+    assert inner_call.arg_values[-1] == StringValue("has no kernel")
 
 
 def test_reassigned_local_import_head_has_no_exception_identity(tmp_path):
@@ -257,6 +250,8 @@ def _pinned_pandas_root() -> Path:
     from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 
     return authenticated_pandas_corpus().root
+
+
 PINNED_DATETIMELIKE_CID = (
     "blake3-512:a8a3afcef87a93452db841a304673c4bca0a52e29e5a63932580a3b638f39300"
     "2003a95d615bfd1bec91d03c90f792b2600a007f5e5c98120c8ca56bb8b79f00"
@@ -332,7 +327,9 @@ def _with_routers(sugar):
 def _real_three_deep_assertion_resource_chain():
     identity = _pinned_identity("tests/io/test_common.py", PINNED_IO_COMMON_CID)
     probe = SourceFile(identity)
-    function = next(node for node in probe.functions() if node.name == "test_close_on_error")
+    function = next(
+        node for node in probe.functions() if node.name == "test_close_on_error"
+    )
     with_nodes = sorted(
         (node for node in function.walk() if node.kind == "With"),
         key=lambda node: node.line_col_span().start_line,
@@ -438,7 +435,14 @@ def _three_deep_manager_halt(exception_name: str):
     original_middle = middle
     original_inner = inner
     middle_exit, inner_enter, inner_exit = [], [], []
-    effect = RaiseEffect(exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]), occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name)
+    effect = RaiseEffect(
+        exception_type_coordinate=ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(exception_name)],
+        ),
+        occurrence=AuthenticatedRaiseLocus.of("test_common.py:640"),
+        exception_name=exception_name,
+    )
     inner = replace(
         inner,
         manager=_FixedOutcomeSugar(Incomplete(effect)),
@@ -588,7 +592,14 @@ def _three_deep_level_receipts(exception_name: str):
     outer, middle, inner = _with_routers(
         _built_function(identity, "test_close_on_error", rows)
     )
-    effect = RaiseEffect(exception_type_coordinate=ctor('python:exception_type_identity', [str_const('builtins'), str_const(exception_name)]), occurrence=AuthenticatedRaiseLocus.of('test_common.py:640'), exception_name=exception_name)
+    effect = RaiseEffect(
+        exception_type_coordinate=ctor(
+            "python:exception_type_identity",
+            [str_const("builtins"), str_const(exception_name)],
+        ),
+        occurrence=AuthenticatedRaiseLocus.of("test_common.py:640"),
+        exception_name=exception_name,
+    )
     inner = replace(
         inner,
         manager=_FixedOutcomeSugar(Incomplete(effect)),
@@ -726,6 +737,7 @@ def test_pinned_juxtaposition_cannot_swap_the_two_item_occurrences():
     outer, inner = _real_juxtaposed_assertion_resource_chain()
     assert not isinstance(outer, WithResourceSugar)
     assert not isinstance(inner, WithEffectBoundarySugar)
+
 
 def _real_resource_outer_boundary_inner():
     root = _pinned_pandas_root()

--- a/implementations/python/sugar-source-tree/tests/test_nested_loop_control_temporal.py
+++ b/implementations/python/sugar-source-tree/tests/test_nested_loop_control_temporal.py
@@ -20,33 +20,39 @@ def _returned_int(source: str) -> int:
 
 
 def test_inner_break_preserves_outer_state_and_does_not_suppress_outer_else() -> None:
-    assert _returned_int(
-        "def arbitrary():\n"
-        "    carried = 0\n"
-        "    for outer in (0, 1):\n"
-        "        carried = carried + 10\n"
-        "        for inner in (0, 1):\n"
-        "            carried = carried + 1\n"
-        "            break\n"
-        "    else:\n"
-        "        carried = carried + 100\n"
-        "    return carried\n"
-    ) == 122
+    assert (
+        _returned_int(
+            "def arbitrary():\n"
+            "    carried = 0\n"
+            "    for outer in (0, 1):\n"
+            "        carried = carried + 10\n"
+            "        for inner in (0, 1):\n"
+            "            carried = carried + 1\n"
+            "            break\n"
+            "    else:\n"
+            "        carried = carried + 100\n"
+            "    return carried\n"
+        )
+        == 122
+    )
 
 
 def test_inner_continue_preserves_iteration_state_before_outer_tail() -> None:
-    assert _returned_int(
-        "def arbitrary():\n"
-        "    carried = 0\n"
-        "    for outer in (0, 1):\n"
-        "        for inner in (0, 1):\n"
-        "            carried = carried + 1\n"
-        "            continue\n"
-        "        carried = carried + 10\n"
-        "    else:\n"
-        "        carried = carried + 100\n"
-        "    return carried\n"
-    ) == 124
+    assert (
+        _returned_int(
+            "def arbitrary():\n"
+            "    carried = 0\n"
+            "    for outer in (0, 1):\n"
+            "        for inner in (0, 1):\n"
+            "            carried = carried + 1\n"
+            "            continue\n"
+            "        carried = carried + 10\n"
+            "    else:\n"
+            "        carried = carried + 100\n"
+            "    return carried\n"
+        )
+        == 124
+    )
 
 
 def test_inner_and_outer_controls_mint_distinct_target_coordinates() -> None:
@@ -57,8 +63,6 @@ def test_inner_and_outer_controls_mint_distinct_target_coordinates() -> None:
         "            break\n"
         "        continue\n"
     )
-    controls = [
-        node for node in function.walk() if node.kind in {"Break", "Continue"}
-    ]
+    controls = [node for node in function.walk() if node.kind in {"Break", "Continue"}]
     targets = {node.kind: node.sugar().target_cid for node in controls}
     assert targets["Break"] != targets["Continue"]

--- a/implementations/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py
+++ b/implementations/python/sugar-source-tree/tests/test_no_swallowed_cm_ref_panic.py
@@ -37,7 +37,9 @@ def _panic(*, owner: str) -> UnsupportedContextManagerSemantics:
 class _DuckWith:
     """Duck-typed self for With.substitution_binding — avoids frozen Node layout."""
 
-    def __init__(self, *, panic: UnsupportedContextManagerSemantics, frame_projection: bool):
+    def __init__(
+        self, *, panic: UnsupportedContextManagerSemantics, frame_projection: bool
+    ):
         self.unit = SimpleNamespace(
             construction_context=SimpleNamespace(frame_projection=frame_projection)
         )
@@ -95,11 +97,11 @@ def test_production_source_has_no_soft_dual_mode_catch():
     assert "_require_narrow_cm_ref" in binding_src
 
     nodes_src = (
-        Path(__file__).resolve().parents[1]
-        / "src"
-        / "sugar_source_tree"
-        / "nodes.py"
+        Path(__file__).resolve().parents[1] / "src" / "sugar_source_tree" / "nodes.py"
     ).read_text(encoding="utf-8")
-    assert "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import" not in nodes_src
+    assert (
+        "from sugar_lift_py_tests.sugar.soft_unresolved_with_sugar import"
+        not in nodes_src
+    )
     assert "return SoftUnresolvedWithSugar" not in nodes_src
     assert "noqa: BLE001" not in nodes_src

--- a/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
+++ b/implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py
@@ -86,9 +86,7 @@ def _entries(out) -> tuple:
 
 
 def _demand_cids(out) -> set[str]:
-    return {
-        demand.demand_cid for entry in _entries(out) for demand in entry.demands
-    }
+    return {demand.demand_cid for entry in _entries(out) for demand in entry.demands}
 
 
 def _formal_cids(out) -> set[str]:
@@ -272,7 +270,10 @@ def test_the_effect_itself_is_not_altered_by_the_carried_demand():
     """
     from sugar_lift_py_tests.effect import RaiseEffect
 
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:476:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:476:0",
+    )
     bare = Incomplete(effect)
     carrying = Incomplete(effect, (), ("sentinel-entry",))
 
@@ -355,7 +356,12 @@ def test_an_effect_face_is_no_longer_the_partition_gap():
 
     joined = rewrap_pending(
         entry,
-        Incomplete(RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:441:0')),
+        Incomplete(
+            RaiseEffect.for_builtin(
+                "ValueError",
+                occurrence="implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:441:0",
+            )
+        ),
         owner="test_effect_face",
         blame=entry.source_node,
     )
@@ -382,7 +388,10 @@ def _halted_carrier(guard=None):
 
     out = _out("def f(p):\n return [p[0]]\n")
     (entry,) = _entries(out)
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:385:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:385:0",
+    )
     incomplete = Incomplete(effect, (guard,) if guard is not None else (), (entry,))
     exits = outcome_to_exitset(incomplete)
     (arm,) = exits.exits
@@ -438,7 +447,10 @@ def test_halted_arms_owing_different_things_are_different_destinations():
 
     first = _entries(_out("def f(p):\n return [p[0]]\n"))[0]
     second = _entries(_out("def f(q):\n return [q[1]]\n"))[0]
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:358:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:358:0",
+    )
 
     merged = ExitSet(
         (
@@ -473,7 +485,10 @@ def test_halted_arms_owing_the_same_thing_still_merge():
     from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
 
     (entry,) = _entries(_out("def f(p):\n return [p[0]]\n"))
-    effect = RaiseEffect.for_builtin('ValueError', occurrence='implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:275:0')
+    effect = RaiseEffect.for_builtin(
+        "ValueError",
+        occurrence="implementations/python/sugar-source-tree/tests/test_parameter_contract_demand_set.py:275:0",
+    )
 
     merged = ExitSet(
         (

--- a/implementations/python/sugar-source-tree/tests/test_parso_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_parso_adapter.py
@@ -12,9 +12,7 @@ import pytest
 
 from declared_corpus import OPTIONAL_PROVIDER, optional_law_import
 
-parso = optional_law_import(
-    "parso", OPTIONAL_PROVIDER, "parso backend not installed"
-)
+parso = optional_law_import("parso", OPTIONAL_PROVIDER, "parso backend not installed")
 
 from pathlib import Path
 

--- a/implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py
+++ b/implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py
@@ -58,12 +58,16 @@ def test_second_pass_over_same_files_does_not_reprepare() -> None:
     ]
     for identity in files:
         SourceFile(identity)
-    counts_after_p1 = {identity[2]: prepare_count_for(identity[2]) for identity in files}
+    counts_after_p1 = {
+        identity[2]: prepare_count_for(identity[2]) for identity in files
+    }
     assert all(c == 1 for c in counts_after_p1.values()), counts_after_p1
 
     for identity in files:
         SourceFile(identity)
-    counts_after_p2 = {identity[2]: prepare_count_for(identity[2]) for identity in files}
+    counts_after_p2 = {
+        identity[2]: prepare_count_for(identity[2]) for identity in files
+    }
     assert counts_after_p2 == counts_after_p1
     assert all(c == 1 for c in counts_after_p2.values())
 

--- a/implementations/python/sugar-source-tree/tests/test_provider_gated_exception_type_identity.py
+++ b/implementations/python/sugar-source-tree/tests/test_provider_gated_exception_type_identity.py
@@ -38,9 +38,7 @@ def _tree(tmp_path: Path, source: str, name: str = "provider_gate.py"):
 
 def _attribute_named(tree: SourceFile, attr: str):
     return next(
-        node
-        for node in tree.nodes()
-        if node.kind == "Attribute" and node.attr == attr
+        node for node in tree.nodes() if node.kind == "Attribute" and node.attr == attr
     )
 
 
@@ -81,9 +79,7 @@ def test_static_import_attribute_exception_identity_still_works(tmp_path):
     """Ordinary static import remains the primary door."""
     tree = _tree(
         tmp_path,
-        "import pyarrow\n"
-        "def f():\n"
-        "    return pyarrow.ArrowInvalid\n",
+        "import pyarrow\n" "def f():\n" "    return pyarrow.ArrowInvalid\n",
     )
     attr = _attribute_named(tree, "ArrowInvalid")
     assert tree.root.unit.imported_exception_type_identity(attr) == _identity(

--- a/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_raise_sugar.py
@@ -105,9 +105,7 @@ def test_raise_call_form_carries_exception_type_coordinate():
 
 def test_local_exception_class_constructs_authenticated_raise_effect():
     """Source ClassDef exception types construct through the Raise door."""
-    effect = _effect(
-        "class E(Exception):\n    pass\n\ndef A():\n    raise E\n"
-    )
+    effect = _effect("class E(Exception):\n    pass\n\ndef A():\n    raise E\n")
     assert effect.exception_name == "E"
     assert effect.exception_type_coordinate is not None
 

--- a/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
+++ b/implementations/python/sugar-source-tree/tests/test_sequence_projection_receivers.py
@@ -424,9 +424,7 @@ def test_each_conditional_face_owes_its_own_operand_not_a_shared_one() -> None:
     shared operand would look identical in arity and be wrong about what the
     caller must satisfy."""
     _, out = _receivers("def A(c, p, q):\n a, b = p if c else q\n return a\n")
-    operands = {
-        str(exit_.effect.runtime_operand.term.args[0]) for exit_ in out.exits
-    }
+    operands = {str(exit_.effect.runtime_operand.term.args[0]) for exit_ in out.exits}
     assert len(operands) == 2, operands
     assert any("p" in operand for operand in operands)
     assert any("q" in operand for operand in operands)

--- a/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_call_frame_definition_site.py
@@ -10,7 +10,9 @@ from sugar_source_tree.nodes import ClassDef
 from sugar_source_tree.tree import SourceFile
 
 
-def test_source_call_frame_rejects_same_source_foreign_definition_site(tmp_path) -> None:
+def test_source_call_frame_rejects_same_source_foreign_definition_site(
+    tmp_path,
+) -> None:
     path = tmp_path / "two_frames.py"
     path.write_text(
         "def left(value):\n"
@@ -20,7 +22,9 @@ def test_source_call_frame_rejects_same_source_foreign_definition_site(tmp_path)
         "    return value\n",
         encoding="utf-8",
     )
-    functions = {function.name: function for function in SourceFile.from_path(path).functions()}
+    functions = {
+        function.name: function for function in SourceFile.from_path(path).functions()
+    }
     left = functions["left"].source_visible_call_frame()
     right = functions["right"].source_visible_call_frame()
     actual = TermValue(7)
@@ -69,9 +73,7 @@ def test_class_constructor_rejects_same_arity_foreign_initializer_roster(
         encoding="utf-8",
     )
     source = SourceFile.from_path(path)
-    classes = {
-        node.name: node for node in source.nodes() if isinstance(node, ClassDef)
-    }
+    classes = {node.name: node for node in source.nodes() if isinstance(node, ClassDef)}
     left = classes["Left"].source_visible_constructor_frame()
     right = classes["Right"].source_visible_constructor_frame()
     wrong_roster = replace(

--- a/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_source_visible_constructor_door.py
@@ -364,6 +364,8 @@ def test_source_visible_new_constructor_refuses_nonexact_field_roster(
 
     assert isinstance(coordinate, CallSiteValue)
     assert coordinate.body is None
+
+
 def test_constructor_frame_retains_exact_source_visible_new_method() -> None:
     """The class producer carries its exact ``__new__`` testimony to the body."""
     context = TreeConstructionContextV1.for_source_call_construction()
@@ -380,9 +382,7 @@ def test_constructor_frame_retains_exact_source_visible_new_method() -> None:
         "        self.value = value\n",
         context=context,
     )
-    classes = {
-        node.name: node for node in source.nodes() if isinstance(node, ClassDef)
-    }
+    classes = {node.name: node for node in source.nodes() if isinstance(node, ClassDef)}
     first_new = next(
         item
         for item in classes["First"].body
@@ -411,6 +411,8 @@ def test_constructor_frame_retains_exact_source_visible_new_method() -> None:
         == _coordinate(second_new)
     )
     assert second_frame.constructed_new_method is not testimony
+
+
 def test_source_frame_binds_constructed_defaults_and_variadics() -> None:
     context = TreeConstructionContextV1.for_source_call_construction()
     source = _source_file(

--- a/implementations/python/sugar-source-tree/tests/test_sourcefile_construction_door_shared_fixture.py
+++ b/implementations/python/sugar-source-tree/tests/test_sourcefile_construction_door_shared_fixture.py
@@ -57,7 +57,10 @@ def test_backend_materialize_module_is_the_canonical_event_owner() -> None:
 def test_shared_sourcefile_construction_door_evidence_is_typed_sealed_and_closed(
     sourcefile_construction_door_evidence: SourceFileConstructionDoorEvidence,
 ) -> None:
-    assert assert_test_owned_evidence(sourcefile_construction_door_evidence) is sourcefile_construction_door_evidence
+    assert (
+        assert_test_owned_evidence(sourcefile_construction_door_evidence)
+        is sourcefile_construction_door_evidence
+    )
 
 
 def test_projection_callers_are_discovered_not_self_seeded() -> None:
@@ -114,8 +117,7 @@ def test_lying_twin_empty_projection_callers_is_red() -> None:
         owner_source=owner_source,
     )
     assert callers == (), (
-        "empty caller set must stay empty; got fabricated callers: "
-        f"{callers!r}"
+        "empty caller set must stay empty; got fabricated callers: " f"{callers!r}"
     )
 
     # assert_closed projection axis refuses the empty measurement.
@@ -196,34 +198,37 @@ def _graph(tmp_path: Path, sources: dict[str, str]) -> SymbolGraph:
 
 
 def test_symbol_graph_uses_source_ordered_reaching_definitions(tmp_path: Path) -> None:
-    graph = _graph(tmp_path, {
-        "m": (
-            "def first(): pass\n"
-            "def second(): pass\n"
-            "def caller(flag, doomed):\n"
-            "    target = first\n"
-            "    if flag:\n"
-            "        target = second\n"
-            "    target()\n"
-            "    del target\n"
-            "    target()\n"
-            "def loop_caller(flag):\n"
-            "    target = first\n"
-            "    while flag:\n"
-            "        target = second\n"
-            "        flag = False\n"
-            "    target()\n"
-            "def try_caller():\n"
-            "    target = second\n"
-            "    try:\n"
-            "        target = first\n"
-            "    except Exception:\n"
-            "        target = second\n"
-            "    finally:\n"
-            "        target = first\n"
-            "    target()\n"
-        )
-    })
+    graph = _graph(
+        tmp_path,
+        {
+            "m": (
+                "def first(): pass\n"
+                "def second(): pass\n"
+                "def caller(flag, doomed):\n"
+                "    target = first\n"
+                "    if flag:\n"
+                "        target = second\n"
+                "    target()\n"
+                "    del target\n"
+                "    target()\n"
+                "def loop_caller(flag):\n"
+                "    target = first\n"
+                "    while flag:\n"
+                "        target = second\n"
+                "        flag = False\n"
+                "    target()\n"
+                "def try_caller():\n"
+                "    target = second\n"
+                "    try:\n"
+                "        target = first\n"
+                "    except Exception:\n"
+                "        target = second\n"
+                "    finally:\n"
+                "        target = first\n"
+                "    target()\n"
+            )
+        },
+    )
     calls = [edge for edge in graph.calls if edge.expression == "target"]
     assert {target.name for target in calls[0].targets} == {"first", "second"}
     assert calls[0].dynamic is False
@@ -237,25 +242,31 @@ def test_symbol_graph_uses_source_ordered_reaching_definitions(tmp_path: Path) -
 def test_symbol_graph_does_not_fall_through_a_later_local_rebind(
     tmp_path: Path,
 ) -> None:
-    graph = _graph(tmp_path, {
-        "m": (
-            "def outer(): pass\n"
-            "def caller():\n"
-            "    outer()\n"
-            "    outer = lambda: None\n"
-        )
-    })
+    graph = _graph(
+        tmp_path,
+        {
+            "m": (
+                "def outer(): pass\n"
+                "def caller():\n"
+                "    outer()\n"
+                "    outer = lambda: None\n"
+            )
+        },
+    )
     call = next(edge for edge in graph.calls if edge.expression == "outer")
     assert call.targets == ()
     assert call.dynamic is True
 
 
 def test_symbol_graph_resolves_fixed_point_reexports(tmp_path: Path) -> None:
-    graph = _graph(tmp_path, {
-        "a": "def owner(): pass\n",
-        "b": "from a import *\nforwarded = owner\n",
-        "c": "from b import forwarded as again\nagain()\n",
-    })
+    graph = _graph(
+        tmp_path,
+        {
+            "a": "def owner(): pass\n",
+            "b": "from a import *\nforwarded = owner\n",
+            "c": "from b import forwarded as again\nagain()\n",
+        },
+    )
     call = next(edge for edge in graph.calls if edge.expression == "again")
     assert {(target.module, target.name) for target in call.targets} == {("a", "owner")}
     assert call.dynamic is False
@@ -274,14 +285,16 @@ def test_symbol_graph_resolves_fixed_point_reexports(tmp_path: Path) -> None:
         (consumer_path, consumer_source),
     ):
         path.write_text(source, encoding="utf-8")
-    relative_graph = SymbolGraph({
-        "pkg": (init_path, ast.parse(init_source, str(init_path))),
-        "pkg.inner": (inner_path, ast.parse(inner_source, str(inner_path))),
-        "consumer": (
-            consumer_path,
-            ast.parse(consumer_source, str(consumer_path)),
-        ),
-    })
+    relative_graph = SymbolGraph(
+        {
+            "pkg": (init_path, ast.parse(init_source, str(init_path))),
+            "pkg.inner": (inner_path, ast.parse(inner_source, str(inner_path))),
+            "consumer": (
+                consumer_path,
+                ast.parse(consumer_source, str(consumer_path)),
+            ),
+        }
+    )
     relative_call = next(
         edge for edge in relative_graph.calls if edge.expression == "forwarded"
     )
@@ -291,25 +304,26 @@ def test_symbol_graph_resolves_fixed_point_reexports(tmp_path: Path) -> None:
 
 
 def test_symbol_graph_resolves_classmethod_cls_to_its_class(tmp_path: Path) -> None:
-    graph = _graph(tmp_path, {
-        "m": (
-            "class SourceFile:\n"
-            "    def __init__(self, identity): pass\n"
-            "    @classmethod\n"
-            "    def from_path(cls, identity):\n"
-            "        return cls(identity)\n"
-            "def invoke(callback=SourceFile.from_path):\n"
-            "    return callback(('source', 'file.py', 'cid'))\n"
-        )
-    })
+    graph = _graph(
+        tmp_path,
+        {
+            "m": (
+                "class SourceFile:\n"
+                "    def __init__(self, identity): pass\n"
+                "    @classmethod\n"
+                "    def from_path(cls, identity):\n"
+                "        return cls(identity)\n"
+                "def invoke(callback=SourceFile.from_path):\n"
+                "    return callback(('source', 'file.py', 'cid'))\n"
+            )
+        },
+    )
     call = next(edge for edge in graph.calls if edge.expression == "cls")
     assert {(target.name, target.lexical) for target in call.targets} == {
         ("SourceFile", ())
     }
     assert call.dynamic is False
-    callback_call = next(
-        edge for edge in graph.calls if edge.expression == "callback"
-    )
+    callback_call = next(edge for edge in graph.calls if edge.expression == "callback")
     assert {(target.name, target.lexical) for target in callback_call.targets} == {
         ("from_path", ("SourceFile",))
     }

--- a/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_target_effect.py
@@ -202,7 +202,12 @@ def test_rhs_constructs_before_halted_receiver_and_store_does_not_continue():
     sugar = assignment.sugar()
     receiver_calls = []
     value_calls = []
-    halt = Incomplete(RaiseEffect.for_builtin('ArbitraryError', occurrence='implementations/python/sugar-source-tree/tests/test_store_target_effect.py:205:0'))
+    halt = Incomplete(
+        RaiseEffect.for_builtin(
+            "ArbitraryError",
+            occurrence="implementations/python/sugar-source-tree/tests/test_store_target_effect.py:205:0",
+        )
+    )
     rewritten = replace(
         sugar,
         receiver=_OutcomeSugar(halt, receiver_calls),

--- a/implementations/python/sugar-source-tree/tests/test_store_unpack_not_foreign_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_unpack_not_foreign_target.py
@@ -54,9 +54,7 @@ def test_mixed_name_subscript_unpack_does_not_raise_foreign_target(
     sf = _open(
         tmp_path,
         "mixed_unpack.py",
-        "def f(out, codes, a, b):\n"
-        "    out, codes[-1] = a, b\n"
-        "    return out\n",
+        "def f(out, codes, a, b):\n" "    out, codes[-1] = a, b\n" "    return out\n",
     )
     assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
     # May or may not enroll depending on _is_binding_target_pattern (mixed = no).
@@ -71,9 +69,7 @@ def test_pure_name_unpack_still_has_pattern_and_binds(tmp_path: Path) -> None:
     sf = _open(
         tmp_path,
         "name_unpack.py",
-        "def f(key):\n"
-        "    root, leaf = split(key)\n"
-        "    return root\n",
+        "def f(key):\n" "    root, leaf = split(key)\n" "    return root\n",
     )
     assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
     assert len(assignment.target_patterns) == 1

--- a/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
+++ b/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
@@ -13,7 +13,6 @@ from sugar_source_tree import nodes
 from sugar_source_tree.binding_provenance import BindingCoordinateV1
 from sugar_source_tree.tree import SourceFile
 
-
 SOURCE = """\
 def fixture(value, items):
     a, (b, *c) = value
@@ -53,14 +52,41 @@ def _open_source_file(path: Path, root: Path) -> SourceFile:
 
 
 EXPECTED = {
-    ("Assign", 2, 0): (("a", ("targets", 0, 0)), ("b", ("targets", 0, 1, 0)), ("c", ("targets", 0, 1, 1, "star"))),
-    ("For", 3, 0): (("a", ("target", 0)), ("b", ("target", 1, 0)), ("c", ("target", 1, 1, "star"))),
-    ("ListComp", 5, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
-    ("SetComp", 6, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
-    ("DictComp", 7, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
-    ("ListComp", 8, 0): (("a", ("generators", 0, "target", 0)), ("rest", ("generators", 0, "target", 1, "star"))),
+    ("Assign", 2, 0): (
+        ("a", ("targets", 0, 0)),
+        ("b", ("targets", 0, 1, 0)),
+        ("c", ("targets", 0, 1, 1, "star")),
+    ),
+    ("For", 3, 0): (
+        ("a", ("target", 0)),
+        ("b", ("target", 1, 0)),
+        ("c", ("target", 1, 1, "star")),
+    ),
+    ("ListComp", 5, 0): (
+        ("a", ("generators", 0, "target", 0)),
+        ("b", ("generators", 0, "target", 1, 0)),
+        ("c", ("generators", 0, "target", 1, 1, "star")),
+    ),
+    ("SetComp", 6, 0): (
+        ("a", ("generators", 0, "target", 0)),
+        ("b", ("generators", 0, "target", 1, 0)),
+        ("c", ("generators", 0, "target", 1, 1, "star")),
+    ),
+    ("DictComp", 7, 0): (
+        ("a", ("generators", 0, "target", 0)),
+        ("b", ("generators", 0, "target", 1, 0)),
+        ("c", ("generators", 0, "target", 1, 1, "star")),
+    ),
+    ("ListComp", 8, 0): (
+        ("a", ("generators", 0, "target", 0)),
+        ("rest", ("generators", 0, "target", 1, "star")),
+    ),
     ("ListComp", 8, 1): (("b", ("generators", 1, "target")),),
-    ("GeneratorExp", 9, 0): (("a", ("generators", 0, "target", 0)), ("b", ("generators", 0, "target", 1, 0)), ("c", ("generators", 0, "target", 1, 1, "star"))),
+    ("GeneratorExp", 9, 0): (
+        ("a", ("generators", 0, "target", 0)),
+        ("b", ("generators", 0, "target", 1, 0)),
+        ("c", ("generators", 0, "target", 1, 1, "star")),
+    ),
 }
 
 
@@ -71,7 +97,7 @@ def _source_file(tmp_path: Path, name: str = "target_patterns.py") -> SourceFile
 
 
 def _products(source_file: SourceFile):
-    function, = tuple(source_file.functions())
+    (function,) = tuple(source_file.functions())
     products = []
     for consumer in function.walk():
         key = (consumer.kind, consumer.line_col_span().start_line)
@@ -127,15 +153,15 @@ def test_ordinary_nested_star_consumers_construct_exact_patterns_once(tmp_path: 
     live_path = tmp_path / "live.py"
     live_path.write_text(LIVE_SOURCE)
     live_file = _open_source_file(live_path, tmp_path)
-    live_function, = tuple(live_file.functions())
+    (live_function,) = tuple(live_file.functions())
     live_loop = next(node for node in live_function.walk() if node.kind == "For")
-    live_pattern, = live_loop.target_patterns
+    (live_pattern,) = live_loop.target_patterns
     live_function.sugar()
     live_function.sugar()
     repeated_live_loop = next(
         node for node in live_function.walk() if node.kind == "For"
     )
-    repeated_live_pattern, = repeated_live_loop.target_patterns
+    (repeated_live_pattern,) = repeated_live_loop.target_patterns
     assert repeated_live_pattern is live_pattern
     assert live_file.unit.target_pattern_construction_count == 1
 
@@ -157,14 +183,10 @@ def test_target_pattern_rejects_wrong_occurrence_and_order(tmp_path: Path):
     assert wrong_occurrence.value.target_occurrence is foreign[0].target_occurrence
 
     first_for = next(
-        pattern
-        for pattern in truthful
-        if pattern.consumer_occurrence.kind == "For"
+        pattern for pattern in truthful if pattern.consumer_occurrence.kind == "For"
     )
     second_for = next(
-        pattern
-        for pattern in foreign
-        if pattern.consumer_occurrence.kind == "For"
+        pattern for pattern in foreign if pattern.consumer_occurrence.kind == "For"
     )
     before_count = first.unit.target_pattern_construction_count
     with pytest.raises(nodes.TargetPatternConstructionGapV1) as foreign_consumer:
@@ -189,11 +211,11 @@ def test_same_unit_foreign_for_cannot_claim_local_target(tmp_path: Path):
     path = tmp_path / "two_loops.py"
     path.write_text(TWO_LOOPS_SOURCE)
     source_file = _open_source_file(path, tmp_path)
-    function, = tuple(source_file.functions())
+    (function,) = tuple(source_file.functions())
     loops = tuple(node for node in function.walk() if node.kind == "For")
     assert len(loops) == 2
-    first_pattern, = loops[0].target_patterns
-    second_pattern, = loops[1].target_patterns
+    (first_pattern,) = loops[0].target_patterns
+    (second_pattern,) = loops[1].target_patterns
     before = source_file.unit.target_pattern_construction_count
 
     with pytest.raises(nodes.TargetPatternConstructionGapV1) as rejected:
@@ -220,20 +242,21 @@ def test_assign_rhs_rewrite_retains_its_authenticated_target_pattern(
         "    return root[leaf]\n"
     )
     source_file = _open_source_file(path, tmp_path)
-    function, = tuple(source_file.functions())
+    (function,) = tuple(source_file.functions())
     original = next(
         node
         for node in function.walk()
         if node.kind == "Assign" and node.line_col_span().start_line == 3
     )
-    original_pattern, = original.target_patterns
+    (original_pattern,) = original.target_patterns
 
     frame = function.source_visible_call_frame()
 
     assert frame.owner is function
-    assert source_file.unit.require_target_pattern(
-        original, original.targets[0]
-    ) is original_pattern
+    assert (
+        source_file.unit.require_target_pattern(original, original.targets[0])
+        is original_pattern
+    )
     assert source_file.unit.target_pattern_construction_count == 1
 
 
@@ -278,7 +301,6 @@ def test_legacy_reharvest_manifestations_are_retired():
         )
         for match in re.finditer(pattern, source)
     )
-    assert offenders == (), (
-        f"R_target_reharvest_manifestations={len(offenders)}; "
-        + "; ".join(offenders)
-    )
+    assert (
+        offenders == ()
+    ), f"R_target_reharvest_manifestations={len(offenders)}; " + "; ".join(offenders)

--- a/implementations/python/sugar-source-tree/tests/test_tree_sitter_adapter.py
+++ b/implementations/python/sugar-source-tree/tests/test_tree_sitter_adapter.py
@@ -15,7 +15,8 @@ tree_sitter = optional_law_import(
     "tree_sitter", OPTIONAL_PROVIDER, "tree-sitter backend not installed"
 )
 optional_law_import(
-    "tree_sitter_python", OPTIONAL_PROVIDER,
+    "tree_sitter_python",
+    OPTIONAL_PROVIDER,
     "tree-sitter Python grammar not installed",
 )
 

--- a/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_exitset_law.py
@@ -70,6 +70,7 @@ import pytest
 from sugar_source_tree.panic import SugarNotWritten
 from with_resolution_fixture import source_file_with_preconstruction
 
+
 def _identity(name: str):
     from sugar_lift_py_tests.floor.ground_exit import (
         _builtin_exception_identity,
@@ -77,7 +78,6 @@ def _identity(name: str):
 
     identity, _mro = _builtin_exception_identity(name)
     return identity
-
 
 
 def _fn(src: str):
@@ -395,7 +395,7 @@ def test_bare_reraise_preserves_the_same_effect_occurrence():
     # Occurrence is the original raise site (line of ``raise ValueError``),
     # not a reconstructed site at the bare re-raise.
     assert out.effect.occurrence.endswith(":6:8")
-    assert out.effect.exception_type_coordinate == _identity('ValueError')
+    assert out.effect.exception_type_coordinate == _identity("ValueError")
 
 
 def test_bare_reraise_is_not_a_reconstructed_raise_at_handler_site():

--- a/implementations/python/sugar-source-tree/tests/test_try_sugar.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_sugar.py
@@ -36,9 +36,7 @@ def _fn(src):
 
 def _exception_identity(function, name: str):
     occurrence = next(
-        node
-        for node in function.walk()
-        if node.kind == "Name" and node.id == name
+        node for node in function.walk() if node.kind == "Name" and node.id == name
     )
     identity = function.unit.exception_type_identity(occurrence)
     assert identity is not None

--- a/implementations/python/sugar-source-tree/tests/test_while_temporal_recurrence.py
+++ b/implementations/python/sugar-source-tree/tests/test_while_temporal_recurrence.py
@@ -62,9 +62,7 @@ def test_body_state_is_the_next_condition_input_not_the_stale_initial_state(
     )
 
     assert len(test_transforms) == 2
-    assert initial["testValueConstructionCid"] == (
-        while_node.test.fragment.seal().cid
-    )
+    assert initial["testValueConstructionCid"] == (while_node.test.fragment.seal().cid)
     assert recurrence["testValueConstructionCid"] == initial["testValueConstructionCid"]
     assert initial["inputStateCid"] == graph["root"]["preStateCid"]
     assert latch["inputStateCid"] != graph["root"]["preStateCid"]
@@ -116,9 +114,7 @@ def test_swapping_only_recurrence_test_back_to_pre_state_is_refused(tmp_path: Pa
     latch.clear()
     latch.update(replacement_latch)
     tampered["root"]["latchObligationCids"] = [
-        replacement_latch["latchObligationCid"]
-        if cid == old_latch_cid
-        else cid
+        replacement_latch["latchObligationCid"] if cid == old_latch_cid else cid
         for cid in tampered["root"]["latchObligationCids"]
     ]
     assert old_transform_cid != replacement["testTransformCid"]

--- a/implementations/python/sugar-source-tree/tests/test_with_item_construction_l3d.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_item_construction_l3d.py
@@ -113,9 +113,7 @@ def test_gap_row_panics_with_manager_symbol_and_kind_detail():
         "runtime-selected",
         (),
     )
-    refs = ResolvedContractRefsV1(
-        _cid("c"), _cid("t"), MappingProxyType({site: gap})
-    )
+    refs = ResolvedContractRefsV1(_cid("c"), _cid("t"), MappingProxyType({site: gap}))
     sf = SourceFile(
         (src, "l3d_gap.py", blake3_512_of(src.encode())),
         construction_context=TreeConstructionContextV1(refs),

--- a/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py
@@ -380,7 +380,14 @@ def test_discrimination_first_exit_is_not_skipped_on_the_halted_edge():
     unran. Assert the wrong expectation and show it fails."""
     outer_exit, inner_exit = [], []
     sugar = _nested_pair(
-        _FixedSugar(Incomplete(RaiseEffect.for_builtin('OSError', occurrence='implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:383:0'))),
+        _FixedSugar(
+            Incomplete(
+                RaiseEffect.for_builtin(
+                    "OSError",
+                    occurrence="implementations/python/sugar-source-tree/tests/test_with_multiple_managers.py:383:0",
+                )
+            )
+        ),
         outer_exit_probe=outer_exit,
         inner_exit_probe=inner_exit,
     )

--- a/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_partition_shared_algebra.py
@@ -1026,7 +1026,10 @@ def test_expected_observation_with_no_constructed_occurrence_stays_loud(tmp_path
     with pytest.raises(SugarNotWritten) as raised:
         boundary.desugar()
     assert raised.value.owner == "WithEffectBoundarySugar.warning_observation"
-    assert raised.value.observed == "warning boundary carries an unprojected message pattern"
+    assert (
+        raised.value.observed
+        == "warning boundary carries an unprojected message pattern"
+    )
 
 
 def test_discrimination_the_same_site_routes_under_a_constructed_effect_kind(tmp_path):

--- a/implementations/python/sugar-source-tree/tests/test_with_store_binding_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_with_store_binding_target.py
@@ -187,15 +187,11 @@ ATTRIBUTE_TARGET = HEADER + (
 
 # Renamed from the real corpus tuple-destructure site.
 TUPLE_TARGET = HEADER + (
-    "def f():\n"
-    "    with manager() as (yes, no):\n"
-    "        return yes\n"
+    "def f():\n" "    with manager() as (yes, no):\n" "        return yes\n"
 )
 
 NAME_TARGET = HEADER + (
-    "def f():\n"
-    "    with manager() as entered:\n"
-    "        return entered\n"
+    "def f():\n" "    with manager() as entered:\n" "        return entered\n"
 )
 
 NO_TARGET = HEADER + ("def f():\n    with manager():\n        return 1\n")


### PR DESCRIPTION
The acid vector currently has two Black jobs red for sugar-lift-py-tests and sugar-source-tree, plus their Python-format enrollment aggregate. This change applies the exact CI-pinned Black 26.5.1 formatter to those two sibling package roots in one mechanical-only commit.

Measured scope:
- 366 Python files reformatted: 306 under sugar-lift-py-tests and 60 under sugar-source-tree
- zero files deleted
- zero changed paths outside the two named package roots
- production and test logic are not intentionally changed; this is formatter output only

Verification at b77a96651a:
- direct parent and merge-base are current main 462b7a6666; exactly one commit, zero behind
- Black 26.5.1 check: all 1,152 files unchanged
- git diff --check: clean
- no non-Python files changed

Predicted epsilon: the two package Black jobs and their format-enrollment aggregate move red to green. This does not claim the showcase jobs or the overall acid aggregate become green; those remain a separately diagnosed cause.

Supersedes #7241, whose preflight correctly refused it after main advanced and whose path-smoke was red. This branch was recreated from current main rather than force-pushed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply Black 26.5.1 formatting to Python test and source packages
> Runs the Black formatter across the `sugar-lift-py-tests` and `sugar-source-tree` Python packages, touching hundreds of test and source files. Changes are purely cosmetic: line wrapping, quote normalization, trailing commas, and collapsing or expanding multi-line expressions to satisfy Black's style rules. One incidental fix in [test_builtin_closed_operation_instrument.py](https://github.com/TSavo/sugar/pull/7242/files#diff-b9662450bd2dc64255151458c0981012a88e410a15a2552a80a9ac5c3b93381f) corrects indentation inside a dynamically constructed source string so the snippet parses as intended.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b77a966.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->