### PR TITLE
Preserve manager authentication failure detail

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1406,9 +1406,13 @@ def populate_source_derived_resource_refs(
                 graph = authenticate_dependency_top_level(
                     top_level, distribution_index=distribution_index
                 )
-            except DependencyArtifactAuthenticationError:
+            except DependencyArtifactAuthenticationError as exc:
                 _install_derivation_gap(
-                    context, coordinate, receipt, "no-derived-contract"
+                    context,
+                    coordinate,
+                    receipt,
+                    "no-derived-contract",
+                    f"dependency artifact authentication failed for {top_level}: {exc}",
                 )
                 continue
             graphs[top_level] = graph

--- a/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
@@ -7,6 +7,8 @@ Local ``with M():`` has no import receipt. Populate must still derive a
 
 from __future__ import annotations
 
+import csv
+import importlib.metadata
 import textwrap
 from pathlib import Path
 
@@ -35,6 +37,74 @@ def _source_file(
     context = TreeConstructionContextV1.for_source_call_construction()
     tree = SourceFile((source, str(path), cid), construction_context=context)
     return tree, context, path
+
+
+def _installed_distribution(
+    root: Path,
+    *,
+    package: str,
+    source: str,
+    duplicate_module_seat: bool = False,
+) -> importlib.metadata.Distribution:
+    package_dir = root / package
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text(source, encoding="utf-8")
+    recorded = [f"{package}/__init__.py"]
+    if duplicate_module_seat:
+        (root / f"{package}.py").write_text(source, encoding="utf-8")
+        recorded.append(f"{package}.py")
+    metadata = root / f"{package}_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {package}-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (metadata / "top_level.txt").write_text(f"{package}\n", encoding="utf-8")
+    recorded.extend(
+        (
+            f"{package}_dist-1.0.dist-info/METADATA",
+            f"{package}_dist-1.0.dist-info/top_level.txt",
+            f"{package}_dist-1.0.dist-info/RECORD",
+        )
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for seat in recorded:
+            writer.writerow((seat, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _imported_manager_gap(
+    tmp_path: Path,
+    *,
+    package: str,
+    distribution: importlib.metadata.Distribution | None = None,
+):
+    source = textwrap.dedent(f"""\
+        from {package} import M
+        def f():
+            with M():
+                return 1
+        """)
+    tree, context, path = _source_file(tmp_path, source)
+    distribution_index = None if distribution is None else {package: distribution}
+    enrolled_distribution = (
+        "consumer" if distribution is None else distribution.metadata["Name"]
+    )
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        distribution_index=distribution_index,
+        distribution=enrolled_distribution,
+    )
+    assert len(context.source_derived_contract_refs) == 1
+    gap = next(iter(context.source_derived_contract_refs.values()))
+    assert type(gap).__name__ == "ContextManagerResolutionGapV1"
+    with_node = next(node for node in tree.nodes() if isinstance(node, With))
+    with pytest.raises(ContextManagerResolutionConstructionGap) as caught:
+        with_node.sugar()
+    return gap, caught.value.observed
 
 
 def test_local_classdef_cm_derives_and_constructs(tmp_path: Path):
@@ -111,3 +181,63 @@ def test_install_gap_never_attribute_errors_on_import_auth_fail(tmp_path: Path):
     gap = next(iter(context.source_derived_contract_refs.values()))
     assert type(gap).__name__ == "ContextManagerResolutionGapV1"
     assert gap.kind == "no-derived-contract"
+
+
+def test_manager_derivation_reasons_distinguish_dependency_failure_causes(
+    tmp_path: Path,
+) -> None:
+    """Absent, ambiguous, and contract-missing are distinct receipt reasons."""
+    absent_root = tmp_path / "absent"
+    absent_root.mkdir()
+    absent, absent_observed = _imported_manager_gap(
+        absent_root, package="absent_manager_pkg"
+    )
+
+    ambiguous_root = tmp_path / "ambiguous"
+    ambiguous_root.mkdir()
+    ambiguous_distribution = _installed_distribution(
+        ambiguous_root,
+        package="ambiguous_manager_pkg",
+        source="class M:\n    pass\n",
+        duplicate_module_seat=True,
+    )
+    ambiguous, ambiguous_observed = _imported_manager_gap(
+        ambiguous_root,
+        package="ambiguous_manager_pkg",
+        distribution=ambiguous_distribution,
+    )
+
+    missing_contract_root = tmp_path / "missing_contract"
+    missing_contract_root.mkdir()
+    missing_contract_distribution = _installed_distribution(
+        missing_contract_root,
+        package="missing_contract_pkg",
+        source="class M:\n    pass\n",
+    )
+    missing_contract, missing_contract_observed = _imported_manager_gap(
+        missing_contract_root,
+        package="missing_contract_pkg",
+        distribution=missing_contract_distribution,
+    )
+
+    reasons = {
+        "absent": (absent.kind, absent.detail),
+        "ambiguous": (ambiguous.kind, ambiguous.detail),
+        "missing-contract": (missing_contract.kind, missing_contract.detail),
+    }
+    assert len(set(reasons.values())) == 3, reasons
+    assert "absent_manager_pkg" in (absent.detail or "")
+    assert "authenticated stdlib root" in (absent.detail or "")
+    assert "ambiguous_manager_pkg" in (ambiguous.detail or "")
+    assert "duplicate module seat" in (ambiguous.detail or "")
+    assert missing_contract.kind == "enter-missing"
+    assert missing_contract.detail == "source-visible method"
+    observed_reasons = {
+        absent_observed,
+        ambiguous_observed,
+        missing_contract_observed,
+    }
+    assert len(observed_reasons) == 3, observed_reasons
+    assert absent.detail in absent_observed
+    assert ambiguous.detail in ambiguous_observed
+    assert missing_contract.detail in missing_contract_observed


### PR DESCRIPTION
## What changed

`manager_summary_derivation` now preserves `DependencyArtifactAuthenticationError` detail at its existing `no-derived-contract` gap entrance. The detail includes the authenticated top-level being resolved, so an absence message that is otherwise generic still names its subject.

The discrimination tooth constructs three real outcomes and proves both the stored gap and the `With` construction panic preserve distinct reasons:

- absent -> `no-derived-contract` + named top-level/authenticated-stdlib absence
- ambiguous -> `no-derived-contract` + named top-level/duplicate module seat
- missing contract -> `enter-missing` + `source-visible method`

## Why

Before this change, only two causes actually collapsed: absent and ambiguous authentication both recorded exactly `("no-derived-contract", None)`. The genuinely missing contract was already distinguishable as `("enter-missing", "source-visible method")`.

That collapse forced Hockney to replay the authentication boundary to separate four sealed rows. Three of those rows were simply packages not installed, not missing contracts; those facts demand different responses. The receipt appeared to answer the cause question but could not answer it from its own output.

With the causes retained, actionable classification can be derived from receipt rows instead of maintained as another authored count. Six authored counts drifted today; this removes the need for one permanently.

## Scope

This does not install absent packages, change the population membrane, repair NumPy's duplicate module seat, or add a second gap entrance.

## Evidence

Base pin: `c3ac15f40d2e04758437182388cd3b1dbcaa9386`.

- Red discrimination: focused test exited 1 because absent and ambiguous were both `("no-derived-contract", None)` while missing-contract was already `("enter-missing", "source-visible method")`.
- Green focused owning paths: `6 passed in 7.91s`, unpiped exit 0, covering enrollment authority, off-population membrane behavior, stored reason discrimination, and `With` panic transport.
- Black 26.5.1: 2 files unchanged, exit 0.

The legacy same-module test file also contains three stale callers that omit the now-required enrolled distribution roster. They fail before the changed authentication catcher and are not claimed or repaired here.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve authentication failure detail in manager derivation gap messages
> - In `populate_source_derived_resource_refs`, the `DependencyArtifactAuthenticationError` exception is now captured and its message included in the `_install_derivation_gap` call, giving the gap a descriptive detail string instead of only a kind.
> - Adds a test (`test_manager_derivation_reasons_distinguish_dependency_failure_causes`) that verifies gap kinds, detail strings, and construction error messages are distinct across absent, ambiguous, and missing-contract failure modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7d7341.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->