### PR TITLE
Derive and attest showcase offline build closure

### DIFF
--- a/.github/showcase-editable-requirements.txt
+++ b/.github/showcase-editable-requirements.txt
@@ -1,0 +1,5 @@
+# The one enrolled first-party population for showcase environment construction.
+-e implementations/python/sugar-build-witness
+-e implementations/python/sugar-lift-py-tests[test]
+-e implementations/python/sugar-lift-python-source
+-e implementations/python/sugar-lift-py-pytest-witness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,18 +426,28 @@ jobs:
         run: |
           set -euo pipefail
           env_dir="$RUNNER_TEMP/showcase-wheelhouse"
+          build_requirements="$RUNNER_TEMP/showcase-build-requirements.txt"
           rm -rf "$env_dir"
           mkdir -p "$env_dir"
-          # Same package set every showcase shard used to install independently.
+          python tools/showcase_wheelhouse.py derive \
+            --repo-root . \
+            --editable-requirements .github/showcase-editable-requirements.txt \
+            --output "$build_requirements"
+          # Resolve both dependency families. The editable manifest owns the
+          # runtime population; each package's [build-system].requires owns
+          # the build-isolation population.
           python -m pip wheel --quiet --wheel-dir "$env_dir" \
-            ./implementations/python/sugar-build-witness \
-            './implementations/python/sugar-lift-py-tests[test]' \
-            ./implementations/python/sugar-lift-python-source \
-            ./implementations/python/sugar-lift-py-pytest-witness
+            --requirement .github/showcase-editable-requirements.txt
+          python -m pip wheel --quiet --wheel-dir "$env_dir" \
+            --requirement "$build_requirements"
           # Keep third-party wheels only. First-party installs from checkout
           # paths so each shard measures this tip's tree.
           shopt -s nullglob
           rm -f "$env_dir"/sugar_*.whl
+          python tools/showcase_wheelhouse.py verify \
+            --repo-root . \
+            --editable-requirements .github/showcase-editable-requirements.txt \
+            --wheelhouse "$env_dir"
           ls -la "$env_dir" | head -50
       - name: Upload showcase wheelhouse
         uses: actions/upload-artifact@v4
@@ -482,10 +492,7 @@ jobs:
           # paths so the shard measures this tip's tree.
           python -m pip install --quiet \
             --no-index --find-links "$RUNNER_TEMP/showcase-wheelhouse" \
-            -e implementations/python/sugar-build-witness \
-            -e 'implementations/python/sugar-lift-py-tests[test]' \
-            -e implementations/python/sugar-lift-python-source \
-            -e implementations/python/sugar-lift-py-pytest-witness
+            --requirement .github/showcase-editable-requirements.txt
 
       - name: Set up Java 21
         uses: actions/setup-java@v4

--- a/tests/test_showcase_shared_setup_enrollment.py
+++ b/tests/test_showcase_shared_setup_enrollment.py
@@ -5,22 +5,187 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import showcase_wheelhouse  # noqa: E402
+
 CI = ROOT / ".github/workflows/ci.yml"
 ATTEND = ROOT / "tools/showcase_shard_attendance.py"
 
 
+def _write_build_project(root: Path, name: str, requires: list[str]) -> Path:
+    project = root / name
+    project.mkdir(parents=True)
+    quoted = ", ".join(json.dumps(requirement) for requirement in requires)
+    (project / "pyproject.toml").write_text(
+        "[build-system]\n"
+        f"requires = [{quoted}]\n"
+        'build-backend = "setuptools.build_meta"\n',
+        encoding="utf-8",
+    )
+    return project
+
+
+def _write_editable_manifest(path: Path, projects: list[Path], root: Path) -> None:
+    path.write_text(
+        "".join(f"-e {project.relative_to(root)}\n" for project in projects),
+        encoding="utf-8",
+    )
+
+
+def _write_wheel(
+    wheelhouse: Path,
+    distribution: str,
+    version: str,
+    *,
+    requires: tuple[str, ...] = (),
+) -> None:
+    filename_name = distribution.replace("-", "_")
+    dist_info = f"{filename_name}-{version}.dist-info"
+    wheel = wheelhouse / f"{filename_name}-{version}-py3-none-any.whl"
+    requires_dist = "".join(f"Requires-Dist: {item}\n" for item in requires)
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"{dist_info}/METADATA",
+            "Metadata-Version: 2.1\n"
+            f"Name: {distribution}\n"
+            f"Version: {version}\n"
+            f"{requires_dist}",
+        )
+        archive.writestr(
+            f"{dist_info}/WHEEL",
+            "Wheel-Version: 1.0\n"
+            "Generator: showcase-wheelhouse-test\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n",
+        )
+        archive.writestr(f"{dist_info}/RECORD", "")
+        archive.writestr(
+            f"{filename_name}/_vendor/nested-1.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: nested\nVersion: 1\n",
+        )
+
+
 def test_showcase_prepare_builds_one_wheelhouse_for_all_shards() -> None:
     text = CI.read_text(encoding="utf-8")
+    prepare = text.split("  showcase-prepare:", 1)[1].split("\n  showcases:", 1)[0]
     assert "showcase-prepare" in text
     assert "showcase-wheelhouse" in text
     assert "pip wheel" in text
+    assert "tools/showcase_wheelhouse.py derive" in prepare
+    assert "tools/showcase_wheelhouse.py verify" in prepare
+    assert ".github/showcase-editable-requirements.txt" in prepare
+    assert "setuptools>=68" not in prepare
     # Shards consume the artifact — not four independent network resolves of
     # the same package set as the only install path.
     assert "Download shared wheelhouse" in text
     assert "--no-index --find-links" in text or "--find-links" in text
+
+
+def test_build_requirements_are_derived_from_every_editable_project(
+    tmp_path: Path,
+) -> None:
+    first = _write_build_project(
+        tmp_path,
+        "first",
+        ["setuptools>=68", "wheel"],
+    )
+    second = _write_build_project(
+        tmp_path,
+        "second",
+        ["hatchling>=1", "setuptools>=68"],
+    )
+    manifest = tmp_path / "editables.txt"
+    output = tmp_path / "build-requirements.txt"
+    _write_editable_manifest(manifest, [first, second], tmp_path)
+
+    returncode = showcase_wheelhouse.main(
+        [
+            "derive",
+            "--repo-root",
+            str(tmp_path),
+            "--editable-requirements",
+            str(manifest),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert returncode == 0
+    assert output.read_text(encoding="utf-8") == (
+        "hatchling>=1\nsetuptools>=68\nwheel\n"
+    )
+
+
+def test_incomplete_wheelhouse_refuses_by_missing_distribution_name(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    project = _write_build_project(
+        tmp_path,
+        "first",
+        ["missing-build-backend>=68"],
+    )
+    manifest = tmp_path / "editables.txt"
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _write_editable_manifest(manifest, [project], tmp_path)
+
+    returncode = showcase_wheelhouse.main(
+        [
+            "verify",
+            "--repo-root",
+            str(tmp_path),
+            "--editable-requirements",
+            str(manifest),
+            "--wheelhouse",
+            str(wheelhouse),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert returncode != 0
+    assert "missing distribution 'missing-build-backend'" in captured.err
+    assert "required for offline editable install" in captured.err
+
+
+def test_transitive_build_requirement_is_part_of_the_verified_closure(
+    tmp_path: Path, capsys
+) -> None:
+    project = _write_build_project(tmp_path, "first", ["fixture-backend>=1"])
+    manifest = tmp_path / "editables.txt"
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _write_editable_manifest(manifest, [project], tmp_path)
+    _write_wheel(
+        wheelhouse,
+        "fixture-backend",
+        "1",
+        requires=("fixture-build-hook>=2",),
+    )
+
+    args = [
+        "verify",
+        "--repo-root",
+        str(tmp_path),
+        "--editable-requirements",
+        str(manifest),
+        "--wheelhouse",
+        str(wheelhouse),
+    ]
+    assert showcase_wheelhouse.main(args) != 0
+    captured = capsys.readouterr()
+    assert "missing distribution 'fixture-build-hook'" in captured.err
+    assert "required for offline editable install" in captured.err
+
+    _write_wheel(wheelhouse, "fixture-build-hook", "2")
+    assert showcase_wheelhouse.main(args) == 0
+    captured = capsys.readouterr()
+    assert "showcase-wheelhouse-verified" in captured.out
 
 
 def test_four_shards_remain_for_genuine_per_shard_work() -> None:

--- a/tools/showcase_wheelhouse.py
+++ b/tools/showcase_wheelhouse.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Derive and verify the showcase offline build-isolation wheelhouse."""
+
+from __future__ import annotations
+
+import argparse
+from email.parser import BytesParser
+from email.policy import default
+import re
+import sys
+import tomllib
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from packaging.requirements import Requirement
+    from packaging.tags import sys_tags
+    from packaging.utils import canonicalize_name, parse_wheel_filename
+except ModuleNotFoundError:  # pip necessarily exists at this provisioning door
+    from pip._vendor.packaging.requirements import Requirement
+    from pip._vendor.packaging.tags import sys_tags
+    from pip._vendor.packaging.utils import canonicalize_name, parse_wheel_filename
+
+
+class WheelhouseRefusal(RuntimeError):
+    """The showcase environment cannot be constructed honestly."""
+
+
+def _editable_projects(repo_root: Path, manifest: Path) -> tuple[Path, ...]:
+    projects: list[Path] = []
+    for line_number, raw_line in enumerate(
+        manifest.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if not line.startswith("-e "):
+            raise WheelhouseRefusal(
+                f"{manifest}:{line_number}: expected an editable '-e PATH' entry, "
+                f"observed {line!r}"
+            )
+        editable = line[3:].strip()
+        match = re.fullmatch(r"(?P<path>.+?)(?:\[[^]]+\])?", editable)
+        if match is None:
+            raise WheelhouseRefusal(
+                f"{manifest}:{line_number}: cannot resolve editable entry {line!r}"
+            )
+        project = (repo_root / match.group("path")).resolve()
+        try:
+            project.relative_to(repo_root)
+        except ValueError as exc:
+            raise WheelhouseRefusal(
+                f"{manifest}:{line_number}: editable project escapes repo root: {project}"
+            ) from exc
+        projects.append(project)
+    if not projects:
+        raise WheelhouseRefusal(f"{manifest}: no editable projects enrolled")
+    return tuple(projects)
+
+
+def derive_build_requirements(
+    repo_root: Path, editable_requirements: Path
+) -> tuple[str, ...]:
+    repo_root = repo_root.resolve()
+    requirements: set[str] = set()
+    for project in _editable_projects(repo_root, editable_requirements.resolve()):
+        pyproject = project / "pyproject.toml"
+        if not pyproject.is_file():
+            raise WheelhouseRefusal(f"missing build declaration {pyproject}")
+        with pyproject.open("rb") as stream:
+            document = tomllib.load(stream)
+        declared = document.get("build-system", {}).get("requires")
+        if not isinstance(declared, list) or not declared:
+            raise WheelhouseRefusal(
+                f"{pyproject}: [build-system].requires must be a non-empty list"
+            )
+        for requirement in declared:
+            if not isinstance(requirement, str) or not requirement.strip():
+                raise WheelhouseRefusal(
+                    f"{pyproject}: invalid [build-system].requires entry "
+                    f"{requirement!r}"
+                )
+            requirements.add(requirement.strip())
+    return tuple(sorted(requirements, key=str.casefold))
+
+
+def write_build_requirements(
+    repo_root: Path, editable_requirements: Path, output: Path
+) -> tuple[str, ...]:
+    requirements = derive_build_requirements(repo_root, editable_requirements)
+    output.write_text("".join(f"{item}\n" for item in requirements), encoding="utf-8")
+    return requirements
+
+
+@dataclass(frozen=True)
+class _Wheel:
+    name: str
+    version: object
+    requires: tuple[str, ...]
+
+
+def _wheel_index(wheelhouse: Path) -> dict[str, list[_Wheel]]:
+    compatible_tags = set(sys_tags())
+    index: dict[str, list[_Wheel]] = {}
+    for path in sorted(wheelhouse.glob("*.whl")):
+        try:
+            filename_name, filename_version, _, tags = parse_wheel_filename(path.name)
+        except ValueError as exc:
+            raise WheelhouseRefusal(
+                f"malformed wheel filename {path.name}: {exc}"
+            ) from exc
+        if tags.isdisjoint(compatible_tags):
+            continue
+        with zipfile.ZipFile(path) as archive:
+            metadata_paths = [
+                name
+                for name in archive.namelist()
+                if name.endswith(".dist-info/METADATA") and name.count("/") == 1
+            ]
+            if len(metadata_paths) != 1:
+                raise WheelhouseRefusal(
+                    f"{path.name}: expected one .dist-info/METADATA, "
+                    f"observed {len(metadata_paths)}"
+                )
+            metadata = BytesParser(policy=default).parsebytes(
+                archive.read(metadata_paths[0])
+            )
+        metadata_name = metadata.get("Name")
+        metadata_version = metadata.get("Version")
+        if canonicalize_name(metadata_name or "") != canonicalize_name(filename_name):
+            raise WheelhouseRefusal(
+                f"{path.name}: filename distribution {filename_name!s} disagrees "
+                f"with METADATA Name {metadata_name!r}"
+            )
+        if metadata_version != str(filename_version):
+            raise WheelhouseRefusal(
+                f"{path.name}: filename version {filename_version!s} disagrees "
+                f"with METADATA Version {metadata_version!r}"
+            )
+        name = canonicalize_name(metadata_name)
+        index.setdefault(name, []).append(
+            _Wheel(
+                name=name,
+                version=filename_version,
+                requires=tuple(metadata.get_all("Requires-Dist", [])),
+            )
+        )
+    return index
+
+
+def _marker_applies(requirement: Requirement, extras: set[str]) -> bool:
+    if requirement.marker is None:
+        return True
+    return any(
+        requirement.marker.evaluate({"extra": extra}) for extra in extras or {""}
+    )
+
+
+def verify_wheelhouse(
+    repo_root: Path, editable_requirements: Path, wheelhouse: Path
+) -> None:
+    declared = derive_build_requirements(repo_root, editable_requirements)
+    if not wheelhouse.is_dir():
+        raise WheelhouseRefusal(
+            f"missing wheelhouse {wheelhouse}; build requirements are required "
+            "for offline editable install"
+        )
+    index = _wheel_index(wheelhouse)
+    pending = [(Requirement(text), {""}) for text in declared]
+    constraints: dict[str, list[Requirement]] = {}
+    requested_extras: dict[str, set[str]] = {}
+    expanded: set[tuple[str, object, tuple[str, ...]]] = set()
+    while pending:
+        requirement, parent_extras = pending.pop(0)
+        if not _marker_applies(requirement, parent_extras):
+            continue
+        name = canonicalize_name(requirement.name)
+        constraints.setdefault(name, []).append(requirement)
+        requested_extras.setdefault(name, set()).update(requirement.extras)
+        candidates = [
+            wheel
+            for wheel in index.get(name, [])
+            if all(
+                not item.specifier
+                or item.specifier.contains(wheel.version, prereleases=True)
+                for item in constraints[name]
+            )
+        ]
+        if not candidates:
+            raise WheelhouseRefusal(
+                f"missing distribution '{name}' (requirement {str(requirement)!r}); "
+                "it is required for offline editable install build isolation"
+            )
+        selected = max(candidates, key=lambda wheel: wheel.version)
+        expansion = (
+            name,
+            selected.version,
+            tuple(sorted(requested_extras[name])),
+        )
+        if expansion in expanded:
+            continue
+        expanded.add(expansion)
+        pending.extend(
+            (Requirement(text), requested_extras[name]) for text in selected.requires
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("derive", "verify"):
+        child = subparsers.add_parser(command)
+        child.add_argument("--repo-root", type=Path, default=Path("."))
+        child.add_argument("--editable-requirements", type=Path, required=True)
+        if command == "derive":
+            child.add_argument("--output", type=Path, required=True)
+        else:
+            child.add_argument("--wheelhouse", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "derive":
+            requirements = write_build_requirements(
+                args.repo_root, args.editable_requirements, args.output
+            )
+            print(
+                "showcase-wheelhouse-build-requirements "
+                f"count={len(requirements)} output={args.output}"
+            )
+        else:
+            verify_wheelhouse(
+                args.repo_root, args.editable_requirements, args.wheelhouse
+            )
+            print("showcase-wheelhouse-verified purpose=offline-editable-install")
+    except (OSError, tomllib.TOMLDecodeError, WheelhouseRefusal) as exc:
+        print(f"showcase-wheelhouse-refused: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- make `.github/showcase-editable-requirements.txt` the single enrolled first-party package population used by both the shared producer and shard installs
- derive the build-isolation requirements from every enrolled package's `[build-system].requires`
- materialize those requirements and their dependency closure into the shared wheelhouse
- verify the resulting wheel artifact recursively through top-level wheel `METADATA` before it can be uploaded
- refuse deliberately with the missing distribution's name and state that it is required for offline editable install

## Why

Acid run `30842932401` at `a5534eb0084bccd12c4d88575e6e3e69360d286b` showed the same first terminal in shards 0/1/2/3: editable `sugar-build-witness` entered PEP 517 build isolation, the shared wheelhouse could not provide `setuptools>=68`, and no shard body was constructed. Enrollment then correctly reported `attended=0`, `R_showcase_shard_attendance=4`.

The defect was introduced by #7020 / `409c0410576`: `pip wheel` preserved runtime dependency wheels and discarded first-party wheels, but did not preserve the build-isolation dependency closure needed to reinstall those first-party packages from checkout under `--no-index`. Adding `setuptools` and `wheel` by hand would reproduce the same defect on the next build declaration. This change derives the population from source declarations instead.

**ALL SHOWCASE SEMANTICS ARE CURRENTLY UNMEASURED, not failing.** No showcase result from any run in this censored window may be quoted for anything. Whatever appears after this repair is discovery, not regression, and may be red for real product reasons. Every shard was censored before `Run showcase shard`; this PR does not claim there is no deeper showcase defect.

## Instrument and retirement path

The planted incomplete-wheelhouse twin exits nonzero and names both the missing direct distribution and the `offline editable install` purpose. A recursive twin supplies a backend wheel whose `Requires-Dist` names an absent build hook: it goes red by the transitive distribution's name, then green only after that wheel is present. The verifier reads top-level wheel metadata and walks the dependency closure, so vendored nested `.dist-info` records do not impersonate artifact members.

The source domain remains open: future enrolled packages may change their build declarations. Therefore the verifier remains as the producer membrane. It can retire only if the package/build substrate itself makes an incomplete offline build closure unconstructable before artifact upload.

## Validation

Measured after rebasing onto main `299cf6b19be7e94246fa0286571becd01e63ccb3`:

- `BCARGO_REMOTE_ROOT=/home/tsavo/remote/sugar-kobayashi-showcase-233dc27f bin/bpytest -q tests/test_showcase_shared_setup_enrollment.py` — exit 0, 8 passed in 0.69s on battleaxe
- `GOTOOLCHAIN=local go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml` — exit 0
- `python -m black --check tools/showcase_wheelhouse.py tests/test_showcase_shared_setup_enrollment.py` — exit 0 under Black 26.5.1
- `python -m py_compile tools/showcase_wheelhouse.py tests/test_showcase_shared_setup_enrollment.py` — exit 0
- current declarations derive exactly three constraints: `setuptools>=64`, `setuptools>=68`, and `wheel`
- building a wheelhouse from those derived constraints exits 0; `showcase_wheelhouse.py verify` then exits 0 and prints `showcase-wheelhouse-verified purpose=offline-editable-install`

Predicted impact: the single shared showcase provisioning cause is removed. No showcase product number has been measured by this PR; the next real run is the first semantic discovery after the repair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated preparation and verification of offline package wheelhouses for showcase environments.
  * Build requirements are now derived from editable projects and validated, including transitive dependencies and compatible package versions.
  * Added support for managing showcase editable requirements through a shared manifest.

* **Bug Fixes**
  * Improved detection and reporting of missing, invalid, or incomplete package dependencies before showcase setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive and attest showcase offline build closure with `showcase_wheelhouse.py`
> - Adds [tools/showcase_wheelhouse.py](https://github.com/TSavo/sugar/pull/7245/files#diff-0fe47373d9afa29ddaf7dd97449a2fbf8bac97b700f122086819d692b06439ef) with `derive` and `verify` subcommands: `derive` reads editable project `pyproject.toml` files to produce a unified build-requirements file; `verify` checks that the wheelhouse contains a complete transitive closure of all build dependencies.
> - Introduces [.github/showcase-editable-requirements.txt](https://github.com/TSavo/sugar/pull/7245/files#diff-b33368bd9fff874c1ac79eaa58a10c9b241a0422652709daf3a15b10d1d6906b) as a single manifest of first-party editable packages for the showcase environment.
> - Updates the CI `Build wheelhouse` step in [.github/workflows/ci.yml](https://github.com/TSavo/sugar/pull/7245/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to invoke `derive` before building and `verify` after, replacing hardcoded `-e` install arguments with `--requirement` references.
> - Adds tests covering `derive` aggregation across multiple projects, `verify` rejection of incomplete wheelhouses, and transitive dependency resolution.
> - Behavioral Change: showcase shard jobs now install first-party editables via the requirements file rather than explicit `-e` paths; the wheelhouse build will fail if any required distribution is missing from the offline closure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 233dc27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->