### PR TITLE
Bind recensus path-smoke roster authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_path_smoke.py
@@ -340,7 +340,12 @@ def _measure_opaque(module, path: Path, workspace: Path) -> dict[str, Any]:
         refs = provisional_contract_refs_from_demands(iso)
         ctx = tree_construction_context_for_workspace(iso, contract_refs=refs)
         source_file = open_source_file_for_construction(
-            plant, root=iso, construction_context=ctx, populate_derived=True
+            plant,
+            root=iso,
+            construction_context=ctx,
+            populate_derived=True,
+            distribution="recensus_path_smoke",
+            source_workspace_root=iso,
         )
         resolution_rows = module._tally_cm_resolutions(
             ctx, source_cid=source_file.unit.source_cid

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -344,11 +344,18 @@ def open_source_file_for_construction(
 
         # Multi-resolve owner: walk-scoped session when none given so census
         # and same-content re-open share projection memos under one root.
-        session = (
-            resolution_session
-            if resolution_session is not None
-            else walk_session_for(root)
-        )
+        if resolution_session is not None:
+            session = resolution_session
+        else:
+            if distribution is None:
+                raise TypeError(
+                    "open_source_file_for_construction requires distribution "
+                    "to construct the walk session's enrolled distribution roster"
+                )
+            session = walk_session_for(
+                root,
+                enrolled_distributions=frozenset({distribution}),
+            )
         # Catch Exception, not BaseException: KeyboardInterrupt / SystemExit /
         # GeneratorExit still halt the process. Do not enumerate SNW/TypeError
         # here — that was the two-costume allowlist that left the class open.
@@ -2390,19 +2397,25 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 if level == "context-manager-resolutions":
                     distribution = options.get("distribution")
                     source_workspace_root = options.get("sourceWorkspaceRoot")
+                    if not isinstance(distribution, str) or not distribution:
+                        raise TypeError(
+                            "context-manager-resolutions requires distribution "
+                            "to construct the walk session's enrolled distribution roster"
+                        )
                     populate_source_derived_resource_refs(
                         tree_file,
                         root=root,
                         path=full_path,
-                        session=walk_session_for(root),
+                        session=walk_session_for(
+                            root,
+                            enrolled_distributions=frozenset({distribution}),
+                        ),
                         source_workspace_root=(
                             Path(source_workspace_root)
                             if isinstance(source_workspace_root, str)
                             else None
                         ),
-                        distribution=(
-                            str(distribution) if isinstance(distribution, str) else None
-                        ),
+                        distribution=distribution,
                     )
                     from sugar_lift_py_tests.context_manager_resolution import (
                         context_manager_resolution_outcome,


### PR DESCRIPTION
## Outcome

Restores the production recensus path smoke after #7250 made an absent enrollment roster unconstructible.

The path-smoke caller is **not** a rosterless source walk. Its four-file micro-population is content-pinned under the synthetic distribution `recensus_path_smoke`, and the clean/panic siblings already authenticate that same distribution and workspace root. This change therefore passes the real singleton roster `frozenset({distribution})`; it does not use `frozenset()` as a convenient route to green.

Two masked entrances on the same production path required that authority:

1. `open_source_file_for_construction` default walk-session construction, reached first by the opaque plant.
2. `_handle_enumerate` context-manager-resolution construction, exposed only after the first terminal was repaired and reached by the clean plant.

That first-terminal chain is the small-scale masking law in executable form: the first refusal hid the second. A frontier reports the first terminal it can reach, not every descendant defect behind it.

No other session caller is repaired here. The remaining caller population belongs to the separate caller repair.

## Instrument and receipts

- Red before: #7250 `recensus-path-smoke (PATH integrity)` failed at `open_source_file_for_construction:350`, missing required keyword-only `enrolled_distributions`.
- Intermediate red at `0126646274`: constructed and opaque measured; clean enumeration then exposed `_handle_enumerate:2404 -> walk_session_for(root)`. `PATH_RED`, exit 1.
- Green at `4d7c0b08cebc2a0e3e3f819af25db9f199ab88b4`: the four-file planted population executed constructed, opaque, clean enumeration, and planted panic; `constructed=1`, `unconstructed=1`, conservation `2/2`, `cpanic=1`, `PATH_OK`, unpiped exit 0 in 0.8s.
- Black 26.5.1: 2 files unchanged, exit 0.

## Refusal evidence preserved

The five named formerly-silent invocations remain deliberately refusing on battleaxe: 5 failed in 1.40s, exit 1.

- `unresolved_source_call`
- `module_import_attribute` with both import spellings
- `enum_dict_class_transport`
- `enum_dict_receiver_mutation`

The first three refuse at session construction; the last two refuse at `_graph_is_off_population(session=None)`. Those invocations were green about the wrong thing before #7250: `roster=None` permissively treated every non-stdlib distribution as enrolled.

## Shot accounting

- Intended axis: `R_recensus_path_smoke_roster_authority`, predicted `Epsilon R = -2` masked production entrances on this single path.
- Floors preserved: no refusal weakened, no default roster restored, no unrelated callers repaired, no product count minted from an instrument failure.
- Not claiming: no remaining caller population was repaired; no corpus/product measurement was taken; the broader 478-failure suite is not classified by this PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require enrolled distribution session in recensus path-smoke roster authority
> - `open_source_file_for_construction` in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7251/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now requires a non-None `distribution` when `populate_derived` is True and no explicit `resolution_session` is provided, constructing the walk session with that distribution enrolled via `walk_session_for(root, enrolled_distributions=frozenset({distribution}))`.
> - The `sugar.enumerate` JSON-RPC handler now validates that `options["distribution"]` is a non-empty string for the `context-manager-resolutions` level, raising `TypeError` (returned as a JSON-RPC error) if missing or invalid, and constructs the session with the distribution enrolled.
> - [recensus_path_smoke.py](https://github.com/TSavo/sugar/pull/7251/files#diff-419ffb7c8217e7e524f04dca798335ee64add79efdc1d1a2b5a824686a4d0933) passes `distribution="recensus_path_smoke"` and `source_workspace_root=iso` to `open_source_file_for_construction` to satisfy the new requirements.
> - Risk: callers of `open_source_file_for_construction` with `populate_derived=True` that omit `distribution` will now receive a `TypeError` where previously they would silently proceed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d7c0b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace data construction for the `recensus_path_smoke` distribution.
  * Added validation to ensure distribution details are provided when creating implicit walk sessions.
  * Improved context-manager resolution handling by preserving validated distribution information.
  * Existing behavior for explicitly provided resolution sessions remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->