### PR TITLE
Retire context-manager edges from source-agnostic enumeration

### DIFF
--- a/implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py
+++ b/implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py
@@ -374,7 +374,6 @@ _EMPTY_CENSUS_LEVELS = frozenset(
         "contract-declarations",
         "provider-contract-members",
         "contract-demands",
-        "context-manager-edges",
         "parameter-contract-resume",
     }
 )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2111,52 +2111,6 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 }
             )
             return
-        if level == "context-manager-edges":
-            if _BOUND_CONTRACT_REFS is None:
-                raise ValueError(
-                    "context-manager edge enumeration requires frozen contract refs"
-                )
-            from sugar_lift_python_source.source_oracle import path_source
-            from sugar_source_tree.tree import SourceFile as _TreeSourceFile
-            from sugar_lift_py_tests.context_manager_resolution import (
-                TreeConstructionContextV1,
-            )
-
-            rows = []
-            construction_context = TreeConstructionContextV1(_BOUND_CONTRACT_REFS)
-            # One session for the whole package walk: the same dependency
-            # definition projected for many consumer files amortizes once.
-            from sugar_lift_python_source.resolution_session import walk_session_for
-
-            package_session = walk_session_for(root)
-            for source_path in sorted(root.rglob("*.py")):
-                identity = path_source(str(source_path))
-                source_file = _TreeSourceFile(
-                    identity, construction_context=construction_context
-                )
-                from sugar_lift_python_source.manager_summary_derivation import (
-                    populate_source_derived_resource_refs,
-                )
-
-                populate_source_derived_resource_refs(
-                    source_file,
-                    root=root,
-                    path=source_path,
-                    session=package_session,
-                )
-                for function in source_file.functions():
-                    function_sugar = function.sugar()
-                    rows.extend(
-                        edge.to_rpc() for edge in function_sugar.context_manager_edges()
-                    )
-            _send(
-                {
-                    "jsonrpc": "2.0",
-                    "id": msg_id,
-                    "result": {"contextManagerEdges": rows},
-                }
-            )
-            return
         if level == "source_files":
             # The source_files level IS SourceTree.fragments(): whole-file
             # fragments minted through the SourceOracle — identity without

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -182,3 +182,25 @@ def test_kit_has_no_context_manager_admission_declaration_door(monkeypatch):
         },
     )
     assert sent[-1] == {"jsonrpc": "2.0", "id": 9, "result": {"rows": []}}
+
+
+def test_context_manager_edges_is_not_an_enumeration_level(tmp_path, monkeypatch):
+    """Python keeps edge construction; the source-agnostic protocol does not."""
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+
+    lift_rpc._handle_enumerate(
+        10,
+        {
+            "level": "context-manager-edges",
+            "workspace_root": str(tmp_path),
+            "options": {},
+        },
+    )
+
+    assert len(sent) == 1
+    error = sent[0]["error"]
+    assert error == {
+        "code": -32602,
+        "message": "sugar.enumerate: unknown level 'context-manager-edges'",
+    }

--- a/implementations/rust/sugar-compiler/src/tree.rs
+++ b/implementations/rust/sugar-compiler/src/tree.rs
@@ -108,7 +108,6 @@ pub enum Level {
     ContractDeclarations,
     ProviderContractMembers,
     ContractDemands,
-    ContextManagerEdges,
     ParameterContractLinkUnits,
     ParameterContractResume,
 }
@@ -127,7 +126,6 @@ impl Level {
             Level::ContractDeclarations => "contract-declarations",
             Level::ProviderContractMembers => "provider-contract-members",
             Level::ContractDemands => "contract-demands",
-            Level::ContextManagerEdges => "context-manager-edges",
             Level::ParameterContractLinkUnits => "parameter-contract-link-units",
             Level::ParameterContractResume => "parameter-contract-resume",
         }
@@ -1103,66 +1101,6 @@ fn preconstruction_rows_rpc(conn: &KitConn, level: Level) -> Result<Vec<Value>, 
         })
 }
 
-fn context_manager_edges_rpc(conn: &KitConn) -> Result<Vec<Value>, EnumerateError> {
-    let plugin = conn.surface.clone();
-    let Some((catalog_cid, table_cid)) =
-        conn.transport
-            .contract_ref_generation()
-            .map_err(|error| EnumerateError::Unavailable {
-                plugin: plugin.clone(),
-                reason: error.to_string(),
-            })?
-    else {
-        return Err(EnumerateError::Malformed {
-            plugin,
-            reason: "context-manager edge enumeration requires frozen contract refs".into(),
-        });
-    };
-    let mut options = json!({
-        "contractRefs": {"catalogCid": catalog_cid, "tableCid": table_cid},
-    });
-    if let Some((call_catalog_cid, call_table_cid)) = conn
-        .transport
-        .call_contract_ref_generation()
-        .map_err(|error| EnumerateError::Unavailable {
-            plugin: plugin.clone(),
-            reason: error.to_string(),
-        })?
-    {
-        options["callContractRefs"] = json!({
-            "catalogCid": call_catalog_cid,
-            "tableCid": call_table_cid,
-        });
-    }
-    let response = conn
-        .transport
-        .request(&json!({
-            "level": Level::ContextManagerEdges.wire(),
-            "workspace_root": conn.workspace_root.display().to_string(),
-            "options": options,
-        }))
-        .map_err(|error| EnumerateError::Unavailable {
-            plugin: plugin.clone(),
-            reason: error.to_string(),
-        })?;
-    let result = response
-        .get("result")
-        .unwrap_or(&response)
-        .as_object()
-        .ok_or_else(|| EnumerateError::Malformed {
-            plugin: plugin.clone(),
-            reason: "context-manager edge result must be an object".into(),
-        })?;
-    result
-        .get("contextManagerEdges")
-        .and_then(Value::as_array)
-        .cloned()
-        .ok_or_else(|| EnumerateError::Malformed {
-            plugin,
-            reason: "context-manager edge result missing contextManagerEdges array".into(),
-        })
-}
-
 /// `LiftPluginKit::request` has already checked and removed the JSON-RPC
 /// envelope. Keep this boundary explicit: enumeration consumes that result
 /// payload directly. A second `result` unwrap turns every lawful node set into
@@ -1861,12 +1799,6 @@ fn merge_recovered_audit_core(
 }
 
 impl Kit {
-    pub fn context_manager_edges(&self, workspace_root: &Path) -> Result<Vec<Value>, KitError> {
-        Ok(context_manager_edges_rpc(
-            &self.enumerate_conn(workspace_root),
-        )?)
-    }
-
     pub fn context_manager_demands(&self, workspace_root: &Path) -> Result<Vec<Value>, KitError> {
         Ok(preconstruction_rows_rpc(
             &self.enumerate_conn(workspace_root),

--- a/implementations/rust/sugar-lift-rust-cargo-test-witness/src/bin/witness_rpc.rs
+++ b/implementations/rust/sugar-lift-rust-cargo-test-witness/src/bin/witness_rpc.rs
@@ -100,7 +100,6 @@ const EMPTY_CENSUS_LEVELS: &[&str] = &[
     "contract-declarations",
     "provider-contract-members",
     "contract-demands",
-    "context-manager-edges",
     "parameter-contract-resume",
 ];
 


### PR DESCRIPTION
## What changed

- remove `Level::ContextManagerEdges` and its wire spelling from `sugar-compiler`
- remove the uncalled `context_manager_edges_rpc` and `Kit::context_manager_edges` wrapper
- remove the Python source-kit RPC branch and witness-kit empty compatibility entries
- preserve `FunctionUniverseSugar.context_manager_edges` and `LiftReportPayloadDto.contextManagerEdges`: Python still owns Python `with` construction and its Python-side transport
- convert the former missing-roster tooth into a protocol-retirement tooth: a legacy `context-manager-edges` request is rejected as an unknown enumeration level

## Why

The enumeration protocol has one job: assemble the proof graph. Python context-manager edges become no graph node, no graph edge, no ProofIR member, and no report row. The Rust wrapper had zero callers because there is no proof-graph concept for its result; the zero call sites were the symptom, not the cause.

`ContextManagerEdges` was the only language-shaped value in an otherwise source-agnostic level enum. It made the Rust CLI ask every kit a Python `with`-protocol question. Retiring the crossing absorbs that idiosyncrasy back into the Python kit instead of plumbing distribution authority across the Rust/Python boundary.

The old red tooth expected a named missing-authority refusal because the level tried to construct without an enrolled distribution. That refusal is deliberately retired, not deleted to reach green: the test now proves the request cannot enter the protocol at all. The roster defect at the removed Python handler dissolves with the side door.

## Evidence

- repository-wide consumer audit: `Kit::context_manager_edges` had zero call sites; the result was parsed and had nowhere to enter the proof graph
- retirement discrimination: legacy level -> JSON-RPC `-32602`, `sugar.enumerate: unknown level 'context-manager-edges'`
- focused tooth: `1 passed in 0.95s`, exit 0, CPython 3.12.13, current-checkout `PYTHONPATH`
- `cargo fmt --package sugar-compiler -- --check`: exit 0
- focused Python `py_compile`: exit 0
- `git diff --check`: exit 0
- battleaxe `cargo check -p sugar-compiler`: **unmeasured**. Two fresh-root attempts never reached Cargo: the first remained in remote reaping, and the `BCARGO_REAP_DAYS=0` retry remained in the remote menagerie-removal setup step for more than three minutes. Both were terminated. No Rust check result is claimed; CI is the next Rust signal.

## Follow-up findings

- #7255 records the separate `ContractDemands` leak: live generic call-contract rows share a level with Python-specific context-manager rows that Rust ignores.
- #7256 traces every remaining level to its proof-graph or report contribution. `Exports`, `ContractDeclarations`, and `ProviderContractMembers` currently go cold, but this PR does not delete them without a separate ruling.

## Not claiming

This does not retire Python context-manager construction, does not change the Python edge DTO, does not repair or remove `ContractDemands`, and does not authorize deleting any other enumeration level. It also does not claim a battleaxe Rust check ran.
