### PR TITLE
Refresh panic-catch scanner for attested recensus membranes

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """R_construction_panic_catches_outside_audit — permanent floor.
 
-``ConstructionPanic`` is a sanctioned typed construction gap. Five membranes
+``ConstructionPanic`` is a sanctioned typed construction gap. Reviewed membranes
 may catch it without pure re-raise:
 
 1. **Audit enumeration** — ``audit_only/collect_construction_gaps.py``,
@@ -13,6 +13,10 @@ may catch it without pure re-raise:
    construction panics are not misclassified as bare Python exceptions.
    That path does NOT convert the panic into Incomplete, opacity, soft None,
    or a missing report row.
+3. **Recensus per-file terminals** — ``scripts/recensus_enumerate_consumer.py``
+   authenticates the panic identity, then emits the exact roster,
+   context-manager, or residual ``category=panic`` terminal. These witnesses
+   are enrolled by exact path, function, and AST shape.
 
 Every other ``except ConstructionPanic`` (or catch via BaseException / bare
 except) under production sources is debt unless the handler body is pure
@@ -152,6 +156,114 @@ except BaseException as error:
 """),
         }
     ),
+    (
+        "recensus_enumerate_consumer.py",
+        "measure_file_via_enumerate",
+    ): frozenset(
+        {
+            _canonical_handler("""
+except BaseException as error:
+    if _is_process_control(error):
+        raise
+    auth = int(ast_fn) if ast_fn is not None else 0
+    panic = _panic_from_exception(error, file_rel=file_rel, phase="roster")
+    if panic is None:
+        return _instrument_failure_row(
+            error,
+            file_rel=file_rel,
+            phase="roster",
+            source_cid=source_cid,
+            function_nodes=[],
+            functions_total=auth,
+            functions_enumerated=0,
+        )
+    row = _empty_shell(
+        file_rel=file_rel,
+        category="panic",
+        functions_total=auth,
+        functions_enumerated=0,
+        defect=panic,
+        panic=panic,
+        functions_clean=None if auth > 0 else 0,
+        clean_ratio_refused=auth > 0,
+        clean_refuse_reason=(
+            "roster demand panicked; clean not measured" if auth > 0 else None
+        ),
+        ast_fn=ast_fn,
+    )
+    return _attest_terminal_row(
+        row,
+        file_rel=file_rel,
+        source_cid=source_cid,
+        function_nodes=[],
+    )
+"""),
+            _canonical_handler("""
+except BaseException as error:
+    if _is_process_control(error):
+        raise
+    panic = _panic_from_exception(
+        error, file_rel=file_rel, phase="context-manager-resolutions"
+    )
+    if panic is None:
+        return _instrument_failure_row(
+            error,
+            file_rel=file_rel,
+            phase="context-manager-resolutions",
+            source_cid=source_cid,
+            function_nodes=function_nodes,
+            functions_total=len(function_nodes),
+            functions_enumerated=len(function_nodes),
+        )
+    row = _empty_shell(
+        file_rel=file_rel,
+        category="panic",
+        functions_total=len(function_nodes),
+        functions_enumerated=len(function_nodes),
+        defect=panic,
+        panic=panic,
+        functions_clean=None,
+        clean_ratio_refused=True,
+        clean_refuse_reason="CM resolution panic after roster; clean not measured",
+        ast_fn=ast_fn,
+    )
+    row["constructionPanics"] = [panic]
+    row["enumerateConstructionPanics"] = [panic]
+    row["contextManagerResolutionEvents"] = _provisional_resolution_events(
+        contract_refs=contract_refs,
+        source_cid=source_cid,
+    )
+    return _attest_terminal_row(
+        row,
+        file_rel=file_rel,
+        source_cid=source_cid,
+        function_nodes=function_nodes,
+    )
+"""),
+            _canonical_handler("""
+except BaseException as error:
+    if _is_process_control(error):
+        raise
+    row = terminal_from_enumerate(
+        file_rel=file_rel,
+        function_nodes=function_nodes,
+        function_gaps=[],
+        audit=None,
+        construction_gaps=[],
+        residual_phase_failed=True,
+        residual_error=error,
+        ast_fn=ast_fn,
+        source_cid=source_cid,
+        context_manager_resolution_events=cm_events,
+    )
+    row["d3Residency"] = _complete_d3_residency_observation(
+        source_cid=source_cid,
+        present_before_demand=d3_present_before_demand,
+    )
+    return row
+"""),
+        }
+    ),
 }
 
 _SANCTIONED_ISINSTANCE_SHAPES = {
@@ -160,7 +272,26 @@ _SANCTIONED_ISINSTANCE_SHAPES = {
 if isinstance(error, ConstructionPanic):
     return _construction_panic_row(error)
 """)}
-    )
+    ),
+    ("recensus_enumerate_consumer.py", "_panic_from_exception"): frozenset(
+        {_canonical_statement("""
+if isinstance(error, ConstructionPanic):
+    info = error.info.to_json()
+    owner = str(info["owner"])
+    coordinate = str(info["blame"])
+    observed = str(info["observed"])
+    requested = str(info["requested"])
+    fix = str(info["fix"])
+elif isinstance(error, SugarNotWritten):
+    owner = str(error.owner)
+    coordinate = str(error.blame)
+    observed = str(error.observed)
+    requested = str(error.requested)
+    fix = str(error.fix)
+else:
+    return None
+""")}
+    ),
 }
 
 
@@ -223,6 +354,31 @@ def _handler_names(handler: ast.ExceptHandler) -> set[str]:
 def _catches_construction_panic(handler: ast.ExceptHandler) -> bool:
     names = _handler_names(handler)
     return bool(names & {"ConstructionPanic", "BaseException"}) or names == {"<bare>"}
+
+
+def _prior_pure_reraise_intercepts_construction_panic(
+    handler: ast.ExceptHandler,
+    parents: dict[ast.AST, ast.AST],
+) -> bool:
+    """Whether an earlier sibling catches ConstructionPanic and pure re-raises.
+
+    Except handlers are ordered. An exact earlier ``except ConstructionPanic``
+    that terminates every path with ``raise`` makes a later BaseException/bare
+    handler unreachable for ConstructionPanic. This is semantic catch
+    precedence, not a path allowlist; removing or softening the earlier handler
+    makes the later broad catch red again.
+    """
+    parent = parents.get(handler)
+    if not isinstance(parent, (ast.Try, ast.TryStar)):
+        return False
+    try:
+        index = parent.handlers.index(handler)
+    except ValueError:
+        return False
+    return any(
+        "ConstructionPanic" in _handler_names(prior) and _pure_reraise(prior)
+        for prior in parent.handlers[:index]
+    )
 
 
 def _is_terminal_raise(stmt: ast.AST) -> bool:
@@ -375,6 +531,8 @@ def scan_package(package_root: Path) -> list[PanicCatchOffender]:
             if not isinstance(node, ast.ExceptHandler):
                 continue
             if not _catches_construction_panic(node):
+                continue
+            if _prior_pure_reraise_intercepts_construction_panic(node, parents):
                 continue
             if _is_sanctioned_handler(rel, node, parents):
                 continue

--- a/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_construction_panic_catch_law.py
@@ -188,6 +188,77 @@ def audit():
     }
 
 
+def test_current_recensus_membranes_and_reraises_are_recognized(
+    tmp_path: Path,
+) -> None:
+    """The seven reviewed loci are accepted by shape, not by filename."""
+    package = tmp_path / "src" / "sugar_lift_py_tests"
+    package.mkdir(parents=True)
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    for name in (
+        "control_effect_recensus.py",
+        "recensus_enumerate_consumer.py",
+    ):
+        (scripts / name).write_text(
+            (_KIT / "scripts" / name).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+    offenders = _SCANNER.scan_repository(tmp_path)
+
+    assert offenders == [], _SCANNER.format_report(offenders)
+
+
+def test_recensus_membrane_path_still_rejects_a_planted_suppressor(
+    tmp_path: Path,
+) -> None:
+    """An exact membrane path cannot authorize a swallow; pure re-raise can."""
+    package = tmp_path / "src" / "sugar_lift_py_tests"
+    package.mkdir(parents=True)
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    consumer = scripts / "recensus_enumerate_consumer.py"
+    consumer.write_text(
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def measure_file_via_enumerate():
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        pass
+""",
+        encoding="utf-8",
+    )
+
+    rejected = _SCANNER.scan_repository(tmp_path)
+
+    assert [(row.path, row.kind) for row in rejected] == [
+        (
+            "scripts/recensus_enumerate_consumer.py",
+            "construction-panic-catch-outside-membrane",
+        )
+    ]
+
+    consumer.write_text(
+        """
+from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+def measure_file_via_enumerate():
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        raise
+""",
+        encoding="utf-8",
+    )
+
+    accepted = _SCANNER.scan_repository(tmp_path)
+
+    assert accepted == []
+
+
 def test_named_membrane_path_does_not_hide_parse_error(tmp_path: Path) -> None:
     package = tmp_path / "src" / "sugar_lift_py_tests"
     package.mkdir(parents=True)


### PR DESCRIPTION
The panic-catch audit was healthy but its intraprocedural knowledge was stale: auditor_errors=0 proved the scanner ran, not that its allowlist understood the current recensus membrane. It reported seven loci on main, but per-row triage established four legitimate typed panic membranes and three catches already made unreachable for ConstructionPanic by the pure re-raise repairs in #7217.

This refresh recognizes the seven lawfully without weakening the floor:
- the three #7217 sites are accepted by semantic exception precedence: an earlier exact ConstructionPanic handler must pure re-raise on every path before a later broad handler is excluded. Removing or softening that sibling makes the broad catch red again.
- the four current recensus sites are exact path, enclosing function, and AST witnesses: _panic_from_exception authenticates the payload, while roster, context-manager, and residual handlers emit their reviewed loud panic terminals.
- no filename exemption is added and no production catch is changed.

The discrimination arm is load-bearing. An exact-path planted except ConstructionPanic: pass with no re-raise and no attested row is reported RED as construction-panic-catch-outside-membrane. Replacing that planted suppressor with a pure re-raise returns GREEN. A panic auditor that cannot detect that twin would be worse than none.

Measured at 3baed80c0d on battleaxe under authenticated CPython 3.12.13 and pandas 3.0.3:
- exact scanner tooth file: 16/16 passed in 3.00s
- live repository axis: R_construction_panic_catches_outside_audit=0
- Black 26.5.1 check on both changed files: green
- py_compile and git diff --check: green
- two scanner/test files only; zero file deletions

This does not claim the seven were suppression sites; that hypothesis was falsified by per-locus inspection. It restores an honest zero while preserving the planted-suppressor bite.

Closes #7186.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh panic-catch scanner to recognize attested `recensus_enumerate_consumer` membranes
> - Adds sanctioned handler shapes for `recensus_enumerate_consumer.measure_file_via_enumerate` (roster, context-manager-resolution, and residual phases) and `_panic_from_exception` to [construction_panic_catch_law.py](https://github.com/TSavo/sugar/pull/7244/files#diff-3c0ecda4c2eb0dfeac0c6cc310ed867b7a677b14e310685a6146ec899dcad1cf), so these catches are no longer reported as debt.
> - Introduces `_prior_pure_reraise_intercepts_construction_panic` helper that walks the AST to detect when an earlier sibling `except ConstructionPanic` performs a pure re-raise, making subsequent broad handlers unreachable for `ConstructionPanic`.
> - Gates broad-catch reporting in `scan_package` on the new helper, eliminating false positives when a prior pure re-raise is present.
> - Adds two tests in [test_construction_panic_catch_law.py](https://github.com/TSavo/sugar/pull/7244/files#diff-8a44d435efd68177a6f5b50c837ff83b09af96b1907f3f13ba90f33f02e3b676): one asserting no offenders on the real files, and one verifying that a planted suppressor is rejected but a pure re-raise is accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3baed80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->