### PR TITLE
Make session enrollment authority unconstructible

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1307,18 +1307,18 @@ def _graph_is_off_population(
     """True when ``graph`` is outside the enrolled measurement population.
 
     - stdlib is always off-pin (CPython is not the corpus pin).
-    - when ``session.enrolled_distributions`` is set, any distribution whose
-      name is not in that set is off-pin (pytest on a pandas test open was
-      40 frames / ~3.8s after the stdlib-only membrane — same law, broader door).
-    - when enrolled is None, legacy stdlib-only membrane (backward compatible).
+    - any distribution whose name is absent from the session's authoritative
+      roster is off-pin (pytest on a pandas test open was 40 frames / ~3.8s
+      after the stdlib-only membrane — same law, broader door).
     """
+    if session is None:
+        raise TypeError(
+            "population classification requires an enrolled distribution roster"
+        )
     if getattr(graph, "artifact_kind", None) == "stdlib":
         return True
-    enrolled = None if session is None else session.enrolled_distributions
-    if enrolled is None:
-        return False
     name = getattr(graph, "distribution_name", None)
-    return name is not None and name not in enrolled
+    return name is not None and name not in session.enrolled_distributions
 
 
 def _off_population_materialize_gap(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -38,7 +38,7 @@ Decision of record (session-memo liveness)
 The memos on this class are real amortization, not decorative. They fire in two
 places:
 
-1. **Inside one call tree** -- even a single-shot ``session_or_new(None)`` entry
+1. **Inside one call tree** -- even a single-shot explicitly constructed session
    still needs ``frame_active`` (cycle detection) and nested export/frame hits
    while that one top-level resolve walks reexports and nested callees.
 2. **Across top-level resolves** -- only when the *same* session object is
@@ -52,9 +52,9 @@ Deletion of these memos is refused: the pandas megamodule wall was re-materializ
 SourceFile + class-base sugar once per call-site receipt of the same authenticated
 definition. The session is the boundary that makes that amortization safe.
 
-``session_or_new(None)`` remains the honest single-shot leaf: slower, always
-correct, never process-global. It is not permission for a multi-resolve owner to
-drop the session.
+An explicitly constructed session remains the honest single-shot leaf: slower,
+always correct, never process-global. ``None`` is unknown population authority
+and refuses; it is not permission for any owner to invent a roster.
 
 Walk-scoped multi-resolve owner (``walk_session_for``)
 ------------------------------------------------------
@@ -84,9 +84,10 @@ Legitimacy (why this is not process-global free-for-all):
   amortization that is real (identical definition coordinates hit). Do not bet
   a 6× census cut on walk session alone.
 
-``walk_session_for(root)`` is the small production default for multi-file doors.
-Callers that need isolation pass an explicit ``SourceResolutionSession()`` or
-``session_or_new(None)``.
+``walk_session_for(root, enrolled_distributions=...)`` is the small production
+default for multi-file doors. Callers that need isolation construct an explicit
+``SourceResolutionSession(enrolled_distributions=...)``. Unknown authority is
+not a session state; an authoritative empty population is ``frozenset()``.
 """
 
 from __future__ import annotations
@@ -96,14 +97,27 @@ import os
 from pathlib import Path
 from typing import Any
 
-# Resolved workspace root path -> walk-owned session. Not content-keyed; not a
-# substitute for §4 residency. Cleared only by tests (clear_walk_sessions).
-_WALK_SESSIONS: dict[str, "SourceResolutionSession"] = {}
+# (resolved workspace root, authenticated population) -> walk-owned session.
+# Not content-keyed; not a substitute for §4 residency. Cleared only by tests.
+_WALK_SESSIONS: dict[tuple[str, frozenset[str]], "SourceResolutionSession"] = {}
+_ROSTER_UNSET = object()
 
 # Default matches process-resident file LRU (#7071). A walk-scoped session that
 # retained frame_holds for every projected SourceFile forever recreated the
 # "shared context degrades across opens" disease at corpus scale.
 _DEFAULT_FRAME_MEMO_LIMIT = 512
+
+
+def _require_enrolled_distribution_roster(value: object) -> frozenset[str]:
+    """Return one explicit population authority; unknown is unconstructible."""
+    if not isinstance(value, frozenset) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise TypeError(
+            "enrolled_distributions must be an authoritative frozenset[str]; "
+            "None is unknown, not empty"
+        )
+    return value
 
 
 def _frame_memo_limit() -> int:
@@ -144,16 +158,18 @@ class SourceResolutionSession:
     def __init__(
         self,
         *,
+        enrolled_distributions: frozenset[str],
         enabled: bool = True,
-        enrolled_distributions: frozenset[str] | None = None,
     ) -> None:
+        enrolled_distributions = _require_enrolled_distribution_roster(
+            enrolled_distributions
+        )
         self.enabled = enabled
-        # Pin membership for the population membrane.  None = legacy
-        # stdlib-only off-population (pre-#707x).  When set, any graph whose
-        # distribution_name is not in this set is off-pin and must cite, never
-        # MaterializeModule (pytest on a pandas test open was 40 frames / ~3.8s
-        # of residual wall after the stdlib membrane).
-        self.enrolled_distributions: frozenset[str] | None = enrolled_distributions
+        # Pin membership for the population membrane. Any graph whose
+        # distribution_name is absent is off-pin and must cite, never
+        # MaterializeModule. An empty set is authoritative emptiness; there is
+        # no unknown/None state that can silently admit every distribution.
+        self.enrolled_distributions = enrolled_distributions
         # (distribution_artifact_cid, module_name, exported_name) -> pure-entry
         # resolution (includes module-structural reexport warrants; no path
         # import_binding_cid).
@@ -318,33 +334,57 @@ class SourceResolutionSession:
             self.lexical_passes[source_cid] = runner
 
 
-def session_or_new(session: SourceResolutionSession | None) -> SourceResolutionSession:
-    """Resolve the caller's session, or open one bounded to this single call tree.
-
-    ``None`` never means "share the process": it means "this call is its own
-    session". Nested resolves inside that call still share the returned object
-    (cycle detection and within-tree amortization stay real). The memo dies with
-    the call tree -- slower across independent top-level calls, always correct.
+def session_or_new(
+    session: SourceResolutionSession | None,
+    *,
+    enrolled_distributions: frozenset[str] | object = _ROSTER_UNSET,
+) -> SourceResolutionSession:
+    """Return the caller's authoritative session; refuse unknown authority.
 
     Multi-resolve owners (populate, package enumeration, file-open, census walk)
     must pass an explicit session — or use ``walk_session_for(workspace_root)``
     — so amortization reaches every receipt they own. Do not call this at those
     doors and throw the result away between receipts.
     """
-    return SourceResolutionSession() if session is None else session
+    if session is None:
+        if enrolled_distributions is _ROSTER_UNSET:
+            raise TypeError(
+                "session construction requires an enrolled distribution roster; "
+                "pass enrolled_distributions=frozenset(...)"
+            )
+        return SourceResolutionSession(
+            enrolled_distributions=_require_enrolled_distribution_roster(
+                enrolled_distributions
+            )
+        )
+    if (
+        enrolled_distributions is not _ROSTER_UNSET
+        and enrolled_distributions != session.enrolled_distributions
+    ):
+        raise ValueError(
+            "supplied enrolled distribution roster differs from session authority"
+        )
+    return session
 
 
-def walk_session_for(workspace_root: Path | str) -> SourceResolutionSession:
+def walk_session_for(
+    workspace_root: Path | str,
+    *,
+    enrolled_distributions: frozenset[str],
+) -> SourceResolutionSession:
     """Return the multi-resolve session owned by one workspace walk.
 
-    One resolved root → one session for the life of the process (or until
-    ``clear_walk_sessions``). Legitimate because a corpus walk is one authority
-    locus; not process-global free-for-all (see module docstring).
+    One resolved root + one explicit roster → one session for the life of the
+    process (or until ``clear_walk_sessions``). Different population authority
+    cannot share projection state merely because the filesystem root matches.
     """
-    key = str(Path(workspace_root).resolve())
+    enrolled_distributions = _require_enrolled_distribution_roster(
+        enrolled_distributions
+    )
+    key = (str(Path(workspace_root).resolve()), enrolled_distributions)
     session = _WALK_SESSIONS.get(key)
     if session is None:
-        session = SourceResolutionSession()
+        session = SourceResolutionSession(enrolled_distributions=enrolled_distributions)
         _WALK_SESSIONS[key] = session
     return session
 

--- a/implementations/python/sugar-lift-python-source/tests/test_session_population_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_session_population_authority.py
@@ -1,0 +1,72 @@
+"""Population authority is constructed with a session, never inferred later."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sugar_lift_python_source.manager_construction import _graph_is_off_population
+from sugar_lift_python_source.resolution_session import (
+    SourceResolutionSession,
+    clear_walk_sessions,
+    session_or_new,
+    walk_session_for,
+)
+
+
+def test_source_resolution_session_requires_an_explicit_roster() -> None:
+    """Omitted and unknown rosters cannot construct the session state."""
+    with pytest.raises(TypeError, match="enrolled_distributions"):
+        SourceResolutionSession()  # type: ignore[call-arg]
+    with pytest.raises(TypeError, match="enrolled_distributions"):
+        SourceResolutionSession(enrolled_distributions=None)  # type: ignore[arg-type]
+
+
+def test_empty_roster_is_authority_while_unknown_cannot_classify() -> None:
+    """Empty means no distributions enrolled; unknown is not the same fact."""
+    graph = SimpleNamespace(
+        artifact_kind="distribution",
+        distribution_name="example-dist",
+    )
+    empty = SourceResolutionSession(enrolled_distributions=frozenset())
+
+    assert _graph_is_off_population(graph, session=empty) is True
+    with pytest.raises(TypeError, match="enrolled distribution roster"):
+        _graph_is_off_population(graph, session=None)
+
+
+def test_session_or_new_refuses_to_mint_unknown_authority() -> None:
+    """The leaf helper may return authority, but cannot invent it."""
+    with pytest.raises(TypeError, match="enrolled distribution roster"):
+        session_or_new(None)
+
+    constructed = session_or_new(
+        None,
+        enrolled_distributions=frozenset(),
+    )
+    assert constructed.enrolled_distributions == frozenset()
+
+    empty = SourceResolutionSession(enrolled_distributions=frozenset())
+    assert session_or_new(empty) is empty
+
+
+def test_walk_session_requires_and_preserves_roster_authority(tmp_path: Path) -> None:
+    """A walk cache key includes the roster whose projections it may serve."""
+    clear_walk_sessions()
+    try:
+        with pytest.raises(TypeError, match="enrolled_distributions"):
+            walk_session_for(tmp_path)  # type: ignore[call-arg]
+
+        empty = walk_session_for(
+            tmp_path,
+            enrolled_distributions=frozenset(),
+        )
+        pandas = walk_session_for(
+            tmp_path,
+            enrolled_distributions=frozenset({"pandas"}),
+        )
+        assert empty.enrolled_distributions == frozenset()
+        assert pandas.enrolled_distributions == frozenset({"pandas"})
+        assert empty is not pandas
+    finally:
+        clear_walk_sessions()


### PR DESCRIPTION
## Refusal first

This is the first of two arrivals. It makes unknown population authority unconstructible and deliberately leaves dependent callers refusing. The caller repairs must land separately; squashing the refusal and repairs together would erase the interval proving the refusal bites.

`SourceResolutionSession` now requires a non-optional `frozenset[str]` roster. There is no default. `frozenset()` is authoritative emptiness; `None` is unknown and refuses. `session_or_new(None)` cannot invent authority, `walk_session_for` requires a roster and keys its memo by `(workspace root, roster)`, and `_graph_is_off_population` refuses a missing session instead of interpreting it.

## Root cause

`roster=None` had one reader: `_graph_is_off_population`. That reader gave `None` the permissive meaning `False` for every non-stdlib distribution. An absent roster did not fail closed—it silently classified every distribution as enrolled.

Three lower doors accepted or minted that state:

- `_module_prefix_outcome`
- `prefix_has_completed_fallthrough`
- `resolve_source_visible_frame` through `_off_population_materialize_gap`

A static audit found four direct call sites passing a real distribution graph without a session. Their five parameterized invocations all passed before this change in 1.56s while silently treating the distribution as enrolled. That is a lower bound, not a global runtime count.

Those five were green about the wrong thing. They were succeeding about a question nobody asked, like a stale editable install testing the wrong code.

## Load-bearing refusal

There are 62 direct `populate_source_derived_resource_refs` calls: 3 already carry both authorities, 1 deliberately tests missing authority, and 58 are statically stale. On current main, all 58 refuse at `manager_summary_derivation:1292` before reaching `_graph_is_off_population`; zero are currently misclassified through that path. That refusal is the only thing standing between those callers and the former permissive `None` behavior. Removing or weakening it would turn 58 loud dependents back into silent mis-enrollment.

This PR does not repair any of those callers.

## Teeth and discovery

Base: `66e39aa86ec658fd8230bdd25d5f58ab6b583e19` (#7249 included).

Constructor teeth, unpiped exit 0:

- `4 passed in 0.61s`
- omission refuses
- explicit `None` refuses
- explicit `frozenset()` classifies a non-stdlib distribution off-population
- `session_or_new(None)` and rosterless `walk_session_for` refuse
- walk sessions under one root but different rosters cannot alias

The five formerly silent invocations now deliberately refuse, unpiped exit 1 (`5 failed in 0.98s`):

- `test_unresolved_source_call_is_parked_at_its_exact_coordinate` — refuses at `resolve_import_binding -> session_or_new(None)`
- `test_module_import_attribute_call_preserves_authenticated_stdlib_frame[import re]` — same entrance
- `test_module_import_attribute_call_preserves_authenticated_stdlib_frame[import re as regex]` — same entrance
- `test_enum_dict_class_transport_retains_authenticated_builtin_dict_base` — refuses at `_graph_is_off_population(session=None)`
- `test_enum_dict_receiver_mutation_retains_identity_and_source_methods` — same entrance

These reds are discovery, not regressions. PR 2 will assign each caller either its real authoritative distribution roster or a deliberately justified empty `frozenset()`. Empty will not be used as a quiet fallback.

Black 26.5.1 leaves all three changed files unchanged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `SourceResolutionSession` require an explicit enrolled distribution roster at construction
> - `SourceResolutionSession.__init__` now requires a `frozenset[str]` `enrolled_distributions` argument; passing `None` or omitting it raises `TypeError`.
> - `session_or_new` raises `TypeError` when called with `session=None` and no roster; raises `ValueError` if the supplied roster conflicts with an existing session's roster.
> - `walk_session_for` now requires a roster argument and keys its session cache by `(resolved_root, enrolled_roster)`, so different rosters on the same root yield distinct sessions.
> - `_graph_is_off_population` raises `TypeError` when `session` is `None`, removing the legacy default of treating a missing session as in-population.
> - Risk: any existing call sites that construct a session or call these functions without an explicit roster will now raise `TypeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 337a99e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->