### PR TITLE
Make control-effect recensus job name dispatchable

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -65,7 +65,7 @@ jobs:
   # Resolve population, pin denominator, LPT-assign enrolled files into k bins.
   # Does not measure. planCid is the content-addressed identity workers bind.
   plan:
-    name: LPT plan k=${{ env.RECENSUS_SHARD_COUNT }}
+    name: LPT plan
     runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     outputs:


### PR DESCRIPTION
#7239 correctly made actionlint part of every PR path-smoke and immediately exposed an invalid pre-dispatch expression at control-effect-recensus.yml:68: jobs.plan.name used the env context, which GitHub does not permit there. That turned a known main-only workflow red into a universal PR block.

This repair is deliberately one line: jobs.plan.name becomes the static string LPT plan. The actionlint guard is unchanged, not weakened, relocated, or excluded. The workflow body and every measurement obligation are unchanged.

Measured at 773ec5acfb on direct parent and merge-base b160af49a6:
- pinned actionlint v1.7.12 dispatchability suite: 7/7 green
- the discriminator still rejects illegal workflow/job context use and accepts lawful static/step-context use
- git diff --check: clean
- one workflow file, one insertion, one deletion, zero file deletions

This does not prejudge #7235. Making the workflow legal is separate from deciding whether its obligation should exist; #7235 remains the owner of that decision.

Load-bearing consequence: once line 68 is legal, this workflow becomes dispatchable and may execute for the first time in more than one hundred pushes. Nobody has current execution testimony for what follows. Any new red after dispatch is discovery, not regression from this syntax repair, and must not be attributed to this PR. This is the same distinction that applied when claim-mass and the shell tier first passed provisioning and finally measured their bodies.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove shard count from `control-effect-recensus` job display name
> Simplifies the `LPT plan` job name in [control-effect-recensus.yml](.github/workflows/control-effect-recensus.yml) by removing the `k=${{ env.RECENSUS_SHARD_COUNT }}` suffix, making the job name static and dispatchable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 773ec5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->