### PR TITLE
Bank the first sealed frontier closing account

### DIFF
--- a/.receipts/first-sealed-frontier-1b3ac2dd9/CLOSING_ACCOUNT.md
+++ b/.receipts/first-sealed-frontier-1b3ac2dd9/CLOSING_ACCOUNT.md
@@ -1,0 +1,43 @@
+# Sealed frontier closing account
+
+Source receipt SHA-256: `cedb430388de1bd85b8bddcdc4d547a8dfcba3954e00e8930d8419bc936274b4`
+
+Measured commit: `1b3ac2dd9675b00507ea438a7580306dd95015f7`
+
+The closing account is derived from all 477 `constructionPanics` rows by the
+selectors and exact `file:start` manifests in `closing-account.jq`. The
+generated `closing-account.json` carries every original row identity and its
+single assigned class.
+
+| Class | Rows | Meaning at the measured first terminal |
+|---|---:|---|
+| deliberate membrane | 301 | 290 pytest-distribution and 11 stdlib targets explicitly outside the enrolled pandas population |
+| boundary exposure terminating early | 70 | The row terminates before the population predicate; authenticated counterfactual ownership is outside enrolled pandas |
+| landed defect | 95 | pandas was falsely off-population through path-derived roster seeding; fixed after this receipt by `25d1dc7d02e75275117d2b958721c299f0d50062` (#7227) |
+| existing construct behind wrong entrance | 5 | Two `parser.read_csv` receiver-method rows and three same-module `FunctionDef` rows whose construction exists but is unreachable through the current entrance |
+| entrance defect | 3 | Same-module class manager enrollment lacks the callsite body for `TextFileReader`, `HDFStore`, and `StataReader` |
+| engine invariant | 3 | Construction recursion escapes at one `Module` and two `FunctionDef` roots |
+| **Total** | **477** | Exact row-identity union |
+
+Validation: 477 accounted, zero uncovered, zero multiply classified, and zero
+duplicate stable row identities. The generated JSON SHA-256 is recorded by the
+handoff report.
+
+The five existing-construct rows are two distinct entrance surfaces, not one:
+
+- `tests/io/parser/common/test_chunksize.py:53` and
+  `tests/io/parser/common/test_iterator.py:42` use a fixture/formal
+  receiver-method entrance to pandas `TextFileReader`, which already owns
+  `__enter__`/`__exit__`.
+- `io/formats/format.py:1044`, `io/sql.py:354`, and `io/common.py:405` use a
+  missing same-module `FunctionDef` entrance. Existing import-backed
+  `FunctionDef` construction machinery is present. The `urlopen` row may expose
+  a stdlib boundary next; that descendant is currently masked and unmeasured.
+
+Caveats:
+
+- 477 is a **FIRST-TERMINAL LOWER BOUND**.
+- Descendants behind each first terminal remain masked.
+- 944/1421 is attendance testimony, not completion.
+- Files-unblocked means the current first terminal **MOVES**; it does not mean
+  the file completes or remaining work falls by that count.

--- a/.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.jq
+++ b/.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.jq
@@ -1,0 +1,215 @@
+def row_identity:
+  [
+    .owner,
+    .file,
+    (.coordinate | tostring),
+    .observed,
+    .requested,
+    .entrance
+  ];
+
+def file_start:
+  . as $row
+  | if (($row.coordinate | tostring) | test("start_line=[0-9]+")) then
+      ($row.file + ":" + (($row.coordinate | tostring) | capture("start_line=(?<line>[0-9]+)").line))
+    elif (($row.coordinate | tostring) | test(":" + "[0-9]+" + ":")) then
+      ($row.file + ":" + (($row.coordinate | tostring) | capture(":(?<line>[0-9]+):").line))
+    else
+      ($row.file + ":" + ($row.coordinate | tostring))
+    end;
+
+def deliberate_membrane:
+  .owner == "With._construct_sugar"
+  and (.observed | contains("call-target-off-population"))
+  and (
+    (.observed | contains("distribution 'pytest'"))
+    or (.observed | contains("stdlib module"))
+  );
+
+def landed_defect:
+  .owner == "With._construct_sugar"
+  and (.observed | contains("call-target-off-population"))
+  and (.observed | contains("distribution 'pandas'"));
+
+def boundary_early_manifest:
+  [
+    "conftest.py:2151",
+    "tests/arithmetic/test_numeric.py:35",
+    "tests/arrays/categorical/test_indexing.py:377",
+    "tests/config/test_config.py:15",
+    "tests/config/test_localization.py:97",
+    "tests/extension/test_numpy.py:71",
+    "tests/frame/test_arithmetic.py:51",
+    "tests/frame/test_stack_unstack.py:2293",
+    "tests/generic/test_frame.py:106",
+    "tests/generic/test_series.py:110",
+    "tests/indexes/datetimes/test_iter.py:71",
+    "tests/indexes/multi/test_duplicates.py:263",
+    "tests/indexes/multi/test_integrity.py:131",
+    "tests/io/formats/test_console.py:36",
+    "tests/io/parser/dtypes/test_categorical.py:128",
+    "tests/io/parser/test_index_col.py:255",
+    "tests/io/test_clipboard.py:107",
+    "tests/io/test_gcs.py:103",
+    "tests/reshape/test_pivot.py:2152",
+    "tests/series/methods/test_isin.py:207",
+    "tests/series/test_arithmetic.py:36",
+    "tests/test_expressions.py:138",
+    "tests/test_nanops.py:23",
+
+    "_version.py:159",
+    "core/series.py:1573",
+    "tests/frame/methods/test_to_csv.py:730",
+    "tests/io/conftest.py:141",
+    "tests/io/formats/style/test_html.py:64",
+    "tests/io/formats/test_to_csv.py:34",
+    "tests/io/formats/test_to_html.py:49",
+    "tests/io/formats/test_to_latex.py:34",
+    "tests/io/generate_legacy_storage_files.py:361",
+    "tests/io/json/test_pandas.py:1482",
+    "tests/io/parser/common/test_common_basic.py:864",
+    "tests/io/parser/common/test_file_buffer_url.py:429",
+    "tests/io/parser/test_compression.py:30",
+    "tests/io/parser/test_encoding.py:66",
+    "tests/io/parser/test_network.py:45",
+    "tests/io/parser/test_python_parser_only.py:167",
+    "tests/io/parser/test_read_fwf.py:679",
+    "tests/io/parser/test_textreader.py:40",
+    "tests/io/sas/test_sas7bdat.py:59",
+    "tests/io/test_feather.py:164",
+    "tests/io/test_html.py:217",
+    "tests/io/test_iceberg.py:51",
+    "tests/io/test_parquet.py:701",
+    "tests/io/xml/test_to_xml.py:997",
+    "tests/io/xml/test_xml_dtypes.py:35",
+    "tests/series/methods/test_to_csv.py:57",
+    "tests/util/test_show_versions.py:19",
+    "util/_print_versions.py:148",
+
+    "core/base.py:1643",
+    "core/window/rolling.py:589",
+    "tests/frame/test_npfuncs.py:23",
+    "tests/frame/methods/test_info.py:193",
+    "tests/io/parser/test_c_parser_only.py:304",
+    "tests/io/pytables/test_compat.py:37",
+    "tests/io/pytables/test_keys.py:46",
+    "io/formats/xml.py:553",
+    "io/xml.py:537",
+    "tests/plotting/frame/test_frame_subplots.py:556",
+    "tests/plotting/test_datetimelike.py:1692",
+
+    "plotting/_matplotlib/__init__.py:67",
+    "tests/plotting/test_style.py:25",
+    "_testing/__init__.py:541",
+    "tests/io/test_fsspec.py:76",
+    "tests/io/test_sql.py:877",
+    "_testing/_io.py:128",
+    "tests/io/test_common.py:92",
+    "tests/io/test_pickle.py:297"
+  ];
+
+def existing_construct_wrong_entrance_manifest:
+  [
+    "tests/io/parser/common/test_chunksize.py:53",
+    "tests/io/parser/common/test_iterator.py:42",
+    "io/formats/format.py:1044",
+    "io/sql.py:354",
+    "io/common.py:405"
+  ];
+
+def matching_classes:
+  . as $row
+  | [
+      if deliberate_membrane then "deliberate-membrane" else empty end,
+      if landed_defect then "landed-defect" else empty end,
+      if (boundary_early_manifest | index($row | file_start)) != null
+        then "boundary-exposure-terminating-early" else empty end,
+      if (existing_construct_wrong_entrance_manifest | index($row | file_start)) != null
+        then "existing-construct-behind-wrong-entrance" else empty end,
+      if .owner == "populate_same_module_class_manager"
+        then "entrance-defect" else empty end,
+      if .owner == "roll_call.discharge"
+        and (.observed | startswith("RecursionError while constructing"))
+        then "engine-invariant" else empty end
+    ];
+
+def class_name:
+  matching_classes as $classes
+  | if ($classes | length) == 1 then $classes[0]
+    elif ($classes | length) == 0 then "uncovered"
+    else "multiply-classified"
+    end;
+
+. as $receipt
+| ($receipt.constructionPanics | map(. + {
+    rowIdentity: row_identity,
+    fileStart: file_start,
+    matchingClasses: matching_classes,
+    closingClass: class_name
+  })) as $rows
+| {
+    schema: "sugar.frontier-closing-account.v1",
+    sourceReceipt: {
+      sha256: "cedb430388de1bd85b8bddcdc4d547a8dfcba3954e00e8930d8419bc936274b4",
+      measuredCommit: $receipt.measuredCommit,
+      frontierWidth: $receipt.frontierWidth,
+      denominator: $receipt.denominator
+    },
+    caveats: [
+      "477 is a FIRST-TERMINAL LOWER BOUND.",
+      "Descendants behind each first terminal remain masked.",
+      "944/1421 is attendance testimony, not completion.",
+      "Files-unblocked means the current first terminal MOVES; it does not mean the file completes or remaining work falls by that count."
+    ],
+    selectors: {
+      deliberateMembrane: "owner == With._construct_sugar AND observed contains call-target-off-population AND (distribution pytest OR stdlib module)",
+      landedDefect: "owner == With._construct_sugar AND observed contains call-target-off-population AND distribution pandas; fixed after the measured commit by #7227/25d1dc7d02e75275117d2b958721c299f0d50062",
+      boundaryExposureTerminatingEarly: {
+        rule: "exact file:start membership after normalizing the source coordinate; every member terminates before the population predicate and counterfactually belongs outside enrolled pandas",
+        manifest: boundary_early_manifest
+      },
+      existingConstructBehindWrongEntrance: {
+        rule: "exact file:start membership; source construction exists but the current entrance cannot reach it",
+        manifest: existing_construct_wrong_entrance_manifest
+      },
+      entranceDefect: "owner == populate_same_module_class_manager",
+      engineInvariant: "owner == roll_call.discharge AND observed starts with RecursionError while constructing"
+    },
+    classCounts: (
+      $rows
+      | group_by(.closingClass)
+      | map({key: .[0].closingClass, value: length})
+      | from_entries
+    ),
+    accountedCount: ($rows | map(select(.closingClass != "uncovered")) | length),
+    uncoveredCount: ($rows | map(select(.closingClass == "uncovered")) | length),
+    uncoveredRows: ($rows | map(select(.closingClass == "uncovered") | {
+      rowIdentity, fileStart, owner, coordinate, observed, requested, entrance
+    })),
+    multiplyClassifiedCount: ($rows | map(select(.closingClass == "multiply-classified")) | length),
+    multiplyClassifiedRows: ($rows | map(select(.closingClass == "multiply-classified") | {
+      rowIdentity, fileStart, matchingClasses, owner, coordinate, observed, requested, entrance
+    })),
+    duplicateRowIdentities: (
+      $rows
+      | group_by(.rowIdentity)
+      | map(select(length > 1) | {rowIdentity: .[0].rowIdentity, count: length})
+    ),
+    rowsByClass: (
+      $rows
+      | group_by(.closingClass)
+      | map({
+          key: .[0].closingClass,
+          value: map({
+            rowIdentity,
+            fileStart,
+            owner,
+            coordinate,
+            observed,
+            requested,
+            entrance
+          })
+        })
+      | from_entries
+    )
+  }

--- a/.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.json
+++ b/.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.json
@@ -1,0 +1,9217 @@
+{
+  "schema": "sugar.frontier-closing-account.v1",
+  "sourceReceipt": {
+    "sha256": "cedb430388de1bd85b8bddcdc4d547a8dfcba3954e00e8930d8419bc936274b4",
+    "measuredCommit": "1b3ac2dd9675b00507ea438a7580306dd95015f7",
+    "frontierWidth": 477,
+    "denominator": {
+      "files": {
+        "enrolled": 1421,
+        "terminal": 1421,
+        "completed": 944,
+        "panicked": 477,
+        "missing": 0,
+        "terminalRows": 1421,
+        "corpusManifestCid": "sha256:a223a4499d0909f22190748b4aca9144e35a58fec31e84cb924e2c25fd3c03d0",
+        "enrolledFiles": [
+          "pandas/__init__.py",
+          "pandas/_config/__init__.py",
+          "pandas/_config/config.py",
+          "pandas/_config/dates.py",
+          "pandas/_config/display.py",
+          "pandas/_config/localization.py",
+          "pandas/_libs/__init__.py",
+          "pandas/_libs/tslibs/__init__.py",
+          "pandas/_libs/window/__init__.py",
+          "pandas/_testing/__init__.py",
+          "pandas/_testing/_hypothesis.py",
+          "pandas/_testing/_io.py",
+          "pandas/_testing/_warnings.py",
+          "pandas/_testing/asserters.py",
+          "pandas/_testing/compat.py",
+          "pandas/_testing/contexts.py",
+          "pandas/_typing.py",
+          "pandas/_version.py",
+          "pandas/_version_meson.py",
+          "pandas/api/__init__.py",
+          "pandas/api/executors/__init__.py",
+          "pandas/api/extensions/__init__.py",
+          "pandas/api/indexers/__init__.py",
+          "pandas/api/interchange/__init__.py",
+          "pandas/api/internals.py",
+          "pandas/api/types/__init__.py",
+          "pandas/api/typing/__init__.py",
+          "pandas/api/typing/aliases.py",
+          "pandas/arrays/__init__.py",
+          "pandas/compat/__init__.py",
+          "pandas/compat/_constants.py",
+          "pandas/compat/_optional.py",
+          "pandas/compat/numpy/__init__.py",
+          "pandas/compat/numpy/function.py",
+          "pandas/compat/pickle_compat.py",
+          "pandas/compat/pyarrow.py",
+          "pandas/conftest.py",
+          "pandas/core/__init__.py",
+          "pandas/core/_numba/__init__.py",
+          "pandas/core/_numba/executor.py",
+          "pandas/core/_numba/extensions.py",
+          "pandas/core/_numba/kernels/__init__.py",
+          "pandas/core/_numba/kernels/mean_.py",
+          "pandas/core/_numba/kernels/min_max_.py",
+          "pandas/core/_numba/kernels/shared.py",
+          "pandas/core/_numba/kernels/sum_.py",
+          "pandas/core/_numba/kernels/var_.py",
+          "pandas/core/accessor.py",
+          "pandas/core/algorithms.py",
+          "pandas/core/api.py",
+          "pandas/core/apply.py",
+          "pandas/core/array_algos/__init__.py",
+          "pandas/core/array_algos/datetimelike_accumulations.py",
+          "pandas/core/array_algos/masked_accumulations.py",
+          "pandas/core/array_algos/masked_reductions.py",
+          "pandas/core/array_algos/putmask.py",
+          "pandas/core/array_algos/quantile.py",
+          "pandas/core/array_algos/replace.py",
+          "pandas/core/array_algos/take.py",
+          "pandas/core/array_algos/transforms.py",
+          "pandas/core/arraylike.py",
+          "pandas/core/arrays/__init__.py",
+          "pandas/core/arrays/_arrow_string_mixins.py",
+          "pandas/core/arrays/_mixins.py",
+          "pandas/core/arrays/_ranges.py",
+          "pandas/core/arrays/_utils.py",
+          "pandas/core/arrays/arrow/__init__.py",
+          "pandas/core/arrays/arrow/_arrow_utils.py",
+          "pandas/core/arrays/arrow/accessors.py",
+          "pandas/core/arrays/arrow/array.py",
+          "pandas/core/arrays/arrow/extension_types.py",
+          "pandas/core/arrays/base.py",
+          "pandas/core/arrays/boolean.py",
+          "pandas/core/arrays/categorical.py",
+          "pandas/core/arrays/datetimelike.py",
+          "pandas/core/arrays/datetimes.py",
+          "pandas/core/arrays/floating.py",
+          "pandas/core/arrays/integer.py",
+          "pandas/core/arrays/interval.py",
+          "pandas/core/arrays/masked.py",
+          "pandas/core/arrays/numeric.py",
+          "pandas/core/arrays/numpy_.py",
+          "pandas/core/arrays/period.py",
+          "pandas/core/arrays/sparse/__init__.py",
+          "pandas/core/arrays/sparse/accessor.py",
+          "pandas/core/arrays/sparse/array.py",
+          "pandas/core/arrays/sparse/scipy_sparse.py",
+          "pandas/core/arrays/string_.py",
+          "pandas/core/arrays/string_arrow.py",
+          "pandas/core/arrays/timedeltas.py",
+          "pandas/core/base.py",
+          "pandas/core/col.py",
+          "pandas/core/common.py",
+          "pandas/core/computation/__init__.py",
+          "pandas/core/computation/align.py",
+          "pandas/core/computation/api.py",
+          "pandas/core/computation/check.py",
+          "pandas/core/computation/common.py",
+          "pandas/core/computation/engines.py",
+          "pandas/core/computation/eval.py",
+          "pandas/core/computation/expr.py",
+          "pandas/core/computation/expressions.py",
+          "pandas/core/computation/ops.py",
+          "pandas/core/computation/parsing.py",
+          "pandas/core/computation/pytables.py",
+          "pandas/core/computation/scope.py",
+          "pandas/core/config_init.py",
+          "pandas/core/construction.py",
+          "pandas/core/dtypes/__init__.py",
+          "pandas/core/dtypes/api.py",
+          "pandas/core/dtypes/astype.py",
+          "pandas/core/dtypes/base.py",
+          "pandas/core/dtypes/cast.py",
+          "pandas/core/dtypes/common.py",
+          "pandas/core/dtypes/concat.py",
+          "pandas/core/dtypes/dtypes.py",
+          "pandas/core/dtypes/generic.py",
+          "pandas/core/dtypes/inference.py",
+          "pandas/core/dtypes/missing.py",
+          "pandas/core/flags.py",
+          "pandas/core/frame.py",
+          "pandas/core/generic.py",
+          "pandas/core/groupby/__init__.py",
+          "pandas/core/groupby/base.py",
+          "pandas/core/groupby/categorical.py",
+          "pandas/core/groupby/generic.py",
+          "pandas/core/groupby/groupby.py",
+          "pandas/core/groupby/grouper.py",
+          "pandas/core/groupby/indexing.py",
+          "pandas/core/groupby/numba_.py",
+          "pandas/core/groupby/ops.py",
+          "pandas/core/indexers/__init__.py",
+          "pandas/core/indexers/objects.py",
+          "pandas/core/indexers/utils.py",
+          "pandas/core/indexes/__init__.py",
+          "pandas/core/indexes/accessors.py",
+          "pandas/core/indexes/api.py",
+          "pandas/core/indexes/base.py",
+          "pandas/core/indexes/category.py",
+          "pandas/core/indexes/datetimelike.py",
+          "pandas/core/indexes/datetimes.py",
+          "pandas/core/indexes/extension.py",
+          "pandas/core/indexes/frozen.py",
+          "pandas/core/indexes/interval.py",
+          "pandas/core/indexes/multi.py",
+          "pandas/core/indexes/period.py",
+          "pandas/core/indexes/range.py",
+          "pandas/core/indexes/timedeltas.py",
+          "pandas/core/indexing.py",
+          "pandas/core/interchange/__init__.py",
+          "pandas/core/interchange/buffer.py",
+          "pandas/core/interchange/column.py",
+          "pandas/core/interchange/dataframe.py",
+          "pandas/core/interchange/dataframe_protocol.py",
+          "pandas/core/interchange/from_dataframe.py",
+          "pandas/core/interchange/utils.py",
+          "pandas/core/internals/__init__.py",
+          "pandas/core/internals/api.py",
+          "pandas/core/internals/blocks.py",
+          "pandas/core/internals/concat.py",
+          "pandas/core/internals/construction.py",
+          "pandas/core/internals/managers.py",
+          "pandas/core/internals/ops.py",
+          "pandas/core/methods/__init__.py",
+          "pandas/core/methods/describe.py",
+          "pandas/core/methods/selectn.py",
+          "pandas/core/methods/to_dict.py",
+          "pandas/core/missing.py",
+          "pandas/core/nanops.py",
+          "pandas/core/ops/__init__.py",
+          "pandas/core/ops/array_ops.py",
+          "pandas/core/ops/common.py",
+          "pandas/core/ops/dispatch.py",
+          "pandas/core/ops/docstrings.py",
+          "pandas/core/ops/invalid.py",
+          "pandas/core/ops/mask_ops.py",
+          "pandas/core/ops/missing.py",
+          "pandas/core/resample.py",
+          "pandas/core/reshape/__init__.py",
+          "pandas/core/reshape/api.py",
+          "pandas/core/reshape/concat.py",
+          "pandas/core/reshape/encoding.py",
+          "pandas/core/reshape/melt.py",
+          "pandas/core/reshape/merge.py",
+          "pandas/core/reshape/pivot.py",
+          "pandas/core/reshape/reshape.py",
+          "pandas/core/reshape/tile.py",
+          "pandas/core/roperator.py",
+          "pandas/core/sample.py",
+          "pandas/core/series.py",
+          "pandas/core/shared_docs.py",
+          "pandas/core/sorting.py",
+          "pandas/core/sparse/__init__.py",
+          "pandas/core/sparse/api.py",
+          "pandas/core/strings/__init__.py",
+          "pandas/core/strings/accessor.py",
+          "pandas/core/strings/object_array.py",
+          "pandas/core/tools/__init__.py",
+          "pandas/core/tools/datetimes.py",
+          "pandas/core/tools/numeric.py",
+          "pandas/core/tools/timedeltas.py",
+          "pandas/core/tools/times.py",
+          "pandas/core/util/__init__.py",
+          "pandas/core/util/hashing.py",
+          "pandas/core/util/numba_.py",
+          "pandas/core/window/__init__.py",
+          "pandas/core/window/common.py",
+          "pandas/core/window/doc.py",
+          "pandas/core/window/ewm.py",
+          "pandas/core/window/expanding.py",
+          "pandas/core/window/numba_.py",
+          "pandas/core/window/online.py",
+          "pandas/core/window/rolling.py",
+          "pandas/errors/__init__.py",
+          "pandas/errors/cow.py",
+          "pandas/io/__init__.py",
+          "pandas/io/_util.py",
+          "pandas/io/api.py",
+          "pandas/io/clipboard/__init__.py",
+          "pandas/io/clipboards.py",
+          "pandas/io/common.py",
+          "pandas/io/excel/__init__.py",
+          "pandas/io/excel/_base.py",
+          "pandas/io/excel/_calamine.py",
+          "pandas/io/excel/_odfreader.py",
+          "pandas/io/excel/_odswriter.py",
+          "pandas/io/excel/_openpyxl.py",
+          "pandas/io/excel/_pyxlsb.py",
+          "pandas/io/excel/_util.py",
+          "pandas/io/excel/_xlrd.py",
+          "pandas/io/excel/_xlsxwriter.py",
+          "pandas/io/feather_format.py",
+          "pandas/io/formats/__init__.py",
+          "pandas/io/formats/_color_data.py",
+          "pandas/io/formats/console.py",
+          "pandas/io/formats/css.py",
+          "pandas/io/formats/csvs.py",
+          "pandas/io/formats/excel.py",
+          "pandas/io/formats/format.py",
+          "pandas/io/formats/html.py",
+          "pandas/io/formats/info.py",
+          "pandas/io/formats/printing.py",
+          "pandas/io/formats/string.py",
+          "pandas/io/formats/style.py",
+          "pandas/io/formats/style_render.py",
+          "pandas/io/formats/xml.py",
+          "pandas/io/html.py",
+          "pandas/io/iceberg.py",
+          "pandas/io/json/__init__.py",
+          "pandas/io/json/_json.py",
+          "pandas/io/json/_normalize.py",
+          "pandas/io/json/_table_schema.py",
+          "pandas/io/orc.py",
+          "pandas/io/parquet.py",
+          "pandas/io/parsers/__init__.py",
+          "pandas/io/parsers/arrow_parser_wrapper.py",
+          "pandas/io/parsers/base_parser.py",
+          "pandas/io/parsers/c_parser_wrapper.py",
+          "pandas/io/parsers/python_parser.py",
+          "pandas/io/parsers/readers.py",
+          "pandas/io/pickle.py",
+          "pandas/io/pytables.py",
+          "pandas/io/sas/__init__.py",
+          "pandas/io/sas/sas7bdat.py",
+          "pandas/io/sas/sas_constants.py",
+          "pandas/io/sas/sas_xport.py",
+          "pandas/io/sas/sasreader.py",
+          "pandas/io/spss.py",
+          "pandas/io/sql.py",
+          "pandas/io/stata.py",
+          "pandas/io/xml.py",
+          "pandas/plotting/__init__.py",
+          "pandas/plotting/_core.py",
+          "pandas/plotting/_matplotlib/__init__.py",
+          "pandas/plotting/_matplotlib/boxplot.py",
+          "pandas/plotting/_matplotlib/converter.py",
+          "pandas/plotting/_matplotlib/core.py",
+          "pandas/plotting/_matplotlib/groupby.py",
+          "pandas/plotting/_matplotlib/hist.py",
+          "pandas/plotting/_matplotlib/misc.py",
+          "pandas/plotting/_matplotlib/style.py",
+          "pandas/plotting/_matplotlib/timeseries.py",
+          "pandas/plotting/_matplotlib/tools.py",
+          "pandas/plotting/_misc.py",
+          "pandas/testing.py",
+          "pandas/tests/__init__.py",
+          "pandas/tests/api/__init__.py",
+          "pandas/tests/api/test_api.py",
+          "pandas/tests/api/test_types.py",
+          "pandas/tests/apply/__init__.py",
+          "pandas/tests/apply/common.py",
+          "pandas/tests/apply/conftest.py",
+          "pandas/tests/apply/test_frame_apply.py",
+          "pandas/tests/apply/test_frame_apply_relabeling.py",
+          "pandas/tests/apply/test_frame_transform.py",
+          "pandas/tests/apply/test_invalid_arg.py",
+          "pandas/tests/apply/test_numba.py",
+          "pandas/tests/apply/test_series_apply.py",
+          "pandas/tests/apply/test_series_apply_relabeling.py",
+          "pandas/tests/apply/test_series_transform.py",
+          "pandas/tests/apply/test_str.py",
+          "pandas/tests/arithmetic/__init__.py",
+          "pandas/tests/arithmetic/common.py",
+          "pandas/tests/arithmetic/conftest.py",
+          "pandas/tests/arithmetic/test_array_ops.py",
+          "pandas/tests/arithmetic/test_bool.py",
+          "pandas/tests/arithmetic/test_categorical.py",
+          "pandas/tests/arithmetic/test_datetime64.py",
+          "pandas/tests/arithmetic/test_interval.py",
+          "pandas/tests/arithmetic/test_numeric.py",
+          "pandas/tests/arithmetic/test_object.py",
+          "pandas/tests/arithmetic/test_period.py",
+          "pandas/tests/arithmetic/test_string.py",
+          "pandas/tests/arithmetic/test_timedelta64.py",
+          "pandas/tests/arrays/__init__.py",
+          "pandas/tests/arrays/boolean/__init__.py",
+          "pandas/tests/arrays/boolean/test_arithmetic.py",
+          "pandas/tests/arrays/boolean/test_astype.py",
+          "pandas/tests/arrays/boolean/test_comparison.py",
+          "pandas/tests/arrays/boolean/test_construction.py",
+          "pandas/tests/arrays/boolean/test_function.py",
+          "pandas/tests/arrays/boolean/test_indexing.py",
+          "pandas/tests/arrays/boolean/test_logical.py",
+          "pandas/tests/arrays/boolean/test_ops.py",
+          "pandas/tests/arrays/boolean/test_reduction.py",
+          "pandas/tests/arrays/boolean/test_repr.py",
+          "pandas/tests/arrays/categorical/__init__.py",
+          "pandas/tests/arrays/categorical/test_algos.py",
+          "pandas/tests/arrays/categorical/test_analytics.py",
+          "pandas/tests/arrays/categorical/test_api.py",
+          "pandas/tests/arrays/categorical/test_astype.py",
+          "pandas/tests/arrays/categorical/test_constructors.py",
+          "pandas/tests/arrays/categorical/test_dtypes.py",
+          "pandas/tests/arrays/categorical/test_indexing.py",
+          "pandas/tests/arrays/categorical/test_map.py",
+          "pandas/tests/arrays/categorical/test_missing.py",
+          "pandas/tests/arrays/categorical/test_operators.py",
+          "pandas/tests/arrays/categorical/test_replace.py",
+          "pandas/tests/arrays/categorical/test_repr.py",
+          "pandas/tests/arrays/categorical/test_sorting.py",
+          "pandas/tests/arrays/categorical/test_subclass.py",
+          "pandas/tests/arrays/categorical/test_take.py",
+          "pandas/tests/arrays/categorical/test_warnings.py",
+          "pandas/tests/arrays/datetimes/__init__.py",
+          "pandas/tests/arrays/datetimes/test_constructors.py",
+          "pandas/tests/arrays/datetimes/test_cumulative.py",
+          "pandas/tests/arrays/datetimes/test_reductions.py",
+          "pandas/tests/arrays/floating/__init__.py",
+          "pandas/tests/arrays/floating/conftest.py",
+          "pandas/tests/arrays/floating/test_arithmetic.py",
+          "pandas/tests/arrays/floating/test_astype.py",
+          "pandas/tests/arrays/floating/test_comparison.py",
+          "pandas/tests/arrays/floating/test_concat.py",
+          "pandas/tests/arrays/floating/test_construction.py",
+          "pandas/tests/arrays/floating/test_contains.py",
+          "pandas/tests/arrays/floating/test_function.py",
+          "pandas/tests/arrays/floating/test_repr.py",
+          "pandas/tests/arrays/floating/test_to_numpy.py",
+          "pandas/tests/arrays/integer/__init__.py",
+          "pandas/tests/arrays/integer/conftest.py",
+          "pandas/tests/arrays/integer/test_arithmetic.py",
+          "pandas/tests/arrays/integer/test_comparison.py",
+          "pandas/tests/arrays/integer/test_concat.py",
+          "pandas/tests/arrays/integer/test_construction.py",
+          "pandas/tests/arrays/integer/test_dtypes.py",
+          "pandas/tests/arrays/integer/test_function.py",
+          "pandas/tests/arrays/integer/test_indexing.py",
+          "pandas/tests/arrays/integer/test_reduction.py",
+          "pandas/tests/arrays/integer/test_repr.py",
+          "pandas/tests/arrays/interval/__init__.py",
+          "pandas/tests/arrays/interval/test_astype.py",
+          "pandas/tests/arrays/interval/test_formats.py",
+          "pandas/tests/arrays/interval/test_interval.py",
+          "pandas/tests/arrays/interval/test_interval_pyarrow.py",
+          "pandas/tests/arrays/interval/test_overlaps.py",
+          "pandas/tests/arrays/masked/__init__.py",
+          "pandas/tests/arrays/masked/test_arithmetic.py",
+          "pandas/tests/arrays/masked/test_arrow_compat.py",
+          "pandas/tests/arrays/masked/test_function.py",
+          "pandas/tests/arrays/masked/test_indexing.py",
+          "pandas/tests/arrays/masked_shared.py",
+          "pandas/tests/arrays/numpy_/__init__.py",
+          "pandas/tests/arrays/numpy_/test_indexing.py",
+          "pandas/tests/arrays/numpy_/test_numpy.py",
+          "pandas/tests/arrays/period/__init__.py",
+          "pandas/tests/arrays/period/test_arrow_compat.py",
+          "pandas/tests/arrays/period/test_astype.py",
+          "pandas/tests/arrays/period/test_constructors.py",
+          "pandas/tests/arrays/period/test_reductions.py",
+          "pandas/tests/arrays/sparse/__init__.py",
+          "pandas/tests/arrays/sparse/test_accessor.py",
+          "pandas/tests/arrays/sparse/test_arithmetics.py",
+          "pandas/tests/arrays/sparse/test_array.py",
+          "pandas/tests/arrays/sparse/test_astype.py",
+          "pandas/tests/arrays/sparse/test_combine_concat.py",
+          "pandas/tests/arrays/sparse/test_constructors.py",
+          "pandas/tests/arrays/sparse/test_dtype.py",
+          "pandas/tests/arrays/sparse/test_indexing.py",
+          "pandas/tests/arrays/sparse/test_libsparse.py",
+          "pandas/tests/arrays/sparse/test_reductions.py",
+          "pandas/tests/arrays/sparse/test_unary.py",
+          "pandas/tests/arrays/string_/__init__.py",
+          "pandas/tests/arrays/string_/test_concat.py",
+          "pandas/tests/arrays/string_/test_string.py",
+          "pandas/tests/arrays/string_/test_string_arrow.py",
+          "pandas/tests/arrays/test_array.py",
+          "pandas/tests/arrays/test_datetimelike.py",
+          "pandas/tests/arrays/test_datetimes.py",
+          "pandas/tests/arrays/test_ndarray_backed.py",
+          "pandas/tests/arrays/test_period.py",
+          "pandas/tests/arrays/test_timedeltas.py",
+          "pandas/tests/arrays/timedeltas/__init__.py",
+          "pandas/tests/arrays/timedeltas/test_constructors.py",
+          "pandas/tests/arrays/timedeltas/test_cumulative.py",
+          "pandas/tests/arrays/timedeltas/test_reductions.py",
+          "pandas/tests/base/__init__.py",
+          "pandas/tests/base/common.py",
+          "pandas/tests/base/test_constructors.py",
+          "pandas/tests/base/test_conversion.py",
+          "pandas/tests/base/test_fillna.py",
+          "pandas/tests/base/test_misc.py",
+          "pandas/tests/base/test_transpose.py",
+          "pandas/tests/base/test_unique.py",
+          "pandas/tests/base/test_value_counts.py",
+          "pandas/tests/computation/__init__.py",
+          "pandas/tests/computation/test_compat.py",
+          "pandas/tests/computation/test_eval.py",
+          "pandas/tests/config/__init__.py",
+          "pandas/tests/config/test_config.py",
+          "pandas/tests/config/test_localization.py",
+          "pandas/tests/construction/__init__.py",
+          "pandas/tests/construction/test_extract_array.py",
+          "pandas/tests/copy_view/__init__.py",
+          "pandas/tests/copy_view/index/__init__.py",
+          "pandas/tests/copy_view/index/test_datetimeindex.py",
+          "pandas/tests/copy_view/index/test_index.py",
+          "pandas/tests/copy_view/index/test_intervalindex.py",
+          "pandas/tests/copy_view/index/test_periodindex.py",
+          "pandas/tests/copy_view/index/test_timedeltaindex.py",
+          "pandas/tests/copy_view/test_array.py",
+          "pandas/tests/copy_view/test_astype.py",
+          "pandas/tests/copy_view/test_chained_assignment_deprecation.py",
+          "pandas/tests/copy_view/test_clip.py",
+          "pandas/tests/copy_view/test_constructors.py",
+          "pandas/tests/copy_view/test_copy_deprecation.py",
+          "pandas/tests/copy_view/test_core_functionalities.py",
+          "pandas/tests/copy_view/test_functions.py",
+          "pandas/tests/copy_view/test_indexing.py",
+          "pandas/tests/copy_view/test_internals.py",
+          "pandas/tests/copy_view/test_interp_fillna.py",
+          "pandas/tests/copy_view/test_methods.py",
+          "pandas/tests/copy_view/test_replace.py",
+          "pandas/tests/copy_view/test_setitem.py",
+          "pandas/tests/copy_view/test_util.py",
+          "pandas/tests/copy_view/util.py",
+          "pandas/tests/dtypes/__init__.py",
+          "pandas/tests/dtypes/cast/__init__.py",
+          "pandas/tests/dtypes/cast/test_box_unbox.py",
+          "pandas/tests/dtypes/cast/test_can_hold_element.py",
+          "pandas/tests/dtypes/cast/test_construct_from_scalar.py",
+          "pandas/tests/dtypes/cast/test_construct_ndarray.py",
+          "pandas/tests/dtypes/cast/test_construct_object_arr.py",
+          "pandas/tests/dtypes/cast/test_dict_compat.py",
+          "pandas/tests/dtypes/cast/test_downcast.py",
+          "pandas/tests/dtypes/cast/test_find_common_type.py",
+          "pandas/tests/dtypes/cast/test_infer_datetimelike.py",
+          "pandas/tests/dtypes/cast/test_infer_dtype.py",
+          "pandas/tests/dtypes/cast/test_promote.py",
+          "pandas/tests/dtypes/test_common.py",
+          "pandas/tests/dtypes/test_concat.py",
+          "pandas/tests/dtypes/test_dtypes.py",
+          "pandas/tests/dtypes/test_generic.py",
+          "pandas/tests/dtypes/test_inference.py",
+          "pandas/tests/dtypes/test_missing.py",
+          "pandas/tests/extension/__init__.py",
+          "pandas/tests/extension/array_with_attr/__init__.py",
+          "pandas/tests/extension/array_with_attr/array.py",
+          "pandas/tests/extension/array_with_attr/test_array_with_attr.py",
+          "pandas/tests/extension/base/__init__.py",
+          "pandas/tests/extension/base/accumulate.py",
+          "pandas/tests/extension/base/base.py",
+          "pandas/tests/extension/base/casting.py",
+          "pandas/tests/extension/base/constructors.py",
+          "pandas/tests/extension/base/dim2.py",
+          "pandas/tests/extension/base/dtype.py",
+          "pandas/tests/extension/base/getitem.py",
+          "pandas/tests/extension/base/groupby.py",
+          "pandas/tests/extension/base/index.py",
+          "pandas/tests/extension/base/interface.py",
+          "pandas/tests/extension/base/io.py",
+          "pandas/tests/extension/base/methods.py",
+          "pandas/tests/extension/base/missing.py",
+          "pandas/tests/extension/base/ops.py",
+          "pandas/tests/extension/base/printing.py",
+          "pandas/tests/extension/base/reduce.py",
+          "pandas/tests/extension/base/reshaping.py",
+          "pandas/tests/extension/base/setitem.py",
+          "pandas/tests/extension/conftest.py",
+          "pandas/tests/extension/date/__init__.py",
+          "pandas/tests/extension/date/array.py",
+          "pandas/tests/extension/decimal/__init__.py",
+          "pandas/tests/extension/decimal/array.py",
+          "pandas/tests/extension/decimal/test_decimal.py",
+          "pandas/tests/extension/json/__init__.py",
+          "pandas/tests/extension/json/array.py",
+          "pandas/tests/extension/json/test_json.py",
+          "pandas/tests/extension/list/__init__.py",
+          "pandas/tests/extension/list/array.py",
+          "pandas/tests/extension/list/test_list.py",
+          "pandas/tests/extension/test_arrow.py",
+          "pandas/tests/extension/test_categorical.py",
+          "pandas/tests/extension/test_common.py",
+          "pandas/tests/extension/test_datetime.py",
+          "pandas/tests/extension/test_extension.py",
+          "pandas/tests/extension/test_interval.py",
+          "pandas/tests/extension/test_masked.py",
+          "pandas/tests/extension/test_numpy.py",
+          "pandas/tests/extension/test_period.py",
+          "pandas/tests/extension/test_sparse.py",
+          "pandas/tests/extension/test_string.py",
+          "pandas/tests/extension/uuid/__init__.py",
+          "pandas/tests/extension/uuid/test_uuid.py",
+          "pandas/tests/frame/__init__.py",
+          "pandas/tests/frame/common.py",
+          "pandas/tests/frame/conftest.py",
+          "pandas/tests/frame/constructors/__init__.py",
+          "pandas/tests/frame/constructors/test_from_dict.py",
+          "pandas/tests/frame/constructors/test_from_records.py",
+          "pandas/tests/frame/indexing/__init__.py",
+          "pandas/tests/frame/indexing/test_coercion.py",
+          "pandas/tests/frame/indexing/test_delitem.py",
+          "pandas/tests/frame/indexing/test_get.py",
+          "pandas/tests/frame/indexing/test_get_value.py",
+          "pandas/tests/frame/indexing/test_getitem.py",
+          "pandas/tests/frame/indexing/test_indexing.py",
+          "pandas/tests/frame/indexing/test_insert.py",
+          "pandas/tests/frame/indexing/test_mask.py",
+          "pandas/tests/frame/indexing/test_set_value.py",
+          "pandas/tests/frame/indexing/test_setitem.py",
+          "pandas/tests/frame/indexing/test_take.py",
+          "pandas/tests/frame/indexing/test_where.py",
+          "pandas/tests/frame/indexing/test_xs.py",
+          "pandas/tests/frame/methods/__init__.py",
+          "pandas/tests/frame/methods/test_add_prefix_suffix.py",
+          "pandas/tests/frame/methods/test_align.py",
+          "pandas/tests/frame/methods/test_asfreq.py",
+          "pandas/tests/frame/methods/test_asof.py",
+          "pandas/tests/frame/methods/test_assign.py",
+          "pandas/tests/frame/methods/test_astype.py",
+          "pandas/tests/frame/methods/test_at_time.py",
+          "pandas/tests/frame/methods/test_between_time.py",
+          "pandas/tests/frame/methods/test_clip.py",
+          "pandas/tests/frame/methods/test_combine.py",
+          "pandas/tests/frame/methods/test_combine_first.py",
+          "pandas/tests/frame/methods/test_compare.py",
+          "pandas/tests/frame/methods/test_convert_dtypes.py",
+          "pandas/tests/frame/methods/test_copy.py",
+          "pandas/tests/frame/methods/test_count.py",
+          "pandas/tests/frame/methods/test_cov_corr.py",
+          "pandas/tests/frame/methods/test_describe.py",
+          "pandas/tests/frame/methods/test_diff.py",
+          "pandas/tests/frame/methods/test_dot.py",
+          "pandas/tests/frame/methods/test_drop.py",
+          "pandas/tests/frame/methods/test_drop_duplicates.py",
+          "pandas/tests/frame/methods/test_droplevel.py",
+          "pandas/tests/frame/methods/test_dropna.py",
+          "pandas/tests/frame/methods/test_dtypes.py",
+          "pandas/tests/frame/methods/test_duplicated.py",
+          "pandas/tests/frame/methods/test_equals.py",
+          "pandas/tests/frame/methods/test_explode.py",
+          "pandas/tests/frame/methods/test_fillna.py",
+          "pandas/tests/frame/methods/test_filter.py",
+          "pandas/tests/frame/methods/test_first_valid_index.py",
+          "pandas/tests/frame/methods/test_get_numeric_data.py",
+          "pandas/tests/frame/methods/test_head_tail.py",
+          "pandas/tests/frame/methods/test_infer_objects.py",
+          "pandas/tests/frame/methods/test_info.py",
+          "pandas/tests/frame/methods/test_interpolate.py",
+          "pandas/tests/frame/methods/test_is_homogeneous_dtype.py",
+          "pandas/tests/frame/methods/test_isetitem.py",
+          "pandas/tests/frame/methods/test_isin.py",
+          "pandas/tests/frame/methods/test_iterrows.py",
+          "pandas/tests/frame/methods/test_join.py",
+          "pandas/tests/frame/methods/test_map.py",
+          "pandas/tests/frame/methods/test_matmul.py",
+          "pandas/tests/frame/methods/test_nlargest.py",
+          "pandas/tests/frame/methods/test_pct_change.py",
+          "pandas/tests/frame/methods/test_pipe.py",
+          "pandas/tests/frame/methods/test_pop.py",
+          "pandas/tests/frame/methods/test_quantile.py",
+          "pandas/tests/frame/methods/test_rank.py",
+          "pandas/tests/frame/methods/test_reindex.py",
+          "pandas/tests/frame/methods/test_reindex_like.py",
+          "pandas/tests/frame/methods/test_rename.py",
+          "pandas/tests/frame/methods/test_rename_axis.py",
+          "pandas/tests/frame/methods/test_reorder_levels.py",
+          "pandas/tests/frame/methods/test_replace.py",
+          "pandas/tests/frame/methods/test_reset_index.py",
+          "pandas/tests/frame/methods/test_round.py",
+          "pandas/tests/frame/methods/test_sample.py",
+          "pandas/tests/frame/methods/test_select_dtypes.py",
+          "pandas/tests/frame/methods/test_set_axis.py",
+          "pandas/tests/frame/methods/test_set_index.py",
+          "pandas/tests/frame/methods/test_shift.py",
+          "pandas/tests/frame/methods/test_size.py",
+          "pandas/tests/frame/methods/test_sort_index.py",
+          "pandas/tests/frame/methods/test_sort_values.py",
+          "pandas/tests/frame/methods/test_swaplevel.py",
+          "pandas/tests/frame/methods/test_to_csv.py",
+          "pandas/tests/frame/methods/test_to_dict.py",
+          "pandas/tests/frame/methods/test_to_dict_of_blocks.py",
+          "pandas/tests/frame/methods/test_to_numpy.py",
+          "pandas/tests/frame/methods/test_to_period.py",
+          "pandas/tests/frame/methods/test_to_records.py",
+          "pandas/tests/frame/methods/test_to_timestamp.py",
+          "pandas/tests/frame/methods/test_transpose.py",
+          "pandas/tests/frame/methods/test_truncate.py",
+          "pandas/tests/frame/methods/test_tz_convert.py",
+          "pandas/tests/frame/methods/test_tz_localize.py",
+          "pandas/tests/frame/methods/test_update.py",
+          "pandas/tests/frame/methods/test_value_counts.py",
+          "pandas/tests/frame/methods/test_values.py",
+          "pandas/tests/frame/test_alter_axes.py",
+          "pandas/tests/frame/test_api.py",
+          "pandas/tests/frame/test_arithmetic.py",
+          "pandas/tests/frame/test_arrow_interface.py",
+          "pandas/tests/frame/test_block_internals.py",
+          "pandas/tests/frame/test_constructors.py",
+          "pandas/tests/frame/test_cumulative.py",
+          "pandas/tests/frame/test_iteration.py",
+          "pandas/tests/frame/test_logical_ops.py",
+          "pandas/tests/frame/test_nonunique_indexes.py",
+          "pandas/tests/frame/test_npfuncs.py",
+          "pandas/tests/frame/test_query_eval.py",
+          "pandas/tests/frame/test_reductions.py",
+          "pandas/tests/frame/test_repr.py",
+          "pandas/tests/frame/test_stack_unstack.py",
+          "pandas/tests/frame/test_subclass.py",
+          "pandas/tests/frame/test_ufunc.py",
+          "pandas/tests/frame/test_unary.py",
+          "pandas/tests/frame/test_validate.py",
+          "pandas/tests/generic/__init__.py",
+          "pandas/tests/generic/test_duplicate_labels.py",
+          "pandas/tests/generic/test_finalize.py",
+          "pandas/tests/generic/test_frame.py",
+          "pandas/tests/generic/test_generic.py",
+          "pandas/tests/generic/test_label_or_level_utils.py",
+          "pandas/tests/generic/test_series.py",
+          "pandas/tests/generic/test_to_xarray.py",
+          "pandas/tests/groupby/__init__.py",
+          "pandas/tests/groupby/aggregate/__init__.py",
+          "pandas/tests/groupby/aggregate/test_aggregate.py",
+          "pandas/tests/groupby/aggregate/test_cython.py",
+          "pandas/tests/groupby/aggregate/test_numba.py",
+          "pandas/tests/groupby/aggregate/test_other.py",
+          "pandas/tests/groupby/conftest.py",
+          "pandas/tests/groupby/methods/__init__.py",
+          "pandas/tests/groupby/methods/test_describe.py",
+          "pandas/tests/groupby/methods/test_groupby_shift_diff.py",
+          "pandas/tests/groupby/methods/test_is_monotonic.py",
+          "pandas/tests/groupby/methods/test_kurt.py",
+          "pandas/tests/groupby/methods/test_nlargest_nsmallest.py",
+          "pandas/tests/groupby/methods/test_nth.py",
+          "pandas/tests/groupby/methods/test_quantile.py",
+          "pandas/tests/groupby/methods/test_rank.py",
+          "pandas/tests/groupby/methods/test_sample.py",
+          "pandas/tests/groupby/methods/test_size.py",
+          "pandas/tests/groupby/methods/test_skew.py",
+          "pandas/tests/groupby/methods/test_value_counts.py",
+          "pandas/tests/groupby/test_all_methods.py",
+          "pandas/tests/groupby/test_api.py",
+          "pandas/tests/groupby/test_apply.py",
+          "pandas/tests/groupby/test_bin_groupby.py",
+          "pandas/tests/groupby/test_categorical.py",
+          "pandas/tests/groupby/test_counting.py",
+          "pandas/tests/groupby/test_cumulative.py",
+          "pandas/tests/groupby/test_filters.py",
+          "pandas/tests/groupby/test_groupby.py",
+          "pandas/tests/groupby/test_groupby_dropna.py",
+          "pandas/tests/groupby/test_groupby_subclass.py",
+          "pandas/tests/groupby/test_grouping.py",
+          "pandas/tests/groupby/test_index_as_string.py",
+          "pandas/tests/groupby/test_indexing.py",
+          "pandas/tests/groupby/test_libgroupby.py",
+          "pandas/tests/groupby/test_missing.py",
+          "pandas/tests/groupby/test_numba.py",
+          "pandas/tests/groupby/test_numeric_only.py",
+          "pandas/tests/groupby/test_pipe.py",
+          "pandas/tests/groupby/test_raises.py",
+          "pandas/tests/groupby/test_reductions.py",
+          "pandas/tests/groupby/test_timegrouper.py",
+          "pandas/tests/groupby/transform/__init__.py",
+          "pandas/tests/groupby/transform/test_numba.py",
+          "pandas/tests/groupby/transform/test_transform.py",
+          "pandas/tests/indexes/__init__.py",
+          "pandas/tests/indexes/base_class/__init__.py",
+          "pandas/tests/indexes/base_class/test_constructors.py",
+          "pandas/tests/indexes/base_class/test_formats.py",
+          "pandas/tests/indexes/base_class/test_indexing.py",
+          "pandas/tests/indexes/base_class/test_pickle.py",
+          "pandas/tests/indexes/base_class/test_reshape.py",
+          "pandas/tests/indexes/base_class/test_setops.py",
+          "pandas/tests/indexes/base_class/test_where.py",
+          "pandas/tests/indexes/categorical/__init__.py",
+          "pandas/tests/indexes/categorical/test_append.py",
+          "pandas/tests/indexes/categorical/test_astype.py",
+          "pandas/tests/indexes/categorical/test_category.py",
+          "pandas/tests/indexes/categorical/test_constructors.py",
+          "pandas/tests/indexes/categorical/test_equals.py",
+          "pandas/tests/indexes/categorical/test_fillna.py",
+          "pandas/tests/indexes/categorical/test_formats.py",
+          "pandas/tests/indexes/categorical/test_indexing.py",
+          "pandas/tests/indexes/categorical/test_map.py",
+          "pandas/tests/indexes/categorical/test_reindex.py",
+          "pandas/tests/indexes/categorical/test_setops.py",
+          "pandas/tests/indexes/conftest.py",
+          "pandas/tests/indexes/datetimelike_/__init__.py",
+          "pandas/tests/indexes/datetimelike_/test_drop_duplicates.py",
+          "pandas/tests/indexes/datetimelike_/test_equals.py",
+          "pandas/tests/indexes/datetimelike_/test_indexing.py",
+          "pandas/tests/indexes/datetimelike_/test_is_monotonic.py",
+          "pandas/tests/indexes/datetimelike_/test_nat.py",
+          "pandas/tests/indexes/datetimelike_/test_sort_values.py",
+          "pandas/tests/indexes/datetimelike_/test_value_counts.py",
+          "pandas/tests/indexes/datetimes/__init__.py",
+          "pandas/tests/indexes/datetimes/methods/__init__.py",
+          "pandas/tests/indexes/datetimes/methods/test_asof.py",
+          "pandas/tests/indexes/datetimes/methods/test_astype.py",
+          "pandas/tests/indexes/datetimes/methods/test_delete.py",
+          "pandas/tests/indexes/datetimes/methods/test_factorize.py",
+          "pandas/tests/indexes/datetimes/methods/test_fillna.py",
+          "pandas/tests/indexes/datetimes/methods/test_insert.py",
+          "pandas/tests/indexes/datetimes/methods/test_isocalendar.py",
+          "pandas/tests/indexes/datetimes/methods/test_map.py",
+          "pandas/tests/indexes/datetimes/methods/test_normalize.py",
+          "pandas/tests/indexes/datetimes/methods/test_repeat.py",
+          "pandas/tests/indexes/datetimes/methods/test_resolution.py",
+          "pandas/tests/indexes/datetimes/methods/test_round.py",
+          "pandas/tests/indexes/datetimes/methods/test_shift.py",
+          "pandas/tests/indexes/datetimes/methods/test_snap.py",
+          "pandas/tests/indexes/datetimes/methods/test_to_frame.py",
+          "pandas/tests/indexes/datetimes/methods/test_to_julian_date.py",
+          "pandas/tests/indexes/datetimes/methods/test_to_period.py",
+          "pandas/tests/indexes/datetimes/methods/test_to_pydatetime.py",
+          "pandas/tests/indexes/datetimes/methods/test_to_series.py",
+          "pandas/tests/indexes/datetimes/methods/test_tz_convert.py",
+          "pandas/tests/indexes/datetimes/methods/test_tz_localize.py",
+          "pandas/tests/indexes/datetimes/methods/test_unique.py",
+          "pandas/tests/indexes/datetimes/test_arithmetic.py",
+          "pandas/tests/indexes/datetimes/test_constructors.py",
+          "pandas/tests/indexes/datetimes/test_date_range.py",
+          "pandas/tests/indexes/datetimes/test_datetime.py",
+          "pandas/tests/indexes/datetimes/test_formats.py",
+          "pandas/tests/indexes/datetimes/test_freq_attr.py",
+          "pandas/tests/indexes/datetimes/test_indexing.py",
+          "pandas/tests/indexes/datetimes/test_iter.py",
+          "pandas/tests/indexes/datetimes/test_join.py",
+          "pandas/tests/indexes/datetimes/test_npfuncs.py",
+          "pandas/tests/indexes/datetimes/test_ops.py",
+          "pandas/tests/indexes/datetimes/test_partial_slicing.py",
+          "pandas/tests/indexes/datetimes/test_pickle.py",
+          "pandas/tests/indexes/datetimes/test_reindex.py",
+          "pandas/tests/indexes/datetimes/test_scalar_compat.py",
+          "pandas/tests/indexes/datetimes/test_setops.py",
+          "pandas/tests/indexes/datetimes/test_timezones.py",
+          "pandas/tests/indexes/interval/__init__.py",
+          "pandas/tests/indexes/interval/test_astype.py",
+          "pandas/tests/indexes/interval/test_constructors.py",
+          "pandas/tests/indexes/interval/test_equals.py",
+          "pandas/tests/indexes/interval/test_formats.py",
+          "pandas/tests/indexes/interval/test_indexing.py",
+          "pandas/tests/indexes/interval/test_interval.py",
+          "pandas/tests/indexes/interval/test_interval_range.py",
+          "pandas/tests/indexes/interval/test_interval_tree.py",
+          "pandas/tests/indexes/interval/test_join.py",
+          "pandas/tests/indexes/interval/test_pickle.py",
+          "pandas/tests/indexes/interval/test_setops.py",
+          "pandas/tests/indexes/multi/__init__.py",
+          "pandas/tests/indexes/multi/conftest.py",
+          "pandas/tests/indexes/multi/test_analytics.py",
+          "pandas/tests/indexes/multi/test_astype.py",
+          "pandas/tests/indexes/multi/test_compat.py",
+          "pandas/tests/indexes/multi/test_constructors.py",
+          "pandas/tests/indexes/multi/test_conversion.py",
+          "pandas/tests/indexes/multi/test_copy.py",
+          "pandas/tests/indexes/multi/test_drop.py",
+          "pandas/tests/indexes/multi/test_duplicates.py",
+          "pandas/tests/indexes/multi/test_equivalence.py",
+          "pandas/tests/indexes/multi/test_formats.py",
+          "pandas/tests/indexes/multi/test_get_level_values.py",
+          "pandas/tests/indexes/multi/test_get_set.py",
+          "pandas/tests/indexes/multi/test_indexing.py",
+          "pandas/tests/indexes/multi/test_integrity.py",
+          "pandas/tests/indexes/multi/test_isin.py",
+          "pandas/tests/indexes/multi/test_join.py",
+          "pandas/tests/indexes/multi/test_lexsort.py",
+          "pandas/tests/indexes/multi/test_missing.py",
+          "pandas/tests/indexes/multi/test_monotonic.py",
+          "pandas/tests/indexes/multi/test_names.py",
+          "pandas/tests/indexes/multi/test_partial_indexing.py",
+          "pandas/tests/indexes/multi/test_pickle.py",
+          "pandas/tests/indexes/multi/test_reindex.py",
+          "pandas/tests/indexes/multi/test_reshape.py",
+          "pandas/tests/indexes/multi/test_setops.py",
+          "pandas/tests/indexes/multi/test_sorting.py",
+          "pandas/tests/indexes/multi/test_take.py",
+          "pandas/tests/indexes/multi/test_util.py",
+          "pandas/tests/indexes/numeric/__init__.py",
+          "pandas/tests/indexes/numeric/test_astype.py",
+          "pandas/tests/indexes/numeric/test_indexing.py",
+          "pandas/tests/indexes/numeric/test_join.py",
+          "pandas/tests/indexes/numeric/test_numeric.py",
+          "pandas/tests/indexes/numeric/test_setops.py",
+          "pandas/tests/indexes/object/__init__.py",
+          "pandas/tests/indexes/object/test_astype.py",
+          "pandas/tests/indexes/object/test_indexing.py",
+          "pandas/tests/indexes/period/__init__.py",
+          "pandas/tests/indexes/period/methods/__init__.py",
+          "pandas/tests/indexes/period/methods/test_asfreq.py",
+          "pandas/tests/indexes/period/methods/test_astype.py",
+          "pandas/tests/indexes/period/methods/test_factorize.py",
+          "pandas/tests/indexes/period/methods/test_fillna.py",
+          "pandas/tests/indexes/period/methods/test_insert.py",
+          "pandas/tests/indexes/period/methods/test_is_full.py",
+          "pandas/tests/indexes/period/methods/test_repeat.py",
+          "pandas/tests/indexes/period/methods/test_shift.py",
+          "pandas/tests/indexes/period/methods/test_to_timestamp.py",
+          "pandas/tests/indexes/period/test_constructors.py",
+          "pandas/tests/indexes/period/test_formats.py",
+          "pandas/tests/indexes/period/test_freq_attr.py",
+          "pandas/tests/indexes/period/test_indexing.py",
+          "pandas/tests/indexes/period/test_join.py",
+          "pandas/tests/indexes/period/test_monotonic.py",
+          "pandas/tests/indexes/period/test_partial_slicing.py",
+          "pandas/tests/indexes/period/test_period.py",
+          "pandas/tests/indexes/period/test_period_range.py",
+          "pandas/tests/indexes/period/test_pickle.py",
+          "pandas/tests/indexes/period/test_resolution.py",
+          "pandas/tests/indexes/period/test_scalar_compat.py",
+          "pandas/tests/indexes/period/test_searchsorted.py",
+          "pandas/tests/indexes/period/test_setops.py",
+          "pandas/tests/indexes/period/test_tools.py",
+          "pandas/tests/indexes/ranges/__init__.py",
+          "pandas/tests/indexes/ranges/test_constructors.py",
+          "pandas/tests/indexes/ranges/test_indexing.py",
+          "pandas/tests/indexes/ranges/test_join.py",
+          "pandas/tests/indexes/ranges/test_range.py",
+          "pandas/tests/indexes/ranges/test_setops.py",
+          "pandas/tests/indexes/string/__init__.py",
+          "pandas/tests/indexes/string/test_astype.py",
+          "pandas/tests/indexes/string/test_indexing.py",
+          "pandas/tests/indexes/test_any_index.py",
+          "pandas/tests/indexes/test_base.py",
+          "pandas/tests/indexes/test_common.py",
+          "pandas/tests/indexes/test_datetimelike.py",
+          "pandas/tests/indexes/test_engines.py",
+          "pandas/tests/indexes/test_frozen.py",
+          "pandas/tests/indexes/test_index_new.py",
+          "pandas/tests/indexes/test_indexing.py",
+          "pandas/tests/indexes/test_numpy_compat.py",
+          "pandas/tests/indexes/test_old_base.py",
+          "pandas/tests/indexes/test_setops.py",
+          "pandas/tests/indexes/test_subclass.py",
+          "pandas/tests/indexes/timedeltas/__init__.py",
+          "pandas/tests/indexes/timedeltas/methods/__init__.py",
+          "pandas/tests/indexes/timedeltas/methods/test_astype.py",
+          "pandas/tests/indexes/timedeltas/methods/test_factorize.py",
+          "pandas/tests/indexes/timedeltas/methods/test_fillna.py",
+          "pandas/tests/indexes/timedeltas/methods/test_insert.py",
+          "pandas/tests/indexes/timedeltas/methods/test_repeat.py",
+          "pandas/tests/indexes/timedeltas/methods/test_shift.py",
+          "pandas/tests/indexes/timedeltas/test_arithmetic.py",
+          "pandas/tests/indexes/timedeltas/test_constructors.py",
+          "pandas/tests/indexes/timedeltas/test_delete.py",
+          "pandas/tests/indexes/timedeltas/test_formats.py",
+          "pandas/tests/indexes/timedeltas/test_freq_attr.py",
+          "pandas/tests/indexes/timedeltas/test_indexing.py",
+          "pandas/tests/indexes/timedeltas/test_join.py",
+          "pandas/tests/indexes/timedeltas/test_ops.py",
+          "pandas/tests/indexes/timedeltas/test_pickle.py",
+          "pandas/tests/indexes/timedeltas/test_scalar_compat.py",
+          "pandas/tests/indexes/timedeltas/test_searchsorted.py",
+          "pandas/tests/indexes/timedeltas/test_setops.py",
+          "pandas/tests/indexes/timedeltas/test_timedelta.py",
+          "pandas/tests/indexes/timedeltas/test_timedelta_range.py",
+          "pandas/tests/indexing/__init__.py",
+          "pandas/tests/indexing/common.py",
+          "pandas/tests/indexing/interval/__init__.py",
+          "pandas/tests/indexing/interval/test_interval.py",
+          "pandas/tests/indexing/interval/test_interval_new.py",
+          "pandas/tests/indexing/multiindex/__init__.py",
+          "pandas/tests/indexing/multiindex/test_chaining_and_caching.py",
+          "pandas/tests/indexing/multiindex/test_datetime.py",
+          "pandas/tests/indexing/multiindex/test_getitem.py",
+          "pandas/tests/indexing/multiindex/test_iloc.py",
+          "pandas/tests/indexing/multiindex/test_indexing_slow.py",
+          "pandas/tests/indexing/multiindex/test_loc.py",
+          "pandas/tests/indexing/multiindex/test_multiindex.py",
+          "pandas/tests/indexing/multiindex/test_partial.py",
+          "pandas/tests/indexing/multiindex/test_setitem.py",
+          "pandas/tests/indexing/multiindex/test_slice.py",
+          "pandas/tests/indexing/multiindex/test_sorted.py",
+          "pandas/tests/indexing/test_at.py",
+          "pandas/tests/indexing/test_categorical.py",
+          "pandas/tests/indexing/test_chaining_and_caching.py",
+          "pandas/tests/indexing/test_check_indexer.py",
+          "pandas/tests/indexing/test_coercion.py",
+          "pandas/tests/indexing/test_datetime.py",
+          "pandas/tests/indexing/test_floats.py",
+          "pandas/tests/indexing/test_iat.py",
+          "pandas/tests/indexing/test_iloc.py",
+          "pandas/tests/indexing/test_indexers.py",
+          "pandas/tests/indexing/test_indexing.py",
+          "pandas/tests/indexing/test_loc.py",
+          "pandas/tests/indexing/test_na_indexing.py",
+          "pandas/tests/indexing/test_partial.py",
+          "pandas/tests/indexing/test_scalar.py",
+          "pandas/tests/interchange/__init__.py",
+          "pandas/tests/interchange/test_impl.py",
+          "pandas/tests/interchange/test_spec_conformance.py",
+          "pandas/tests/interchange/test_utils.py",
+          "pandas/tests/internals/__init__.py",
+          "pandas/tests/internals/test_api.py",
+          "pandas/tests/internals/test_internals.py",
+          "pandas/tests/io/__init__.py",
+          "pandas/tests/io/conftest.py",
+          "pandas/tests/io/excel/__init__.py",
+          "pandas/tests/io/excel/test_odf.py",
+          "pandas/tests/io/excel/test_odswriter.py",
+          "pandas/tests/io/excel/test_openpyxl.py",
+          "pandas/tests/io/excel/test_readers.py",
+          "pandas/tests/io/excel/test_style.py",
+          "pandas/tests/io/excel/test_writers.py",
+          "pandas/tests/io/excel/test_xlrd.py",
+          "pandas/tests/io/excel/test_xlsxwriter.py",
+          "pandas/tests/io/formats/__init__.py",
+          "pandas/tests/io/formats/style/__init__.py",
+          "pandas/tests/io/formats/style/test_bar.py",
+          "pandas/tests/io/formats/style/test_exceptions.py",
+          "pandas/tests/io/formats/style/test_format.py",
+          "pandas/tests/io/formats/style/test_highlight.py",
+          "pandas/tests/io/formats/style/test_html.py",
+          "pandas/tests/io/formats/style/test_matplotlib.py",
+          "pandas/tests/io/formats/style/test_non_unique.py",
+          "pandas/tests/io/formats/style/test_style.py",
+          "pandas/tests/io/formats/style/test_to_latex.py",
+          "pandas/tests/io/formats/style/test_to_string.py",
+          "pandas/tests/io/formats/style/test_to_typst.py",
+          "pandas/tests/io/formats/style/test_tooltip.py",
+          "pandas/tests/io/formats/test_console.py",
+          "pandas/tests/io/formats/test_css.py",
+          "pandas/tests/io/formats/test_eng_formatting.py",
+          "pandas/tests/io/formats/test_format.py",
+          "pandas/tests/io/formats/test_ipython_compat.py",
+          "pandas/tests/io/formats/test_printing.py",
+          "pandas/tests/io/formats/test_to_csv.py",
+          "pandas/tests/io/formats/test_to_excel.py",
+          "pandas/tests/io/formats/test_to_html.py",
+          "pandas/tests/io/formats/test_to_latex.py",
+          "pandas/tests/io/formats/test_to_markdown.py",
+          "pandas/tests/io/formats/test_to_string.py",
+          "pandas/tests/io/generate_legacy_storage_files.py",
+          "pandas/tests/io/json/__init__.py",
+          "pandas/tests/io/json/conftest.py",
+          "pandas/tests/io/json/test_compression.py",
+          "pandas/tests/io/json/test_deprecated_kwargs.py",
+          "pandas/tests/io/json/test_json_table_schema.py",
+          "pandas/tests/io/json/test_json_table_schema_ext_dtype.py",
+          "pandas/tests/io/json/test_normalize.py",
+          "pandas/tests/io/json/test_pandas.py",
+          "pandas/tests/io/json/test_readlines.py",
+          "pandas/tests/io/json/test_ujson.py",
+          "pandas/tests/io/parser/__init__.py",
+          "pandas/tests/io/parser/common/__init__.py",
+          "pandas/tests/io/parser/common/test_chunksize.py",
+          "pandas/tests/io/parser/common/test_common_basic.py",
+          "pandas/tests/io/parser/common/test_data_list.py",
+          "pandas/tests/io/parser/common/test_decimal.py",
+          "pandas/tests/io/parser/common/test_file_buffer_url.py",
+          "pandas/tests/io/parser/common/test_float.py",
+          "pandas/tests/io/parser/common/test_index.py",
+          "pandas/tests/io/parser/common/test_inf.py",
+          "pandas/tests/io/parser/common/test_ints.py",
+          "pandas/tests/io/parser/common/test_iterator.py",
+          "pandas/tests/io/parser/common/test_read_errors.py",
+          "pandas/tests/io/parser/conftest.py",
+          "pandas/tests/io/parser/dtypes/__init__.py",
+          "pandas/tests/io/parser/dtypes/test_categorical.py",
+          "pandas/tests/io/parser/dtypes/test_dtypes_basic.py",
+          "pandas/tests/io/parser/dtypes/test_empty.py",
+          "pandas/tests/io/parser/test_c_parser_only.py",
+          "pandas/tests/io/parser/test_comment.py",
+          "pandas/tests/io/parser/test_compression.py",
+          "pandas/tests/io/parser/test_concatenate_chunks.py",
+          "pandas/tests/io/parser/test_converters.py",
+          "pandas/tests/io/parser/test_dialect.py",
+          "pandas/tests/io/parser/test_encoding.py",
+          "pandas/tests/io/parser/test_header.py",
+          "pandas/tests/io/parser/test_index_col.py",
+          "pandas/tests/io/parser/test_mangle_dupes.py",
+          "pandas/tests/io/parser/test_multi_thread.py",
+          "pandas/tests/io/parser/test_na_values.py",
+          "pandas/tests/io/parser/test_network.py",
+          "pandas/tests/io/parser/test_parse_dates.py",
+          "pandas/tests/io/parser/test_python_parser_only.py",
+          "pandas/tests/io/parser/test_quoting.py",
+          "pandas/tests/io/parser/test_read_fwf.py",
+          "pandas/tests/io/parser/test_skiprows.py",
+          "pandas/tests/io/parser/test_textreader.py",
+          "pandas/tests/io/parser/test_unsupported.py",
+          "pandas/tests/io/parser/test_upcast.py",
+          "pandas/tests/io/parser/usecols/__init__.py",
+          "pandas/tests/io/parser/usecols/test_parse_dates.py",
+          "pandas/tests/io/parser/usecols/test_strings.py",
+          "pandas/tests/io/parser/usecols/test_usecols_basic.py",
+          "pandas/tests/io/pytables/__init__.py",
+          "pandas/tests/io/pytables/common.py",
+          "pandas/tests/io/pytables/conftest.py",
+          "pandas/tests/io/pytables/test_append.py",
+          "pandas/tests/io/pytables/test_categorical.py",
+          "pandas/tests/io/pytables/test_compat.py",
+          "pandas/tests/io/pytables/test_complex.py",
+          "pandas/tests/io/pytables/test_errors.py",
+          "pandas/tests/io/pytables/test_file_handling.py",
+          "pandas/tests/io/pytables/test_keys.py",
+          "pandas/tests/io/pytables/test_put.py",
+          "pandas/tests/io/pytables/test_pytables_missing.py",
+          "pandas/tests/io/pytables/test_read.py",
+          "pandas/tests/io/pytables/test_retain_attributes.py",
+          "pandas/tests/io/pytables/test_round_trip.py",
+          "pandas/tests/io/pytables/test_select.py",
+          "pandas/tests/io/pytables/test_store.py",
+          "pandas/tests/io/pytables/test_subclass.py",
+          "pandas/tests/io/pytables/test_time_series.py",
+          "pandas/tests/io/pytables/test_timezones.py",
+          "pandas/tests/io/sas/__init__.py",
+          "pandas/tests/io/sas/test_byteswap.py",
+          "pandas/tests/io/sas/test_sas.py",
+          "pandas/tests/io/sas/test_sas7bdat.py",
+          "pandas/tests/io/sas/test_xport.py",
+          "pandas/tests/io/test_clipboard.py",
+          "pandas/tests/io/test_common.py",
+          "pandas/tests/io/test_compression.py",
+          "pandas/tests/io/test_feather.py",
+          "pandas/tests/io/test_fsspec.py",
+          "pandas/tests/io/test_gcs.py",
+          "pandas/tests/io/test_html.py",
+          "pandas/tests/io/test_http_headers.py",
+          "pandas/tests/io/test_iceberg.py",
+          "pandas/tests/io/test_orc.py",
+          "pandas/tests/io/test_parquet.py",
+          "pandas/tests/io/test_pickle.py",
+          "pandas/tests/io/test_s3.py",
+          "pandas/tests/io/test_spss.py",
+          "pandas/tests/io/test_sql.py",
+          "pandas/tests/io/test_stata.py",
+          "pandas/tests/io/test_util.py",
+          "pandas/tests/io/xml/__init__.py",
+          "pandas/tests/io/xml/conftest.py",
+          "pandas/tests/io/xml/test_to_xml.py",
+          "pandas/tests/io/xml/test_xml.py",
+          "pandas/tests/io/xml/test_xml_dtypes.py",
+          "pandas/tests/libs/__init__.py",
+          "pandas/tests/libs/test_hashtable.py",
+          "pandas/tests/libs/test_join.py",
+          "pandas/tests/libs/test_lib.py",
+          "pandas/tests/libs/test_libalgos.py",
+          "pandas/tests/plotting/__init__.py",
+          "pandas/tests/plotting/common.py",
+          "pandas/tests/plotting/conftest.py",
+          "pandas/tests/plotting/frame/__init__.py",
+          "pandas/tests/plotting/frame/test_frame.py",
+          "pandas/tests/plotting/frame/test_frame_color.py",
+          "pandas/tests/plotting/frame/test_frame_groupby.py",
+          "pandas/tests/plotting/frame/test_frame_legend.py",
+          "pandas/tests/plotting/frame/test_frame_subplots.py",
+          "pandas/tests/plotting/frame/test_hist_box_by.py",
+          "pandas/tests/plotting/test_backend.py",
+          "pandas/tests/plotting/test_boxplot_method.py",
+          "pandas/tests/plotting/test_common.py",
+          "pandas/tests/plotting/test_converter.py",
+          "pandas/tests/plotting/test_datetimelike.py",
+          "pandas/tests/plotting/test_groupby.py",
+          "pandas/tests/plotting/test_hist_method.py",
+          "pandas/tests/plotting/test_misc.py",
+          "pandas/tests/plotting/test_series.py",
+          "pandas/tests/plotting/test_style.py",
+          "pandas/tests/reductions/__init__.py",
+          "pandas/tests/reductions/test_reductions.py",
+          "pandas/tests/reductions/test_stat_reductions.py",
+          "pandas/tests/resample/__init__.py",
+          "pandas/tests/resample/conftest.py",
+          "pandas/tests/resample/test_base.py",
+          "pandas/tests/resample/test_datetime_index.py",
+          "pandas/tests/resample/test_period_index.py",
+          "pandas/tests/resample/test_resample_api.py",
+          "pandas/tests/resample/test_resampler_grouper.py",
+          "pandas/tests/resample/test_time_grouper.py",
+          "pandas/tests/resample/test_timedelta.py",
+          "pandas/tests/reshape/__init__.py",
+          "pandas/tests/reshape/concat/__init__.py",
+          "pandas/tests/reshape/concat/test_append.py",
+          "pandas/tests/reshape/concat/test_append_common.py",
+          "pandas/tests/reshape/concat/test_categorical.py",
+          "pandas/tests/reshape/concat/test_concat.py",
+          "pandas/tests/reshape/concat/test_dataframe.py",
+          "pandas/tests/reshape/concat/test_datetimes.py",
+          "pandas/tests/reshape/concat/test_empty.py",
+          "pandas/tests/reshape/concat/test_index.py",
+          "pandas/tests/reshape/concat/test_invalid.py",
+          "pandas/tests/reshape/concat/test_series.py",
+          "pandas/tests/reshape/concat/test_sort.py",
+          "pandas/tests/reshape/merge/__init__.py",
+          "pandas/tests/reshape/merge/test_join.py",
+          "pandas/tests/reshape/merge/test_merge.py",
+          "pandas/tests/reshape/merge/test_merge_antijoin.py",
+          "pandas/tests/reshape/merge/test_merge_asof.py",
+          "pandas/tests/reshape/merge/test_merge_cross.py",
+          "pandas/tests/reshape/merge/test_merge_index_as_string.py",
+          "pandas/tests/reshape/merge/test_merge_ordered.py",
+          "pandas/tests/reshape/merge/test_multi.py",
+          "pandas/tests/reshape/test_crosstab.py",
+          "pandas/tests/reshape/test_cut.py",
+          "pandas/tests/reshape/test_from_dummies.py",
+          "pandas/tests/reshape/test_get_dummies.py",
+          "pandas/tests/reshape/test_melt.py",
+          "pandas/tests/reshape/test_pivot.py",
+          "pandas/tests/reshape/test_pivot_multilevel.py",
+          "pandas/tests/reshape/test_qcut.py",
+          "pandas/tests/reshape/test_union_categoricals.py",
+          "pandas/tests/scalar/__init__.py",
+          "pandas/tests/scalar/interval/__init__.py",
+          "pandas/tests/scalar/interval/test_arithmetic.py",
+          "pandas/tests/scalar/interval/test_constructors.py",
+          "pandas/tests/scalar/interval/test_contains.py",
+          "pandas/tests/scalar/interval/test_formats.py",
+          "pandas/tests/scalar/interval/test_interval.py",
+          "pandas/tests/scalar/interval/test_overlaps.py",
+          "pandas/tests/scalar/period/__init__.py",
+          "pandas/tests/scalar/period/test_arithmetic.py",
+          "pandas/tests/scalar/period/test_asfreq.py",
+          "pandas/tests/scalar/period/test_period.py",
+          "pandas/tests/scalar/test_na_scalar.py",
+          "pandas/tests/scalar/test_nat.py",
+          "pandas/tests/scalar/timedelta/__init__.py",
+          "pandas/tests/scalar/timedelta/methods/__init__.py",
+          "pandas/tests/scalar/timedelta/methods/test_as_unit.py",
+          "pandas/tests/scalar/timedelta/methods/test_round.py",
+          "pandas/tests/scalar/timedelta/test_arithmetic.py",
+          "pandas/tests/scalar/timedelta/test_constructors.py",
+          "pandas/tests/scalar/timedelta/test_formats.py",
+          "pandas/tests/scalar/timedelta/test_timedelta.py",
+          "pandas/tests/scalar/timestamp/__init__.py",
+          "pandas/tests/scalar/timestamp/methods/__init__.py",
+          "pandas/tests/scalar/timestamp/methods/test_as_unit.py",
+          "pandas/tests/scalar/timestamp/methods/test_normalize.py",
+          "pandas/tests/scalar/timestamp/methods/test_replace.py",
+          "pandas/tests/scalar/timestamp/methods/test_round.py",
+          "pandas/tests/scalar/timestamp/methods/test_timestamp_method.py",
+          "pandas/tests/scalar/timestamp/methods/test_to_julian_date.py",
+          "pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py",
+          "pandas/tests/scalar/timestamp/methods/test_tz_convert.py",
+          "pandas/tests/scalar/timestamp/methods/test_tz_localize.py",
+          "pandas/tests/scalar/timestamp/test_arithmetic.py",
+          "pandas/tests/scalar/timestamp/test_comparisons.py",
+          "pandas/tests/scalar/timestamp/test_constructors.py",
+          "pandas/tests/scalar/timestamp/test_formats.py",
+          "pandas/tests/scalar/timestamp/test_timestamp.py",
+          "pandas/tests/scalar/timestamp/test_timezones.py",
+          "pandas/tests/series/__init__.py",
+          "pandas/tests/series/accessors/__init__.py",
+          "pandas/tests/series/accessors/test_cat_accessor.py",
+          "pandas/tests/series/accessors/test_dt_accessor.py",
+          "pandas/tests/series/accessors/test_list_accessor.py",
+          "pandas/tests/series/accessors/test_sparse_accessor.py",
+          "pandas/tests/series/accessors/test_str_accessor.py",
+          "pandas/tests/series/accessors/test_struct_accessor.py",
+          "pandas/tests/series/indexing/__init__.py",
+          "pandas/tests/series/indexing/test_datetime.py",
+          "pandas/tests/series/indexing/test_delitem.py",
+          "pandas/tests/series/indexing/test_get.py",
+          "pandas/tests/series/indexing/test_getitem.py",
+          "pandas/tests/series/indexing/test_indexing.py",
+          "pandas/tests/series/indexing/test_mask.py",
+          "pandas/tests/series/indexing/test_set_value.py",
+          "pandas/tests/series/indexing/test_setitem.py",
+          "pandas/tests/series/indexing/test_take.py",
+          "pandas/tests/series/indexing/test_where.py",
+          "pandas/tests/series/indexing/test_xs.py",
+          "pandas/tests/series/methods/__init__.py",
+          "pandas/tests/series/methods/test_add_prefix_suffix.py",
+          "pandas/tests/series/methods/test_align.py",
+          "pandas/tests/series/methods/test_argsort.py",
+          "pandas/tests/series/methods/test_asof.py",
+          "pandas/tests/series/methods/test_astype.py",
+          "pandas/tests/series/methods/test_autocorr.py",
+          "pandas/tests/series/methods/test_between.py",
+          "pandas/tests/series/methods/test_case_when.py",
+          "pandas/tests/series/methods/test_clip.py",
+          "pandas/tests/series/methods/test_combine.py",
+          "pandas/tests/series/methods/test_combine_first.py",
+          "pandas/tests/series/methods/test_compare.py",
+          "pandas/tests/series/methods/test_convert_dtypes.py",
+          "pandas/tests/series/methods/test_copy.py",
+          "pandas/tests/series/methods/test_count.py",
+          "pandas/tests/series/methods/test_cov_corr.py",
+          "pandas/tests/series/methods/test_describe.py",
+          "pandas/tests/series/methods/test_diff.py",
+          "pandas/tests/series/methods/test_drop.py",
+          "pandas/tests/series/methods/test_drop_duplicates.py",
+          "pandas/tests/series/methods/test_dropna.py",
+          "pandas/tests/series/methods/test_dtypes.py",
+          "pandas/tests/series/methods/test_duplicated.py",
+          "pandas/tests/series/methods/test_equals.py",
+          "pandas/tests/series/methods/test_explode.py",
+          "pandas/tests/series/methods/test_fillna.py",
+          "pandas/tests/series/methods/test_get_numeric_data.py",
+          "pandas/tests/series/methods/test_head_tail.py",
+          "pandas/tests/series/methods/test_infer_objects.py",
+          "pandas/tests/series/methods/test_info.py",
+          "pandas/tests/series/methods/test_interpolate.py",
+          "pandas/tests/series/methods/test_is_monotonic.py",
+          "pandas/tests/series/methods/test_is_unique.py",
+          "pandas/tests/series/methods/test_isin.py",
+          "pandas/tests/series/methods/test_isna.py",
+          "pandas/tests/series/methods/test_item.py",
+          "pandas/tests/series/methods/test_map.py",
+          "pandas/tests/series/methods/test_matmul.py",
+          "pandas/tests/series/methods/test_nlargest.py",
+          "pandas/tests/series/methods/test_nunique.py",
+          "pandas/tests/series/methods/test_pct_change.py",
+          "pandas/tests/series/methods/test_pop.py",
+          "pandas/tests/series/methods/test_quantile.py",
+          "pandas/tests/series/methods/test_rank.py",
+          "pandas/tests/series/methods/test_reindex.py",
+          "pandas/tests/series/methods/test_reindex_like.py",
+          "pandas/tests/series/methods/test_rename.py",
+          "pandas/tests/series/methods/test_rename_axis.py",
+          "pandas/tests/series/methods/test_repeat.py",
+          "pandas/tests/series/methods/test_replace.py",
+          "pandas/tests/series/methods/test_reset_index.py",
+          "pandas/tests/series/methods/test_round.py",
+          "pandas/tests/series/methods/test_searchsorted.py",
+          "pandas/tests/series/methods/test_set_name.py",
+          "pandas/tests/series/methods/test_size.py",
+          "pandas/tests/series/methods/test_sort_index.py",
+          "pandas/tests/series/methods/test_sort_values.py",
+          "pandas/tests/series/methods/test_to_csv.py",
+          "pandas/tests/series/methods/test_to_dict.py",
+          "pandas/tests/series/methods/test_to_frame.py",
+          "pandas/tests/series/methods/test_to_numpy.py",
+          "pandas/tests/series/methods/test_tolist.py",
+          "pandas/tests/series/methods/test_truncate.py",
+          "pandas/tests/series/methods/test_tz_localize.py",
+          "pandas/tests/series/methods/test_unique.py",
+          "pandas/tests/series/methods/test_unstack.py",
+          "pandas/tests/series/methods/test_update.py",
+          "pandas/tests/series/methods/test_value_counts.py",
+          "pandas/tests/series/methods/test_values.py",
+          "pandas/tests/series/test_api.py",
+          "pandas/tests/series/test_arithmetic.py",
+          "pandas/tests/series/test_arrow_interface.py",
+          "pandas/tests/series/test_constructors.py",
+          "pandas/tests/series/test_cumulative.py",
+          "pandas/tests/series/test_formats.py",
+          "pandas/tests/series/test_iteration.py",
+          "pandas/tests/series/test_logical_ops.py",
+          "pandas/tests/series/test_missing.py",
+          "pandas/tests/series/test_npfuncs.py",
+          "pandas/tests/series/test_reductions.py",
+          "pandas/tests/series/test_subclass.py",
+          "pandas/tests/series/test_ufunc.py",
+          "pandas/tests/series/test_unary.py",
+          "pandas/tests/series/test_validate.py",
+          "pandas/tests/strings/__init__.py",
+          "pandas/tests/strings/conftest.py",
+          "pandas/tests/strings/test_api.py",
+          "pandas/tests/strings/test_case_justify.py",
+          "pandas/tests/strings/test_cat.py",
+          "pandas/tests/strings/test_extract.py",
+          "pandas/tests/strings/test_find_replace.py",
+          "pandas/tests/strings/test_get_dummies.py",
+          "pandas/tests/strings/test_split_partition.py",
+          "pandas/tests/strings/test_string_array.py",
+          "pandas/tests/strings/test_strings.py",
+          "pandas/tests/test_aggregation.py",
+          "pandas/tests/test_algos.py",
+          "pandas/tests/test_col.py",
+          "pandas/tests/test_common.py",
+          "pandas/tests/test_downstream.py",
+          "pandas/tests/test_errors.py",
+          "pandas/tests/test_expressions.py",
+          "pandas/tests/test_flags.py",
+          "pandas/tests/test_multilevel.py",
+          "pandas/tests/test_nanops.py",
+          "pandas/tests/test_optional_dependency.py",
+          "pandas/tests/test_register_accessor.py",
+          "pandas/tests/test_sorting.py",
+          "pandas/tests/test_take.py",
+          "pandas/tests/tools/__init__.py",
+          "pandas/tests/tools/test_to_datetime.py",
+          "pandas/tests/tools/test_to_numeric.py",
+          "pandas/tests/tools/test_to_time.py",
+          "pandas/tests/tools/test_to_timedelta.py",
+          "pandas/tests/tseries/__init__.py",
+          "pandas/tests/tseries/frequencies/__init__.py",
+          "pandas/tests/tseries/frequencies/test_freq_code.py",
+          "pandas/tests/tseries/frequencies/test_frequencies.py",
+          "pandas/tests/tseries/frequencies/test_inference.py",
+          "pandas/tests/tseries/holiday/__init__.py",
+          "pandas/tests/tseries/holiday/test_calendar.py",
+          "pandas/tests/tseries/holiday/test_federal.py",
+          "pandas/tests/tseries/holiday/test_holiday.py",
+          "pandas/tests/tseries/holiday/test_observance.py",
+          "pandas/tests/tseries/offsets/__init__.py",
+          "pandas/tests/tseries/offsets/common.py",
+          "pandas/tests/tseries/offsets/test_business_day.py",
+          "pandas/tests/tseries/offsets/test_business_halfyear.py",
+          "pandas/tests/tseries/offsets/test_business_hour.py",
+          "pandas/tests/tseries/offsets/test_business_month.py",
+          "pandas/tests/tseries/offsets/test_business_quarter.py",
+          "pandas/tests/tseries/offsets/test_business_year.py",
+          "pandas/tests/tseries/offsets/test_common.py",
+          "pandas/tests/tseries/offsets/test_custom_business_day.py",
+          "pandas/tests/tseries/offsets/test_custom_business_hour.py",
+          "pandas/tests/tseries/offsets/test_custom_business_month.py",
+          "pandas/tests/tseries/offsets/test_dst.py",
+          "pandas/tests/tseries/offsets/test_easter.py",
+          "pandas/tests/tseries/offsets/test_fiscal.py",
+          "pandas/tests/tseries/offsets/test_halfyear.py",
+          "pandas/tests/tseries/offsets/test_index.py",
+          "pandas/tests/tseries/offsets/test_month.py",
+          "pandas/tests/tseries/offsets/test_offsets.py",
+          "pandas/tests/tseries/offsets/test_offsets_properties.py",
+          "pandas/tests/tseries/offsets/test_quarter.py",
+          "pandas/tests/tseries/offsets/test_ticks.py",
+          "pandas/tests/tseries/offsets/test_week.py",
+          "pandas/tests/tseries/offsets/test_year.py",
+          "pandas/tests/tslibs/__init__.py",
+          "pandas/tests/tslibs/test_api.py",
+          "pandas/tests/tslibs/test_array_to_datetime.py",
+          "pandas/tests/tslibs/test_ccalendar.py",
+          "pandas/tests/tslibs/test_conversion.py",
+          "pandas/tests/tslibs/test_fields.py",
+          "pandas/tests/tslibs/test_libfrequencies.py",
+          "pandas/tests/tslibs/test_liboffsets.py",
+          "pandas/tests/tslibs/test_np_datetime.py",
+          "pandas/tests/tslibs/test_npy_units.py",
+          "pandas/tests/tslibs/test_parse_iso8601.py",
+          "pandas/tests/tslibs/test_parsing.py",
+          "pandas/tests/tslibs/test_period.py",
+          "pandas/tests/tslibs/test_resolution.py",
+          "pandas/tests/tslibs/test_strptime.py",
+          "pandas/tests/tslibs/test_timedeltas.py",
+          "pandas/tests/tslibs/test_timezones.py",
+          "pandas/tests/tslibs/test_to_offset.py",
+          "pandas/tests/tslibs/test_tzconversion.py",
+          "pandas/tests/util/__init__.py",
+          "pandas/tests/util/conftest.py",
+          "pandas/tests/util/test_assert_almost_equal.py",
+          "pandas/tests/util/test_assert_attr_equal.py",
+          "pandas/tests/util/test_assert_categorical_equal.py",
+          "pandas/tests/util/test_assert_extension_array_equal.py",
+          "pandas/tests/util/test_assert_frame_equal.py",
+          "pandas/tests/util/test_assert_index_equal.py",
+          "pandas/tests/util/test_assert_interval_array_equal.py",
+          "pandas/tests/util/test_assert_numpy_array_equal.py",
+          "pandas/tests/util/test_assert_produces_warning.py",
+          "pandas/tests/util/test_assert_series_equal.py",
+          "pandas/tests/util/test_deprecate.py",
+          "pandas/tests/util/test_deprecate_kwarg.py",
+          "pandas/tests/util/test_deprecate_nonkeyword_arguments.py",
+          "pandas/tests/util/test_doc.py",
+          "pandas/tests/util/test_hashing.py",
+          "pandas/tests/util/test_numba.py",
+          "pandas/tests/util/test_rewrite_warning.py",
+          "pandas/tests/util/test_shares_memory.py",
+          "pandas/tests/util/test_show_versions.py",
+          "pandas/tests/util/test_util.py",
+          "pandas/tests/util/test_validate_args.py",
+          "pandas/tests/util/test_validate_args_and_kwargs.py",
+          "pandas/tests/util/test_validate_inclusive.py",
+          "pandas/tests/util/test_validate_kwargs.py",
+          "pandas/tests/window/__init__.py",
+          "pandas/tests/window/conftest.py",
+          "pandas/tests/window/moments/__init__.py",
+          "pandas/tests/window/moments/conftest.py",
+          "pandas/tests/window/moments/test_moments_consistency_ewm.py",
+          "pandas/tests/window/moments/test_moments_consistency_expanding.py",
+          "pandas/tests/window/moments/test_moments_consistency_rolling.py",
+          "pandas/tests/window/test_api.py",
+          "pandas/tests/window/test_apply.py",
+          "pandas/tests/window/test_base_indexer.py",
+          "pandas/tests/window/test_cython_aggregations.py",
+          "pandas/tests/window/test_dtypes.py",
+          "pandas/tests/window/test_ewm.py",
+          "pandas/tests/window/test_expanding.py",
+          "pandas/tests/window/test_groupby.py",
+          "pandas/tests/window/test_numba.py",
+          "pandas/tests/window/test_online.py",
+          "pandas/tests/window/test_pairwise.py",
+          "pandas/tests/window/test_rolling.py",
+          "pandas/tests/window/test_rolling_functions.py",
+          "pandas/tests/window/test_rolling_quantile.py",
+          "pandas/tests/window/test_rolling_skew_kurt.py",
+          "pandas/tests/window/test_timeseries_window.py",
+          "pandas/tests/window/test_win_type.py",
+          "pandas/tseries/__init__.py",
+          "pandas/tseries/api.py",
+          "pandas/tseries/frequencies.py",
+          "pandas/tseries/holiday.py",
+          "pandas/tseries/offsets.py",
+          "pandas/util/__init__.py",
+          "pandas/util/_decorators.py",
+          "pandas/util/_doctools.py",
+          "pandas/util/_exceptions.py",
+          "pandas/util/_print_versions.py",
+          "pandas/util/_test_decorators.py",
+          "pandas/util/_tester.py",
+          "pandas/util/_validators.py",
+          "pandas/util/version/__init__.py"
+        ],
+        "missingFiles": [],
+        "duplicateFiles": [],
+        "malformedRows": [],
+        "complete": true
+      },
+      "functions": {
+        "total": 28264,
+        "enumerated": 28264,
+        "unaccounted": 0,
+        "unit": "construction-function-locus",
+        "factCids": {
+          "population": "blake3-512:1d45ac64f61e732563199675e18cdd74f74c615c14424b365ee84143fe3ea596c962d71670ec42a4b1d9f197c42b5372298f8e016fb015f88425a25aeeb9d1d1",
+          "enumerated": "blake3-512:a4a20439dd4391bf3378f17c0edd506ae0dc6a3623aaecc539c4d27866559534984ed2d02afbc3127250a7e197e1c241d5c86df9a44fdf05e467239284a03989",
+          "clean": "blake3-512:8d118d7ecd9616cd1636a3c3dd356fb0c802f09a974d317d2eb7ee1ab77e741b6cfef478cdc8222adae606821feaecc672eb47a166f7e640114b99210419507c"
+        },
+        "clean": null,
+        "cleanRatioRefused": true,
+        "cleanRefuseReason": "one or more files refused functionsClean (would be tautological clean%)"
+      }
+    }
+  },
+  "caveats": [
+    "477 is a FIRST-TERMINAL LOWER BOUND.",
+    "Descendants behind each first terminal remain masked.",
+    "944/1421 is attendance testimony, not completion.",
+    "Files-unblocked means the current first terminal MOVES; it does not mean the file completes or remaining work falls by that count."
+  ],
+  "selectors": {
+    "deliberateMembrane": "owner == With._construct_sugar AND observed contains call-target-off-population AND (distribution pytest OR stdlib module)",
+    "landedDefect": "owner == With._construct_sugar AND observed contains call-target-off-population AND distribution pandas; fixed after the measured commit by #7227/25d1dc7d02e75275117d2b958721c299f0d50062",
+    "boundaryExposureTerminatingEarly": {
+      "rule": "exact file:start membership after normalizing the source coordinate; every member terminates before the population predicate and counterfactually belongs outside enrolled pandas",
+      "manifest": [
+        "conftest.py:2151",
+        "tests/arithmetic/test_numeric.py:35",
+        "tests/arrays/categorical/test_indexing.py:377",
+        "tests/config/test_config.py:15",
+        "tests/config/test_localization.py:97",
+        "tests/extension/test_numpy.py:71",
+        "tests/frame/test_arithmetic.py:51",
+        "tests/frame/test_stack_unstack.py:2293",
+        "tests/generic/test_frame.py:106",
+        "tests/generic/test_series.py:110",
+        "tests/indexes/datetimes/test_iter.py:71",
+        "tests/indexes/multi/test_duplicates.py:263",
+        "tests/indexes/multi/test_integrity.py:131",
+        "tests/io/formats/test_console.py:36",
+        "tests/io/parser/dtypes/test_categorical.py:128",
+        "tests/io/parser/test_index_col.py:255",
+        "tests/io/test_clipboard.py:107",
+        "tests/io/test_gcs.py:103",
+        "tests/reshape/test_pivot.py:2152",
+        "tests/series/methods/test_isin.py:207",
+        "tests/series/test_arithmetic.py:36",
+        "tests/test_expressions.py:138",
+        "tests/test_nanops.py:23",
+        "_version.py:159",
+        "core/series.py:1573",
+        "tests/frame/methods/test_to_csv.py:730",
+        "tests/io/conftest.py:141",
+        "tests/io/formats/style/test_html.py:64",
+        "tests/io/formats/test_to_csv.py:34",
+        "tests/io/formats/test_to_html.py:49",
+        "tests/io/formats/test_to_latex.py:34",
+        "tests/io/generate_legacy_storage_files.py:361",
+        "tests/io/json/test_pandas.py:1482",
+        "tests/io/parser/common/test_common_basic.py:864",
+        "tests/io/parser/common/test_file_buffer_url.py:429",
+        "tests/io/parser/test_compression.py:30",
+        "tests/io/parser/test_encoding.py:66",
+        "tests/io/parser/test_network.py:45",
+        "tests/io/parser/test_python_parser_only.py:167",
+        "tests/io/parser/test_read_fwf.py:679",
+        "tests/io/parser/test_textreader.py:40",
+        "tests/io/sas/test_sas7bdat.py:59",
+        "tests/io/test_feather.py:164",
+        "tests/io/test_html.py:217",
+        "tests/io/test_iceberg.py:51",
+        "tests/io/test_parquet.py:701",
+        "tests/io/xml/test_to_xml.py:997",
+        "tests/io/xml/test_xml_dtypes.py:35",
+        "tests/series/methods/test_to_csv.py:57",
+        "tests/util/test_show_versions.py:19",
+        "util/_print_versions.py:148",
+        "core/base.py:1643",
+        "core/window/rolling.py:589",
+        "tests/frame/test_npfuncs.py:23",
+        "tests/frame/methods/test_info.py:193",
+        "tests/io/parser/test_c_parser_only.py:304",
+        "tests/io/pytables/test_compat.py:37",
+        "tests/io/pytables/test_keys.py:46",
+        "io/formats/xml.py:553",
+        "io/xml.py:537",
+        "tests/plotting/frame/test_frame_subplots.py:556",
+        "tests/plotting/test_datetimelike.py:1692",
+        "plotting/_matplotlib/__init__.py:67",
+        "tests/plotting/test_style.py:25",
+        "_testing/__init__.py:541",
+        "tests/io/test_fsspec.py:76",
+        "tests/io/test_sql.py:877",
+        "_testing/_io.py:128",
+        "tests/io/test_common.py:92",
+        "tests/io/test_pickle.py:297"
+      ]
+    },
+    "existingConstructBehindWrongEntrance": {
+      "rule": "exact file:start membership; source construction exists but the current entrance cannot reach it",
+      "manifest": [
+        "tests/io/parser/common/test_chunksize.py:53",
+        "tests/io/parser/common/test_iterator.py:42",
+        "io/formats/format.py:1044",
+        "io/sql.py:354",
+        "io/common.py:405"
+      ]
+    },
+    "entranceDefect": "owner == populate_same_module_class_manager",
+    "engineInvariant": "owner == roll_call.discharge AND observed starts with RecursionError while constructing"
+  },
+  "classCounts": {
+    "boundary-exposure-terminating-early": 70,
+    "deliberate-membrane": 301,
+    "engine-invariant": 3,
+    "entrance-defect": 3,
+    "existing-construct-behind-wrong-entrance": 5,
+    "landed-defect": 95
+  },
+  "accountedCount": 477,
+  "uncoveredCount": 0,
+  "uncoveredRows": [],
+  "multiplyClassifiedCount": 0,
+  "multiplyClassifiedRows": [],
+  "duplicateRowIdentities": [],
+  "rowsByClass": {
+    "boundary-exposure-terminating-early": [
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "_testing/__init__.py",
+          "_testing/__init__.py:541:4-567:22[With]",
+          "authenticated preconstruction resolution has no contract ref: dynamic-export for manager 'python:concurrent.futures.ThreadPoolExecutor'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "_testing/__init__.py:541",
+        "owner": "With._construct_sugar",
+        "coordinate": "_testing/__init__.py:541:4-567:22[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: dynamic-export for manager 'python:concurrent.futures.ThreadPoolExecutor'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "_testing/_io.py",
+          "_testing/_io.py:128:4-129:33[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "_testing/_io.py:128",
+        "owner": "With._construct_sugar",
+        "coordinate": "_testing/_io.py:128:4-129:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "_version.py",
+          "_version.py:159:8-172:54[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "_version.py:159",
+        "owner": "With._construct_sugar",
+        "coordinate": "_version.py:159:8-172:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "conftest.py",
+          "conftest.py:2151:4-2152:16[With]",
+          "authenticated preconstruction resolution has no contract ref: target-outside-binding for manager 'python:pytest.MonkeyPatch.context'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "conftest.py:2151",
+        "owner": "With._construct_sugar",
+        "coordinate": "conftest.py:2151:4-2152:16[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: target-outside-binding for manager 'python:pytest.MonkeyPatch.context'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/base.py",
+          "core/base.py:1643:8-1644:60[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:numpy.errstate'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/base.py:1643",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/base.py:1643:8-1644:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:numpy.errstate'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/series.py",
+          "core/series.py:1573:12-1574:31[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/series.py:1573",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/series.py:1573:12-1574:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/window/rolling.py",
+          "core/window/rolling.py:589:12-590:37[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:numpy.errstate'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/window/rolling.py:589",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/window/rolling.py:589:12-590:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:numpy.errstate'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/formats/xml.py",
+          "SourceFragmentCoordinateV1(source_cid='blake3-512:380fa1b2b63af798cdea8b19e9290bf96814847e9e81a2a1322dbdd68f5483068225685d7c30f8e402ab07c3d69c262252bbdd0bce9e143dca66e5ffd7af817e', start_line=553, start_col=13, end_line=553, end_col=24)",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "io/formats/xml.py:553",
+        "owner": "With._construct_sugar",
+        "coordinate": "SourceFragmentCoordinateV1(source_cid='blake3-512:380fa1b2b63af798cdea8b19e9290bf96814847e9e81a2a1322dbdd68f5483068225685d7c30f8e402ab07c3d69c262252bbdd0bce9e143dca66e5ffd7af817e', start_line=553, start_col=13, end_line=553, end_col=24)",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/xml.py",
+          "SourceFragmentCoordinateV1(source_cid='blake3-512:102e7699c29b02918e0f895b42dc642335cd8e358992a5ccfedda16ebca3c752e7d3d1c890d0f40130d0d2f4dd7d275c8a18a3328a1795fc91cfe02306068cd6', start_line=537, start_col=13, end_line=537, end_col=24)",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "io/xml.py:537",
+        "owner": "With._construct_sugar",
+        "coordinate": "SourceFragmentCoordinateV1(source_cid='blake3-512:102e7699c29b02918e0f895b42dc642335cd8e358992a5ccfedda16ebca3c752e7d3d1c890d0f40130d0d2f4dd7d275c8a18a3328a1795fc91cfe02306068cd6', start_line=537, start_col=13, end_line=537, end_col=24)",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "plotting/_matplotlib/__init__.py",
+          "plotting/_matplotlib/__init__.py:67:12-68:30[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:matplotlib.pyplot.rc_context'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "plotting/_matplotlib/__init__.py:67",
+        "owner": "With._construct_sugar",
+        "coordinate": "plotting/_matplotlib/__init__.py:67:12-68:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:matplotlib.pyplot.rc_context'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arithmetic/test_numeric.py",
+          "tests/arithmetic/test_numeric.py:35:4-37:27[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arithmetic/test_numeric.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arithmetic/test_numeric.py:35:4-37:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_indexing.py",
+          "tests/arrays/categorical/test_indexing.py:377:4-379:13[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_indexing.py:377",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_indexing.py:377:4-379:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/config/test_config.py",
+          "tests/config/test_config.py:15:8-26:17[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/config/test_config.py:15",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/config/test_config.py:15:8-26:17[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/config/test_localization.py",
+          "tests/config/test_localization.py:97:4-99:37[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/config/test_localization.py:97",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/config/test_localization.py:97:4-99:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/test_numpy.py",
+          "tests/extension/test_numpy.py:71:4-74:13[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/test_numpy.py:71",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/test_numpy.py:71:4-74:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_info.py",
+          "tests/frame/methods/test_info.py:193:4-195:47[With]",
+          "authenticated preconstruction resolution has no contract ref: artifact-module-absent for manager 'python:io.StringIO'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_info.py:193",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_info.py:193:4-195:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: artifact-module-absent for manager 'python:io.StringIO'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_to_csv.py",
+          "tests/frame/methods/test_to_csv.py:730:8-732:50[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_to_csv.py:730",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_to_csv.py:730:8-732:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_arithmetic.py",
+          "tests/frame/test_arithmetic.py:51:4-53:27[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_arithmetic.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_arithmetic.py:51:4-53:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_npfuncs.py",
+          "tests/frame/test_npfuncs.py:23:8-24:41[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:numpy.errstate'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_npfuncs.py:23",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_npfuncs.py:23:8-24:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:numpy.errstate'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_stack_unstack.py",
+          "tests/frame/test_stack_unstack.py:2293:8-2302:32[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_stack_unstack.py:2293",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_stack_unstack.py:2293:8-2302:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/generic/test_frame.py",
+          "tests/generic/test_frame.py:106:8-131:47[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/generic/test_frame.py:106",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/generic/test_frame.py:106:8-131:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/generic/test_series.py",
+          "tests/generic/test_series.py:110:8-119:38[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/generic/test_series.py:110",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/generic/test_series.py:110:8-119:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_iter.py",
+          "tests/indexes/datetimes/test_iter.py:71:8-75:24[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_iter.py:71",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_iter.py:71:8-75:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_duplicates.py",
+          "tests/indexes/multi/test_duplicates.py:263:4-268:61[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_duplicates.py:263",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_duplicates.py:263:4-268:61[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_integrity.py",
+          "tests/indexes/multi/test_integrity.py:131:4-141:30[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_integrity.py:131",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_integrity.py:131:4-141:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/conftest.py",
+          "tests/io/conftest.py:141:8-142:59[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/conftest.py:141",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/conftest.py:141:8-142:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/style/test_html.py",
+          "tests/io/formats/style/test_html.py:64:4-65:28[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/style/test_html.py:64",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/style/test_html.py:64:4-65:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/test_console.py",
+          "tests/io/formats/test_console.py:36:4-39:50[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/test_console.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/test_console.py:36:4-39:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/test_to_csv.py",
+          "tests/io/formats/test_to_csv.py:34:8-35:40[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/test_to_csv.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/test_to_csv.py:34:8-35:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/test_to_html.py",
+          "tests/io/formats/test_to_html.py:49:4-50:23[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/test_to_html.py:49",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/test_to_html.py:49:4-50:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/test_to_latex.py",
+          "tests/io/formats/test_to_latex.py:34:8-35:53[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/test_to_latex.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/test_to_latex.py:34:8-35:53[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/generate_legacy_storage_files.py",
+          "tests/io/generate_legacy_storage_files.py:361:4-362:80[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/generate_legacy_storage_files.py:361",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/generate_legacy_storage_files.py:361:4-362:80[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/json/test_pandas.py",
+          "tests/io/json/test_pandas.py:1482:8-1483:63[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/json/test_pandas.py:1482",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/json/test_pandas.py:1482:8-1483:63[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_common_basic.py",
+          "tests/io/parser/common/test_common_basic.py:864:4-866:38[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/common/test_common_basic.py:864",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/common/test_common_basic.py:864:4-866:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_file_buffer_url.py",
+          "SourceFragmentCoordinateV1(source_cid='blake3-512:95a491978180d153e7437061cc0278df0578a4f50fdf48712f658bed550745f12a5e9c3a138e1bac34bef3fac602c9eaa47918d3c7a0de1cab7faa5fad6b6e4d', start_line=429, start_col=9, end_line=429, end_col=74)",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "tests/io/parser/common/test_file_buffer_url.py:429",
+        "owner": "With._construct_sugar",
+        "coordinate": "SourceFragmentCoordinateV1(source_cid='blake3-512:95a491978180d153e7437061cc0278df0578a4f50fdf48712f658bed550745f12a5e9c3a138e1bac34bef3fac602c9eaa47918d3c7a0de1cab7faa5fad6b6e4d', start_line=429, start_col=9, end_line=429, end_col=74)",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/dtypes/test_categorical.py",
+          "tests/io/parser/dtypes/test_categorical.py:128:4-130:85[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/dtypes/test_categorical.py:128",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/dtypes/test_categorical.py:128:4-130:85[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_c_parser_only.py",
+          "tests/io/parser/test_c_parser_only.py:304:4-306:31[With]",
+          "authenticated preconstruction resolution has no contract ref: artifact-module-absent for manager 'python:io.StringIO'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_c_parser_only.py:304",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_c_parser_only.py:304:4-306:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: artifact-module-absent for manager 'python:io.StringIO'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_compression.py",
+          "tests/io/parser/test_compression.py:30:4-31:23[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_compression.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_compression.py:30:4-31:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_encoding.py",
+          "tests/io/parser/test_encoding.py:66:4-67:27[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_encoding.py:66",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_encoding.py:66:4-67:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_index_col.py",
+          "tests/io/parser/test_index_col.py:255:4-257:58[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_index_col.py:255",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_index_col.py:255:4-257:58[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_network.py",
+          "tests/io/parser/test_network.py:45:4-46:50[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_network.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_network.py:45:4-46:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_python_parser_only.py",
+          "tests/io/parser/test_python_parser_only.py:167:4-168:23[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_python_parser_only.py:167",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_python_parser_only.py:167:4-168:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_read_fwf.py",
+          "tests/io/parser/test_read_fwf.py:679:4-682:47[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_read_fwf.py:679",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_read_fwf.py:679:4-682:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_textreader.py",
+          "tests/io/parser/test_textreader.py:40:8-42:25[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_textreader.py:40",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_textreader.py:40:8-42:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_compat.py",
+          "tests/io/pytables/test_compat.py:37:4-42:26[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:tables.open_file'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_compat.py:37",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_compat.py:37:4-42:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:tables.open_file'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_keys.py",
+          "tests/io/pytables/test_keys.py:46:4-50:63[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:tables.open_file'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_keys.py:46",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_keys.py:46:4-50:63[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:tables.open_file'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/sas/test_sas7bdat.py",
+          "tests/io/sas/test_sas7bdat.py:59:12-60:31[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/sas/test_sas7bdat.py:59",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/sas/test_sas7bdat.py:59:12-60:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_clipboard.py",
+          "tests/io/test_clipboard.py:107:4-109:13[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_clipboard.py:107",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_clipboard.py:107:4-109:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_common.py",
+          "tests/io/test_common.py:92:8-93:64[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:fsspec.open'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_common.py:92",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_common.py:92:8-93:64[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:fsspec.open'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_feather.py",
+          "tests/io/test_feather.py:164:8-166:46[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_feather.py:164",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_feather.py:164:8-166:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_fsspec.py",
+          "tests/io/test_fsspec.py:76:4-77:21[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_fsspec.py:76",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_fsspec.py:76:4-77:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_gcs.py",
+          "tests/io/test_gcs.py:103:8-106:36[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_gcs.py:103",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_gcs.py:103:8-106:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_html.py",
+          "tests/io/test_html.py:217:8-228:13[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_html.py:217",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_html.py:217:8-228:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_iceberg.py",
+          "tests/io/test_iceberg.py:51:8-57:30[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_iceberg.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_iceberg.py:51:8-57:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_parquet.py",
+          "tests/io/test_parquet.py:701:8-703:60[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_parquet.py:701",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_parquet.py:701:8-703:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_pickle.py",
+          "SourceFragmentCoordinateV1(source_cid='blake3-512:2532d0b58246c0127bb7da8cbb97f4476da7d671ee9410b2d505b88afc473a87238f04dedc77da2c1bab6cb94d8a0875b9c867079d93072a31da3412477900c1', start_line=297, start_col=17, end_line=297, end_col=82)",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected for manager 'zipfile.ZipFile'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "tests/io/test_pickle.py:297",
+        "owner": "With._construct_sugar",
+        "coordinate": "SourceFragmentCoordinateV1(source_cid='blake3-512:2532d0b58246c0127bb7da8cbb97f4476da7d671ee9410b2d505b88afc473a87238f04dedc77da2c1bab6cb94d8a0875b9c867079d93072a31da3412477900c1', start_line=297, start_col=17, end_line=297, end_col=82)",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected for manager 'zipfile.ZipFile'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_sql.py",
+          "SourceFragmentCoordinateV1(source_cid='blake3-512:8970567f5d72f94975bb5c8eb89c4857decca6f4b0bc477d8c9f5c7773a210c3da7caf12ba6ba70ab769aedeea91644e9e9bc7bb754ae2ccd2f8967f5c47a480', start_line=877, start_col=13, end_line=877, end_col=25)",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "tests/io/test_sql.py:877",
+        "owner": "With._construct_sugar",
+        "coordinate": "SourceFragmentCoordinateV1(source_cid='blake3-512:8970567f5d72f94975bb5c8eb89c4857decca6f4b0bc477d8c9f5c7773a210c3da7caf12ba6ba70ab769aedeea91644e9e9bc7bb754ae2ccd2f8967f5c47a480', start_line=877, start_col=13, end_line=877, end_col=25)",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/xml/test_to_xml.py",
+          "tests/io/xml/test_to_xml.py:997:4-1000:59[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/xml/test_to_xml.py:997",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/xml/test_to_xml.py:997:4-1000:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/xml/test_xml_dtypes.py",
+          "tests/io/xml/test_xml_dtypes.py:35:4-36:21[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/xml/test_xml_dtypes.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/xml/test_xml_dtypes.py:35:4-36:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/plotting/frame/test_frame_subplots.py",
+          "tests/plotting/frame/test_frame_subplots.py:556:12-557:40[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/plotting/frame/test_frame_subplots.py:556",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/plotting/frame/test_frame_subplots.py:556:12-557:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/plotting/test_datetimelike.py",
+          "tests/plotting/test_datetimelike.py:1692:8-1693:34[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/plotting/test_datetimelike.py:1692",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/plotting/test_datetimelike.py:1692:8-1693:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/plotting/test_style.py",
+          "tests/plotting/test_style.py:25:8-27:37[With]",
+          "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:matplotlib.rc_context'",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/plotting/test_style.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/plotting/test_style.py:25:8-27:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: no-derived-contract for manager 'python:matplotlib.rc_context'",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/test_pivot.py",
+          "tests/reshape/test_pivot.py:2152:8-2163:21[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/test_pivot.py:2152",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/test_pivot.py:2152:8-2163:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_isin.py",
+          "tests/series/methods/test_isin.py:207:4-209:41[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_isin.py:207",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_isin.py:207:4-209:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_to_csv.py",
+          "tests/series/methods/test_to_csv.py:57:8-58:59[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_to_csv.py:57",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_to_csv.py:57:8-58:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_arithmetic.py",
+          "tests/series/test_arithmetic.py:36:4-38:13[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_arithmetic.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_arithmetic.py:36:4-38:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_expressions.py",
+          "tests/test_expressions.py:138:8-152:49[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_expressions.py:138",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_expressions.py:138:8-152:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_nanops.py",
+          "tests/test_nanops.py:23:4-25:13[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_nanops.py:23",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_nanops.py:23:4-25:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_show_versions.py",
+          "tests/util/test_show_versions.py:19:4-21:30[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_show_versions.py:19",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_show_versions.py:19:4-21:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "util/_print_versions.py",
+          "util/_print_versions.py:148:12-149:41[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "util/_print_versions.py:148",
+        "owner": "With._construct_sugar",
+        "coordinate": "util/_print_versions.py:148:12-149:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      }
+    ],
+    "deliberate-membrane": [
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "_testing/_warnings.py",
+          "_testing/_warnings.py:101:4-142:17[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "_testing/_warnings.py:101",
+        "owner": "With._construct_sugar",
+        "coordinate": "_testing/_warnings.py:101:4-142:17[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "compat/numpy/__init__.py",
+          "compat/numpy/__init__.py:31:8-38:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "compat/numpy/__init__.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "compat/numpy/__init__.py:31:8-38:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/dtypes/dtypes.py",
+          "core/dtypes/dtypes.py:1817:16-1825:68[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/dtypes/dtypes.py:1817",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/dtypes/dtypes.py:1817:16-1825:68[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/indexes/datetimes.py",
+          "core/indexes/datetimes.py:107:8-111:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/indexes/datetimes.py:107",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/indexes/datetimes.py:107:8-111:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/clipboard/__init__.py",
+          "io/clipboard/__init__.py:102:8-105:54[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:subprocess.Popen' [stdlib module 'subprocess' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/clipboard/__init__.py:102",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/clipboard/__init__.py:102:8-105:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:subprocess.Popen' [stdlib module 'subprocess' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/excel/_base.py",
+          "io/excel/_base.py:1469:8-1474:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:zipfile.ZipFile' [stdlib module 'zipfile' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/excel/_base.py:1469",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/excel/_base.py:1469:8-1474:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:zipfile.ZipFile' [stdlib module 'zipfile' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/apply/test_invalid_arg.py",
+          "tests/apply/test_invalid_arg.py:37:4-38:70[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/apply/test_invalid_arg.py:37",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/apply/test_invalid_arg.py:37:4-38:70[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arithmetic/common.py",
+          "tests/arithmetic/common.py:34:4-35:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arithmetic/common.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arithmetic/common.py:34:4-35:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arithmetic/test_array_ops.py",
+          "tests/arithmetic/test_array_ops.py:21:4-22:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arithmetic/test_array_ops.py:21",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arithmetic/test_array_ops.py:21:4-22:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arithmetic/test_bool.py",
+          "tests/arithmetic/test_bool.py:16:4-17:18[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arithmetic/test_bool.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arithmetic/test_bool.py:16:4-17:18[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arithmetic/test_datetime64.py",
+          "tests/arithmetic/test_datetime64.py:130:8-131:23[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arithmetic/test_datetime64.py:130",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arithmetic/test_datetime64.py:130:8-131:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/boolean/test_astype.py",
+          "tests/arrays/boolean/test_astype.py:12:4-13:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/boolean/test_astype.py:12",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/boolean/test_astype.py:12:4-13:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/boolean/test_construction.py",
+          "tests/arrays/boolean/test_construction.py:18:4-19:43[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/boolean/test_construction.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/boolean/test_construction.py:18:4-19:43[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/boolean/test_function.py",
+          "tests/arrays/boolean/test_function.py:50:4-51:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/boolean/test_function.py:50",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/boolean/test_function.py:50:4-51:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/boolean/test_logical.py",
+          "tests/arrays/boolean/test_logical.py:69:8-70:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/boolean/test_logical.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/boolean/test_logical.py:69:8-70:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_analytics.py",
+          "tests/arrays/categorical/test_analytics.py:30:8-31:22[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_analytics.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_analytics.py:30:8-31:22[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_api.py",
+          "tests/arrays/categorical/test_api.py:51:8-52:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_api.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_api.py:51:8-52:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_astype.py",
+          "tests/arrays/categorical/test_astype.py:30:8-31:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_astype.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_astype.py:30:8-31:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_constructors.py",
+          "tests/arrays/categorical/test_constructors.py:47:8-48:51[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_constructors.py:47",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_constructors.py:47:8-48:51[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_operators.py",
+          "tests/arrays/categorical/test_operators.py:80:8-81:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_operators.py:80",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_operators.py:80:8-81:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_sorting.py",
+          "tests/arrays/categorical/test_sorting.py:36:8-37:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_sorting.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_sorting.py:36:8-37:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/datetimes/test_constructors.py",
+          "tests/arrays/datetimes/test_constructors.py:16:8-17:60[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/datetimes/test_constructors.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/datetimes/test_constructors.py:16:8-17:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/datetimes/test_cumulative.py",
+          "tests/arrays/datetimes/test_cumulative.py:43:8-44:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/datetimes/test_cumulative.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/datetimes/test_cumulative.py:43:8-44:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/datetimes/test_reductions.py",
+          "tests/arrays/datetimes/test_reductions.py:98:8-99:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/datetimes/test_reductions.py:98",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/datetimes/test_reductions.py:98:8-99:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/floating/test_astype.py",
+          "tests/arrays/floating/test_astype.py:12:4-13:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/floating/test_astype.py:12",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/floating/test_astype.py:12:4-13:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/masked/test_indexing.py",
+          "tests/arrays/masked/test_indexing.py:15:8-16:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/masked/test_indexing.py:15",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/masked/test_indexing.py:15:8-16:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/masked_shared.py",
+          "tests/arrays/masked_shared.py:134:8-135:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/masked_shared.py:134",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/masked_shared.py:134:8-135:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/period/test_astype.py",
+          "tests/arrays/period/test_astype.py:18:8-19:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/period/test_astype.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/period/test_astype.py:18:8-19:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/sparse/test_accessor.py",
+          "tests/arrays/sparse/test_accessor.py:96:8-97:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/sparse/test_accessor.py:96",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/sparse/test_accessor.py:96:8-97:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/sparse/test_astype.py",
+          "tests/arrays/sparse/test_astype.py:37:8-38:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/sparse/test_astype.py:37",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/sparse/test_astype.py:37:8-38:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/sparse/test_constructors.py",
+          "tests/arrays/sparse/test_constructors.py:88:8-89:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/sparse/test_constructors.py:88",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/sparse/test_constructors.py:88:8-89:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/sparse/test_reductions.py",
+          "tests/arrays/sparse/test_reductions.py:62:8-63:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/sparse/test_reductions.py:62",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/sparse/test_reductions.py:62:8-63:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/test_array.py",
+          "tests/arrays/test_array.py:41:4-42:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/test_array.py:41",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/test_array.py:41:4-42:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/test_datetimes.py",
+          "tests/arrays/test_datetimes.py:106:8-107:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/test_datetimes.py:106",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/test_datetimes.py:106:8-107:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/test_timedeltas.py",
+          "tests/arrays/test_timedeltas.py:34:8-35:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/test_timedeltas.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/test_timedeltas.py:34:8-35:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/timedeltas/test_constructors.py",
+          "tests/arrays/timedeltas/test_constructors.py:10:8-11:76[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/timedeltas/test_constructors.py:10",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/timedeltas/test_constructors.py:10:8-11:76[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/timedeltas/test_cumulative.py",
+          "tests/arrays/timedeltas/test_cumulative.py:11:8-12:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/timedeltas/test_cumulative.py:11",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/timedeltas/test_cumulative.py:11:8-12:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/base/test_conversion.py",
+          "tests/base/test_conversion.py:67:12-68:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/base/test_conversion.py:67",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/base/test_conversion.py:67:12-68:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/base/test_fillna.py",
+          "tests/base/test_fillna.py:20:8-21:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/base/test_fillna.py:20",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/base/test_fillna.py:20:8-21:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/base/test_value_counts.py",
+          "tests/base/test_value_counts.py:36:8-37:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/base/test_value_counts.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/base/test_value_counts.py:36:8-37:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/copy_view/test_array.py",
+          "tests/copy_view/test_array.py:48:4-49:18[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/copy_view/test_array.py:48",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/copy_view/test_array.py:48:4-49:18[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/copy_view/test_chained_assignment_deprecation.py",
+          "tests/copy_view/test_chained_assignment_deprecation.py:23:4-24:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.warns' [distribution 'pytest' module '_pytest.recwarn' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/copy_view/test_chained_assignment_deprecation.py:23",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/copy_view/test_chained_assignment_deprecation.py:23:4-24:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.warns' [distribution 'pytest' module '_pytest.recwarn' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/copy_view/test_interp_fillna.py",
+          "tests/copy_view/test_interp_fillna.py:24:8-25:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/copy_view/test_interp_fillna.py:24",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/copy_view/test_interp_fillna.py:24:8-25:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/dtypes/test_dtypes.py",
+          "tests/dtypes/test_dtypes.py:59:8-60:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/dtypes/test_dtypes.py:59",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/dtypes/test_dtypes.py:59:8-60:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/dtypes/test_generic.py",
+          "tests/dtypes/test_generic.py:63:12-66:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/dtypes/test_generic.py:63",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/dtypes/test_generic.py:63:12-66:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/accumulate.py",
+          "tests/extension/base/accumulate.py:38:12-40:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/accumulate.py:38",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/accumulate.py:38:12-40:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/constructors.py",
+          "tests/extension/base/constructors.py:84:8-85:54[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/constructors.py:84",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/constructors.py:84:8-85:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/dtype.py",
+          "tests/extension/base/dtype.py:100:8-101:61[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/dtype.py:100",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/dtype.py:100:8-101:61[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/getitem.py",
+          "tests/extension/base/getitem.py:130:8-131:23[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/getitem.py:130",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/getitem.py:130:8-131:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/groupby.py",
+          "tests/extension/base/groupby.py:169:12-170:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/groupby.py:169",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/groupby.py:169:12-170:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/methods.py",
+          "tests/extension/base/methods.py:155:8-156:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/methods.py:155",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/methods.py:155:8-156:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/missing.py",
+          "tests/extension/base/missing.py:135:8-136:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/missing.py:135",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/missing.py:135:8-136:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/ops.py",
+          "tests/extension/base/ops.py:91:12-92:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/ops.py:91",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/ops.py:91:12-92:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/reduce.py",
+          "tests/extension/base/reduce.py:91:12-92:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/reduce.py:91",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/reduce.py:91:12-92:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/setitem.py",
+          "tests/extension/base/setitem.py:58:12-59:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/setitem.py:58",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/setitem.py:58:12-59:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/constructors/test_from_dict.py",
+          "tests/frame/constructors/test_from_dict.py:146:8-151:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/constructors/test_from_dict.py:146",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/constructors/test_from_dict.py:146:8-151:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/constructors/test_from_records.py",
+          "tests/frame/constructors/test_from_records.py:31:8-32:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/constructors/test_from_records.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/constructors/test_from_records.py:31:8-32:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_coercion.py",
+          "tests/frame/indexing/test_coercion.py:54:4-55:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_coercion.py:54",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_coercion.py:54:4-55:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_delitem.py",
+          "tests/frame/indexing/test_delitem.py:33:8-34:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_delitem.py:33",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_delitem.py:33:8-34:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_get_value.py",
+          "tests/frame/indexing/test_get_value.py:14:8-15:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_get_value.py:14",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_get_value.py:14:8-15:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_getitem.py",
+          "tests/frame/indexing/test_getitem.py:35:8-36:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_getitem.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_getitem.py:35:8-36:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_indexing.py",
+          "tests/frame/indexing/test_indexing.py:51:8-52:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_indexing.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_indexing.py:51:8-52:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_insert.py",
+          "tests/frame/indexing/test_insert.py:36:8-37:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_insert.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_insert.py:36:8-37:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_set_value.py",
+          "tests/frame/indexing/test_set_value.py:43:8-44:50[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_set_value.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_set_value.py:43:8-44:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_setitem.py",
+          "tests/frame/indexing/test_setitem.py:81:8-82:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_setitem.py:81",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_setitem.py:81:8-82:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/indexing/test_take.py",
+          "tests/frame/indexing/test_take.py:12:8-13:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/indexing/test_take.py:12",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/indexing/test_take.py:12:8-13:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_align.py",
+          "tests/frame/methods/test_align.py:85:8-86:67[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_align.py:85",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_align.py:85:8-86:67[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_asfreq.py",
+          "tests/frame/methods/test_asfreq.py:254:8-255:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_asfreq.py:254",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_asfreq.py:254:8-255:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_assign.py",
+          "tests/frame/methods/test_assign.py:69:8-70:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_assign.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_assign.py:69:8-70:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_at_time.py",
+          "tests/frame/methods/test_at_time.py:83:12-84:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_at_time.py:83",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_at_time.py:83:12-84:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_between_time.py",
+          "tests/frame/methods/test_between_time.py:69:8-70:78[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_between_time.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_between_time.py:69:8-70:78[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_cov_corr.py",
+          "tests/frame/methods/test_cov_corr.py:44:8-45:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_cov_corr.py:44",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_cov_corr.py:44:8-45:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_describe.py",
+          "tests/frame/methods/test_describe.py:371:8-372:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_describe.py:371",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_describe.py:371:8-372:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_diff.py",
+          "tests/frame/methods/test_diff.py:17:8-18:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_diff.py:17",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_diff.py:17:8-18:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_dot.py",
+          "tests/frame/methods/test_dot.py:74:8-75:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_dot.py:74",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_dot.py:74:8-75:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_drop.py",
+          "tests/frame/methods/test_drop.py:31:4-32:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_drop.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_drop.py:31:4-32:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_drop_duplicates.py",
+          "tests/frame/methods/test_drop_duplicates.py:21:4-22:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_drop_duplicates.py:21",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_drop_duplicates.py:21:4-22:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_droplevel.py",
+          "tests/frame/methods/test_droplevel.py:35:12-36:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_droplevel.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_droplevel.py:35:12-36:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_dropna.py",
+          "tests/frame/methods/test_dropna.py:129:8-130:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_dropna.py:129",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_dropna.py:129:8-130:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_duplicated.py",
+          "tests/frame/methods/test_duplicated.py:21:4-22:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_duplicated.py:21",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_duplicated.py:21:4-22:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_explode.py",
+          "tests/frame/methods/test_explode.py:14:4-17:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_explode.py:14",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_explode.py:14:4-17:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_filter.py",
+          "tests/frame/methods/test_filter.py:54:8-55:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_filter.py:54",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_filter.py:54:8-55:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_interpolate.py",
+          "tests/frame/methods/test_interpolate.py:79:8-80:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_interpolate.py:79",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_interpolate.py:79:8-80:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_isetitem.py",
+          "tests/frame/methods/test_isetitem.py:45:8-46:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_isetitem.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_isetitem.py:45:8-46:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_isin.py",
+          "tests/frame/methods/test_isin.py:71:8-72:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_isin.py:71",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_isin.py:71:8-72:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_matmul.py",
+          "tests/frame/methods/test_matmul.py:83:8-84:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_matmul.py:83",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_matmul.py:83:8-84:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_pipe.py",
+          "tests/frame/methods/test_pipe.py:38:8-39:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_pipe.py:38",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_pipe.py:38:8-39:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_rank.py",
+          "tests/frame/methods/test_rank.py:135:8-136:43[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_rank.py:135",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_rank.py:135:8-136:43[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_reindex.py",
+          "tests/frame/methods/test_reindex.py:545:8-546:50[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_reindex.py:545",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_reindex.py:545:8-546:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_rename.py",
+          "tests/frame/methods/test_rename.py:62:8-63:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_rename.py:62",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_rename.py:62:8-63:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_rename_axis.py",
+          "tests/frame/methods/test_rename_axis.py:46:8-47:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_rename_axis.py:46",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_rename_axis.py:46:8-47:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_reorder_levels.py",
+          "tests/frame/methods/test_reorder_levels.py:70:8-71:46[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_reorder_levels.py:70",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_reorder_levels.py:70:8-71:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_round.py",
+          "tests/frame/methods/test_round.py:42:8-43:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_round.py:42",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_round.py:42:8-43:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_sample.py",
+          "tests/frame/methods/test_sample.py:81:8-82:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_sample.py:81",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_sample.py:81:8-82:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_select_dtypes.py",
+          "tests/frame/methods/test_select_dtypes.py:99:8-100:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_select_dtypes.py:99",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_select_dtypes.py:99:8-100:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_set_axis.py",
+          "tests/frame/methods/test_set_axis.py:80:8-81:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_set_axis.py:80",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_set_axis.py:80:8-81:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_shift.py",
+          "tests/frame/methods/test_shift.py:43:8-44:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_shift.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_shift.py:43:8-44:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_swaplevel.py",
+          "tests/frame/methods/test_swaplevel.py:35:8-36:43[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_swaplevel.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_swaplevel.py:35:8-36:43[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_to_dict.py",
+          "tests/frame/methods/test_to_dict.py:78:8-79:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_to_dict.py:78",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_to_dict.py:78:8-79:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_to_period.py",
+          "tests/frame/methods/test_to_period.py:77:8-78:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_to_period.py:77",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_to_period.py:77:8-78:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_to_records.py",
+          "tests/frame/methods/test_to_records.py:395:12-396:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_to_records.py:395",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_to_records.py:395:12-396:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_truncate.py",
+          "tests/frame/methods/test_truncate.py:64:8-67:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_truncate.py:64",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_truncate.py:64:8-67:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_tz_convert.py",
+          "tests/frame/methods/test_tz_convert.py:55:8-56:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_tz_convert.py:55",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_tz_convert.py:55:8-56:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_tz_localize.py",
+          "tests/frame/methods/test_tz_localize.py:50:8-51:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_tz_localize.py:50",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_tz_localize.py:50:8-51:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_update.py",
+          "tests/frame/methods/test_update.py:100:8-101:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_update.py:100",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_update.py:100:8-101:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_values.py",
+          "tests/frame/methods/test_values.py:17:8-18:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_values.py:17",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_values.py:17:8-18:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_api.py",
+          "tests/frame/test_api.py:54:8-55:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_api.py:54",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_api.py:54:8-55:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_constructors.py",
+          "tests/frame/test_constructors.py:113:8-114:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_constructors.py:113",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_constructors.py:113:8-114:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_logical_ops.py",
+          "tests/frame/test_logical_ops.py:105:8-106:21[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_logical_ops.py:105",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_logical_ops.py:105:8-106:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_nonunique_indexes.py",
+          "tests/frame/test_nonunique_indexes.py:45:8-46:67[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_nonunique_indexes.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_nonunique_indexes.py:45:8-46:67[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_unary.py",
+          "tests/frame/test_unary.py:55:8-56:17[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_unary.py:55",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_unary.py:55:8-56:17[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_validate.py",
+          "tests/frame/test_validate.py:36:8-37:46[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_validate.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_validate.py:36:8-37:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/generic/test_duplicate_labels.py",
+          "tests/generic/test_duplicate_labels.py:234:8-235:64[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/generic/test_duplicate_labels.py:234",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/generic/test_duplicate_labels.py:234:8-235:64[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/aggregate/test_numba.py",
+          "tests/groupby/aggregate/test_numba.py:38:4-39:67[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/aggregate/test_numba.py:38",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/aggregate/test_numba.py:38:4-39:67[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/aggregate/test_other.py",
+          "tests/groupby/aggregate/test_other.py:44:4-45:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/aggregate/test_other.py:44",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/aggregate/test_other.py:44:4-45:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/methods/test_rank.py",
+          "tests/groupby/methods/test_rank.py:25:4-26:17[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/methods/test_rank.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/methods/test_rank.py:25:4-26:17[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/test_grouping.py",
+          "tests/groupby/test_grouping.py:41:8-42:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/test_grouping.py:41",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/test_grouping.py:41:8-42:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/test_numba.py",
+          "tests/groupby/test_numba.py:70:8-71:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/test_numba.py:70",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/test_numba.py:70:8-71:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/test_numeric_only.py",
+          "tests/groupby/test_numeric_only.py:182:12-183:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/test_numeric_only.py:182",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/test_numeric_only.py:182:12-183:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/test_reductions.py",
+          "tests/groupby/test_reductions.py:66:4-67:58[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/test_reductions.py:66",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/test_reductions.py:66:4-67:58[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/transform/test_numba.py",
+          "tests/groupby/transform/test_numba.py:36:4-37:73[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/transform/test_numba.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/transform/test_numba.py:36:4-37:73[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/base_class/test_constructors.py",
+          "tests/indexes/base_class/test_constructors.py:24:8-25:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/base_class/test_constructors.py:24",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/base_class/test_constructors.py:24:8-25:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/base_class/test_indexing.py",
+          "tests/indexes/base_class/test_indexing.py:31:8-32:57[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/base_class/test_indexing.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/base_class/test_indexing.py:31:8-32:57[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/base_class/test_reshape.py",
+          "tests/indexes/base_class/test_reshape.py:83:8-84:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/base_class/test_reshape.py:83",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/base_class/test_reshape.py:83:8-84:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_append.py",
+          "tests/indexes/categorical/test_append.py:33:8-34:61[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_append.py:33",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_append.py:33:8-34:61[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_constructors.py",
+          "tests/indexes/categorical/test_constructors.py:18:8-19:76[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_constructors.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_constructors.py:18:8-19:76[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_equals.py",
+          "tests/indexes/categorical/test_equals.py:34:8-35:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_equals.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_equals.py:34:8-35:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_fillna.py",
+          "tests/indexes/categorical/test_fillna.py:20:8-21:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_fillna.py:20",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_fillna.py:20:8-21:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_indexing.py",
+          "tests/indexes/categorical/test_indexing.py:69:8-70:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_indexing.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_indexing.py:69:8-70:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_reindex.py",
+          "tests/indexes/categorical/test_reindex.py:18:8-19:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_reindex.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_reindex.py:18:8-19:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_astype.py",
+          "tests/indexes/datetimes/methods/test_astype.py:68:8-69:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_astype.py:68",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_astype.py:68:8-69:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_delete.py",
+          "tests/indexes/datetimes/methods/test_delete.py:45:8-47:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_delete.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_delete.py:45:8-47:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_repeat.py",
+          "tests/indexes/datetimes/methods/test_repeat.py:82:8-83:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_repeat.py:82",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_repeat.py:82:8-83:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_round.py",
+          "tests/indexes/datetimes/methods/test_round.py:40:8-41:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_round.py:40",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_round.py:40:8-41:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_shift.py",
+          "tests/indexes/datetimes/methods/test_shift.py:92:8-93:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_shift.py:92",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_shift.py:92:8-93:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_to_period.py",
+          "tests/indexes/datetimes/methods/test_to_period.py:77:8-78:60[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_to_period.py:77",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_to_period.py:77:8-78:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_constructors.py",
+          "tests/indexes/datetimes/test_constructors.py:50:8-51:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_constructors.py:50",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_constructors.py:50:8-51:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_datetime.py",
+          "tests/indexes/datetimes/test_datetime.py:140:8-141:87[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_datetime.py:140",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_datetime.py:140:8-141:87[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_freq_attr.py",
+          "tests/indexes/datetimes/test_freq_attr.py:26:8-27:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_freq_attr.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_freq_attr.py:26:8-27:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_indexing.py",
+          "tests/indexes/datetimes/test_indexing.py:101:8-103:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_indexing.py:101",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_indexing.py:101:8-103:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_join.py",
+          "tests/indexes/datetimes/test_join.py:136:8-137:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_join.py:136",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_join.py:136:8-137:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_partial_slicing.py",
+          "tests/indexes/datetimes/test_partial_slicing.py:194:8-195:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_partial_slicing.py:194",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_partial_slicing.py:194:8-195:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_scalar_compat.py",
+          "tests/indexes/datetimes/test_scalar_compat.py:36:8-37:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_scalar_compat.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_scalar_compat.py:36:8-37:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/test_timezones.py",
+          "tests/indexes/datetimes/test_timezones.py:239:8-240:85[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/test_timezones.py:239",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/test_timezones.py:239:8-240:85[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/interval/test_indexing.py",
+          "tests/indexes/interval/test_indexing.py:53:8-54:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/interval/test_indexing.py:53",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/interval/test_indexing.py:53:8-54:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/interval/test_interval.py",
+          "tests/indexes/interval/test_interval.py:197:8-198:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/interval/test_interval.py:197",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/interval/test_interval.py:197:8-198:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_analytics.py",
+          "tests/indexes/multi/test_analytics.py:15:4-16:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_analytics.py:15",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_analytics.py:15:4-16:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_astype.py",
+          "tests/indexes/multi/test_astype.py:16:4-17:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_astype.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_astype.py:16:4-17:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_compat.py",
+          "tests/indexes/multi/test_compat.py:10:4-11:15[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_compat.py:10",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_compat.py:10:4-11:15[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_drop.py",
+          "tests/indexes/multi/test_drop.py:31:4-32:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_drop.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_drop.py:31:4-32:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_indexing.py",
+          "tests/indexes/multi/test_indexing.py:70:8-71:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_indexing.py:70",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_indexing.py:70:8-71:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_missing.py",
+          "tests/indexes/multi/test_missing.py:12:4-13:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_missing.py:12",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_missing.py:12:4-13:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_pickle.py",
+          "tests/indexes/multi/test_pickle.py:9:4-10:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_pickle.py:9",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_pickle.py:9:4-10:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_reshape.py",
+          "tests/indexes/multi/test_reshape.py:34:4-35:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_reshape.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_reshape.py:34:4-35:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_setops.py",
+          "tests/indexes/multi/test_setops.py:27:4-28:45[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_setops.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_setops.py:27:4-28:45[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_take.py",
+          "tests/indexes/multi/test_take.py:16:4-17:16[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_take.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_take.py:16:4-17:16[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_util.py",
+          "tests/indexes/multi/test_util.py:52:8-53:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_util.py:52",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_util.py:52:8-53:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/numeric/test_astype.py",
+          "tests/indexes/numeric/test_astype.py:21:8-22:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/numeric/test_astype.py:21",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/numeric/test_astype.py:21:8-22:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/numeric/test_indexing.py",
+          "tests/indexes/numeric/test_indexing.py:27:8-28:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/numeric/test_indexing.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/numeric/test_indexing.py:27:8-28:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/numeric/test_numeric.py",
+          "tests/indexes/numeric/test_numeric.py:98:8-99:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/numeric/test_numeric.py:98",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/numeric/test_numeric.py:98:8-99:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/object/test_astype.py",
+          "tests/indexes/object/test_astype.py:14:4-15:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/object/test_astype.py:14",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/object/test_astype.py:14:4-15:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/object/test_indexing.py",
+          "tests/indexes/object/test_indexing.py:36:8-37:69[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/object/test_indexing.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/object/test_indexing.py:36:8-37:69[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/methods/test_asfreq.py",
+          "tests/indexes/period/methods/test_asfreq.py:76:8-77:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/methods/test_asfreq.py:76",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/methods/test_asfreq.py:76:8-77:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/methods/test_astype.py",
+          "tests/indexes/period/methods/test_astype.py:22:8-23:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/methods/test_astype.py:22",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/methods/test_astype.py:22:8-23:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/methods/test_is_full.py",
+          "tests/indexes/period/methods/test_is_full.py:20:4-21:21[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/methods/test_is_full.py:20",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/methods/test_is_full.py:20:4-21:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/methods/test_shift.py",
+          "tests/indexes/period/methods/test_shift.py:70:8-72:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/methods/test_shift.py:70",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/methods/test_shift.py:70:8-72:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/methods/test_to_timestamp.py",
+          "tests/indexes/period/methods/test_to_timestamp.py:78:8-79:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/methods/test_to_timestamp.py:78",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/methods/test_to_timestamp.py:78:8-79:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/test_constructors.py",
+          "tests/indexes/period/test_constructors.py:39:8-40:69[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/test_constructors.py:39",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/test_constructors.py:39:8-40:69[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/test_partial_slicing.py",
+          "tests/indexes/period/test_partial_slicing.py:66:12-67:23[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/test_partial_slicing.py:66",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/test_partial_slicing.py:66:12-67:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/test_period.py",
+          "tests/indexes/period/test_period.py:203:4-204:43[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/test_period.py:203",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/test_period.py:203:4-204:43[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/test_period_range.py",
+          "tests/indexes/period/test_period_range.py:22:8-23:53[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/test_period_range.py:22",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/test_period_range.py:22:8-23:53[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/test_searchsorted.py",
+          "tests/indexes/period/test_searchsorted.py:31:8-32:61[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/test_searchsorted.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/test_searchsorted.py:31:8-32:61[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/ranges/test_constructors.py",
+          "tests/indexes/ranges/test_constructors.py:38:8-39:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/ranges/test_constructors.py:38",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/ranges/test_constructors.py:38:8-39:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/ranges/test_indexing.py",
+          "tests/indexes/ranges/test_indexing.py:76:8-77:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/ranges/test_indexing.py:76",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/ranges/test_indexing.py:76:8-77:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/ranges/test_range.py",
+          "tests/indexes/ranges/test_range.py:32:8-33:45[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/ranges/test_range.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/ranges/test_range.py:32:8-33:45[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_any_index.py",
+          "tests/indexes/test_any_index.py:18:4-20:16[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_any_index.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_any_index.py:18:4-20:16[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_base.py",
+          "tests/indexes/test_base.py:60:8-62:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_base.py:60",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_base.py:60:8-62:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_common.py",
+          "tests/indexes/test_common.py:73:12-77:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_common.py:73",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_common.py:73:12-77:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_datetimelike.py",
+          "tests/indexes/test_datetimelike.py:95:8-96:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_datetimelike.py:95",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_datetimelike.py:95:8-96:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_index_new.py",
+          "tests/indexes/test_index_new.py:280:8-281:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_index_new.py:280",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_index_new.py:280:8-281:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_indexing.py",
+          "tests/indexes/test_indexing.py:47:8-48:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_indexing.py:47",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_indexing.py:47:8-48:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/test_old_base.py",
+          "tests/indexes/test_old_base.py:92:8-93:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/test_old_base.py:92",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/test_old_base.py:92:8-93:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/methods/test_astype.py",
+          "tests/indexes/timedeltas/methods/test_astype.py:80:8-81:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/methods/test_astype.py:80",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/methods/test_astype.py:80:8-81:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/methods/test_insert.py",
+          "tests/indexes/timedeltas/methods/test_insert.py:141:8-142:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/methods/test_insert.py:141",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/methods/test_insert.py:141:8-142:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/methods/test_shift.py",
+          "tests/indexes/timedeltas/methods/test_shift.py:77:8-78:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/methods/test_shift.py:77",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/methods/test_shift.py:77:8-78:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_constructors.py",
+          "tests/indexes/timedeltas/test_constructors.py:26:8-27:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_constructors.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_constructors.py:26:8-27:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_freq_attr.py",
+          "tests/indexes/timedeltas/test_freq_attr.py:34:8-35:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_freq_attr.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_freq_attr.py:34:8-35:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_scalar_compat.py",
+          "tests/indexes/timedeltas/test_scalar_compat.py:71:8-72:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_scalar_compat.py:71",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_scalar_compat.py:71:8-72:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_searchsorted.py",
+          "tests/indexes/timedeltas/test_searchsorted.py:27:8-28:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_searchsorted.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_searchsorted.py:27:8-28:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_timedelta.py",
+          "tests/indexes/timedeltas/test_timedelta.py:43:8-44:21[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_timedelta.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_timedelta.py:43:8-44:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/interval/test_interval.py",
+          "tests/indexing/interval/test_interval.py:70:8-71:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/interval/test_interval.py:70",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/interval/test_interval.py:70:8-71:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/interval/test_interval_new.py",
+          "tests/indexing/interval/test_interval_new.py:41:8-42:58[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/interval/test_interval_new.py:41",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/interval/test_interval_new.py:41:8-42:58[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/multiindex/test_partial.py",
+          "tests/indexing/multiindex/test_partial.py:32:8-33:17[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/multiindex/test_partial.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/multiindex/test_partial.py:32:8-33:17[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/multiindex/test_slice.py",
+          "tests/indexing/multiindex/test_slice.py:141:8-142:61[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/multiindex/test_slice.py:141",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/multiindex/test_slice.py:141:8-142:61[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_at.py",
+          "tests/indexing/test_at.py:26:4-27:71[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_at.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_at.py:26:4-27:71[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_datetime.py",
+          "tests/indexing/test_datetime.py:25:8-26:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_datetime.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_datetime.py:25:8-26:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_iloc.py",
+          "tests/indexing/test_iloc.py:162:8-163:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_iloc.py:162",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_iloc.py:162:8-163:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_indexing.py",
+          "tests/indexing/test_indexing.py:50:8-51:83[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_indexing.py:50",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_indexing.py:50:8-51:83[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_na_indexing.py",
+          "tests/indexing/test_na_indexing.py:55:8-56:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_na_indexing.py:55",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_na_indexing.py:55:8-56:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_partial.py",
+          "tests/indexing/test_partial.py:69:8-70:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_partial.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_partial.py:69:8-70:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_decimal.py",
+          "tests/io/parser/common/test_decimal.py:45:8-48:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/common/test_decimal.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/common/test_decimal.py:45:8-48:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_read_errors.py",
+          "tests/io/parser/common/test_read_errors.py:60:4-67:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:codecs.StreamRecoder' [stdlib module 'codecs' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/common/test_read_errors.py:60",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/common/test_read_errors.py:60:4-67:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:codecs.StreamRecoder' [stdlib module 'codecs' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_comment.py",
+          "tests/io/parser/test_comment.py:27:8-28:77[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_comment.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_comment.py:27:8-28:77[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_converters.py",
+          "tests/io/parser/test_converters.py:27:8-28:57[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_converters.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_converters.py:27:8-28:57[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_header.py",
+          "tests/io/parser/test_header.py:34:4-35:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_header.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_header.py:34:4-35:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_multi_thread.py",
+          "tests/io/parser/test_multi_thread.py:47:4-56:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:contextlib.ExitStack' [stdlib module 'contextlib' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_multi_thread.py:47",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_multi_thread.py:47:4-56:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:contextlib.ExitStack' [stdlib module 'contextlib' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/test_quoting.py",
+          "tests/io/parser/test_quoting.py:49:4-50:49[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/test_quoting.py:49",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/test_quoting.py:49:4-50:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/usecols/test_usecols_basic.py",
+          "tests/io/parser/usecols/test_usecols_basic.py:54:4-55:56[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/usecols/test_usecols_basic.py:54",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/usecols/test_usecols_basic.py:54:4-55:56[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_categorical.py",
+          "tests/io/pytables/test_categorical.py:113:4-114:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_categorical.py:113",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_categorical.py:113:4-114:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_errors.py",
+          "tests/io/pytables/test_errors.py:39:4-40:49[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_errors.py:39",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_errors.py:39:4-40:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_pytables_missing.py",
+          "tests/io/pytables/test_pytables_missing.py:11:4-12:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_pytables_missing.py:11",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_pytables_missing.py:11:4-12:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/sas/test_sas.py",
+          "tests/io/sas/test_sas.py:18:8-19:23[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/sas/test_sas.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/sas/test_sas.py:18:8-19:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_http_headers.py",
+          "tests/io/test_http_headers.py:29:8-30:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:gzip.GzipFile' [stdlib module 'gzip' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_http_headers.py:29",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_http_headers.py:29:8-30:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:gzip.GzipFile' [stdlib module 'gzip' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/libs/test_lib.py",
+          "tests/libs/test_lib.py:32:8-33:60[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/libs/test_lib.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/libs/test_lib.py:32:8-33:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/plotting/test_common.py",
+          "tests/plotting/test_common.py:20:8-21:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/plotting/test_common.py:20",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/plotting/test_common.py:20:8-21:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/plotting/test_groupby.py",
+          "tests/plotting/test_groupby.py:126:8-127:57[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/plotting/test_groupby.py:126",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/plotting/test_groupby.py:126:8-127:57[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/resample/test_period_index.py",
+          "tests/resample/test_period_index.py:45:8-53:53[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/resample/test_period_index.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/resample/test_period_index.py:45:8-53:53[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_append.py",
+          "tests/reshape/concat/test_append.py:68:8-69:69[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_append.py:68",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_append.py:68:8-69:69[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_concat.py",
+          "tests/reshape/concat/test_concat.py:208:8-209:81[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_concat.py:208",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_concat.py:208:8-209:81[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_dataframe.py",
+          "tests/reshape/concat/test_dataframe.py:150:8-151:56[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_dataframe.py:150",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_dataframe.py:150:8-151:56[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/merge/test_merge_asof.py",
+          "tests/reshape/merge/test_merge_asof.py:787:8-788:73[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/merge/test_merge_asof.py:787",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/merge/test_merge_asof.py:787:8-788:73[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/test_get_dummies.py",
+          "tests/reshape/test_get_dummies.py:55:8-56:43[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/test_get_dummies.py:55",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/test_get_dummies.py:55:8-56:43[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/test_union_categoricals.py",
+          "tests/reshape/test_union_categoricals.py:73:8-74:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/test_union_categoricals.py:73",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/test_union_categoricals.py:73:8-74:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/interval/test_arithmetic.py",
+          "tests/scalar/interval/test_arithmetic.py:30:8-31:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/interval/test_arithmetic.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/interval/test_arithmetic.py:30:8-31:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/interval/test_constructors.py",
+          "tests/scalar/interval/test_constructors.py:24:8-25:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/interval/test_constructors.py:24",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/interval/test_constructors.py:24:8-25:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/interval/test_contains.py",
+          "tests/scalar/interval/test_contains.py:72:12-73:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/interval/test_contains.py:72",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/interval/test_contains.py:72:12-73:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/period/test_arithmetic.py",
+          "tests/scalar/period/test_arithmetic.py:29:8-30:19[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/period/test_arithmetic.py:29",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/period/test_arithmetic.py:29:8-30:19[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/period/test_period.py",
+          "tests/scalar/period/test_period.py:52:8-53:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/period/test_period.py:52",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/period/test_period.py:52:8-53:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timedelta/methods/test_as_unit.py",
+          "tests/scalar/timedelta/methods/test_as_unit.py:45:8-46:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timedelta/methods/test_as_unit.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timedelta/methods/test_as_unit.py:45:8-46:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timedelta/methods/test_round.py",
+          "tests/scalar/timedelta/methods/test_round.py:63:12-64:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timedelta/methods/test_round.py:63",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timedelta/methods/test_round.py:63:12-64:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timedelta/test_arithmetic.py",
+          "tests/scalar/timedelta/test_arithmetic.py:123:8-124:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timedelta/test_arithmetic.py:123",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timedelta/test_arithmetic.py:123:8-124:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timedelta/test_constructors.py",
+          "tests/scalar/timedelta/test_constructors.py:63:8-64:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timedelta/test_constructors.py:63",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timedelta/test_constructors.py:63:8-64:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timedelta/test_timedelta.py",
+          "tests/scalar/timedelta/test_timedelta.py:115:8-116:22[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timedelta/test_timedelta.py:115",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timedelta/test_timedelta.py:115:8-116:22[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_as_unit.py",
+          "tests/scalar/timestamp/methods/test_as_unit.py:46:8-47:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_as_unit.py:46",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_as_unit.py:46:8-47:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_normalize.py",
+          "tests/scalar/timestamp/methods/test_normalize.py:28:8-29:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_normalize.py:28",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_normalize.py:28:8-29:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_replace.py",
+          "tests/scalar/timestamp/methods/test_replace.py:26:8-27:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_replace.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_replace.py:26:8-27:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_round.py",
+          "tests/scalar/timestamp/methods/test_round.py:28:8-29:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_round.py:28",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_round.py:28:8-29:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_tz_localize.py",
+          "tests/scalar/timestamp/methods/test_tz_localize.py:29:8-30:66[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_tz_localize.py:29",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_tz_localize.py:29:8-30:66[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/test_arithmetic.py",
+          "tests/scalar/timestamp/test_arithmetic.py:46:8-47:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/test_arithmetic.py:46",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/test_arithmetic.py:46:8-47:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/test_comparisons.py",
+          "tests/scalar/timestamp/test_comparisons.py:77:12-78:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/test_comparisons.py:77",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/test_comparisons.py:77:12-78:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/test_constructors.py",
+          "tests/scalar/timestamp/test_constructors.py:56:8-57:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/test_constructors.py:56",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/test_constructors.py:56:8-57:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/test_timestamp.py",
+          "tests/scalar/timestamp/test_timestamp.py:107:8-108:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/test_timestamp.py:107",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/test_timestamp.py:107:8-108:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/accessors/test_cat_accessor.py",
+          "tests/series/accessors/test_cat_accessor.py:64:8-65:23[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/accessors/test_cat_accessor.py:64",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/accessors/test_cat_accessor.py:64:8-65:23[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/accessors/test_str_accessor.py",
+          "tests/series/accessors/test_str_accessor.py:19:8-20:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/accessors/test_str_accessor.py:19",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/accessors/test_str_accessor.py:19:8-20:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_datetime.py",
+          "tests/series/indexing/test_datetime.py:42:4-43:21[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_datetime.py:42",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_datetime.py:42:4-43:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_delitem.py",
+          "tests/series/indexing/test_delitem.py:48:8-49:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_delitem.py:48",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_delitem.py:48:8-49:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_getitem.py",
+          "tests/series/indexing/test_getitem.py:77:8-78:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_getitem.py:77",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_getitem.py:77:8-78:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_indexing.py",
+          "tests/series/indexing/test_indexing.py:35:4-36:12[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_indexing.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_indexing.py:35:4-36:12[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_mask.py",
+          "tests/series/indexing/test_mask.py:35:4-36:17[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_mask.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_mask.py:35:4-36:17[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_setitem.py",
+          "tests/series/indexing/test_setitem.py:218:8-219:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_setitem.py:218",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_setitem.py:218:8-219:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/indexing/test_take.py",
+          "tests/series/indexing/test_take.py:13:4-14:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/indexing/test_take.py:13",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/indexing/test_take.py:13:4-14:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_argsort.py",
+          "tests/series/methods/test_argsort.py:18:8-19:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_argsort.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_argsort.py:18:8-19:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_asof.py",
+          "tests/series/methods/test_asof.py:163:8-164:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_asof.py:163",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_asof.py:163:8-164:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_between.py",
+          "tests/series/methods/test_between.py:73:8-74:60[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_between.py:73",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_between.py:73:8-74:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_clip.py",
+          "tests/series/methods/test_clip.py:149:8-150:62[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_clip.py:149",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_clip.py:149:8-150:62[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_convert_dtypes.py",
+          "tests/series/methods/test_convert_dtypes.py:194:12-195:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_convert_dtypes.py:194",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_convert_dtypes.py:194:12-195:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_cov_corr.py",
+          "tests/series/methods/test_cov_corr.py:154:8-155:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_cov_corr.py:154",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_cov_corr.py:154:8-155:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_describe.py",
+          "tests/series/methods/test_describe.py:169:12-172:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_describe.py:169",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_describe.py:169:12-172:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_diff.py",
+          "tests/series/methods/test_diff.py:15:8-16:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_diff.py:15",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_diff.py:15:8-16:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_dropna.py",
+          "tests/series/methods/test_dropna.py:26:8-27:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_dropna.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_dropna.py:26:8-27:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_fillna.py",
+          "tests/series/methods/test_fillna.py:161:8-162:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_fillna.py:161",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_fillna.py:161:8-162:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_item.py",
+          "tests/series/methods/test_item.py:32:8-33:22[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_item.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_item.py:32:8-33:22[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_matmul.py",
+          "tests/series/methods/test_matmul.py:78:8-79:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_matmul.py:78",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_matmul.py:78:8-79:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_quantile.py",
+          "tests/series/methods/test_quantile.py:43:12-44:49[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_quantile.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_quantile.py:43:12-44:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_rename.py",
+          "tests/series/methods/test_rename.py:78:8-79:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_rename.py:78",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_rename.py:78:8-79:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_rename_axis.py",
+          "tests/series/methods/test_rename_axis.py:26:8-27:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_rename_axis.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_rename_axis.py:26:8-27:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_repeat.py",
+          "tests/series/methods/test_repeat.py:32:8-33:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_repeat.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_repeat.py:32:8-33:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_replace.py",
+          "tests/series/methods/test_replace.py:125:8-126:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_replace.py:125",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_replace.py:125:8-126:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_reset_index.py",
+          "tests/series/methods/test_reset_index.py:98:12-99:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_reset_index.py:98",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_reset_index.py:98:12-99:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_round.py",
+          "tests/series/methods/test_round.py:27:8-28:46[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_round.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_round.py:27:8-28:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_searchsorted.py",
+          "tests/series/methods/test_searchsorted.py:76:8-77:34[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_searchsorted.py:76",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_searchsorted.py:76:8-77:34[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_sort_values.py",
+          "tests/series/methods/test_sort_values.py:54:8-55:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_sort_values.py:54",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_sort_values.py:54:8-55:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_truncate.py",
+          "tests/series/methods/test_truncate.py:18:8-20:66[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_truncate.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_truncate.py:18:8-20:66[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_api.py",
+          "tests/series/test_api.py:101:8-102:21[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_api.py:101",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_api.py:101:8-102:21[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_constructors.py",
+          "tests/series/test_constructors.py:90:8-91:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_constructors.py:90",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_constructors.py:90:8-91:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_cumulative.py",
+          "tests/series/test_cumulative.py:230:8-231:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_cumulative.py:230",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_cumulative.py:230:8-231:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_logical_ops.py",
+          "tests/series/test_logical_ops.py:95:8-96:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_logical_ops.py:95",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_logical_ops.py:95:8-96:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_missing.py",
+          "tests/series/test_missing.py:40:8-41:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_missing.py:40",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_missing.py:40:8-41:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_validate.py",
+          "tests/series/test_validate.py:25:4-26:46[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_validate.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_validate.py:25:4-26:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/strings/test_extract.py",
+          "tests/strings/test_extract.py:21:4-22:61[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/strings/test_extract.py:21",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/strings/test_extract.py:21:4-22:61[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/strings/test_string_array.py",
+          "tests/strings/test_string_array.py:22:8-23:56[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/strings/test_string_array.py:22",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/strings/test_string_array.py:22:8-23:56[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/strings/test_strings.py",
+          "tests/strings/test_strings.py:31:4-32:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/strings/test_strings.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/strings/test_strings.py:31:4-32:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_algos.py",
+          "tests/test_algos.py:278:8-279:49[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_algos.py:278",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_algos.py:278:8-279:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_common.py",
+          "tests/test_common.py:90:8-91:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_common.py:90",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_common.py:90:8-91:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_errors.py",
+          "tests/test_errors.py:64:4-65:19[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_errors.py:64",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_errors.py:64:4-65:19[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_flags.py",
+          "tests/test_flags.py:34:8-35:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_flags.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_flags.py:34:8-35:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_multilevel.py",
+          "tests/test_multilevel.py:157:8-158:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_multilevel.py:157",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_multilevel.py:157:8-158:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/test_optional_dependency.py",
+          "tests/test_optional_dependency.py:16:4-17:49[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/test_optional_dependency.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/test_optional_dependency.py:16:4-17:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/tools/test_to_datetime.py",
+          "tests/tools/test_to_datetime.py:146:8-153:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/tools/test_to_datetime.py:146",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/tools/test_to_datetime.py:146:8-153:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/tools/test_to_time.py",
+          "tests/tools/test_to_time.py:51:8-52:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/tools/test_to_time.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/tools/test_to_time.py:51:8-52:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/tools/test_to_timedelta.py",
+          "tests/tools/test_to_timedelta.py:49:8-50:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/tools/test_to_timedelta.py:49",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/tools/test_to_timedelta.py:49:8-50:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/tslibs/test_np_datetime.py",
+          "tests/tslibs/test_np_datetime.py:36:4-37:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/tslibs/test_np_datetime.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/tslibs/test_np_datetime.py:36:4-37:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/tslibs/test_tzconversion.py",
+          "tests/tslibs/test_tzconversion.py:15:8-16:88[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/tslibs/test_tzconversion.py:15",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/tslibs/test_tzconversion.py:15:8-16:88[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_assert_extension_array_equal.py",
+          "tests/util/test_assert_extension_array_equal.py:33:8-34:65[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_assert_extension_array_equal.py:33",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_assert_extension_array_equal.py:33:8-34:65[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_assert_index_equal.py",
+          "tests/util/test_assert_index_equal.py:30:4-31:54[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_assert_index_equal.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_assert_index_equal.py:30:4-31:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_assert_numpy_array_equal.py",
+          "tests/util/test_assert_numpy_array_equal.py:18:4-19:74[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_assert_numpy_array_equal.py:18",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_assert_numpy_array_equal.py:18:4-19:74[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_numba.py",
+          "tests/util/test_numba.py:10:4-12:16[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_numba.py:10",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_numba.py:10:4-12:16[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_validate_inclusive.py",
+          "tests/util/test_validate_inclusive.py:22:4-26:45[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_validate_inclusive.py:22",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_validate_inclusive.py:22:4-26:45[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/window/test_base_indexer.py",
+          "tests/window/test_base_indexer.py:31:4-32:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/window/test_base_indexer.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/window/test_base_indexer.py:31:4-32:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/window/test_online.py",
+          "tests/window/test_online.py:30:8-34:46[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/window/test_online.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/window/test_online.py:30:8-34:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pytest.raises' [distribution 'pytest' module '_pytest.raises' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "util/_exceptions.py",
+          "util/_exceptions.py:89:4-90:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "util/_exceptions.py:89",
+        "owner": "With._construct_sugar",
+        "coordinate": "util/_exceptions.py:89:4-90:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:warnings.catch_warnings' [stdlib module 'warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      }
+    ],
+    "engine-invariant": [
+      {
+        "rowIdentity": [
+          "roll_call.discharge",
+          "core/sorting.py",
+          "core/sorting.py:1:0-737:0[Module]",
+          "RecursionError while constructing Module at /home/tsavo/pandas303-audit/pandas/core/sorting.py:1:0",
+          "bounded construction depth or a written cycle break for this root's sugar graph",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/sorting.py:1",
+        "owner": "roll_call.discharge",
+        "coordinate": "core/sorting.py:1:0-737:0[Module]",
+        "observed": "RecursionError while constructing Module at /home/tsavo/pandas303-audit/pandas/core/sorting.py:1:0",
+        "requested": "bounded construction depth or a written cycle break for this root's sugar graph",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "roll_call.discharge",
+          "tests/base/test_misc.py",
+          "tests/base/test_misc.py:95:4-102:35[FunctionDef]",
+          "RecursionError while constructing FunctionDef at /home/tsavo/pandas303-audit/pandas/tests/base/test_misc.py:95:4",
+          "bounded construction depth or a written cycle break for this root's sugar graph",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/base/test_misc.py:95",
+        "owner": "roll_call.discharge",
+        "coordinate": "tests/base/test_misc.py:95:4-102:35[FunctionDef]",
+        "observed": "RecursionError while constructing FunctionDef at /home/tsavo/pandas303-audit/pandas/tests/base/test_misc.py:95:4",
+        "requested": "bounded construction depth or a written cycle break for this root's sugar graph",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "roll_call.discharge",
+          "tests/dtypes/test_inference.py",
+          "tests/dtypes/test_inference.py:214:4-216:19[FunctionDef]",
+          "RecursionError while constructing FunctionDef at /home/tsavo/pandas303-audit/pandas/tests/dtypes/test_inference.py:214:4",
+          "bounded construction depth or a written cycle break for this root's sugar graph",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/dtypes/test_inference.py:214",
+        "owner": "roll_call.discharge",
+        "coordinate": "tests/dtypes/test_inference.py:214:4-216:19[FunctionDef]",
+        "observed": "RecursionError while constructing FunctionDef at /home/tsavo/pandas303-audit/pandas/tests/dtypes/test_inference.py:214:4",
+        "requested": "bounded construction depth or a written cycle break for this root's sugar graph",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      }
+    ],
+    "entrance-defect": [
+      {
+        "rowIdentity": [
+          "populate_same_module_class_manager",
+          "io/parsers/readers.py",
+          "TextFileReader",
+          "missing callsite body",
+          "force callsite floor",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "io/parsers/readers.py:TextFileReader",
+        "owner": "populate_same_module_class_manager",
+        "coordinate": "TextFileReader",
+        "observed": "missing callsite body",
+        "requested": "force callsite floor",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "populate_same_module_class_manager",
+          "io/pytables.py",
+          "HDFStore",
+          "missing callsite body",
+          "force callsite floor",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "io/pytables.py:HDFStore",
+        "owner": "populate_same_module_class_manager",
+        "coordinate": "HDFStore",
+        "observed": "missing callsite body",
+        "requested": "force callsite floor",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      },
+      {
+        "rowIdentity": [
+          "populate_same_module_class_manager",
+          "io/stata.py",
+          "StataReader",
+          "missing callsite body",
+          "force callsite floor",
+          "sugar.enumerate:context-manager-resolutions"
+        ],
+        "fileStart": "io/stata.py:StataReader",
+        "owner": "populate_same_module_class_manager",
+        "coordinate": "StataReader",
+        "observed": "missing callsite body",
+        "requested": "force callsite floor",
+        "entrance": "sugar.enumerate:context-manager-resolutions"
+      }
+    ],
+    "existing-construct-behind-wrong-entrance": [
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/common.py",
+          "io/common.py:405:8-410:40[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/common.py:405",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/common.py:405:8-410:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/formats/format.py",
+          "io/formats/format.py:1044:4-1049:19[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/formats/format.py:1044",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/formats/format.py:1044:4-1049:19[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/sql.py",
+          "io/sql.py:354:4-366:9[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/sql.py:354",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/sql.py:354:4-366:9[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_chunksize.py",
+          "tests/io/parser/common/test_chunksize.py:53:12-54:28[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/common/test_chunksize.py:53",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/common/test_chunksize.py:53:12-54:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_iterator.py",
+          "tests/io/parser/common/test_iterator.py:42:4-46:35[With]",
+          "authenticated preconstruction resolution has no contract ref: runtime-selected",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/common/test_iterator.py:42",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/common/test_iterator.py:42:4-46:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: runtime-selected",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      }
+    ],
+    "landed-defect": [
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "_config/dates.py",
+          "_config/dates.py:19:0-26:5[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.config_prefix' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "_config/dates.py:19",
+        "owner": "With._construct_sugar",
+        "coordinate": "_config/dates.py:19:0-26:5[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.config_prefix' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "_testing/contexts.py",
+          "_testing/contexts.py:45:4-46:27[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "_testing/contexts.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "_testing/contexts.py:45:4-46:27[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/apply.py",
+          "core/apply.py:1287:8-1288:67[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.core._numba.extensions.set_numba_data' [distribution 'pandas' module 'pandas.core._numba.extensions' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/apply.py:1287",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/apply.py:1287:8-1288:67[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.core._numba.extensions.set_numba_data' [distribution 'pandas' module 'pandas.core._numba.extensions' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/frame.py",
+          "core/frame.py:2988:8-2989:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/frame.py:2988",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/frame.py:2988:8-2989:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "core/groupby/generic.py",
+          "core/groupby/generic.py:517:8-522:68[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.core.common.temp_setattr' [distribution 'pandas' module 'pandas.core.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "core/groupby/generic.py:517",
+        "owner": "With._construct_sugar",
+        "coordinate": "core/groupby/generic.py:517:8-522:68[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.core.common.temp_setattr' [distribution 'pandas' module 'pandas.core.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/feather_format.py",
+          "io/feather_format.py:74:4-77:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/feather_format.py:74",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/feather_format.py:74:4-77:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/formats/csvs.py",
+          "io/formats/csvs.py:251:8-272:24[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/formats/csvs.py:251",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/formats/csvs.py:251:8-272:24[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/formats/html.py",
+          "io/formats/html.py:419:8-420:79[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/formats/html.py:419",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/formats/html.py:419:8-420:79[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/html.py",
+          "io/html.py:134:8-137:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/html.py:134",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/html.py:134:8-137:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/json/_json.py",
+          "io/json/_json.py:248:8-251:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/json/_json.py:248",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/json/_json.py:248:8-251:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/orc.py",
+          "io/orc.py:123:4-135:9[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/orc.py:123",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/orc.py:123:4-135:9[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "io/pickle.py",
+          "io/pickle.py:119:4-127:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "io/pickle.py:119",
+        "owner": "With._construct_sugar",
+        "coordinate": "io/pickle.py:119:4-127:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arithmetic/test_object.py",
+          "tests/arithmetic/test_object.py:41:8-54:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arithmetic/test_object.py:41",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arithmetic/test_object.py:41:8-54:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_dtypes.py",
+          "tests/arrays/categorical/test_dtypes.py:91:8-92:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_dtypes.py:91",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_dtypes.py:91:8-92:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_missing.py",
+          "tests/arrays/categorical/test_missing.py:35:8-36:49[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_missing.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_missing.py:35:8-36:49[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_repr.py",
+          "tests/arrays/categorical/test_repr.py:69:8-70:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_repr.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_repr.py:69:8-70:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/categorical/test_warnings.py",
+          "tests/arrays/categorical/test_warnings.py:17:8-19:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/categorical/test_warnings.py:17",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/categorical/test_warnings.py:17:8-19:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/arrays/string_/test_string_arrow.py",
+          "tests/arrays/string_/test_string_arrow.py:26:4-29:53[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/arrays/string_/test_string_arrow.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/arrays/string_/test_string_arrow.py:26:4-29:53[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/computation/test_eval.py",
+          "tests/computation/test_eval.py:1075:8-1087:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/computation/test_eval.py:1075",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/computation/test_eval.py:1075:8-1087:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/copy_view/test_copy_deprecation.py",
+          "tests/copy_view/test_copy_deprecation.py:43:8-44:51[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/copy_view/test_copy_deprecation.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/copy_view/test_copy_deprecation.py:43:8-44:51[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/extension/base/dim2.py",
+          "tests/extension/base/dim2.py:104:8-105:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/extension/base/dim2.py:104",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/extension/base/dim2.py:104:8-105:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_convert_dtypes.py",
+          "tests/frame/methods/test_convert_dtypes.py:25:8-26:74[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_convert_dtypes.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_convert_dtypes.py:25:8-26:74[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_fillna.py",
+          "tests/frame/methods/test_fillna.py:45:8-46:42[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_fillna.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_fillna.py:45:8-46:42[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_reindex_like.py",
+          "tests/frame/methods/test_reindex_like.py:27:8-28:68[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_reindex_like.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_reindex_like.py:27:8-28:68[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_sort_index.py",
+          "tests/frame/methods/test_sort_index.py:50:8-52:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_sort_index.py:50",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_sort_index.py:50:8-52:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/methods/test_sort_values.py",
+          "tests/frame/methods/test_sort_values.py:22:8-24:50[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/methods/test_sort_values.py:22",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/methods/test_sort_values.py:22:8-24:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_block_internals.py",
+          "tests/frame/test_block_internals.py:51:8-54:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_block_internals.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_block_internals.py:51:8-54:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_repr.py",
+          "tests/frame/test_repr.py:189:8-190:51[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_repr.py:189",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_repr.py:189:8-190:51[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/frame/test_subclass.py",
+          "tests/frame/test_subclass.py:24:8-28:26[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/frame/test_subclass.py:24",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/frame/test_subclass.py:24:8-28:26[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/test_all_methods.py",
+          "tests/groupby/test_all_methods.py:36:4-37:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/test_all_methods.py:36",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/test_all_methods.py:36:4-37:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/groupby/test_groupby_subclass.py",
+          "tests/groupby/test_groupby_subclass.py:43:4-44:55[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/groupby/test_groupby_subclass.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/groupby/test_groupby_subclass.py:43:4-44:55[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/base_class/test_formats.py",
+          "tests/indexes/base_class/test_formats.py:128:8-129:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/base_class/test_formats.py:128",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/base_class/test_formats.py:128:8-129:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_astype.py",
+          "tests/indexes/categorical/test_astype.py:69:8-70:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_astype.py:69",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_astype.py:69:8-70:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_category.py",
+          "tests/indexes/categorical/test_category.py:81:8-83:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_category.py:81",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_category.py:81:8-83:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/categorical/test_formats.py",
+          "tests/indexes/categorical/test_formats.py:76:8-80:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/categorical/test_formats.py:76",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/categorical/test_formats.py:76:8-80:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_normalize.py",
+          "tests/indexes/datetimes/methods/test_normalize.py:90:8-99:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.set_timezone' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_normalize.py:90",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_normalize.py:90:8-99:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.set_timezone' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/datetimes/methods/test_snap.py",
+          "tests/indexes/datetimes/methods/test_snap.py:35:4-36:87[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/datetimes/methods/test_snap.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/datetimes/methods/test_snap.py:35:4-36:87[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/interval/test_astype.py",
+          "tests/indexes/interval/test_astype.py:53:8-54:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/interval/test_astype.py:53",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/interval/test_astype.py:53:8-54:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/interval/test_constructors.py",
+          "tests/indexes/interval/test_constructors.py:104:12-105:81[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/interval/test_constructors.py:104",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/interval/test_constructors.py:104:12-105:81[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/multi/test_formats.py",
+          "tests/indexes/multi/test_formats.py:12:4-15:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/multi/test_formats.py:12",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/multi/test_formats.py:12:4-15:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/period/test_freq_attr.py",
+          "tests/indexes/period/test_freq_attr.py:16:8-17:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/period/test_freq_attr.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/period/test_freq_attr.py:16:8-17:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_delete.py",
+          "tests/indexes/timedeltas/test_delete.py:34:8-36:25[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_delete.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_delete.py:34:8-36:25[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_formats.py",
+          "tests/indexes/timedeltas/test_formats.py:47:8-52:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_formats.py:47",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_formats.py:47:8-52:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_indexing.py",
+          "tests/indexes/timedeltas/test_indexing.py:27:8-28:74[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_indexing.py:27",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_indexing.py:27:8-28:74[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_setops.py",
+          "tests/indexes/timedeltas/test_setops.py:49:8-50:52[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_setops.py:49",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_setops.py:49:8-50:52[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexes/timedeltas/test_timedelta_range.py",
+          "tests/indexes/timedeltas/test_timedelta_range.py:56:8-58:51[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexes/timedeltas/test_timedelta_range.py:56",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexes/timedeltas/test_timedelta_range.py:56:8-58:51[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/multiindex/test_chaining_and_caching.py",
+          "tests/indexing/multiindex/test_chaining_and_caching.py:31:4-32:60[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/multiindex/test_chaining_and_caching.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/multiindex/test_chaining_and_caching.py:31:4-32:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/multiindex/test_multiindex.py",
+          "tests/indexing/multiindex/test_multiindex.py:28:8-29:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/multiindex/test_multiindex.py:28",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/multiindex/test_multiindex.py:28:8-29:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/indexing/test_chaining_and_caching.py",
+          "tests/indexing/test_chaining_and_caching.py:81:8-82:38[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/indexing/test_chaining_and_caching.py:81",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/indexing/test_chaining_and_caching.py:81:8-82:38[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/interchange/test_impl.py",
+          "tests/interchange/test_impl.py:35:4-36:56[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/interchange/test_impl.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/interchange/test_impl.py:35:4-36:56[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_odswriter.py",
+          "tests/io/excel/test_odswriter.py:51:8-52:16[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_odswriter.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_odswriter.py:51:8-52:16[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_openpyxl.py",
+          "tests/io/excel/test_openpyxl.py:89:4-93:39[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel._OpenpyxlWriter' [distribution 'pandas' module 'pandas.io.excel._openpyxl' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_openpyxl.py:89",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_openpyxl.py:89:4-93:39[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel._OpenpyxlWriter' [distribution 'pandas' module 'pandas.io.excel._openpyxl' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_readers.py",
+          "tests/io/excel/test_readers.py:172:8-180:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.ExcelFile' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_readers.py:172",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_readers.py:172:8-180:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.ExcelFile' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_style.py",
+          "tests/io/excel/test_style.py:49:4-50:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_style.py:49",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_style.py:49:4-50:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_writers.py",
+          "tests/io/excel/test_writers.py:132:8-134:76[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_writers.py:132",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_writers.py:132:8-134:76[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_xlrd.py",
+          "tests/io/excel/test_xlrd.py:30:8-31:74[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelFile' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_xlrd.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_xlrd.py:30:8-31:74[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelFile' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/excel/test_xlsxwriter.py",
+          "tests/io/excel/test_xlsxwriter.py:32:4-40:59[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/excel/test_xlsxwriter.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/excel/test_xlsxwriter.py:32:4-40:59[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.excel.ExcelWriter' [distribution 'pandas' module 'pandas.io.excel._base' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/test_ipython_compat.py",
+          "tests/io/formats/test_ipython_compat.py:32:8-33:66[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/test_ipython_compat.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/test_ipython_compat.py:32:8-33:66[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._config.config.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/formats/test_to_markdown.py",
+          "tests/io/formats/test_to_markdown.py:20:4-21:33[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/formats/test_to_markdown.py:20",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/formats/test_to_markdown.py:20:4-21:33[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/json/test_compression.py",
+          "tests/io/json/test_compression.py:26:4-28:31[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.decompress_file' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/json/test_compression.py:26",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/json/test_compression.py:26:4-28:31[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.decompress_file' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/json/test_deprecated_kwargs.py",
+          "tests/io/json/test_deprecated_kwargs.py:16:4-22:67[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/json/test_deprecated_kwargs.py:16",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/json/test_deprecated_kwargs.py:16:4-22:67[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/json/test_readlines.py",
+          "tests/io/json/test_readlines.py:146:4-150:35[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.read_json' [distribution 'pandas' module 'pandas.io.json._json' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/json/test_readlines.py:146",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/json/test_readlines.py:146:4-150:35[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.read_json' [distribution 'pandas' module 'pandas.io.json._json' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/common/test_data_list.py",
+          "tests/io/parser/common/test_data_list.py:32:4-33:30[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.parsers.TextParser' [distribution 'pandas' module 'pandas.io.parsers.readers' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/common/test_data_list.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/common/test_data_list.py:32:4-33:30[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.parsers.TextParser' [distribution 'pandas' module 'pandas.io.parsers.readers' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/parser/conftest.py",
+          "tests/io/parser/conftest.py:45:8-51:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/parser/conftest.py:45",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/parser/conftest.py:45:8-51:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/conftest.py",
+          "tests/io/pytables/conftest.py:24:4-25:19[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.pytables.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/conftest.py:24",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/conftest.py:24:4-25:19[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.pytables.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_file_handling.py",
+          "tests/io/pytables/test_file_handling.py:50:8-51:45[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_file_handling.py:50",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_file_handling.py:50:8-51:45[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_put.py",
+          "tests/io/pytables/test_put.py:76:8-77:54[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_put.py:76",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_put.py:76:8-77:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_read.py",
+          "tests/io/pytables/test_read.py:56:4-62:29[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_read.py:56",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_read.py:56:4-62:29[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_retain_attributes.py",
+          "tests/io/pytables/test_retain_attributes.py:34:4-36:41[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_retain_attributes.py:34",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_retain_attributes.py:34:4-36:41[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_round_trip.py",
+          "tests/io/pytables/test_round_trip.py:383:4-388:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_round_trip.py:383",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_round_trip.py:383:4-388:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_select.py",
+          "tests/io/pytables/test_select.py:732:4-734:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_select.py:732",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_select.py:732:4-734:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_store.py",
+          "tests/io/pytables/test_store.py:43:8-44:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.pytables.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_store.py:43",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_store.py:43:8-44:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.pytables.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_subclass.py",
+          "tests/io/pytables/test_subclass.py:30:8-31:32[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.pytables.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_subclass.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_subclass.py:30:8-31:32[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.pytables.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/pytables/test_timezones.py",
+          "tests/io/pytables/test_timezones.py:331:4-332:64[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/pytables/test_timezones.py:331",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/pytables/test_timezones.py:331:4-332:64[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.HDFStore' [distribution 'pandas' module 'pandas.io.pytables' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/sas/test_xport.py",
+          "tests/io/sas/test_xport.py:37:8-38:46[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.sas.sasreader.read_sas' [distribution 'pandas' module 'pandas.io.sas.sasreader' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/sas/test_xport.py:37",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/sas/test_xport.py:37:8-38:46[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.sas.sasreader.read_sas' [distribution 'pandas' module 'pandas.io.sas.sasreader' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_compression.py",
+          "tests/io/test_compression.py:57:4-63:40[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_compression.py:57",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_compression.py:57:4-63:40[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/test_stata.py",
+          "tests/io/test_stata.py:393:8-406:68[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.stata.StataReader' [distribution 'pandas' module 'pandas.io.stata' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/test_stata.py:393",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/test_stata.py:393:8-406:68[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.stata.StataReader' [distribution 'pandas' module 'pandas.io.stata' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/io/xml/test_xml.py",
+          "tests/io/xml/test_xml.py:272:4-274:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/io/xml/test_xml.py:272",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/io/xml/test_xml.py:272:4-274:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.io.common.get_handle' [distribution 'pandas' module 'pandas.io.common' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/plotting/test_converter.py",
+          "tests/plotting/test_converter.py:88:8-89:20[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/plotting/test_converter.py:88",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/plotting/test_converter.py:88:8-89:20[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reductions/test_stat_reductions.py",
+          "tests/reductions/test_stat_reductions.py:48:8-49:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reductions/test_stat_reductions.py:48",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reductions/test_stat_reductions.py:48:8-49:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_categorical.py",
+          "tests/reshape/concat/test_categorical.py:147:8-150:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_categorical.py:147",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_categorical.py:147:8-150:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_datetimes.py",
+          "tests/reshape/concat/test_datetimes.py:77:8-78:47[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_datetimes.py:77",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_datetimes.py:77:8-78:47[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_index.py",
+          "tests/reshape/concat/test_index.py:305:8-306:50[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_index.py:305",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_index.py:305:8-306:50[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_invalid.py",
+          "tests/reshape/concat/test_invalid.py:51:8-52:54[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.read_csv' [distribution 'pandas' module 'pandas.io.parsers.readers' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_invalid.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_invalid.py:51:8-52:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.read_csv' [distribution 'pandas' module 'pandas.io.parsers.readers' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/reshape/concat/test_sort.py",
+          "tests/reshape/concat/test_sort.py:25:8-26:72[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/reshape/concat/test_sort.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/reshape/concat/test_sort.py:25:8-26:72[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/period/test_asfreq.py",
+          "tests/scalar/period/test_asfreq.py:42:8-43:48[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/period/test_asfreq.py:42",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/period/test_asfreq.py:42:8-43:48[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_timestamp_method.py",
+          "tests/scalar/timestamp/methods/test_timestamp_method.py:31:8-34:51[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.set_timezone' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_timestamp_method.py:31",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_timestamp_method.py:31:8-34:51[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.set_timezone' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/scalar/timestamp/methods/test_to_pydatetime.py",
+          "tests/scalar/timestamp/methods/test_to_pydatetime.py:28:8-31:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/scalar/timestamp/methods/test_to_pydatetime.py:28",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/scalar/timestamp/methods/test_to_pydatetime.py:28:8-31:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_combine_first.py",
+          "tests/series/methods/test_combine_first.py:86:8-87:37[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_combine_first.py:86",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_combine_first.py:86:8-87:37[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_reindex_like.py",
+          "tests/series/methods/test_reindex_like.py:25:4-26:60[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_reindex_like.py:25",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_reindex_like.py:25:4-26:60[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_tz_localize.py",
+          "tests/series/methods/test_tz_localize.py:30:8-31:44[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_tz_localize.py:30",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_tz_localize.py:30:8-31:44[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.external_error_raised' [distribution 'pandas' module 'pandas._testing' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/methods/test_update.py",
+          "tests/series/methods/test_update.py:32:8-33:54[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/methods/test_update.py:32",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/methods/test_update.py:32:8-33:54[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.raises_chained_assignment_error' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/series/test_formats.py",
+          "tests/series/test_formats.py:192:8-193:36[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/series/test_formats.py:192",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/series/test_formats.py:192:8-193:36[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas.option_context' [distribution 'pandas' module 'pandas._config.config' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/tslibs/test_parsing.py",
+          "tests/tslibs/test_parsing.py:51:4-59:28[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.set_timezone' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/tslibs/test_parsing.py:51",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/tslibs/test_parsing.py:51:4-59:28[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.set_timezone' [distribution 'pandas' module 'pandas._testing.contexts' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      },
+      {
+        "rowIdentity": [
+          "With._construct_sugar",
+          "tests/util/test_rewrite_warning.py",
+          "tests/util/test_rewrite_warning.py:35:4-42:13[With]",
+          "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+          "one resolved authenticated ContextManagerContractRefV1",
+          "sugar.enumerate:facts:auditFrontier"
+        ],
+        "fileStart": "tests/util/test_rewrite_warning.py:35",
+        "owner": "With._construct_sugar",
+        "coordinate": "tests/util/test_rewrite_warning.py:35:4-42:13[With]",
+        "observed": "authenticated preconstruction resolution has no contract ref: call-target-off-population for manager 'python:pandas._testing.assert_produces_warning' [distribution 'pandas' module 'pandas._testing._warnings' is off enrolled population; cite via opaque membrane, do not MaterializeModule]",
+        "requested": "one resolved authenticated ContextManagerContractRefV1",
+        "entrance": "sugar.enumerate:facts:auditFrontier"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What this banks

This receipt-only change preserves the first complete closing account of the sealed pandas frontier. Every one of the 477 first-terminal rows is assigned to exactly one class by row identity derived from the sealed receipt, rather than by authored totals:

- deliberate membrane: 301
- boundary exposure terminating early: 70
- landed defect: 95
- existing construct behind wrong entrance: 5
- entrance defect: 3
- engine invariant: 3

The generated account proves 477 accounted, 0 uncovered, 0 multiply classified, and 0 duplicate identities. Its JSON SHA-256 is `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

The row population is pinned to measuredCommit `1b3ac2dd9675b00507ea438a7580306dd95015f7` and source receipt SHA-256 `cedb430388de1bd85b8bddcdc4d547a8dfcba3954e00e8930d8419bc936274b4`. Classification consulted source through `c3ac15f40d2e04758437182388cd3b1dbcaa9386`. Those are distinct pins and are not conflated.

This changes only three receipt artifacts. It adds no product category, kind, label, taxonomy, or residual bucket and deletes nothing.

## Caveats

- 477 is a FIRST-TERMINAL LOWER BOUND.
- Descendants behind each first terminal remain masked.
- 944/1421 is attendance testimony, not completion.
- Files-unblocked means the current first terminal MOVES; it does not mean the file completes or remaining work falls by that count.

## Verification

- Re-ran `closing-account.jq` against the sealed source receipt: byte-identical output.
- Source receipt SHA-256: `cedb430388de1bd85b8bddcdc4d547a8dfcba3954e00e8930d8419bc936274b4`.
- Generated JSON SHA-256 before push: `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.
- `jq` conservation: 477 total, 0 uncovered, 0 multiply classified, 0 duplicate identities.
- `git diff --check`: clean.

Predicted epsilon: no product frontier movement; the durable-account axis moves from absent to one content-verified closing account.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bank the first sealed frontier closing account with 477 classified rows
> - Adds a `closing-account.jq` program that classifies each row from a construction-panics receipt into one of six classes: `deliberate-membrane`, `landed-defect`, `boundary-exposure-terminating-early`, `existing-construct-behind-wrong-entrance`, `entrance-defect`, and `engine-invariant`.
> - Stores the computed output as `closing-account.json` conforming to the `sugar.frontier-closing-account.v1` schema, covering a frontier width of 477 rows.
> - Includes a `CLOSING_ACCOUNT.md` narrative documenting methodology, validation statements, entrance surfaces, and caveats about terminal lower bounds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c56ac9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->