### PR TITLE
Retire out-of-scope Java showcases with testimony

### DIFF
--- a/.github/showcase-retirements.json
+++ b/.github/showcase-retirements.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": 1,
+  "retirements": [
+    {
+      "path": "examples/java-assertion-consistency/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Learns JUnit assertion vocabulary and distinguishes compatible claims from equality/inequality contradictions."
+    },
+    {
+      "path": "examples/java-forall-loop/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Lowers a bounded Java loop to a guarded universal and refutes an in-range contradictory point claim."
+    },
+    {
+      "path": "examples/java-testng-consistency/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Learns TestNG reversed actual/expected argument order and distinguishes compatible from contradictory assertions."
+    },
+    {
+      "path": "examples/java-codec-universe/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks Apache Base64 output alphabets, accepting the vendor vector and refuting URL-safe confusion."
+    },
+    {
+      "path": "examples/java-urlsafe-seam/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Distinguishes standard and URL-safe Base64 alphabets for an input absent from vendor tests."
+    },
+    {
+      "path": "examples/java-b64-strong/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks per-character Base64 block equations, accepting YmFy and refuting alphabet-valid ZmFy."
+    },
+    {
+      "path": "examples/java-b64-tails/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks Base64 tail and padding equations, accepting YmE= and refuting alphabet-valid YmX=."
+    },
+    {
+      "path": "examples/java-abs-universe/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks Math.abs bit-vector semantics, preserving abs(MIN)==MIN and refuting abs(MIN)==MAX."
+    },
+    {
+      "path": "examples/java-bound-federation/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Federates compatible comparison bounds on g(7) and refutes the contradictory greater-than bound."
+    },
+    {
+      "path": "examples/java-abs-bound/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Refutes abs(MIN_VALUE)>=0 from the walked Math.abs bit-vector body."
+    },
+    {
+      "path": "examples/java-callbind-consistency/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Resolves instance-call SSA binding and refutes contradictory claims about the same receiver call."
+    },
+    {
+      "path": "examples/java-instance-universe/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks constructor to final field to getter, accepting new Box(5).get()==5 and refuting 7."
+    },
+    {
+      "path": "examples/java-voltron/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Resolves Wrapper(Box(5)) through two constructor/getter layers, accepting 5 and refuting 7."
+    },
+    {
+      "path": "examples/java-abs-flagship/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Uses JDK AbsTests and Math.abs source to preserve the MIN_VALUE overflow result."
+    },
+    {
+      "path": "examples/java-panama-bridge/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Bridges a Java Panama call to the Rust decoded_len_estimate contract, accepting 3 and refuting 4."
+    },
+    {
+      "path": "examples/java-abs-model/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Derives abs(MIN_VALUE) from the lifted proof expression and refuses when the universe atom is absent."
+    },
+    {
+      "path": "examples/java-mt-reference/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Lifts Commons RNG MT19937 reference points and detects contradictory values for one draw."
+    },
+    {
+      "path": "examples/java-crc32-universe/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks OpenJDK CRC32C table generation and checks the vendor-sworn 0xE3069283 value."
+    },
+    {
+      "path": "examples/java-pattern-regex/run.sh",
+      "language": "java",
+      "outcome": "retired",
+      "reason": "out of scope per scope ruling - Java",
+      "assertion": "Walks JSR-380 Pattern into regex membership, accepting alice_01 and refuting Alice!."
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,28 +519,18 @@ jobs:
           exit_code=$?
           set -e
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
-          python3 - <<PY
-          import json, os
-          from pathlib import Path
-          body = {
-              "schemaVersion": 1,
-              "measurementClass": "test-showcases",
-              "shardIndex": int("${{ matrix.shard }}"),
-              "shardCount": 4,
-              "measuredCommit": os.environ.get("GITHUB_SHA"),
-              "status": "completed",
-              "exitCode": $exit_code,
-          }
-          Path("showcase-shard-body.json").write_text(
-              json.dumps(body, indent=2) + "\n", encoding="utf-8"
-          )
-          PY
+          python3 tools/showcase_scope.py seal-body \
+            --scope-receipt "$SHOWCASE_SCOPE_RECEIPT" \
+            --output showcase-shard-body.json \
+            --measured-commit "$GITHUB_SHA" \
+            --exit-code "$exit_code"
           exit "$exit_code"
         env:
           CI: '1'
           GH_TOKEN: ${{ github.token }}
           SHOWCASE_SHARD_COUNT: '4'
           SHOWCASE_SHARD_INDEX: ${{ matrix.shard }}
+          SHOWCASE_SCOPE_RECEIPT: showcase-scope-receipt.json
 
       - name: Upload shard measurement body
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -521,49 +521,36 @@ test-showcases: check-showcase-kit-preflight check-lift-manifest-pythonpath
 	  bin/sugarbin --profile debug --bin "$$b" >/dev/null || exit $$?; \
 	done; \
 	bin/sugarbin --profile release >/dev/null || exit $$?; \
-	failed=""; \
-	showcase_ordinal=0; \
-	selected=0; \
 	attr_dir="$${SHOWCASE_ATTR_DIR:-$$(mktemp -d -t sugar-showcase-attr.XXXXXX)}"; \
 	mkdir -p "$$attr_dir"; \
-	for s in $(SHOWCASE_RUNS); do \
-		ordinal="$$showcase_ordinal"; showcase_ordinal=$$((showcase_ordinal + 1)); \
-		if [ $$((ordinal % shard_count)) -ne "$$shard_index" ]; then continue; fi; \
-		selected=$$((selected + 1)); \
-		echo ""; \
-		echo "==== [showcase shard $$shard_index/$$shard_count] $$s ===="; \
-		safe=$$(printf '%s' "$$s" | tr '/ ' '__'); \
-		log="$$attr_dir/$$safe.log"; \
-		# Capture per-showcase output so failure-level attribution is not path-list-only. \
-		# Write then cat (not process-substitution tee) so the showcase exit status is preserved. \
-		if "$$s" >"$$log" 2>&1; then \
-		  cat "$$log"; \
-		else \
-		  cat "$$log"; \
-		  failed="$$failed $$s"; \
-		  echo "==== $$s: FAIL ====" | tee -a "$$log"; \
-		fi; \
-	done; \
-	echo ""; \
-	echo "==== showcase shard $$shard_index/$$shard_count selected=$$selected ===="; \
-	if [ -n "$$failed" ]; then \
-	  echo "==== test-showcases FAIL:$$failed ===="; \
-	  echo "==== showcase failure attribution (shard $$shard_index/$$shard_count) ===="; \
-	  # Concatenate per-showcase logs under the sharded headers the scoreboard reads. \
-	  summary="$$attr_dir/shard-$$shard_index-summary.log"; \
-	  : > "$$summary"; \
-	  for s in $$failed; do \
-	    safe=$$(printf '%s' "$$s" | tr '/ ' '__'); \
-	    echo "==== [showcase shard $$shard_index/$$shard_count] $$s ====" >> "$$summary"; \
-	    if [ -f "$$attr_dir/$$safe.log" ]; then cat "$$attr_dir/$$safe.log" >> "$$summary"; fi; \
-	  done; \
-	  echo "==== test-showcases FAIL:$$failed ====" >> "$$summary"; \
-	  $(PYTHON) tools/showcase_verdict_scoreboard.py --from-log "$$summary" \
-	    --output "$$attr_dir/shard-$$shard_index-scoreboard.json" || true; \
-	  echo "showcase attribution dir: $$attr_dir"; \
-	  exit 1; \
+	scope_receipt="$${SHOWCASE_SCOPE_RECEIPT:-$$attr_dir/shard-$$shard_index-scope.json}"; \
+	failed_path="$$attr_dir/shard-$$shard_index-failed.txt"; \
+	summary="$$attr_dir/shard-$$shard_index-summary.log"; \
+	if $(PYTHON) tools/showcase_scope.py run \
+	    --repo-root . \
+	    --manifest .github/showcase-retirements.json \
+	    --shard-count "$$shard_count" \
+	    --shard-index "$$shard_index" \
+	    --attr-dir "$$attr_dir" \
+	    --receipt "$$scope_receipt" \
+	    --failed-path "$$failed_path" \
+	    --summary-path "$$summary" \
+	    -- $(SHOWCASE_RUNS); then \
+	  scope_rc=0; \
+	else \
+	  scope_rc=$$?; \
 	fi; \
-	echo "==== test-showcases: PASS ===="
+	if [ "$$scope_rc" -ne 0 ]; then \
+	  failed="$$(tr '\n' ' ' < "$$failed_path" 2>/dev/null || true)"; \
+	  if [ -n "$$failed" ]; then echo "==== test-showcases FAIL: $$failed ===="; fi; \
+	  echo "==== showcase failure attribution (shard $$shard_index/$$shard_count) ===="; \
+	  if [ -s "$$summary" ]; then $(PYTHON) tools/showcase_verdict_scoreboard.py --from-log "$$summary" \
+	    --output "$$attr_dir/shard-$$shard_index-scoreboard.json" || true; \
+	  fi; \
+	  echo "showcase attribution dir: $$attr_dir"; \
+	  exit "$$scope_rc"; \
+	fi; \
+	echo "==== showcase-scope active execution: PASS; RETIRED testified separately ===="
 
 # --- CI alias ----------------------------------------------------------------
 

--- a/docs/superpowers/plans/2026-08-03-java-showcase-retirement.md
+++ b/docs/superpowers/plans/2026-08-03-java-showcase-retirement.md
@@ -1,0 +1,77 @@
+# Java Showcase Retirement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retire exactly 19 Java showcases with reversible, conserved, per-shard RETIRED testimony while preserving every in-scope failure.
+
+**Architecture:** A source-controlled JSON manifest is the only retirement authority. A focused Python owner validates and partitions the existing Makefile roster; the Makefile executes only active rows while writing a conserved scope receipt, and CI embeds that receipt in each shard body.
+
+**Tech Stack:** Python 3.12, GNU Make and shell, GitHub Actions YAML, JSON.
+
+## Global Constraints
+
+- Retirement must be a distinct outcome, never pass or fail.
+- Exactly 19 Java paths are retired for reason `out of scope per scope ruling - Java`.
+- Per shard, retired plus executed must equal enrolled.
+- Removing a manifest entry must make the showcase execute again.
+- Active Python-path and Rust CLI failures must retain their nonzero exit.
+
+---
+
+### Task 1: Pin the retirement authority and discrimination law
+
+**Files:**
+- Create: `.github/showcase-retirements.json`
+- Create: `tools/showcase_scope.py`
+- Create: `tests/test_showcase_retirement.py`
+
+**Interfaces:**
+- Consumes: the exact ordered `SHOWCASE_RUNS` roster and shard count/index.
+- Produces: a validated JSON partition with `enrolled`, `executed`, and `retired` rows.
+
+- [ ] Write tests for exact Java membership, named refusal arms, reversible removal, non-retired execution selection, and per-shard 5/4/5/5 conservation.
+- [ ] Run the focused test and confirm it fails because the owner and manifest do not exist.
+- [ ] Add the exact manifest and minimal validator/partitioner.
+- [ ] Run the focused test and confirm every discrimination arm passes.
+
+### Task 2: Integrate the partition into test-showcases
+
+**Files:**
+- Modify: `Makefile:396-566`
+- Modify: `tests/test_showcase_retirement.py`
+
+**Interfaces:**
+- Consumes: `tools/showcase_scope.py partition` output.
+- Produces: loud RETIRED lines, no execution for retired paths, unchanged execution and exit status for active paths, and a per-shard scope receipt.
+
+- [ ] Add a harness tooth proving retired bodies do not run, active bodies do run and can fail, and deleting one retirement row reactivates that body.
+- [ ] Run the harness tooth and confirm the current flat runner fails the retirement assertions.
+- [ ] Route the runner through the partition and preserve the existing active failure path.
+- [ ] Re-run the harness tooth and confirm conservation and both execution arms.
+
+### Task 3: Seal retirement testimony in the CI shard body
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:512-550`
+- Modify: `tests/test_showcase_retirement.py`
+- Modify: `tools/showcase_shard_attendance.py`
+
+**Interfaces:**
+- Consumes: the per-shard scope receipt and active `exit_code`.
+- Produces: `showcase-shard-body.json` with distinct retired/executed rows and fail-closed conservation validation.
+
+- [ ] Add artifact tests for distinct RETIRED state, exact reason, 5/4/5/5 distribution, conservation refusal, and active-red propagation.
+- [ ] Run the focused tests and confirm the current body schema fails them.
+- [ ] Embed and validate the scope receipt without changing active exit-code semantics.
+- [ ] Re-run focused tests plus workflow YAML parsing and dispatchability checks.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+- [ ] Run the full focused retirement contract.
+- [ ] Run `git diff --check` and parse every workflow YAML document.
+- [ ] Inspect the diff for exactly 19 Java rows, zero deletions, and zero non-Java retirement entries.
+- [ ] Commit the scoped change, push the branch, and open the PR with predicted A2 movement and explicit non-claims.
+- [ ] After landing, report observed per-shard A1/A2 and attendance; do not claim green while active findings remain.

--- a/docs/superpowers/specs/2026-08-03-java-showcase-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-03-java-showcase-retirement-design.md
@@ -9,8 +9,9 @@ nor a failure and must never be confused with a showcase that was never enrolled
 ## Authority
 
 `.github/showcase-retirements.json` is the sole retirement authority. Every row
-contains an exact enrolled `path`, `language: "java"`, `outcome: "retired"`, and
-the reason `out of scope per scope ruling - Java`. Missing reasons, duplicate
+contains an exact enrolled `path`, `language: "java"`, `outcome: "retired"`, a
+short description of the assertion being retired, and the reason
+`out of scope per scope ruling - Java`. Missing reasons, duplicate
 paths, unknown paths, unsupported outcomes, or non-Java rows refuse.
 
 The enrolled roster remains `SHOWCASE_RUNS` in the Makefile. Retirement does not
@@ -34,7 +35,7 @@ the existing pass/fail path unchanged.
 The runner writes a per-shard scope receipt. The CI step incorporates it into
 `showcase-shard-body.json` as explicit `enrolled`, `executed`, and `retired`
 collections and counts. Each retired object retains its path, language, outcome,
-and reason. `exitCode` continues to represent executed in-scope work, so any
+assertion, and reason. `exitCode` continues to represent executed in-scope work, so any
 Python-path or Rust CLI failure keeps the shard and aggregate red.
 
 ## Exact Retirement Population

--- a/docs/superpowers/specs/2026-08-03-java-showcase-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-03-java-showcase-retirement-design.md
@@ -1,0 +1,80 @@
+# Java Showcase Retirement Design
+
+## Goal
+
+Retire exactly the 19 Java showcases ruled out of scope while preserving them as
+enrolled, source-controlled, per-shard testimony. A retirement is neither a pass
+nor a failure and must never be confused with a showcase that was never enrolled.
+
+## Authority
+
+`.github/showcase-retirements.json` is the sole retirement authority. Every row
+contains an exact enrolled `path`, `language: "java"`, `outcome: "retired"`, and
+the reason `out of scope per scope ruling - Java`. Missing reasons, duplicate
+paths, unknown paths, unsupported outcomes, or non-Java rows refuse.
+
+The enrolled roster remains `SHOWCASE_RUNS` in the Makefile. Retirement does not
+remove a path from that roster. The runner partitions each selected shard row
+through the manifest into exactly one of two outcomes:
+
+- `executed`: the showcase body ran and retains its real exit code;
+- `retired`: the body did not run and the manifest reason is recorded.
+
+There is no implicit third bucket. Per shard, `executed + retired == enrolled`
+is required before a receipt may be written.
+
+## Runtime and Artifact Flow
+
+A small Python owner validates the manifest against the full enrolled roster and
+answers the selected shard partition. `make test-showcases` obtains that
+partition before executing bodies. Retired rows emit a loud line of the form
+`outcome=RETIRED path=... reason=...` and are never invoked. Executed rows follow
+the existing pass/fail path unchanged.
+
+The runner writes a per-shard scope receipt. The CI step incorporates it into
+`showcase-shard-body.json` as explicit `enrolled`, `executed`, and `retired`
+collections and counts. Each retired object retains its path, language, outcome,
+and reason. `exitCode` continues to represent executed in-scope work, so any
+Python-path or Rust CLI failure keeps the shard and aggregate red.
+
+## Exact Retirement Population
+
+- Shard 0: `java-testng-consistency`, `java-b64-tails`,
+  `java-callbind-consistency`, `java-panama-bridge`, `java-pattern-regex`.
+- Shard 1: `java-codec-universe`, `java-abs-universe`,
+  `java-instance-universe`, `java-abs-model`.
+- Shard 2: `java-assertion-consistency`, `java-urlsafe-seam`,
+  `java-bound-federation`, `java-voltron`, `java-mt-reference`.
+- Shard 3: `java-forall-loop`, `java-b64-strong`, `java-abs-bound`,
+  `java-abs-flagship`, `java-crc32-universe`.
+
+All paths are stored in the manifest with the full `examples/.../run.sh`
+coordinate. No non-Java showcase may enter the retirement population.
+
+## Discrimination and Conservation
+
+Focused tests prove all of the following:
+
+1. A retired showcase reports `RETIRED` and its body is not executed.
+2. A non-retired showcase executes and can make the shard red.
+3. Removing a manifest row makes that showcase execute again.
+4. A passed showcase cannot acquire the retired outcome.
+5. Missing/duplicate/foreign/non-Java manifest rows refuse by name.
+6. Each shard conserves `retired + executed == enrolled`.
+7. The artifact carries the exact 5/4/5/5 retirement distribution.
+8. Active nonzero exits remain nonzero in the shard body and aggregate.
+
+## Predicted Measurement
+
+With in-scope output otherwise unchanged, A2 changes only by removing the Java
+nonzero-exit rows: shard 0 `21 -> 16`, shard 1 `22 -> 18`, shard 2 `20 -> 15`,
+and shard 3 `20 -> 15`. A1 remains `1/0/1/1`. All four shard bodies remain
+attended and red while the measured Python-path and Rust CLI findings remain.
+
+## Non-Goals
+
+- No Java showcase directory or source is deleted.
+- No Java result is converted to pass or skip.
+- No Python, Rust, Swift, or linux-kernel row is retired.
+- No in-scope semantic failure is repaired or reclassified.
+- This change does not claim a green acid aggregate.

--- a/tests/test_showcase_retirement.py
+++ b/tests/test_showcase_retirement.py
@@ -1,0 +1,394 @@
+"""Discrimination teeth for explicit, reversible showcase retirement."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import showcase_scope  # noqa: E402
+
+MANIFEST = ROOT / ".github/showcase-retirements.json"
+ATTEND = ROOT / "tools/showcase_shard_attendance.py"
+CI = ROOT / ".github/workflows/ci.yml"
+MAKEFILE = ROOT / "Makefile"
+REASON = "out of scope per scope ruling - Java"
+
+EXPECTED_BY_SHARD = {
+    0: {
+        "examples/java-testng-consistency/run.sh",
+        "examples/java-b64-tails/run.sh",
+        "examples/java-callbind-consistency/run.sh",
+        "examples/java-panama-bridge/run.sh",
+        "examples/java-pattern-regex/run.sh",
+    },
+    1: {
+        "examples/java-codec-universe/run.sh",
+        "examples/java-abs-universe/run.sh",
+        "examples/java-instance-universe/run.sh",
+        "examples/java-abs-model/run.sh",
+    },
+    2: {
+        "examples/java-assertion-consistency/run.sh",
+        "examples/java-urlsafe-seam/run.sh",
+        "examples/java-bound-federation/run.sh",
+        "examples/java-voltron/run.sh",
+        "examples/java-mt-reference/run.sh",
+    },
+    3: {
+        "examples/java-forall-loop/run.sh",
+        "examples/java-b64-strong/run.sh",
+        "examples/java-abs-bound/run.sh",
+        "examples/java-abs-flagship/run.sh",
+        "examples/java-crc32-universe/run.sh",
+    },
+}
+EXPECTED = set().union(*EXPECTED_BY_SHARD.values())
+
+
+def _write_script(path: Path, marker: str, exit_code: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/usr/bin/env sh\n"
+        f"printf '%s\\n' {json.dumps(marker)} >> \"$SHOWCASE_TRACE\"\n"
+        f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _write_manifest(path: Path, rows: list[dict[str, str]]) -> None:
+    path.write_text(
+        json.dumps({"schemaVersion": 1, "retirements": rows}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _retirement(path: str) -> dict[str, str]:
+    return {
+        "path": path,
+        "language": "java",
+        "outcome": "retired",
+        "reason": REASON,
+        "assertion": "fixture Java assertion",
+    }
+
+
+def _run_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    retirements: list[dict[str, str]],
+) -> tuple[int, dict[str, object], str]:
+    java = "examples/java-fixture/run.sh"
+    python = "examples/python-fixture/run.sh"
+    _write_script(tmp_path / java, "java-executed", 0)
+    _write_script(tmp_path / python, "python-executed", 9)
+    manifest = tmp_path / "retirements.json"
+    _write_manifest(manifest, retirements)
+    trace = tmp_path / "trace.txt"
+    monkeypatch.setenv("SHOWCASE_TRACE", str(trace))
+    receipt = tmp_path / "scope.json"
+
+    returncode = showcase_scope.run_shard(
+        repo_root=tmp_path,
+        manifest_path=manifest,
+        enrolled=[java, python],
+        shard_count=1,
+        shard_index=0,
+        attr_dir=tmp_path / "logs",
+        receipt_path=receipt,
+    )
+    return (
+        returncode,
+        json.loads(receipt.read_text(encoding="utf-8")),
+        trace.read_text(encoding="utf-8"),
+    )
+
+
+def test_manifest_is_exact_java_only_authority_with_5_4_5_5_shards() -> None:
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    rows = payload["retirements"]
+    assert len(rows) == 19
+    assert {row["path"] for row in rows} == EXPECTED
+    assert all(row["language"] == "java" for row in rows)
+    assert all(row["outcome"] == "retired" for row in rows)
+    assert all(row["reason"] == REASON for row in rows)
+    assert all(row["assertion"].strip() for row in rows)
+
+    roster = showcase_scope.makefile_showcase_roster(ROOT / "Makefile")
+    retirements = showcase_scope.load_manifest(MANIFEST, roster)
+    for shard, expected in EXPECTED_BY_SHARD.items():
+        plan = showcase_scope.partition(
+            roster, retirements, shard_count=4, shard_index=shard
+        )
+        assert {row["path"] for row in plan["retired"]} == expected
+        assert plan["counts"]["retired"] == len(expected)
+        assert (
+            plan["counts"]["executed"] + plan["counts"]["retired"]
+            == plan["counts"]["enrolled"]
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "crime"),
+    [
+        ({"reason": ""}, "missing retirement reason"),
+        ({"language": "python"}, "non-Java retirement"),
+        ({"outcome": "passed"}, "unsupported retirement outcome"),
+        ({"assertion": ""}, "missing retired assertion"),
+        ({"path": "examples/not-enrolled/run.sh"}, "not enrolled"),
+    ],
+)
+def test_malformed_retirement_refuses_by_name(
+    tmp_path: Path, mutation: dict[str, str], crime: str
+) -> None:
+    enrolled = ["examples/java-fixture/run.sh"]
+    row = _retirement(enrolled[0])
+    row.update(mutation)
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(manifest, [row])
+    with pytest.raises(showcase_scope.ScopeRefusal, match=crime):
+        showcase_scope.load_manifest(manifest, enrolled)
+
+
+def test_duplicate_retirement_refuses_by_name(tmp_path: Path) -> None:
+    enrolled = ["examples/java-fixture/run.sh"]
+    manifest = tmp_path / "manifest.json"
+    row = _retirement(enrolled[0])
+    _write_manifest(manifest, [row, row])
+    with pytest.raises(showcase_scope.ScopeRefusal, match="duplicate retirement"):
+        showcase_scope.load_manifest(manifest, enrolled)
+
+
+def test_retired_does_not_execute_while_active_executes_and_stays_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    returncode, receipt, trace = _run_fixture(
+        tmp_path,
+        monkeypatch,
+        [_retirement("examples/java-fixture/run.sh")],
+    )
+    assert returncode != 0
+    assert "java-executed" not in trace
+    assert "python-executed" in trace
+    assert receipt["counts"] == {
+        "enrolled": 2,
+        "executed": 1,
+        "retired": 1,
+        "passed": 0,
+        "failed": 1,
+    }
+    assert receipt["outcomes"][0]["outcome"] == "retired"
+    assert receipt["outcomes"][0]["reason"] == REASON
+    assert receipt["outcomes"][1]["outcome"] == "failed"
+    assert receipt["outcomes"][1]["exitCode"] == 9
+
+
+def test_removing_manifest_entry_executes_the_showcase_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    returncode, receipt, trace = _run_fixture(tmp_path, monkeypatch, [])
+    assert returncode != 0
+    assert trace.splitlines() == ["java-executed", "python-executed"]
+    assert [row["outcome"] for row in receipt["outcomes"]] == ["passed", "failed"]
+    assert receipt["counts"]["retired"] == 0
+    assert receipt["counts"]["executed"] == receipt["counts"]["enrolled"] == 2
+
+
+def test_retirement_cannot_be_fabricated_by_a_passing_showcase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = "examples/python-pass/run.sh"
+    _write_script(tmp_path / script, "passed", 0)
+    manifest = tmp_path / "manifest.json"
+    _write_manifest(manifest, [])
+    trace = tmp_path / "trace.txt"
+    monkeypatch.setenv("SHOWCASE_TRACE", str(trace))
+    receipt = tmp_path / "scope.json"
+    assert (
+        showcase_scope.run_shard(
+            repo_root=tmp_path,
+            manifest_path=manifest,
+            enrolled=[script],
+            shard_count=1,
+            shard_index=0,
+            attr_dir=tmp_path / "logs",
+            receipt_path=receipt,
+        )
+        == 0
+    )
+    body = json.loads(receipt.read_text(encoding="utf-8"))
+    assert body["outcomes"] == [{"path": script, "outcome": "passed", "exitCode": 0}]
+
+
+def test_conservation_refuses_missing_showcase() -> None:
+    body = {
+        "measurementClass": "test-showcases",
+        "shardIndex": 0,
+        "shardCount": 1,
+        "measuredCommit": "abc",
+        "exitCode": 0,
+        "showcaseCounts": {
+            "enrolled": 2,
+            "executed": 1,
+            "retired": 0,
+            "passed": 1,
+            "failed": 0,
+        },
+        "showcaseOutcomes": [
+            {"path": "examples/python-pass/run.sh", "outcome": "passed", "exitCode": 0}
+        ],
+    }
+    with pytest.raises(showcase_scope.ScopeRefusal, match="conservation"):
+        showcase_scope.validate_shard_body(body)
+
+
+def test_scope_receipt_seals_distinct_outcomes_in_ci_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, scope_receipt, _ = _run_fixture(
+        tmp_path,
+        monkeypatch,
+        [_retirement("examples/java-fixture/run.sh")],
+    )
+    output = tmp_path / "showcase-shard-body.json"
+    body = showcase_scope.seal_shard_body(
+        scope_receipt,
+        measured_commit="abc",
+        exit_code=1,
+        output_path=output,
+    )
+    assert json.loads(output.read_text(encoding="utf-8")) == body
+    assert [row["outcome"] for row in body["showcaseOutcomes"]] == [
+        "retired",
+        "failed",
+    ]
+    assert body["showcaseCounts"]["retired"] == 1
+    assert body["showcaseCounts"]["failed"] == 1
+
+
+def test_makefile_routes_full_roster_through_scope_owner() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    target = text.split("test-showcases:", 1)[1].split("# --- CI alias", 1)[0]
+    assert "tools/showcase_scope.py run" in target
+    assert ".github/showcase-retirements.json" in target
+    assert "SHOWCASE_SCOPE_RECEIPT" in target
+    assert "for s in $(SHOWCASE_RUNS)" not in target
+    assert "showcase-scope active execution: PASS" in target
+
+
+def test_ci_seals_scope_receipt_into_shard_body() -> None:
+    text = CI.read_text(encoding="utf-8")
+    showcase_job = text.split("  showcases:", 1)[1].split("  showcase-attendance:", 1)[
+        0
+    ]
+    assert "SHOWCASE_SCOPE_RECEIPT" in showcase_job
+    assert "tools/showcase_scope.py seal-body" in showcase_job
+    assert "showcaseOutcomes" not in showcase_job
+    assert "showcaseCounts" not in showcase_job
+
+
+def test_attendance_refuses_unconserved_body_as_unmeasured(tmp_path: Path) -> None:
+    body = {
+        "measurementClass": "test-showcases",
+        "shardIndex": 0,
+        "shardCount": 1,
+        "measuredCommit": "abc",
+        "exitCode": 0,
+        "showcaseCounts": {
+            "enrolled": 2,
+            "executed": 1,
+            "retired": 0,
+            "passed": 1,
+            "failed": 0,
+        },
+        "showcaseOutcomes": [
+            {"path": "examples/python-pass/run.sh", "outcome": "passed", "exitCode": 0}
+        ],
+    }
+    (tmp_path / "body.json").write_text(json.dumps(body), encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ATTEND),
+            "--reports-dir",
+            str(tmp_path),
+            "--shard-count",
+            "1",
+            "--require-commit",
+            "abc",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0
+    assert "R_showcase_shard_attendance = 1" in proc.stdout
+    assert "conservation" in proc.stderr
+
+
+def test_attendance_stays_red_for_attended_active_failure(tmp_path: Path) -> None:
+    for shard in range(4):
+        outcomes = [
+            {
+                "path": f"examples/java-retired-{shard}/run.sh",
+                "outcome": "retired",
+                "language": "java",
+                "reason": REASON,
+                "assertion": "retired fixture",
+            },
+            {
+                "path": f"examples/python-active-{shard}/run.sh",
+                "outcome": "failed" if shard == 2 else "passed",
+                "exitCode": 7 if shard == 2 else 0,
+            },
+        ]
+        directory = tmp_path / f"shard-{shard}"
+        directory.mkdir()
+        (directory / "body.json").write_text(
+            json.dumps(
+                {
+                    "measurementClass": "test-showcases",
+                    "shardIndex": shard,
+                    "shardCount": 4,
+                    "measuredCommit": "abc",
+                    "exitCode": 7 if shard == 2 else 0,
+                    "showcaseCounts": {
+                        "enrolled": 2,
+                        "executed": 1,
+                        "retired": 1,
+                        "passed": 0 if shard == 2 else 1,
+                        "failed": 1 if shard == 2 else 0,
+                    },
+                    "showcaseOutcomes": outcomes,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ATTEND),
+            "--reports-dir",
+            str(tmp_path),
+            "--shard-count",
+            "4",
+            "--require-commit",
+            "abc",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode != 0
+    assert "attended: `4`" in proc.stdout
+    assert "R_showcase_shard_attendance = 0" in proc.stdout
+    assert "shard-02: exitCode=7 (showcase red)" in proc.stderr

--- a/tests/test_showcase_shared_setup_enrollment.py
+++ b/tests/test_showcase_shared_setup_enrollment.py
@@ -17,6 +17,25 @@ CI = ROOT / ".github/workflows/ci.yml"
 ATTEND = ROOT / "tools/showcase_shard_attendance.py"
 
 
+def _green_showcase_body(shard_index: int, shard_count: int = 4) -> dict:
+    path = f"examples/python-green-{shard_index}/run.sh"
+    return {
+        "measurementClass": "test-showcases",
+        "shardIndex": shard_index,
+        "shardCount": shard_count,
+        "measuredCommit": "abc",
+        "exitCode": 0,
+        "showcaseCounts": {
+            "enrolled": 1,
+            "executed": 1,
+            "retired": 0,
+            "passed": 1,
+            "failed": 0,
+        },
+        "showcaseOutcomes": [{"path": path, "outcome": "passed", "exitCode": 0}],
+    }
+
+
 def _write_build_project(root: Path, name: str, requires: list[str]) -> Path:
     project = root / name
     project.mkdir(parents=True)
@@ -200,15 +219,7 @@ def test_missing_showcase_shard_is_unmeasured(tmp_path: Path) -> None:
         d = tmp_path / f"showcase-shard-{i}"
         d.mkdir()
         (d / "showcase-shard-body.json").write_text(
-            json.dumps(
-                {
-                    "measurementClass": "test-showcases",
-                    "shardIndex": i,
-                    "shardCount": 4,
-                    "measuredCommit": "abc",
-                    "exitCode": 0,
-                }
-            ),
+            json.dumps(_green_showcase_body(i)),
             encoding="utf-8",
         )
     proc = subprocess.run(
@@ -235,15 +246,7 @@ def test_full_showcase_roster_is_green(tmp_path: Path) -> None:
         d = tmp_path / f"showcase-shard-{i}"
         d.mkdir()
         (d / "body.json").write_text(
-            json.dumps(
-                {
-                    "measurementClass": "test-showcases",
-                    "shardIndex": i,
-                    "shardCount": 4,
-                    "measuredCommit": "abc",
-                    "exitCode": 0,
-                }
-            ),
+            json.dumps(_green_showcase_body(i)),
             encoding="utf-8",
         )
     proc = subprocess.run(

--- a/tools/showcase_scope.py
+++ b/tools/showcase_scope.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Execute the enrolled showcase shard with explicit retirement testimony."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+SCHEMA_VERSION = 1
+RETIREMENT_REASON = "out of scope per scope ruling - Java"
+
+
+class ScopeRefusal(ValueError):
+    """The retirement authority or its conservation receipt is malformed."""
+
+
+def makefile_showcase_roster(path: Path) -> list[str]:
+    """Read the ordered SHOWCASE_RUNS assignment without executing Make."""
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line == "SHOWCASE_RUNS = \\")
+    except StopIteration as exc:
+        raise ScopeRefusal("SHOWCASE_RUNS roster is absent") from exc
+    roster: list[str] = []
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        if not stripped:
+            break
+        if stripped.endswith("\\"):
+            stripped = stripped[:-1].rstrip()
+        if not stripped:
+            raise ScopeRefusal("SHOWCASE_RUNS contains an empty enrolled path")
+        roster.append(stripped)
+    if not roster:
+        raise ScopeRefusal("SHOWCASE_RUNS roster is empty")
+    if len(roster) != len(set(roster)):
+        raise ScopeRefusal("SHOWCASE_RUNS contains a duplicate enrolled path")
+    return roster
+
+
+def load_manifest(path: Path, enrolled: Sequence[str]) -> dict[str, dict[str, str]]:
+    """Validate the sole retirement authority against the enrolled roster."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ScopeRefusal(f"retirement manifest unreadable: {path}: {exc}") from exc
+    if payload.get("schemaVersion") != SCHEMA_VERSION:
+        raise ScopeRefusal("retirement manifest schemaVersion must be 1")
+    rows = payload.get("retirements")
+    if not isinstance(rows, list):
+        raise ScopeRefusal("retirement manifest retirements must be a list")
+    enrolled_set = set(enrolled)
+    result: dict[str, dict[str, str]] = {}
+    for ordinal, raw in enumerate(rows):
+        if not isinstance(raw, dict):
+            raise ScopeRefusal(f"retirement row {ordinal} must be an object")
+        row_path = raw.get("path")
+        if not isinstance(row_path, str) or not row_path:
+            raise ScopeRefusal(f"retirement row {ordinal} has missing path")
+        if row_path in result:
+            raise ScopeRefusal(f"duplicate retirement: {row_path}")
+        if row_path not in enrolled_set:
+            raise ScopeRefusal(f"retirement path is not enrolled: {row_path}")
+        if raw.get("language") != "java":
+            raise ScopeRefusal(f"non-Java retirement: {row_path}")
+        if raw.get("outcome") != "retired":
+            raise ScopeRefusal(f"unsupported retirement outcome: {row_path}")
+        if raw.get("reason") != RETIREMENT_REASON:
+            raise ScopeRefusal(f"missing retirement reason: {row_path}")
+        assertion = raw.get("assertion")
+        if not isinstance(assertion, str) or not assertion.strip():
+            raise ScopeRefusal(f"missing retired assertion: {row_path}")
+        result[row_path] = {
+            "path": row_path,
+            "language": "java",
+            "outcome": "retired",
+            "reason": RETIREMENT_REASON,
+            "assertion": assertion,
+        }
+    return result
+
+
+def partition(
+    enrolled: Sequence[str],
+    retirements: Mapping[str, dict[str, str]],
+    *,
+    shard_count: int,
+    shard_index: int,
+) -> dict[str, Any]:
+    """Partition one shard while retaining the full-roster ordinal."""
+
+    if shard_count < 1 or shard_index < 0 or shard_index >= shard_count:
+        raise ScopeRefusal(f"invalid showcase shard {shard_index}/{shard_count}")
+    selected = [
+        path
+        for ordinal, path in enumerate(enrolled)
+        if ordinal % shard_count == shard_index
+    ]
+    retired = [retirements[path] for path in selected if path in retirements]
+    scheduled = [path for path in selected if path not in retirements]
+    counts = {
+        "enrolled": len(selected),
+        "executed": len(scheduled),
+        "retired": len(retired),
+    }
+    if counts["executed"] + counts["retired"] != counts["enrolled"]:
+        raise ScopeRefusal("showcase scope conservation failed during partition")
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "measurementClass": "showcase-scope",
+        "shardIndex": shard_index,
+        "shardCount": shard_count,
+        "selected": selected,
+        "scheduled": scheduled,
+        "retired": retired,
+        "counts": counts,
+    }
+
+
+def _safe_log_name(path: str) -> str:
+    return path.replace("/", "_").replace(" ", "_") + ".log"
+
+
+def _write_json_atomic(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _validate_outcomes(outcomes: object, counts: object) -> None:
+    if not isinstance(outcomes, list) or not isinstance(counts, dict):
+        raise ScopeRefusal("showcase conservation requires outcomes and counts")
+    paths: set[str] = set()
+    derived = {
+        "enrolled": len(outcomes),
+        "executed": 0,
+        "retired": 0,
+        "passed": 0,
+        "failed": 0,
+    }
+    for ordinal, raw in enumerate(outcomes):
+        if not isinstance(raw, dict):
+            raise ScopeRefusal(f"showcase outcome {ordinal} must be an object")
+        path = raw.get("path")
+        if not isinstance(path, str) or not path:
+            raise ScopeRefusal(f"showcase outcome {ordinal} has missing path")
+        if path in paths:
+            raise ScopeRefusal(f"showcase outcome duplicates path: {path}")
+        paths.add(path)
+        outcome = raw.get("outcome")
+        if outcome == "retired":
+            if raw.get("language") != "java" or raw.get("reason") != RETIREMENT_REASON:
+                raise ScopeRefusal(
+                    f"retired outcome lacks Java scope authority: {path}"
+                )
+            assertion = raw.get("assertion")
+            if not isinstance(assertion, str) or not assertion.strip():
+                raise ScopeRefusal(f"retired outcome lacks assertion: {path}")
+            derived["retired"] += 1
+        elif outcome in ("passed", "failed"):
+            exit_code = raw.get("exitCode")
+            if not isinstance(exit_code, int):
+                raise ScopeRefusal(f"executed outcome lacks integer exitCode: {path}")
+            if outcome == "passed" and exit_code != 0:
+                raise ScopeRefusal(f"passed showcase has nonzero exitCode: {path}")
+            if outcome == "failed" and exit_code == 0:
+                raise ScopeRefusal(f"failed showcase has zero exitCode: {path}")
+            derived["executed"] += 1
+            derived[outcome] += 1
+        else:
+            raise ScopeRefusal(f"unsupported showcase outcome {outcome!r}: {path}")
+    if derived["retired"] + derived["executed"] != derived["enrolled"]:
+        raise ScopeRefusal("showcase scope conservation failed")
+    for name, value in derived.items():
+        if counts.get(name) != value:
+            raise ScopeRefusal(
+                f"showcase scope conservation mismatch for {name}: "
+                f"claimed={counts.get(name)!r} observed={value}"
+            )
+
+
+def validate_shard_body(body: Mapping[str, object]) -> None:
+    """Require a conserved per-showcase outcome ledger in the CI body."""
+
+    outcomes = body.get("showcaseOutcomes")
+    counts = body.get("showcaseCounts")
+    _validate_outcomes(outcomes, counts)
+    assert isinstance(counts, dict)
+    failed = counts.get("failed")
+    exit_code = body.get("exitCode")
+    if failed and exit_code in (0, "0"):
+        raise ScopeRefusal("active showcase failure was hidden by exitCode=0")
+    if failed == 0 and exit_code not in (0, "0"):
+        raise ScopeRefusal("green executed showcase ledger has nonzero exitCode")
+
+
+def seal_shard_body(
+    scope_receipt: Mapping[str, object],
+    *,
+    measured_commit: str,
+    exit_code: int,
+    output_path: Path,
+) -> dict[str, object]:
+    """Seal the conserved scope ledger into the CI attendance body."""
+
+    if scope_receipt.get("measurementClass") != "showcase-scope":
+        raise ScopeRefusal("scope receipt has wrong measurementClass")
+    shard_index = scope_receipt.get("shardIndex")
+    shard_count = scope_receipt.get("shardCount")
+    if not isinstance(shard_index, int) or not isinstance(shard_count, int):
+        raise ScopeRefusal("scope receipt lacks integer shard identity")
+    outcomes = scope_receipt.get("outcomes")
+    counts = scope_receipt.get("counts")
+    _validate_outcomes(outcomes, counts)
+    body: dict[str, object] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "measurementClass": "test-showcases",
+        "shardIndex": shard_index,
+        "shardCount": shard_count,
+        "measuredCommit": measured_commit,
+        "status": "completed",
+        "exitCode": exit_code,
+        "showcaseCounts": counts,
+        "showcaseOutcomes": outcomes,
+    }
+    validate_shard_body(body)
+    _write_json_atomic(output_path, body)
+    return body
+
+
+def run_shard(
+    *,
+    repo_root: Path,
+    manifest_path: Path,
+    enrolled: Sequence[str],
+    shard_count: int,
+    shard_index: int,
+    attr_dir: Path,
+    receipt_path: Path,
+    failed_path: Path | None = None,
+    summary_path: Path | None = None,
+) -> int:
+    """Execute active rows, testify retired rows, and write one conserved receipt."""
+
+    repo_root = repo_root.resolve()
+    retirements = load_manifest(manifest_path, enrolled)
+    plan = partition(
+        enrolled, retirements, shard_count=shard_count, shard_index=shard_index
+    )
+    attr_dir.mkdir(parents=True, exist_ok=True)
+    failed_path = failed_path or attr_dir / f"shard-{shard_index}-failed.txt"
+    summary_path = summary_path or attr_dir / f"shard-{shard_index}-summary.log"
+    outcomes: list[dict[str, object]] = []
+    failed: list[str] = []
+    failed_logs: list[tuple[str, str]] = []
+
+    for path in plan["selected"]:
+        retirement = retirements.get(path)
+        print()
+        print(f"==== [showcase shard {shard_index}/{shard_count}] {path} ====")
+        if retirement is not None:
+            print(
+                "outcome=RETIRED "
+                f"path={path} language=java reason={RETIREMENT_REASON}"
+            )
+            outcomes.append(dict(retirement))
+            continue
+
+        log_path = attr_dir / _safe_log_name(path)
+        try:
+            proc = subprocess.run(
+                [str(repo_root / path)],
+                cwd=repo_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                errors="replace",
+                check=False,
+            )
+            output = proc.stdout
+            returncode = proc.returncode
+        except OSError as exc:
+            output = f"showcase execution failed before body: {exc}\n"
+            returncode = 127
+        log_path.write_text(output, encoding="utf-8")
+        sys.stdout.write(output)
+        if output and not output.endswith("\n"):
+            print()
+        if returncode == 0:
+            outcomes.append({"path": path, "outcome": "passed", "exitCode": 0})
+        else:
+            marker = f"==== {path}: FAIL ====\n"
+            sys.stdout.write(marker)
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write(marker)
+            outcomes.append({"path": path, "outcome": "failed", "exitCode": returncode})
+            failed.append(path)
+            failed_logs.append((path, log_path.read_text(encoding="utf-8")))
+
+    counts = {
+        "enrolled": len(outcomes),
+        "executed": sum(row["outcome"] != "retired" for row in outcomes),
+        "retired": sum(row["outcome"] == "retired" for row in outcomes),
+        "passed": sum(row["outcome"] == "passed" for row in outcomes),
+        "failed": sum(row["outcome"] == "failed" for row in outcomes),
+    }
+    _validate_outcomes(outcomes, counts)
+    if counts["enrolled"] != plan["counts"]["enrolled"]:
+        raise ScopeRefusal("showcase scope conservation lost an enrolled row")
+    receipt = {
+        "schemaVersion": SCHEMA_VERSION,
+        "measurementClass": "showcase-scope",
+        "shardIndex": shard_index,
+        "shardCount": shard_count,
+        "counts": counts,
+        "outcomes": outcomes,
+    }
+    _write_json_atomic(receipt_path, receipt)
+    failed_path.write_text("".join(f"{path}\n" for path in failed), encoding="utf-8")
+    summary = "".join(
+        f"==== [showcase shard {shard_index}/{shard_count}] {path} ====\n{log}"
+        for path, log in failed_logs
+    )
+    if failed:
+        summary += f"==== test-showcases FAIL: {' '.join(failed)} ====\n"
+    summary_path.write_text(summary, encoding="utf-8")
+    print()
+    print(
+        f"==== showcase shard {shard_index}/{shard_count} "
+        f"enrolled={counts['enrolled']} executed={counts['executed']} "
+        f"retired={counts['retired']} ===="
+    )
+    return 1 if failed else 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run", help="execute one conserved showcase shard")
+    run.add_argument("--repo-root", type=Path, required=True)
+    run.add_argument("--manifest", type=Path, required=True)
+    run.add_argument("--shard-count", type=int, required=True)
+    run.add_argument("--shard-index", type=int, required=True)
+    run.add_argument("--attr-dir", type=Path, required=True)
+    run.add_argument("--receipt", type=Path, required=True)
+    run.add_argument("--failed-path", type=Path, required=True)
+    run.add_argument("--summary-path", type=Path, required=True)
+    run.add_argument("enrolled", nargs="+")
+    seal = subparsers.add_parser(
+        "seal-body", help="seal one scope receipt into a CI attendance body"
+    )
+    seal.add_argument("--scope-receipt", type=Path, required=True)
+    seal.add_argument("--output", type=Path, required=True)
+    seal.add_argument("--measured-commit", required=True)
+    seal.add_argument("--exit-code", type=int, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "run":
+        try:
+            return run_shard(
+                repo_root=args.repo_root,
+                manifest_path=args.manifest,
+                enrolled=args.enrolled,
+                shard_count=args.shard_count,
+                shard_index=args.shard_index,
+                attr_dir=args.attr_dir,
+                receipt_path=args.receipt,
+                failed_path=args.failed_path,
+                summary_path=args.summary_path,
+            )
+        except ScopeRefusal as exc:
+            print(f"showcase-scope: REFUSED: {exc}", file=sys.stderr)
+            return 2
+    if args.command == "seal-body":
+        try:
+            scope_receipt = json.loads(args.scope_receipt.read_text(encoding="utf-8"))
+            seal_shard_body(
+                scope_receipt,
+                measured_commit=args.measured_commit,
+                exit_code=args.exit_code,
+                output_path=args.output,
+            )
+            return 0
+        except (OSError, ValueError, ScopeRefusal) as exc:
+            print(f"showcase-scope: REFUSED: {exc}", file=sys.stderr)
+            return 2
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/showcase_shard_attendance.py
+++ b/tools/showcase_shard_attendance.py
@@ -13,6 +13,8 @@ import json
 import sys
 from pathlib import Path
 
+from showcase_scope import ScopeRefusal, validate_shard_body
+
 DEFAULT_SHARD_COUNT = 4
 
 
@@ -39,6 +41,8 @@ def main(argv: list[str] | None = None) -> int:
 
     missing = [i for i in roster if i not in attended]
     crimes: list[str] = []
+    retired_total = 0
+    executed_total = 0
     for idx, path in attended.items():
         body = json.loads(path.read_text(encoding="utf-8"))
         if args.require_commit and body.get("measuredCommit") not in (
@@ -51,6 +55,16 @@ def main(argv: list[str] | None = None) -> int:
             )
             if idx not in missing:
                 missing.append(idx)
+        try:
+            validate_shard_body(body)
+        except ScopeRefusal as exc:
+            crimes.append(f"shard-{idx:02d}: {exc}")
+            if idx not in missing:
+                missing.append(idx)
+        else:
+            counts = body["showcaseCounts"]
+            retired_total += counts["retired"]
+            executed_total += counts["executed"]
         if body.get("exitCode") not in (0, "0"):
             crimes.append(
                 f"shard-{idx:02d}: exitCode={body.get('exitCode')} (showcase red)"
@@ -59,6 +73,8 @@ def main(argv: list[str] | None = None) -> int:
     print("### showcase shard enrollment")
     print(f"- roster: `{args.shard_count}` shards")
     print(f"- attended: `{len(attended)}`")
+    print(f"- executed showcases: `{executed_total}`")
+    print(f"- retired showcases: `{retired_total}`")
     print(f"**R_showcase_shard_attendance = {len(set(missing))}**")
     for i in roster:
         spoke = "yes" if i in attended and i not in missing else "NO — UNMEASURED"


### PR DESCRIPTION
## Outcome

Retire exactly the 19 Java showcases ruled out of scope while keeping retirement visible, reversible, and conserved. Rust CLI and Python-path showcases remain enrolled and executable; their failures continue to make the shard and aggregate red.

`.github/showcase-retirements.json` is the sole authority. Every row names the exact enrolled path, `language=java`, the distinct `retired` outcome, the reason `out of scope per scope ruling - Java`, and the assertion being retired.

The exact retirement population is 5/4/5/5 by shard:

- shard 0: `java-testng-consistency`, `java-b64-tails`, `java-callbind-consistency`, `java-panama-bridge`, `java-pattern-regex`
- shard 1: `java-codec-universe`, `java-abs-universe`, `java-instance-universe`, `java-abs-model`
- shard 2: `java-assertion-consistency`, `java-urlsafe-seam`, `java-bound-federation`, `java-voltron`, `java-mt-reference`
- shard 3: `java-forall-loop`, `java-b64-strong`, `java-abs-bound`, `java-abs-flagship`, `java-crc32-universe`

Hockney independently compared exact identities against the retained in-scope frontier measured at `c3ac15f40d2e04758437182388cd3b1dbcaa9386`: 19 manifest rows/19 unique, overlap with the 44 retained Rust/Python failures = 0, manifest-minus-measured-Java = 0, measured-Java-minus-manifest = 0, disputed paths = none.

## Instrument

`tools/showcase_scope.py` owns partition and execution:

- retired rows emit explicit `RETIRED` testimony and are not invoked;
- non-retired rows execute through the existing pass/fail path;
- removing a manifest row makes that showcase execute again;
- a passing showcase cannot fabricate retirement;
- `retired + executed == enrolled` is required per shard;
- missing, duplicate, non-Java, unreasoned, unsupported, or unenrolled retirement rows refuse by name.

The conserved ledger is sealed into `showcase-shard-body.json`. Attendance validates every per-showcase outcome and reports executed/retired totals. An attended in-scope failure remains red: retirement cannot turn the aggregate green while Python/Rust findings remain.

Predicted post-retirement A2 scoreboard, with active semantics otherwise unchanged: shard 0 `21 -> 16`, shard 1 `22 -> 18`, shard 2 `20 -> 15`, shard 3 `20 -> 15`. A1 remains `1/0/1/1`. These are epsilon predictions, not a post-merge measurement; the actual scoreboard must come from the merged shard firing.

## Evidence

- Retirement discrimination: 10/10 pass, unpiped exit 0.
- Conservation/body/attendance discrimination: 6/6 pass, unpiped exit 0.
- Existing showcase setup/enrollment teeth: 8/8 pass, unpiped exit 0.
- Workflow dispatchability with repository-pinned actionlint v1.7.12: 7/7 pass.
- Black 26.5.1: all four touched Python files unchanged.
- `py_compile`, all workflow YAML parse, Makefile expansion, and `git diff --check`: green.
- Branch preflight: parent/merge-base `b9ad056e04f963929cbecc3381a3e801504d6197`, 0 behind/2 ahead, no deletions, no files outside the retirement authority/runner/artifact/teeth/design scope.

## Non-claims

- No Java showcase passes.
- No Java source is deleted.
- No Rust/Python showcase is retired or weakened.
- No post-retirement full-shard scoreboard or acid-green result is claimed.
- The active in-scope findings remain findings; this change only stops out-of-scope Java from executing and preserves explicit retirement testimony.

Predicted epsilon: active out-of-scope Java execution `19 -> 0`; explicit retired testimony `0 -> 19`; in-scope active failures unchanged until measured otherwise.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retire out-of-scope Java showcases with a retirement manifest and scope owner tool
> - Introduces [showcase-retirements.json](.github/showcase-retirements.json) listing 19 Java showcases as retired with per-entry reason, language, outcome, and assertion fields.
> - Adds [tools/showcase_scope.py](https://github.com/TSavo/sugar/pull/7249/files#diff-a53f2b440efec2dccc0f7d623e336ef165ba9c85a4a4cd077cb811bec9b931ea) as the new scope owner: validates the manifest, partitions showcases per shard into retired vs. scheduled, executes only active showcases, and writes conserved scope receipts and failure attribution files.
> - Updates the [Makefile](https://github.com/TSavo/sugar/pull/7249/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) `test-showcases` target to delegate shard execution to `showcase_scope.py run` instead of a shell loop; retired showcases are skipped entirely and testified separately.
> - Updates [.github/workflows/ci.yml](https://github.com/TSavo/sugar/pull/7249/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) to seal CI shard bodies via `showcase_scope.py seal-body`, embedding `showcaseOutcomes` and `showcaseCounts` from the receipt.
> - Updates [tools/showcase_shard_attendance.py](https://github.com/TSavo/sugar/pull/7249/files#diff-11c4e0af06b1155357b5c0e1689d5e96e1004d8ad10bc029945e1f9b2c4b8e59) to validate conserved shard bodies and report executed/retired totals.
> - Behavioral Change: attendance now rejects previously-accepted minimal shard bodies that lack `showcaseCounts`/`showcaseOutcomes`; CI seal step exits nonzero on malformed or unconserved receipts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 18dab3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->