### PR TITLE
Bind every resolution session to explicit population authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_first_auth_exit_vertical_slices.py
@@ -37,6 +37,10 @@ from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBound
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.dependency_artifact import (
+    authenticate_dependency_top_level,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import (
     Attribute,
@@ -79,7 +83,14 @@ def _build_slice(
         workspace_path_source(str(path), root=str(root)),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    pytest_graph = authenticate_dependency_top_level("pytest")
+    if pytest_graph.artifact_kind != "distribution":
+        raise AssertionError("installed pytest slice requires a distribution graph")
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({pytest_graph.distribution_name})
+    )
+    session.dependency_graphs["pytest"] = pytest_graph
+    populate_source_derived_resource_refs(tree, root=root, path=path, session=session)
     with_node = next(node for node in tree.nodes() if isinstance(node, With))
     body_expr = with_node.body[0].value
     return context, with_node, body_expr

--- a/implementations/python/sugar-lift-py-tests/tests/test_import_member_operations.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_import_member_operations.py
@@ -50,7 +50,9 @@ def _import_member_and_site() -> tuple[ImportMemberValue, object]:
         source_file=source_file,
         module=module,
         target=regex_flag,
-        session=SourceResolutionSession(enabled=False),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(), enabled=False
+        ),
         context=context,
         dependency_graphs={"re": graph},
     )

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -459,6 +459,7 @@ class ResolvedPythonObjectV1:
         *,
         graph: "DependencyArtifactGraph",
         authenticated_use: Any,
+        session: "SourceResolutionSession",
     ) -> "ResolvedPythonObjectV1":
         """Authenticate wire input by re-resolving every cited preimage.
 
@@ -485,7 +486,9 @@ class ResolvedPythonObjectV1:
         warrants = value["reexportWarrants"]
         if not isinstance(warrants, list):
             raise ValueError("reexportWarrants must be a list")
-        revalidated = resolve_import_binding(authenticated_use, graph=graph)
+        revalidated = resolve_import_binding(
+            authenticated_use, graph=graph, session=session
+        )
         if not isinstance(revalidated, cls) or revalidated.to_value() != value:
             raise DependencyArtifactAuthenticationError(
                 "resolved object is not byte-identical to artifact re-resolution"

--- a/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_assigned_multi_manager_with.py
@@ -14,6 +14,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     _projected_manager_call_uses,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import With
 from sugar_source_tree.tree import SourceFile
 
@@ -182,7 +183,12 @@ def test_pandas_303_both_option_context_managers_construct_through_bindings() ->
     site = _line_32_with(tree)
     context = tree.root.unit.construction_context
 
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset({"pandas"})),
+    )
 
     seats = sorted(
         (coordinate.start_line, coordinate.start_col)
@@ -260,7 +266,12 @@ def test_same_spelled_names_bound_elsewhere_do_not_authenticate(tmp_path: Path) 
         if node.kind == "With" and node.line_col_span().start_line == 4
     )
     context = tree.root.unit.construction_context
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=source)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=source,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
 
     assert context.source_manager_provider_calls == {}
     assert _projected_manager_call_uses(tree) == {}
@@ -431,6 +442,9 @@ def test_truthful_local_two_assigned_generators_construct_and_desugar(
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     site = next(node for node in tree.nodes() if isinstance(node, With))
@@ -476,6 +490,9 @@ def test_independent_manager_coordinates_survive_shared_provider_spelling(
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     site = next(node for node in tree.nodes() if isinstance(node, With))
     use_coords = [item._manager_use_site_span() for item in site.items]

--- a/implementations/python/sugar-lift-python-source/tests/test_async_generator_manager_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_async_generator_manager_publication.py
@@ -23,6 +23,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -140,6 +141,9 @@ def test_async_generator_without_async_frame_protocol_stays_typed_gap(tmp_path: 
         root=tmp_path,
         path=consumer,
         distribution_index={"resource_pkg": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     assert len(context.source_derived_contract_refs) == 1

--- a/implementations/python/sugar-lift-python-source/tests/test_auth_once_per_content.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_auth_once_per_content.py
@@ -16,7 +16,8 @@ from sugar_lift_python_source.resolution_session import SourceResolutionSession
 
 
 def test_dependency_graph_for_top_asks_auth_once(monkeypatch) -> None:
-    session = SourceResolutionSession()
+    # Cache-only unit test: no distribution graph is enrolled.
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
     local: dict = {}
     calls: list[str] = []
 
@@ -43,7 +44,7 @@ def test_dependency_graph_for_top_asks_auth_once(monkeypatch) -> None:
 
 
 def test_bind_dependency_graphs_seeds_from_session() -> None:
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
     session.dependency_graphs["re"] = object()
     bound = _bind_dependency_graphs(session, {})
     assert bound["re"] is session.dependency_graphs["re"]
@@ -54,7 +55,7 @@ def test_bind_dependency_graphs_seeds_from_session() -> None:
 
 def test_five_unique_tops_auth_once_each(monkeypatch) -> None:
     """Black cold profile shape: 5 tops, path-local re-ask → 1 auth each."""
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
     calls: list[str] = []
 
     class _FakeGraph:

--- a/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_call_target_gap_mechanisms.py
@@ -48,19 +48,39 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactGraph,
     ResolvedPythonObjectV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
     CALL_TARGET_GAP_KINDS,
     ConstructedCallActualV1,
     ConstructedManagerBehaviorV1,
     _frame_bound_names,
-    construct_manager_behavior,
+    construct_manager_behavior as _construct_manager_behavior,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.nodes import Call, Constant, FunctionDef
 from sugar_source_tree.panic import OpaqueSourceCallResolutionGap
 from sugar_source_tree.tree import SourceFile
+
+
+def _session_enrolling_graph(graph):
+    name = graph.distribution_name
+    if not name:
+        raise AssertionError("call-target graph test requires a distribution name")
+    return SourceResolutionSession(enrolled_distributions=frozenset({name}))
+
+
+def resolve_import_binding(*args, graph, session=None, **kwargs):
+    if session is None:
+        session = _session_enrolling_graph(graph)
+    return _resolve_import_binding(*args, graph=graph, session=session, **kwargs)
+
+
+def construct_manager_behavior(*args, graph, session=None, **kwargs):
+    if session is None:
+        session = _session_enrolling_graph(graph)
+    return _construct_manager_behavior(*args, graph=graph, session=session, **kwargs)
 
 
 def _distribution(

--- a/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_config_prefix_session_memo.py
@@ -43,6 +43,8 @@ def test_json_open_config_sourcefile_at_most_once() -> None:
             root=install_root,
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
             populate_derived=True,
+            distribution="pandas",
+            source_workspace_root=install_root,
         )
         fns = len(tuple(sf.functions()))
     finally:

--- a/implementations/python/sugar-lift-python-source/tests/test_contextlib_source_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_contextlib_source_resource_publication.py
@@ -16,6 +16,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -38,7 +39,12 @@ def test_installed_renamed_contextlib_class_manager_publishes_native_definitions
         construction_context=context,
     )
 
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
 
     assert len(context.source_derived_contract_refs) == 1
     receiver, ref = next(iter(context.source_derived_contract_refs.items()))

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -18,7 +18,7 @@ from sugar_lift_python_source.dependency_artifact import (
     AuthenticatedModuleSourceV1,
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
     export_statement_coverage,
 )
 from sugar_lift_python_source.canonical import blake3_512_of, cid_of_json
@@ -26,6 +26,25 @@ from sugar_lift_python_source.external_exception_construction import (
     AuthenticatedProviderExceptionTypeV1,
     ExternalExceptionConstructionGap,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+
+def _session_enrolling_graph(graph, *, enabled: bool = True):
+    """The graph is this file's authenticated resolution subject."""
+    if graph.artifact_kind == "stdlib":
+        roster = frozenset()
+    else:
+        name = graph.distribution_name
+        if not name:
+            raise AssertionError("distribution graph test requires a distribution name")
+        roster = frozenset({name})
+    return SourceResolutionSession(enabled=enabled, enrolled_distributions=roster)
+
+
+def resolve_import_binding(*args, graph, session=None, **kwargs):
+    if session is None:
+        session = _session_enrolling_graph(graph)
+    return _resolve_import_binding(*args, graph=graph, session=session, **kwargs)
 
 
 def _install_distribution(
@@ -194,7 +213,11 @@ def _returned_module_testimony(tmp_path: Path, *, gate_source: str | None = None
         root=tmp_path,
         path=consumer,
         graph_cache={},
-        session=SourceResolutionSession(),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(
+                {gate.metadata["Name"], provider.metadata["Name"]}
+            )
+        ),
         distribution_index={"gate_pkg": gate, "provider_pkg": provider},
     )
 
@@ -427,7 +450,10 @@ def test_resolved_python_object_round_trips_with_identical_cid(tmp_path: Path) -
 
     encoded = json.loads(json.dumps(result.to_value(), sort_keys=True))
     decoded = ResolvedPythonObjectV1.from_value(
-        encoded, graph=graph, authenticated_use=demand
+        encoded,
+        graph=graph,
+        authenticated_use=demand,
+        session=_session_enrolling_graph(graph),
     )
 
     assert decoded == result
@@ -741,7 +767,12 @@ def test_recomputed_outer_cid_cannot_authenticate_invented_resolved_artifact(
         DependencyArtifactAuthenticationError,
         match="byte-identical",
     ):
-        ResolvedPythonObjectV1.from_value(forged, graph=graph, authenticated_use=demand)
+        ResolvedPythonObjectV1.from_value(
+            forged,
+            graph=graph,
+            authenticated_use=demand,
+            session=_session_enrolling_graph(graph),
+        )
 
 
 def test_final_reaching_definition_wins_without_decorator_name_recognition(
@@ -959,7 +990,7 @@ def test_resolve_export_amortizes_repeated_static_scans(tmp_path: Path) -> None:
     graph = DependencyArtifactGraph.authenticate(distribution)
     # One session, as a real population has: amortization is a property of the
     # session, not of the process.
-    session = SourceResolutionSession()
+    session = _session_enrolling_graph(graph)
 
     n_sites = 8
     lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
@@ -1018,7 +1049,7 @@ def test_resolve_export_reexport_hop_shares_structural_memo(tmp_path: Path) -> N
         implementation_source="def build(value):\n    return value\n",
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
-    session = SourceResolutionSession()
+    session = _session_enrolling_graph(graph)
 
     scans = {"count": 0, "names": []}
     # Production door uses _export_block_with_locus (not bare _export_block).
@@ -1102,7 +1133,7 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
         implementation_source="def build(value):\n    return value\n",
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
-    session = SourceResolutionSession()
+    session = _session_enrolling_graph(graph)
 
     n_sites = 6
     lines = ["import example_pkg"] + [f"example_pkg.build({i})" for i in range(n_sites)]
@@ -1113,7 +1144,9 @@ def test_resolve_source_visible_frame_amortizes_repeated_materialize(
     receipts, _ = authenticated_import_use_receipts(
         tmp_path, path, source, source_cid, module_identities={}
     )
-    resolved = [resolve_import_binding(r, graph=graph) for r in receipts]
+    resolved = [
+        resolve_import_binding(r, graph=graph, session=session) for r in receipts
+    ]
     assert all(isinstance(item, ResolvedPythonObjectV1) for item in resolved)
 
     materializations = {"count": 0}
@@ -1179,7 +1212,7 @@ def test_session_module_materialize_amortizes_across_definitions(
         implementation_source=implementation,
     )
     graph = DependencyArtifactGraph.authenticate(distribution)
-    session = SourceResolutionSession()
+    session = _session_enrolling_graph(graph)
 
     consumer = (
         "from example_pkg.implementation import alpha, beta, gamma, delta\n"
@@ -1238,7 +1271,7 @@ def test_session_module_materialize_amortizes_across_definitions(
     assert len(session.module_materializations) >= 1
 
     # Discrimination: a fresh session re-materializes (isolation, not process memo).
-    other = SourceResolutionSession()
+    other = _session_enrolling_graph(graph)
     materializations["count"] = 0
     materializations["paths"] = []
     mc.SourceFile = CountingSourceFile  # type: ignore[misc, assignment]

--- a/implementations/python/sugar-lift-python-source/tests/test_enum_shadow_transport_laws.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_enum_shadow_transport_laws.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from sugar_lift_py_tests.floor import TermValue
 from sugar_lift_py_tests.outcome import Complete
 from sugar_lift_python_source import manager_construction
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 
 
 def _distribution(root: Path, source: str) -> importlib.metadata.Distribution:
@@ -143,7 +144,12 @@ def test_enum_dict_class_transport_retains_authenticated_builtin_dict_base(
         if statement.lineno > enum_dict.end_lineno
     )
 
-    exits = manager_construction._module_prefix_outcome(module, locus, graph=graph)
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
+    exits = manager_construction._module_prefix_outcome(
+        module, locus, graph=graph, session=session
+    )
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -175,7 +181,12 @@ def test_enum_dict_receiver_mutation_retains_identity_and_source_methods(
     parsed = ast.parse(module.source)
     enum_dict = parsed.body[0]
     exits = manager_construction._module_prefix_outcome(
-        module, parsed.body[1], graph=graph
+        module,
+        parsed.body[1],
+        graph=graph,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({graph.distribution_name})
+        ),
     )
     completed = exits.exits[0]
     value = completed.value.context.temporal.value_if_bound("_EnumDict")

--- a/implementations/python/sugar-lift-python-source/tests/test_exception_class_testimony_catch.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_exception_class_testimony_catch.py
@@ -17,6 +17,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
 )
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.panic import SugarNotWritten
 from sugar_source_tree.tree import SourceFile
 
@@ -188,6 +189,9 @@ def test_builtin_valueerror_formal_still_seals_with_class_value(tmp_path: Path):
         root=tmp_path,
         path=consumer,
         distribution_index={"arbitrary": dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     refs = list(context.source_derived_contract_refs.values())
     assert refs, "expected sealed source-derived CM ref for ValueError formal"

--- a/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_external_call_target_construction.py
@@ -34,7 +34,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactGraph,
     ResolvedPythonObjectV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
     ConstructedCallActualV1,
@@ -42,13 +42,33 @@ from sugar_lift_python_source.manager_construction import (
     ManagerConstructionGapV1,
     _ExternalCallTargetGap,
     _resolve_external_call_frame,
-    construct_manager_behavior,
+    construct_manager_behavior as _construct_manager_behavior,
 )
 from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.nodes import Call, Constant
 from sugar_source_tree.panic import OpaqueSourceCallResolutionGap
 from sugar_source_tree.tree import SourceFile
+
+
+def _session_enrolling_graph(graph):
+    name = graph.distribution_name
+    if not name:
+        raise AssertionError("external-call graph test requires a distribution name")
+    return SourceResolutionSession(enrolled_distributions=frozenset({name}))
+
+
+def resolve_import_binding(*args, graph, session=None, **kwargs):
+    if session is None:
+        session = _session_enrolling_graph(graph)
+    return _resolve_import_binding(*args, graph=graph, session=session, **kwargs)
+
+
+def construct_manager_behavior(*args, graph, session=None, **kwargs):
+    if session is None:
+        session = _session_enrolling_graph(graph)
+    return _construct_manager_behavior(*args, graph=graph, session=session, **kwargs)
+
 
 # No hermetic-frames fixture: there is no process state left to clear.  Every
 # resolution memo is owned by a SourceResolutionSession bounded to its own
@@ -368,7 +388,12 @@ def test_external_call_frame_demand_maps_exactly_onto_availability(
     )
 
     frame = _resolve_external_call_frame(
-        name, resolved=resolved, graph=graph, session=SourceResolutionSession()
+        name,
+        resolved=resolved,
+        graph=graph,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({graph.distribution_name})
+        ),
     )
 
     declined = isinstance(frame, _ExternalCallTargetGap)
@@ -395,7 +420,9 @@ def test_external_call_frame_is_the_callee_defining_source_not_the_caller(tmp_pa
         "ScopedSlot",
         resolved=resolved,
         graph=graph,
-        session=SourceResolutionSession(),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({graph.distribution_name})
+        ),
     )
 
     assert frame is not None

--- a/implementations/python/sugar-lift-python-source/tests/test_frame_memo_lru.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_frame_memo_lru.py
@@ -33,7 +33,8 @@ def test_frame_memo_limit_default() -> None:
 def test_frame_holds_evict_with_memo_row(monkeypatch) -> None:
     """Hold must not outlive the memo it guards."""
     monkeypatch.setenv("SUGAR_SESSION_FRAME_MEMO_LIMIT", "2")
-    session = SourceResolutionSession()
+    # Memo-storage unit test: no distribution graph is enrolled.
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
 
     holds = [object() for _ in range(4)]
     for i, hold in enumerate(holds):
@@ -55,7 +56,7 @@ def test_frame_holds_evict_with_memo_row(monkeypatch) -> None:
 def test_frame_hit_refreshes_lru_order(monkeypatch) -> None:
     """A hit keeps its hold; next eviction drops a colder key."""
     monkeypatch.setenv("SUGAR_SESSION_FRAME_MEMO_LIMIT", "2")
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
     h0, h1, h2 = object(), object(), object()
     session.remember_frame(("k", 0), "r0", hold=h0)
     session.remember_frame(("k", 1), "r1", hold=h1)
@@ -73,7 +74,7 @@ def test_frame_hit_refreshes_lru_order(monkeypatch) -> None:
 def test_remember_frame_without_hold_still_bounded(monkeypatch) -> None:
     """Gap memos (no hold) also count toward the limit."""
     monkeypatch.setenv("SUGAR_SESSION_FRAME_MEMO_LIMIT", "2")
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
     session.remember_frame(("g", 0), "gap0")
     session.remember_frame(("g", 1), "gap1", hold=object())
     session.remember_frame(("g", 2), "gap2")

--- a/implementations/python/sugar-lift-python-source/tests/test_function_roster_floor_law.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_function_roster_floor_law.py
@@ -56,6 +56,8 @@ def _open(tmp_path: Path, path: Path):
         reporter=CollectingReporter(),
         construction_context=ctx,
         populate_derived=True,
+        distribution="roster-floor-fixture",
+        source_workspace_root=tmp_path,
     )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_backed_resource_publication.py
@@ -29,6 +29,7 @@ from sugar_lift_python_source.manager_protocol_construction import (
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -44,7 +45,14 @@ def test_option_context_publishes_one_generator_backed_resource_ref():
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
 
     receivers = [
         coordinate
@@ -202,7 +210,12 @@ def test_open_still_publishes_neither_generator_ref_nor_native_defs(tmp_path: Pa
         path_source(str(path)),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert context.source_manager_provider_calls == {}
     assert not any(
         isinstance(value, SourceDerivedGeneratorResourceRefV1)

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_conditional_exit_faces.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_conditional_exit_faces.py
@@ -25,6 +25,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     GeneratorExitHaltFaceV1,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -72,6 +73,9 @@ def _publish(tmp_path: Path, implementation: str):
         root=tmp_path,
         path=path,
         distribution_index={"unprivileged": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     return next(
         v.protocol

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_face_general_source_cm_law.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_face_general_source_cm_law.py
@@ -31,6 +31,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     _project_generator_lifecycle_faces,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 _HELPERS = """\
@@ -95,6 +96,9 @@ def _publish(tmp_path: Path, consumer: str) -> list:
         root=tmp_path,
         path=path,
         distribution_index={"unprivileged": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     return [
         value.protocol

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_manager_renamed_lifecycle.py
@@ -45,6 +45,7 @@ from sugar_lift_python_source.source_oracle import path_source
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import With
 from sugar_source_tree.tree import SourceFile
 
@@ -181,6 +182,9 @@ def _populate(root: Path, *, shape: _ManagerShape, consumer_source: str, files=N
         root=root,
         path=consumer,
         distribution_index={shape.package: dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return context, tree
 
@@ -671,6 +675,11 @@ def _populate_multi(root: Path, *, dists: dict, consumer_source: str):
         root=root,
         path=consumer,
         distribution_index=dists,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(
+                distribution.metadata["Name"] for distribution in dists.values()
+            )
+        ),
     )
     return context, tree
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_nested_managers.py
@@ -58,6 +58,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -106,6 +107,9 @@ def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
         root=tmp_path,
         path=path,
         distribution_index={"unprivileged": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     return context
 

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_post_yield_exit_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_post_yield_exit_halt.py
@@ -26,6 +26,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -73,6 +74,9 @@ def _publish(tmp_path: Path, implementation: str):
         root=tmp_path,
         path=path,
         distribution_index={"unprivileged": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     return next(
         v.protocol

--- a/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_generator_pre_yield_enter_halt.py
@@ -35,6 +35,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -83,6 +84,9 @@ def _publish(tmp_path: Path, implementation: str, consumer: str | None = None):
         root=tmp_path,
         path=path,
         distribution_index={"unprivileged": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     return context
 

--- a/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_import_value_use_frame_seating.py
@@ -84,6 +84,8 @@ def _frame_for_box_expected(
     helpers: str,
     types: str = "class ArrayType:\n    pass\n",
 ):
+    from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
     distribution = _distribution(tmp_path, helpers, types)
     path, source_file, context = _consumer(
         tmp_path,
@@ -96,6 +98,9 @@ def _frame_for_box_expected(
         root=tmp_path,
         path=path,
         distribution_index={"unprivileged": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     span = call.line_col_span()
     coordinate = SourceFragmentCoordinateV1(
@@ -417,7 +422,8 @@ def test_exact_import_value_receipt_seats_and_constructs_member(
         source_file=source_file,
         module=module,
         target=function,
-        session=SourceResolutionSession(),
+        # Only stdlib imports are present; no distribution is enrolled.
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
         context=context,
         dependency_graphs={},
     )
@@ -531,7 +537,7 @@ def test_receipt_backed_import_member_is_constructed_call_argument(
         source_file=source_file,
         module=module,
         target=function,
-        session=SourceResolutionSession(),
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
         context=context,
         dependency_graphs={},
     )
@@ -587,7 +593,7 @@ def test_import_member_testimony_canonicalizes_only_its_authenticated_token(
         source_file=source_file,
         module=module,
         target=function,
-        session=SourceResolutionSession(),
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
         context=context,
         dependency_graphs={},
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_manager_enrollment_authority.py
@@ -4,10 +4,10 @@ from types import SimpleNamespace
 import pytest
 
 from sugar_lift_python_source.manager_summary_derivation import (
-    MissingEnrolledDistributionRoster,
     _qualified_enrollment_coordinate,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 
 
 def test_package_seat_uses_authenticated_distribution(tmp_path: Path) -> None:
@@ -51,8 +51,8 @@ def test_missing_enrolled_roster_refuses_instead_of_path_seed(tmp_path: Path) ->
         root=SimpleNamespace(unit=SimpleNamespace(construction_context=None))
     )
     with pytest.raises(
-        MissingEnrolledDistributionRoster,
-        match="missing-enrolled-distribution-roster",
+        TypeError,
+        match="session construction requires an enrolled distribution roster",
     ):
         populate_source_derived_resource_refs(
             source_file,
@@ -71,4 +71,5 @@ def test_supplied_enrolled_roster_is_accepted(tmp_path: Path) -> None:
         path=tmp_path / "pandas" / "_config" / "config.py",
         source_workspace_root=tmp_path / "pandas",
         distribution="pandas",
+        session=SourceResolutionSession(enrolled_distributions=frozenset({"pandas"})),
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_match_argument_shapes.py
@@ -82,6 +82,7 @@ from sugar_lift_python_source.manager_construction import (
     _classify_named_call_target,
     _frame_bound_names,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import (
     Attribute,
     Call,
@@ -849,7 +850,10 @@ def test_name_pattern_reaches_authenticated_base_force_floor() -> None:
     )
 
     populate_source_derived_resource_refs(
-        source_file, root=_corpus_root().parent, path=path
+        source_file,
+        root=_corpus_root().parent,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset({"pandas"})),
     )
 
     row = next(
@@ -897,7 +901,10 @@ def test_pattern_sites_manager_floor_is_named_not_synthetic(
     assert argument.segment().strip() == site.expression
 
     populate_source_derived_resource_refs(
-        source_file, root=_corpus_root().parent, path=path
+        source_file,
+        root=_corpus_root().parent,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset({"pandas"})),
     )
 
     row = next(

--- a/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_decorated_class_publication.py
@@ -289,7 +289,9 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
         blake3_512_of(source.encode("utf-8")),
         module_identities={},
     )
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
     resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
     assert isinstance(resolved, ResolvedPythonObjectV1)
 
@@ -341,7 +343,9 @@ def test_reachable_decorated_class_admission_filters_before_symtable_contact(
         blake3_512_of(body_source.encode("utf-8")),
         module_identities={},
     )
-    body_session = SourceResolutionSession()
+    body_session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
     body_resolved = resolve_import_binding(
         body_receipts[0], graph=graph, session=body_session
     )
@@ -464,7 +468,9 @@ def test_reachable_decorated_class_publication_is_attached_to_selected_frame(
         module_identities={},
     )
     assert len(receipts) == 1
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
     resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
     assert isinstance(resolved, ResolvedPythonObjectV1)
 

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_definition_reporter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_definition_reporter.py
@@ -14,6 +14,7 @@ from sugar_lift_py_tests.outcome import Completed
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
 from sugar_lift_python_source.manager_construction import _module_prefix_outcome
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.backend import materialize
 from sugar_source_tree.binding_state import (
     ConstructionTestimonyReporterV1,
@@ -57,7 +58,11 @@ def _coordinate(call: Call) -> SourceFragmentCoordinateV1:
 
 def _published_definition(module: AuthenticatedModuleSourceV1, name: str):
     locus = ast.parse(module.source).body[-1]
-    exits = _module_prefix_outcome(module, locus)
+    exits = _module_prefix_outcome(
+        module,
+        locus,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert len(exits.exits) == 1
     completed = exits.exits[0]
     assert isinstance(completed, Completed)

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
@@ -9,6 +9,7 @@ import pytest
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import AuthenticatedModuleSourceV1
 from sugar_lift_python_source import manager_construction
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.binding_state import (
     ConstructedValueCategoryGap,
     ConstructionTestimonyReporterV1,
@@ -44,7 +45,11 @@ def _observe_prefix(monkeypatch, name: str):
 
     monkeypatch.setattr(manager_construction, "SourceFile", RecordingSourceFile)
     locus = ast.parse(module.source).body[-1]
-    manager_construction._module_prefix_outcome(module, locus)
+    manager_construction._module_prefix_outcome(
+        module,
+        locus,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert len(observed) == 1
     return observed[0]
 

--- a/implementations/python/sugar-lift-python-source/tests/test_open_keeps_function_roster.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_open_keeps_function_roster.py
@@ -35,6 +35,8 @@ def test_pandas_json_open_keeps_function_roster() -> None:
         root=install_root,
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
         populate_derived=True,
+        distribution="pandas",
+        source_workspace_root=install_root,
     )
     functions = tuple(source_file.functions())
     assert len(functions) >= 40, (

--- a/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_option_context_native_publication.py
@@ -29,6 +29,7 @@ from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
 from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 
@@ -76,6 +77,9 @@ def _populate(tmp_path: Path, dist, package: str, consumer_source: str):
         root=tmp_path,
         path=consumer,
         distribution_index={package: dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return context
 
@@ -92,7 +96,14 @@ def test_option_context_publishes_both_context_enter_and_exit_coordinates():
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
 
     receivers = [
         coordinate
@@ -127,7 +138,14 @@ def test_option_context_publishes_at_every_seated_generator_use_site():
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
 
     published = 0
     sample = None
@@ -164,7 +182,12 @@ def test_open_produces_no_source_definition(tmp_path: Path):
         path_source(str(path)),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
 
     assert context.source_manager_provider_calls == {}
     from sugar_source_tree.nodes import With
@@ -509,7 +532,12 @@ def test_lying_twin_spelling_without_binding_publishes_nothing(tmp_path: Path):
         path_source(str(path)),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert context.source_manager_provider_calls == {}
     assert not any(
         slot in (NativeProtocolSlot.CONTEXT_ENTER, NativeProtocolSlot.CONTEXT_EXIT)

--- a/implementations/python/sugar-lift-python-source/tests/test_pandas_regex_source_frame_consumer.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_pandas_regex_source_frame_consumer.py
@@ -61,7 +61,9 @@ def test_real_pandas_select_options_installs_authenticated_re_search_frame(
     )
     regex_graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
     receipt = _consumer_receipt(tmp_path, "truthful.py")
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({pandas_graph.distribution_name})
+    )
     resolved = resolve_import_binding(receipt, graph=pandas_graph, session=session)
     assert type(resolved) is ResolvedPythonObjectV1
 
@@ -113,8 +115,11 @@ def test_same_target_foreign_import_binding_cannot_reauthenticate_definition(
     foreign = _consumer_receipt(tmp_path, "foreign.py", "# foreign source occurrence\n")
     assert truthful.target_symbol == foreign.target_symbol
     assert truthful.import_binding.cid != foreign.import_binding.cid
-    resolved = resolve_import_binding(truthful, graph=graph)
-    foreign_resolved = resolve_import_binding(foreign, graph=graph)
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
+    resolved = resolve_import_binding(truthful, graph=graph, session=session)
+    foreign_resolved = resolve_import_binding(foreign, graph=graph, session=session)
     assert type(resolved) is ResolvedPythonObjectV1
     assert type(foreign_resolved) is ResolvedPythonObjectV1
     assert resolved.definition == foreign_resolved.definition
@@ -125,5 +130,8 @@ def test_same_target_foreign_import_binding_cannot_reauthenticate_definition(
         match="not byte-identical to artifact re-resolution",
     ):
         ResolvedPythonObjectV1.from_value(
-            resolved.to_value(), graph=graph, authenticated_use=foreign
+            resolved.to_value(),
+            graph=graph,
+            authenticated_use=foreign,
+            session=session,
         )

--- a/implementations/python/sugar-lift-python-source/tests/test_populate_reuses_open_sourcefile.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_populate_reuses_open_sourcefile.py
@@ -38,6 +38,8 @@ def test_json_open_plus_populate_materializes_consumer_once() -> None:
             root=install_root,
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
             populate_derived=True,
+            distribution="pandas",
+            source_workspace_root=install_root,
         )
         fns = len(tuple(sf.functions()))
     finally:

--- a/implementations/python/sugar-lift-python-source/tests/test_populate_typeerror_preserves_roster.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_populate_typeerror_preserves_roster.py
@@ -66,6 +66,8 @@ def test_populate_typeerror_preserves_function_roster(
         reporter=CollectingReporter(),
         construction_context=ctx,
         populate_derived=True,
+        distribution="populate-roster-fixture",
+        source_workspace_root=tmp_path,
     )
     assert len(tuple(source_file.functions())) == 3
 
@@ -102,6 +104,8 @@ def test_populate_snw_still_preserves_function_roster(
         reporter=CollectingReporter(),
         construction_context=ctx,
         populate_derived=True,
+        distribution="populate-roster-fixture",
+        source_workspace_root=tmp_path,
     )
     assert len(tuple(source_file.functions())) == 3
 
@@ -189,5 +193,7 @@ def test_per_receipt_typeerror_cites_gap_and_continues(
         reporter=CollectingReporter(),
         construction_context=ctx,
         populate_derived=True,
+        distribution="populate-roster-fixture",
+        source_workspace_root=tmp_path,
     )
     assert len(tuple(source_file.functions())) == 3

--- a/implementations/python/sugar-lift-python-source/tests/test_population_membrane_off_pin_dist.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_membrane_off_pin_dist.py
@@ -70,6 +70,8 @@ def test_pandas_test_open_never_materializes_pytest() -> None:
             root=address_root,
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
             populate_derived=True,
+            distribution="pandas",
+            source_workspace_root=corpus,
         )
     finally:
         SourceFile.__init__ = orig  # type: ignore[method-assign]

--- a/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_membrane_stdlib_cite.py
@@ -132,6 +132,8 @@ def _open_json_once():
             reporter=reporter,
             construction_context=ctx,
             populate_derived=True,
+            distribution="pandas",
+            source_workspace_root=corpus,
         )
     except SugarNotWritten:
         # In-population SNW is not this instrument; seat counts still measured.
@@ -188,7 +190,10 @@ def test_off_population_gap_helper_names_stdlib() -> None:
         module_name = "enum"
 
     stdlib = DependencyArtifactGraph.authenticate_stdlib_module("enum")
-    gap = _off_population_materialize_gap(_Resolved(), graph=stdlib)  # type: ignore[arg-type]
+    empty = SourceResolutionSession(enrolled_distributions=frozenset())
+    gap = _off_population_materialize_gap(
+        _Resolved(), graph=stdlib, session=empty
+    )  # type: ignore[arg-type]
     assert gap is not None
     assert gap.kind == "call-target-off-population"
     assert "enum" in gap.detail
@@ -197,20 +202,27 @@ def test_off_population_gap_helper_names_stdlib() -> None:
     gap_re = _off_population_materialize_gap(
         type("R", (), {"cid": "r", "module_name": "re"})(),
         graph=re_graph,
+        session=empty,
     )
     assert gap_re is not None
     assert gap_re.kind == "call-target-off-population"
 
-    # Legacy (enrolled=None): pin distributions stay on-population.
+    # Explicit enrollment: this test deliberately makes pytest the subject.
     import importlib.metadata
 
     pytest_dist = importlib.metadata.distribution("pytest")
     pytest_graph = DependencyArtifactGraph.authenticate(pytest_dist)
-    gap_legacy = _off_population_materialize_gap(
+    pytest_session = SourceResolutionSession(
+        enrolled_distributions=frozenset({"pytest"})
+    )
+    gap_enrolled = _off_population_materialize_gap(
         type("R", (), {"cid": "p", "module_name": "_pytest.raises"})(),
         graph=pytest_graph,
+        session=pytest_session,
     )
-    assert gap_legacy is None, "without enrolled pin, distributions stay on-population"
+    assert (
+        gap_enrolled is None
+    ), "an explicitly enrolled distribution stays on-population"
 
     # Enrolled pin: foreign distribution is off-population.
     session = SourceResolutionSession(enrolled_distributions=frozenset({"pandas"}))

--- a/implementations/python/sugar-lift-python-source/tests/test_reachable_source_frame_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reachable_source_frame_construction.py
@@ -26,6 +26,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.source_call_preconstruction import (
     populate_source_visible_call_frames,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Call as SourceCall
 from sugar_source_tree.tree import SourceFile
@@ -79,6 +80,9 @@ def _populate(
         root=tmp_path,
         path=path,
         distribution_index={package: dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return context, tree
 

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -22,8 +22,37 @@ from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactGraph,
     PythonObjectResolutionGapV1,
     ResolvedPythonObjectV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+
+def resolve_import_binding(*args, graph, session=None, **kwargs):
+    """This file's authenticated graph is the distribution under test."""
+    if session is None:
+        name = graph.distribution_name
+        if not name:
+            raise AssertionError("re-export graph test requires a distribution name")
+        session = SourceResolutionSession(enrolled_distributions=frozenset({name}))
+    return _resolve_import_binding(*args, graph=graph, session=session, **kwargs)
+
+
+def _prefix_outcome(module, locus, *, distribution=None, graph=None):
+    """Execute a prefix under the distribution authority owned by the fixture."""
+    from sugar_lift_python_source import manager_construction
+
+    if graph is not None and graph.artifact_kind == "stdlib":
+        roster = frozenset()
+    else:
+        if distribution is None:
+            raise AssertionError("prefix fixture requires distribution authority")
+        roster = frozenset({distribution.metadata["Name"]})
+    return manager_construction._module_prefix_outcome(
+        module,
+        locus,
+        graph=graph,
+        session=SourceResolutionSession(enrolled_distributions=roster),
+    )
 
 
 def _dist(
@@ -468,7 +497,7 @@ def test_module_prefix_execution_binds_exact_class_definition_once(
     ]
     locus = ast.parse(source).body[-1]
 
-    exits = manager_construction._module_prefix_outcome(module, locus)
+    exits = _prefix_outcome(module, locus, distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -506,9 +535,7 @@ def test_module_prefix_defers_forward_function_body_until_prefix_temporal_is_liv
         "module_local_call_prefix_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -541,9 +568,7 @@ def test_module_prefix_does_not_construct_an_uncalled_function_body(
         "lazy_module_function_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -577,9 +602,7 @@ def test_module_prefix_publishes_exact_async_definition_without_running_body(
         "async_module_function_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -613,9 +636,7 @@ def test_module_prefix_refuses_synchronous_async_function_application(
     )
     module = DependencyArtifactGraph.authenticate(dist).modules["async_module_call_pkg"]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
     assert len(exits.exits) == 1
     completed = exits.exits[0]
     assert isinstance(completed, Completed)
@@ -665,9 +686,7 @@ def test_module_prefix_sync_function_application_remains_completed(
     )
     module = DependencyArtifactGraph.authenticate(dist).modules["sync_module_call_pkg"]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -717,7 +736,7 @@ def test_module_prefix_refuses_decorated_async_definition_before_completion(
     ]
 
     with pytest.raises(SugarNotWritten) as raised:
-        manager_construction._module_prefix_outcome(module, ast.parse(source).body[-1])
+        _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert raised.value.owner == "module function definition execution"
     assert raised.value.blame.source_cid == module.source_cid
@@ -754,9 +773,7 @@ def test_module_async_function_application_stays_typed_loud_while_plain_function
     module = DependencyArtifactGraph.authenticate(dist).modules[
         "async_call_application_pkg"
     ]
-    published = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    published = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
     async_callable = published.exits[0].value.context.temporal.value_if_bound(
         "async_target"
     )
@@ -767,19 +784,20 @@ def test_module_async_function_application_stays_typed_loud_while_plain_function
     assert raised.value.owner == "module function definition application"
     assert "AsyncFunctionDef" in raised.value.observed
 
-    plain_module = DependencyArtifactGraph.authenticate(
-        _dist(
-            tmp_path / "plain",
-            name="plain-call-application-pkg",
-            files={
-                "plain_call_application_pkg/__init__.py": source.replace(
-                    "return async_target", "return plain_target"
-                )
-            },
-        )
-    ).modules["plain_call_application_pkg"]
-    plain_published = manager_construction._module_prefix_outcome(
-        plain_module, ast.parse(source).body[-1]
+    plain_dist = _dist(
+        tmp_path / "plain",
+        name="plain-call-application-pkg",
+        files={
+            "plain_call_application_pkg/__init__.py": source.replace(
+                "return async_target", "return plain_target"
+            )
+        },
+    )
+    plain_module = DependencyArtifactGraph.authenticate(plain_dist).modules[
+        "plain_call_application_pkg"
+    ]
+    plain_published = _prefix_outcome(
+        plain_module, ast.parse(source).body[-1], distribution=plain_dist
     )
     plain_callable = plain_published.exits[0].value.context.temporal.value_if_bound(
         "plain_target"
@@ -807,9 +825,7 @@ def test_module_prefix_constructs_one_subscript_delete_statement(
         "module_delete_prefix_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Completed)
@@ -831,9 +847,7 @@ def test_module_prefix_chained_names_share_one_rhs_value(tmp_path: Path) -> None
         "module_chained_assignment_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -870,9 +884,7 @@ def test_stdlib_makecodes_return_is_rebound_before_exact_slice_delete() -> None:
     )
     expected_count = len(assignment.value.args) - 2
 
-    exits = manager_construction._module_prefix_outcome(
-        module, next_statement, graph=graph
-    )
+    exits = _prefix_outcome(module, next_statement, graph=graph)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -898,7 +910,7 @@ def test_bodyless_call_result_cannot_be_promoted_to_delete_list(tmp_path: Path) 
     locus = ast.parse(source).body[-1]
 
     with pytest.raises(SugarNotWritten) as raised:
-        manager_construction._module_prefix_outcome(module, locus)
+        _prefix_outcome(module, locus, distribution=dist)
 
     assert raised.value.owner == "SubscriptDeleteEffectSugar._delete"
     assert raised.value.observed == (
@@ -933,9 +945,7 @@ def test_module_prefix_execution_publishes_exact_decorator_result(
         "module_decoration_prefix_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -981,9 +991,7 @@ def test_module_prefix_execution_publishes_exact_metaclass_result(
         "module_metaclass_prefix_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     completed = exits.exits[0]
@@ -1036,7 +1044,7 @@ def test_module_prefix_refuses_untransported_class_creation_keywords(
     ]
 
     with pytest.raises(SugarNotWritten) as raised:
-        manager_construction._module_prefix_outcome(module, ast.parse(source).body[-1])
+        _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert raised.value.owner == "module definition execution"
     assert raised.value.observed == observed
@@ -1063,9 +1071,7 @@ def test_module_prefix_without_class_creation_keywords_still_publishes(
         "module_class_no_keyword_prefix_pkg"
     ]
 
-    exits = manager_construction._module_prefix_outcome(
-        module, ast.parse(source).body[-1]
-    )
+    exits = _prefix_outcome(module, ast.parse(source).body[-1], distribution=dist)
 
     assert len(exits.exits) == 1
     assert isinstance(exits.exits[0], Completed)
@@ -1117,7 +1123,9 @@ def test_prefix_adapter_routes_exact_graph_and_session_to_module_execution(
     graph = DependencyArtifactGraph.authenticate(dist)
     module = graph.modules["prefix_consumer_pkg"]
     locus = ast.parse(source).body[-1]
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
     observed = []
 
     def completed_prefix(actual_module, actual_locus, *, graph, session):

--- a/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
@@ -18,11 +18,11 @@ from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactAuthenticationError,
     DependencyArtifactGraph,
     ResolvedPythonObjectV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
     _seat_import_value_use_receipts,
-    resolve_source_visible_frame,
+    resolve_source_visible_frame as _resolve_source_visible_frame,
 )
 from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
@@ -35,6 +35,23 @@ SOURCE = (
     "def selected(subject):\n"
     '    return re.search("needle", subject, re.I)\n'
 )
+
+
+def _stdlib_session(*, enabled: bool = True) -> SourceResolutionSession:
+    """CPython is cited across an authoritative empty enrolled population."""
+    return SourceResolutionSession(enrolled_distributions=frozenset(), enabled=enabled)
+
+
+def resolve_import_binding(*args, session=None, **kwargs):
+    return _resolve_import_binding(
+        *args, session=_stdlib_session() if session is None else session, **kwargs
+    )
+
+
+def resolve_source_visible_frame(*args, session=None, **kwargs):
+    return _resolve_source_visible_frame(
+        *args, session=_stdlib_session() if session is None else session, **kwargs
+    )
 
 
 def _receipts(tmp_path: Path):
@@ -175,7 +192,7 @@ def test_exact_re_search_receipt_resolves_and_seats_cpython_definition_body(
         source_file=standalone,
         module=module,
         target=standalone_value,
-        session=SourceResolutionSession(enabled=False),
+        session=_stdlib_session(enabled=False),
         context=context,
         dependency_graphs={"re": graph},
     )
@@ -239,7 +256,7 @@ def test_duplicate_identical_call_receipt_is_loud_before_pairing(
         resolve_source_visible_frame(
             resolved,
             graph=graph,
-            session=SourceResolutionSession(enabled=False),
+            session=_stdlib_session(enabled=False),
         )
 
 
@@ -266,7 +283,7 @@ def test_reversed_receipt_iteration_preserves_relation_cid(
 
     ordinary = relation_cid(
         resolve_source_visible_frame(
-            resolved, graph=graph, session=SourceResolutionSession(enabled=False)
+            resolved, graph=graph, session=_stdlib_session(enabled=False)
         )
     )
     import sugar_lift_py_tests.import_binding as import_binding
@@ -292,7 +309,7 @@ def test_reversed_receipt_iteration_preserves_relation_cid(
     )
     reversed_cid = relation_cid(
         resolve_source_visible_frame(
-            resolved, graph=graph, session=SourceResolutionSession(enabled=False)
+            resolved, graph=graph, session=_stdlib_session(enabled=False)
         )
     )
     assert reversed_cid == ordinary
@@ -408,7 +425,7 @@ def test_re_i_value_receipt_cannot_substitute_re_search_call_span(
         source_file=source_file,
         module=module,
         target=function,
-        session=SourceResolutionSession(),
+        session=_stdlib_session(),
         context=context,
         dependency_graphs={"re": graph},
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regexflag_relative_member_seating.py
@@ -38,7 +38,7 @@ def test_regexflag_relative_member_receipt_survives_repeated_frame_seating() -> 
         for node in source_file.root.body
         if isinstance(node, ClassDef) and node.name == "RegexFlag"
     )
-    session = SourceResolutionSession(enabled=False)
+    session = SourceResolutionSession(enrolled_distributions=frozenset(), enabled=False)
 
     for _ in range(2):
         _seat_import_value_use_receipts(
@@ -97,7 +97,9 @@ def test_regexflag_relative_member_missing_foreign_and_crosswired_receipts_refus
         source_file=source_file,
         module=module,
         target=regex_flag,
-        session=SourceResolutionSession(enabled=False),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(), enabled=False
+        ),
         context=context,
         dependency_graphs={"re": graph},
     )
@@ -149,7 +151,9 @@ def test_regexflag_receipt_transports_across_exact_parser_owned_units() -> None:
         source_file=first,
         module=module,
         target=regex_flag,
-        session=SourceResolutionSession(enabled=False),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(), enabled=False
+        ),
         context=context,
         dependency_graphs={"re": graph},
     )
@@ -207,7 +211,9 @@ def test_regexflag_cached_class_sugar_retains_manager_context_product() -> None:
         source_file=manager,
         module=module,
         target=manager_class,
-        session=SourceResolutionSession(enabled=False),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(), enabled=False
+        ),
         context=manager_context,
         dependency_graphs={"re": graph},
     )
@@ -246,7 +252,9 @@ def test_import_receipts_seat_the_exact_source_unit_owned_context() -> None:
         source_file=source_file,
         module=module,
         target=regex_flag,
-        session=SourceResolutionSession(enabled=False),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(), enabled=False
+        ),
         context=external_context,
         dependency_graphs={"re": graph},
     )
@@ -310,13 +318,14 @@ def test_regexflag_field_is_not_swallowed_by_a_parked_imported_call(
     )
     call = next(row for row in calls if row.target_symbol == "python:re.search")
     graph = DependencyArtifactGraph.authenticate_stdlib_module("re")
-    resolved = resolve_import_binding(call, graph=graph)
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
+    resolved = resolve_import_binding(call, graph=graph, session=session)
     assert isinstance(resolved, ResolvedPythonObjectV1)
     from sugar_lift_python_source.manager_construction import (
         resolve_source_visible_frame,
     )
 
-    projected = resolve_source_visible_frame(resolved, graph=graph)
+    projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
     assert isinstance(projected, tuple)
     frame, _ = projected
     context = frame.owner.unit.construction_context
@@ -338,7 +347,9 @@ def test_regexflag_field_is_not_swallowed_by_a_parked_imported_call(
         source_file=source_file,
         module=module,
         target=regex_flag,
-        session=SourceResolutionSession(enabled=False),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset(), enabled=False
+        ),
         context=context,
         dependency_graphs={"re": graph},
     )

--- a/implementations/python/sugar-lift-python-source/tests/test_relative_submodule_member_resolution.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_relative_submodule_member_resolution.py
@@ -18,8 +18,18 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactGraph,
     PythonObjectResolutionGapV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+
+def resolve_import_binding(*args, graph, session=None, **kwargs):
+    """Every graph in this file is the authenticated distribution under test."""
+    if session is None:
+        session = SourceResolutionSession(
+            enrolled_distributions=frozenset({graph.distribution_name})
+        )
+    return _resolve_import_binding(*args, graph=graph, session=session, **kwargs)
 
 
 def _graph(

--- a/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_renamed_generator_manager_publication.py
@@ -38,6 +38,7 @@ from sugar_lift_python_source.manager_protocol_construction import (
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.tree import SourceFile
 
 # ---------------------------------------------------------------------------
@@ -186,6 +187,9 @@ def _populate(root: Path, *, shape: _ManagerShape, consumer_source: str, files=N
         root=root,
         path=consumer,
         distribution_index={shape.package: dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return context, tree
 
@@ -419,7 +423,12 @@ def test_builtin_open_still_enrolls_nothing(tmp_path: Path):
         path_source(str(path)),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert context.source_manager_provider_calls == {}
     assert not any(
         isinstance(value, SourceDerivedGeneratorResourceRefV1)

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -85,6 +85,13 @@ def _project(tmp_path: Path, name: str, implementation_source: str):
     return graph, _receipt(root)
 
 
+def _session_for(*projects, enabled: bool = True) -> SourceResolutionSession:
+    """Enroll exactly the authenticated project distributions under test."""
+    names = frozenset(project[0].distribution_name for project in projects)
+    assert None not in names
+    return SourceResolutionSession(enabled=enabled, enrolled_distributions=names)
+
+
 def _resolve(project, session):
     graph, receipt = project
     resolved = resolve_import_binding(receipt, graph=graph, session=session)
@@ -141,8 +148,8 @@ def test_cold_result_equals_warm_result(tmp_path: Path) -> None:
     """A warm memo answers exactly what a cold resolution answers."""
     project = _project(tmp_path, "p", _IMPL_A)
 
-    cold = _verdict(project, SourceResolutionSession())
-    session = SourceResolutionSession()
+    cold = _verdict(project, _session_for(project))
+    session = _session_for(project)
     _verdict(project, session)  # warm it
     warm = _verdict(project, session)
 
@@ -155,7 +162,7 @@ def test_cold_result_equals_warm_result(tmp_path: Path) -> None:
         _verdict(project, session)
     assert counter.count == 0, "warm session still re-materialized: memo is dead"
     with _MaterializeCounter() as cold_counter:
-        _verdict(project, SourceResolutionSession())
+        _verdict(project, _session_for(project))
     assert cold_counter.count >= 1, "cold session did no work: twin cannot bite"
 
 
@@ -167,11 +174,11 @@ def test_a_then_b_equals_b_then_a(tmp_path: Path) -> None:
     a = _project(tmp_path, "a", _IMPL_A)
     b = _project(tmp_path, "b", _IMPL_B)
 
-    forward = SourceResolutionSession()
+    forward = _session_for(a, b)
     a_first = _verdict(a, forward)
     b_second = _verdict(b, forward)
 
-    backward = SourceResolutionSession()
+    backward = _session_for(a, b)
     b_first = _verdict(b, backward)
     a_second = _verdict(a, backward)
 
@@ -191,9 +198,9 @@ def test_isolated_result_equals_result_after_other_work(tmp_path: Path) -> None:
     target = _project(tmp_path, "target", _IMPL_A)
     noise = _project(tmp_path, "noise", _IMPL_B)
 
-    isolated = _verdict(target, SourceResolutionSession())
+    isolated = _verdict(target, _session_for(target))
 
-    crowded_session = SourceResolutionSession()
+    crowded_session = _session_for(target, noise)
     _verdict(noise, crowded_session)
     crowded = _verdict(target, crowded_session)
 
@@ -209,9 +216,11 @@ def test_isolated_result_equals_result_after_other_work(tmp_path: Path) -> None:
 
 def test_changed_source_content_invalidates_the_answer(tmp_path: Path) -> None:
     """Different source content must never be served the earlier answer."""
-    session = SourceResolutionSession()
-    before = _verdict(_project(tmp_path, "v1", _IMPL_A), session)
-    after = _verdict(_project(tmp_path, "v2", _IMPL_B), session)
+    before_project = _project(tmp_path, "v1", _IMPL_A)
+    after_project = _project(tmp_path, "v2", _IMPL_B)
+    session = _session_for(before_project, after_project)
+    before = _verdict(before_project, session)
+    after = _verdict(after_project, session)
 
     # Discrimination arm and assertion are the same edge: the memo did not
     # answer for content it never saw.
@@ -230,9 +239,9 @@ def test_changed_source_content_invalidates_the_answer(tmp_path: Path) -> None:
 
 def test_equal_paths_under_different_authorities_do_not_alias(tmp_path: Path) -> None:
     """Same module path + same exported name, different authority, no alias."""
-    session = SourceResolutionSession()
     left_graph, _ = left = _project(tmp_path, "left", _IMPL_A)
     right_graph, _ = right = _project(tmp_path, "right", _IMPL_B)
+    session = _session_for(left, right)
 
     left_answer = _verdict(left, session)
     right_answer = _verdict(right, session)
@@ -275,8 +284,8 @@ def test_distinct_sessions_share_content_prep_not_session_tables(
         )
         return target
 
-    session_a = SourceResolutionSession()
-    session_b = SourceResolutionSession()
+    session_a = _session_for(project)
+    session_b = _session_for(project)
     first = project_target(session_a)
     second = project_target(session_b)
 
@@ -288,7 +297,7 @@ def test_distinct_sessions_share_content_prep_not_session_tables(
     assert session_a.frame_results and session_b.frame_results
 
     # Discrimination: inside ONE session the answer is object-stable.
-    shared = SourceResolutionSession()
+    shared = _session_for(project)
     assert project_target(shared) is project_target(shared)
 
 
@@ -306,12 +315,12 @@ def test_byte_identical_modules_prepare_once_process_wide(tmp_path: Path) -> Non
     a = _project(tmp_path, "a", _IMPL_A)
     b = _project(tmp_path, "b", _IMPL_A)  # byte-identical module source
 
-    session_a = SourceResolutionSession()
+    session_a = _session_for(a)
     _verdict(a, session_a)
     impl_cid = next(iter(session_a.module_materializations.values()))[0].unit.source_cid
     assert prepare_count_for(impl_cid) == 1
 
-    session_b = SourceResolutionSession()
+    session_b = _session_for(b)
     _verdict(b, session_b)
     # Second project of same content does not re-prepare the body.
     assert prepare_count_for(impl_cid) == 1
@@ -332,8 +341,8 @@ def test_memo_disablement_changes_performance_only(tmp_path: Path) -> None:
     """The load-bearing law: a memo that changes an answer is not a memo."""
     project = _project(tmp_path, "p", _IMPL_A)
 
-    enabled = SourceResolutionSession(enabled=True)
-    disabled = SourceResolutionSession(enabled=False)
+    enabled = _session_for(project, enabled=True)
+    disabled = _session_for(project, enabled=False)
 
     with _MaterializeCounter() as enabled_counter:
         first_enabled = _verdict(project, enabled)
@@ -381,11 +390,12 @@ def test_disablement_preserves_parked_obligation_verdicts(tmp_path: Path) -> Non
         )
         return frame.frame_cid, target.name, obligations
 
-    warm_session = SourceResolutionSession()
+    roster = frozenset({graph.distribution_name})
+    warm_session = SourceResolutionSession(enrolled_distributions=roster)
     first_warm = answer(warm_session)
     second_warm = answer(warm_session)
-    cold = answer(SourceResolutionSession())
-    off = answer(SourceResolutionSession(enabled=False))
+    cold = answer(SourceResolutionSession(enrolled_distributions=roster))
+    off = answer(SourceResolutionSession(enabled=False, enrolled_distributions=roster))
 
     assert first_warm == second_warm == cold == off
     assert len(first_warm[2]) == 1
@@ -498,9 +508,9 @@ def test_authority_blind_key_aliases_two_distributions(
     tmp_path: Path, authority_blind_key
 ) -> None:
     """DISCRIMINATION for twins 2/3/4/5: dropping the authority aliases them."""
-    session = SourceResolutionSession()
     left_project = _project(tmp_path, "left", _IMPL_A)
     right_project = _project(tmp_path, "right", _IMPL_B)
+    session = _session_for(left_project, right_project)
 
     left = _resolve(left_project, session)
     right = _resolve(right_project, session)
@@ -571,7 +581,9 @@ def test_shared_session_amortizes_across_two_consumer_files(tmp_path: Path) -> N
             )
             assert isinstance(projected, tuple), projected
 
-    shared = SourceResolutionSession()
+    shared = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
     with _MaterializeCounter() as cold_counter:
         project_once(shared)  # two consumers, one session
     cold = cold_counter.count
@@ -588,8 +600,18 @@ def test_shared_session_amortizes_across_two_consumer_files(tmp_path: Path) -> N
     # Discrimination: isolated leaves (session_or_new(None) per project_once)
     # do not share memos — correct isolation, and proves the warm zero is real.
     with _MaterializeCounter() as isolated_counter:
-        project_once(session_or_new(None))
-        project_once(session_or_new(None))
+        project_once(
+            session_or_new(
+                None,
+                enrolled_distributions=frozenset({graph.distribution_name}),
+            )
+        )
+        project_once(
+            session_or_new(
+                None,
+                enrolled_distributions=frozenset({graph.distribution_name}),
+            )
+        )
     assert isolated_counter.count >= cold * 2, (
         f"isolated sessions only materialized {isolated_counter.count} times "
         f"(cold shared was {cold}); the shared-session twin cannot bite"
@@ -616,14 +638,20 @@ def test_file_open_door_threads_resolution_session(tmp_path: Path, monkeypatch) 
 
     monkeypatch.setattr(msd, "populate_source_derived_resource_refs", capture)
 
-    open_source_file_for_construction(path, root=root)
+    distribution = "session-authority-fixture"
+    open_source_file_for_construction(
+        path,
+        root=root,
+        distribution=distribution,
+        source_workspace_root=root,
+    )
     assert len(seen) == 1
     assert isinstance(seen[0], SourceResolutionSession), (
         "file-open dropped the session; populate fell back to session_or_new and "
         "the multi-resolve owner no longer owns amortization"
     )
 
-    shared = SourceResolutionSession()
+    shared = SourceResolutionSession(enrolled_distributions=frozenset({distribution}))
     seen.clear()
     open_source_file_for_construction(path, root=root, resolution_session=shared)
     assert seen == [shared], "explicit package session must reach populate unchanged"

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_assertion_manager.py
@@ -114,6 +114,8 @@ def _feather_tree():
         root=corpus.root.parent,
         construction_context=TreeConstructionContextV1.for_source_call_construction(),
         populate_derived=True,
+        source_workspace_root=corpus.root,
+        distribution=corpus.distribution,
     )
 
 
@@ -226,7 +228,9 @@ def _external_error_attributions():
         by_source[row["useSite"]["sourceCid"]].append(row)
 
     graph_cache = {}
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({corpus.distribution})
+    )
     attributed = []
     for source_cid, selected_rows in sorted(by_source.items()):
         path = paths[source_cid]

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_manager.py
@@ -39,6 +39,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import With
 from sugar_source_tree.tree import SourceFile
 
@@ -140,6 +141,9 @@ def _populate(root: Path, consumer: str, *, dist):
         root=root,
         path=path,
         distribution_index={"arbitrary": dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return tree, context, path
 

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_resource_stack.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_factored_assertion_resource_stack.py
@@ -29,6 +29,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import With
 from sugar_source_tree.tree import SourceFile
 
@@ -100,6 +101,9 @@ def _populate(root: Path, consumer: str, *, dist):
         root=root,
         path=path,
         distribution_index={"arbitrary": dist},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return tree, context, path
 

--- a/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_returned_resource_with_construction.py
@@ -53,6 +53,7 @@ from sugar_lift_py_tests.sugar.with_effect_boundary_sugar import WithEffectBound
 from sugar_lift_py_tests.sugar.with_resource_sugar import WithResourceSugar
 from sugar_lift_py_tests.sugar.with_source_resource_sugar import WithSourceResourceSugar
 from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_lift_python_source.manager_summary_derivation import (
     _projected_manager_call_uses,
     populate_source_derived_resource_refs,
@@ -143,6 +144,9 @@ def _tree(root: Path, consumer: str, *, dist, artifact_graph_cache=None):
         path=path,
         distribution_index={"arbitrary": dist},
         artifact_graph_cache=artifact_graph_cache,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({dist.metadata["Name"]})
+        ),
     )
     return tree, context, path
 
@@ -343,7 +347,14 @@ def test_real_option_context_coordinates_drive_every_resource_lifecycle_face():
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
     with_node = next(
         node
         for node in tree.nodes()
@@ -408,7 +419,14 @@ def test_real_pandas_option_context_runs_authenticated_enter_body_and_exit():
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
     with_node = next(
         node
         for node in tree.nodes()
@@ -464,7 +482,14 @@ def test_real_option_context_published_ref_selects_source_resource_at_constructi
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
     with_node = next(
         node
         for node in tree.nodes()
@@ -535,7 +560,14 @@ def test_real_option_context_executes_its_source_body_and_exit():
     tree = open_source_file_for_construction(
         path, root=root, construction_context=context, populate_derived=False
     )
-    populate_source_derived_resource_refs(tree, root=root, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=root,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({corpus.distribution})
+        ),
+    )
     with_node = next(
         node
         for node in tree.nodes()
@@ -988,7 +1020,12 @@ def test_fixture_supplied_formal_manager_stays_typed_loud_without_actual(
         (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert context.source_derived_contract_refs == {}
     assert _projected_manager_call_uses(tree) == {}
 

--- a/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_same_module_class_manager_derivation.py
@@ -23,6 +23,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import With
 from sugar_source_tree.panic import ContextManagerResolutionConstructionGap
 from sugar_source_tree.tree import SourceFile
@@ -97,6 +98,9 @@ def _imported_manager_gap(
         path=path,
         distribution_index=distribution_index,
         distribution=enrolled_distribution,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({enrolled_distribution})
+        ),
     )
     assert len(context.source_derived_contract_refs) == 1
     gap = next(iter(context.source_derived_contract_refs.values()))
@@ -120,7 +124,12 @@ def test_local_classdef_cm_derives_and_constructs(tmp_path: Path):
                 return 1
         """)
     tree, context, path = _source_file(tmp_path, source)
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
 
     assert len(context.source_derived_contract_refs) == 1
     ref = next(iter(context.source_derived_contract_refs.values()))
@@ -142,7 +151,12 @@ def test_local_classdef_without_protocol_installs_gap(tmp_path: Path):
                 return 1
         """)
     tree, context, path = _source_file(tmp_path, source)
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
 
     assert len(context.source_derived_contract_refs) == 1
     gap = next(iter(context.source_derived_contract_refs.values()))
@@ -176,7 +190,12 @@ def test_install_gap_never_attribute_errors_on_import_auth_fail(tmp_path: Path):
         """)
     tree, context, path = _source_file(tmp_path, source)
     # No distribution_index → authenticate fails → no-derived-contract gap.
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
     assert len(context.source_derived_contract_refs) == 1
     gap = next(iter(context.source_derived_contract_refs.values()))
     assert type(gap).__name__ == "ContextManagerResolutionGapV1"

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -13,7 +13,7 @@ from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.dependency_artifact import (
     DependencyArtifactGraph,
     ResolvedPythonObjectV1,
-    resolve_import_binding,
+    resolve_import_binding as _resolve_import_binding,
 )
 from sugar_lift_python_source.manager_construction import (
     CALL_TARGET_GAP_KINDS as _CALL_TARGET_GAP_KINDS,
@@ -23,8 +23,8 @@ from sugar_lift_python_source.manager_construction import (
     _call_coordinate,
     _install_opaque_call_obligation,
     _install_source_call_frame,
-    construct_manager_behavior,
-    resolve_source_visible_frame,
+    construct_manager_behavior as _construct_manager_behavior,
+    resolve_source_visible_frame as _resolve_source_visible_frame,
 )
 from sugar_lift_python_source.manager_protocol_construction import (
     ConstructedManagerProtocolV1,
@@ -37,10 +37,44 @@ from sugar_lift_python_source.manager_summary_derivation import (
     derive_manager_summary,
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.binding_provenance import ConstructedValueTestimonyV1
 from sugar_source_tree.binding_state import BindingEntryV1
 from sugar_source_tree.nodes import Call, ClassDef, Constant, Name
 from sugar_source_tree.tree import SourceFile
+
+
+def _session_enrolling_graph(graph) -> SourceResolutionSession:
+    return SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
+
+
+def resolve_import_binding(*args, graph, session=None, **kwargs):
+    return _resolve_import_binding(
+        *args,
+        graph=graph,
+        session=_session_enrolling_graph(graph) if session is None else session,
+        **kwargs,
+    )
+
+
+def resolve_source_visible_frame(*args, graph, session=None, **kwargs):
+    return _resolve_source_visible_frame(
+        *args,
+        graph=graph,
+        session=_session_enrolling_graph(graph) if session is None else session,
+        **kwargs,
+    )
+
+
+def construct_manager_behavior(*args, graph, session=None, **kwargs):
+    return _construct_manager_behavior(
+        *args,
+        graph=graph,
+        session=_session_enrolling_graph(graph) if session is None else session,
+        **kwargs,
+    )
 
 
 def _distribution(
@@ -426,6 +460,9 @@ def test_dual_mode_effect_boundary_installs_with_effect_boundary_sugar(tmp_path)
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     reference = next(iter(context.source_derived_contract_refs.values()))
@@ -2326,6 +2363,9 @@ def test_preconstruction_populates_resource_ref_from_authenticated_import(tmp_pa
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -2386,6 +2426,9 @@ def test_preconstruction_can_bound_derivation_to_one_authenticated_use(tmp_path)
         path=path,
         distribution_index={"arbitrary": distribution},
         selected_coordinates=frozenset({selected}),
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     assert tuple(context.source_derived_contract_refs) == (selected,)
@@ -2434,6 +2477,9 @@ def test_preconstruction_populates_renamed_effect_boundary_from_source(tmp_path)
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     reference = next(iter(context.source_derived_contract_refs.values()))
@@ -2486,7 +2532,15 @@ def _installed_pytest_boundary(tmp_path, manager_call: str, body: str):
         (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    pytest_distribution = importlib.metadata.distribution("pytest")
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({pytest_distribution.metadata["Name"]})
+        ),
+    )
     return tree, context
 
 
@@ -2602,7 +2656,15 @@ def test_installed_pandas_warning_manager_names_opaque_generator_transition(tmp_
         (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    pandas_distribution = importlib.metadata.distribution("pandas")
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({pandas_distribution.metadata["Name"]})
+        ),
+    )
 
     boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     assert isinstance(boundary, GeneratorWithSugar)
@@ -2634,6 +2696,9 @@ def test_imported_renamed_generator_manager_installs_native_frame(tmp_path):
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     assert isinstance(
@@ -2666,6 +2731,9 @@ def test_imported_ordinary_factory_cannot_lie_as_generator_manager(tmp_path):
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
 
     assert context.source_call_frames == {}
@@ -2698,7 +2766,15 @@ def _installed_plain_expected_halt_reference(tmp_path, function_body: str):
         (consumer, str(path), blake3_512_of(consumer.encode("utf-8"))),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    pytest_distribution = importlib.metadata.distribution("pytest")
+    populate_source_derived_resource_refs(
+        tree,
+        root=tmp_path,
+        path=path,
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({pytest_distribution.metadata["Name"]})
+        ),
+    )
     reference = next(iter(context.source_derived_contract_refs.values()))
     with_node = next(node for node in tree.nodes() if node.kind == "With")
     if isinstance(reference, SourceDerivedContextManagerRefV1):
@@ -2814,6 +2890,9 @@ def test_protocol_resource_never_selects_effect_boundary_assertion_door(tmp_path
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     reference = next(iter(context.source_derived_contract_refs.values()))
     assert isinstance(reference, SourceDerivedContextManagerRefV1)
@@ -2875,6 +2954,9 @@ def test_expects_effect_boundary_never_installs_as_protocol_resource(tmp_path):
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     reference = next(iter(context.source_derived_contract_refs.values()))
     assert isinstance(reference, SourceDerivedContextManagerRefV1)
@@ -2912,7 +2994,11 @@ def test_installed_stdlib_suppress_reaches_grouped_unpack_after_graph_authentica
     # Graph authentication of stdlib contextlib succeeds. Later-stage residual
     # (exit method ExitSet / unpack) stays a typed gap — not a bare SugarNotWritten.
     populate_source_derived_resource_refs(
-        tree, root=tmp_path, path=path, artifact_graph_cache=graphs
+        tree,
+        root=tmp_path,
+        path=path,
+        artifact_graph_cache=graphs,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
     )
 
     graph = graphs["contextlib"]
@@ -2977,6 +3063,9 @@ def test_renamed_source_boundary_routes_type_and_message_by_derived_formals(
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     from sugar_lift_py_tests.outcome import Completed, Halted, outcome_to_exitset
@@ -3194,6 +3283,9 @@ def test_boundary_consumes_authenticated_builtin_ancestry_only_in_one_direction(
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     boundary = next(node for node in tree.nodes() if node.kind == "With").sugar()
     from sugar_lift_py_tests.outcome import outcome_to_exitset
@@ -3258,6 +3350,9 @@ def _route_boundary_with_binding(
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     from sugar_lift_py_tests.outcome import outcome_to_exitset
 
@@ -3488,6 +3583,9 @@ def test_as_binding_requires_a_contract_that_declares_one(tmp_path):
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     refs = context.source_derived_contract_refs
     coordinate, reference = next(iter(refs.items()))
@@ -3580,6 +3678,9 @@ def _attribute_exception_tree(
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     return tree, context
 
@@ -3722,6 +3823,9 @@ def test_computed_exception_class_factory_stays_typed_opaque(tmp_path):
         root=tmp_path,
         path=path,
         distribution_index={"arbitrary": distribution},
+        session=SourceResolutionSession(
+            enrolled_distributions=frozenset({distribution.metadata["Name"]})
+        ),
     )
     with_node = next(node for node in tree.nodes() if node.kind == "With")
     # Either preconstruction refuses the call actual, or With stays force-floor /

--- a/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_call_preconstruction.py
@@ -19,11 +19,30 @@ from sugar_lift_py_tests.source_call_resolution import (
     SourceCallPreconstructionRefV1,
 )
 from sugar_lift_python_source.source_call_preconstruction import (
-    populate_source_visible_call_frames,
+    populate_source_visible_call_frames as _populate_source_visible_call_frames,
 )
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_source_tree.nodes import Call
 from sugar_source_tree.panic import BackendDefect, SugarNotWritten
 from sugar_source_tree.tree import SourceFile
+
+
+def populate_source_visible_call_frames(
+    *args, distribution_index, session=None, **kwargs
+):
+    """The fixture distribution index is the population under test."""
+    if session is None:
+        roster = frozenset(
+            distribution.metadata["Name"]
+            for distribution in distribution_index.values()
+        )
+        session = SourceResolutionSession(enrolled_distributions=roster)
+    return _populate_source_visible_call_frames(
+        *args,
+        distribution_index=distribution_index,
+        session=session,
+        **kwargs,
+    )
 
 
 def _distribution(root: Path, implementation: str) -> importlib.metadata.Distribution:

--- a/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
@@ -75,7 +75,8 @@ def test_static_pure_binding_prefix_admits_without_outcome(monkeypatch) -> None:
         "sugar_lift_python_source.manager_construction._module_prefix_outcome",
         counting,
     )
-    session = SourceResolutionSession()
+    # This tooth has no dependency graph: its authoritative population is empty.
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
     assert prefix_has_completed_fallthrough(module, locus, session=session) is True
     assert (
         calls["n"] == 0
@@ -116,5 +117,13 @@ def test_stdlib_graph_still_short_circuits(monkeypatch) -> None:
         "sugar_lift_python_source.manager_construction._static_prefix_always_fallthrough",
         boom,
     )
-    assert prefix_has_completed_fallthrough(module, locus, graph=graph) is True
+    assert (
+        prefix_has_completed_fallthrough(
+            module,
+            locus,
+            graph=graph,
+            session=SourceResolutionSession(enrolled_distributions=frozenset()),
+        )
+        is True
+    )
     assert calls["n"] == 0

--- a/implementations/python/sugar-lift-python-source/tests/test_walk_session.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_walk_session.py
@@ -25,19 +25,19 @@ def teardown_function() -> None:
 
 
 def test_walk_session_same_root_is_one_session(tmp_path: Path) -> None:
-    a = walk_session_for(tmp_path)
-    b = walk_session_for(tmp_path / ".")
+    a = walk_session_for(tmp_path, enrolled_distributions=frozenset())
+    b = walk_session_for(tmp_path / ".", enrolled_distributions=frozenset())
     assert a is b
     assert isinstance(a, SourceResolutionSession)
 
 
 def test_walk_session_different_roots_are_isolated(tmp_path: Path) -> None:
-    left = walk_session_for(tmp_path / "left")
-    right = walk_session_for(tmp_path / "right")
+    left = walk_session_for(tmp_path / "left", enrolled_distributions=frozenset())
+    right = walk_session_for(tmp_path / "right", enrolled_distributions=frozenset())
     (tmp_path / "left").mkdir()
     (tmp_path / "right").mkdir()
-    left2 = walk_session_for(tmp_path / "left")
-    right2 = walk_session_for(tmp_path / "right")
+    left2 = walk_session_for(tmp_path / "left", enrolled_distributions=frozenset())
+    right2 = walk_session_for(tmp_path / "right", enrolled_distributions=frozenset())
     assert left2 is left
     assert right2 is right
     assert left is not right
@@ -62,10 +62,14 @@ def test_open_default_uses_walk_session(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(msd, "populate_source_derived_resource_refs", capture)
 
-    open_source_file_for_construction(path, root=root)
-    open_source_file_for_construction(path, root=root)
+    distribution = "walk-session-fixture"
+    roster = frozenset({distribution})
+    open_source_file_for_construction(path, root=root, distribution=distribution)
+    open_source_file_for_construction(path, root=root, distribution=distribution)
     assert len(seen) == 2
-    assert seen[0] is seen[1] is walk_session_for(root), (
+    assert (
+        seen[0] is seen[1] is walk_session_for(root, enrolled_distributions=roster)
+    ), (
         "two opens under the same root must share the walk session so same-content "
         "re-open and census multi-file amortize projection memos"
     )
@@ -89,7 +93,8 @@ def test_open_explicit_session_bypasses_walk(tmp_path: Path, monkeypatch) -> Non
 
     monkeypatch.setattr(msd, "populate_source_derived_resource_refs", capture)
 
-    isolated = SourceResolutionSession()
+    roster = frozenset({"walk-session-fixture"})
+    isolated = SourceResolutionSession(enrolled_distributions=roster)
     open_source_file_for_construction(path, root=root, resolution_session=isolated)
     assert seen == [isolated]
-    assert isolated is not walk_session_for(root)
+    assert isolated is not walk_session_for(root, enrolled_distributions=roster)

--- a/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
+++ b/implementations/python/sugar-source-tree/tests/test_attribute_property_exit_construction.py
@@ -11,6 +11,10 @@ from sugar_lift_py_tests.outcome.exit_set import Halted
 from sugar_lift_python_source.manager_summary_derivation import (
     populate_source_derived_resource_refs,
 )
+from sugar_lift_python_source.dependency_artifact import (
+    authenticate_dependency_top_level,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
 from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.nodes import Attribute, With
 from sugar_source_tree.panic import SugarNotWritten
@@ -40,7 +44,16 @@ def _tree(tmp_path: Path, source: str) -> SourceFile:
         workspace_path_source(str(path), root=str(tmp_path)),
         construction_context=context,
     )
-    populate_source_derived_resource_refs(tree, root=tmp_path, path=path)
+    pytest_graph = authenticate_dependency_top_level("pytest")
+    if pytest_graph.artifact_kind != "distribution":
+        raise AssertionError("installed pytest slice requires a distribution graph")
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({pytest_graph.distribution_name})
+    )
+    session.dependency_graphs["pytest"] = pytest_graph
+    populate_source_derived_resource_refs(
+        tree, root=tmp_path, path=path, session=session
+    )
     return tree
 
 

--- a/implementations/python/sugar-source-tree/tests/test_cross_unit_definition_registration.py
+++ b/implementations/python/sugar-source-tree/tests/test_cross_unit_definition_registration.py
@@ -129,7 +129,9 @@ def _manager_frame(tmp_path: Path, name: str):
         module_identities={},
     )
     assert len(receipts) == 1
-    session = SourceResolutionSession()
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({graph.distribution_name})
+    )
     resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
     assert isinstance(resolved, ResolvedPythonObjectV1)
     projected = resolve_source_visible_frame(resolved, graph=graph, session=session)


### PR DESCRIPTION
## What changed

The constructor refusal in #7250 made an unknown enrollment roster unconstructible. This follow-up binds every remaining production and test caller deliberately:

- authenticated dependency graphs pass their real `graph.distribution_name`
- installed pytest slices authenticate the installed pytest distribution and enroll that exact name
- CPython-only walks pass an explicit authoritative `frozenset()`
- graph-free memo/prefix tests pass an explicit empty roster only where the path does not perform population classification
- `ResolvedPythonObjectV1.from_value` now requires and reuses its caller-owned session while revalidating the import binding

This is one caller-closure arrival after the constructor refusal, not a softened default. No constructor, manager, or population-predicate refusal is weakened.

## Why

Before #7250, `roster=None` had one reader: `_graph_is_off_population`. That reader gave unknown authority the permissive meaning “not off-population,” silently treating every non-stdlib distribution as enrolled. Tests could therefore pass while asking a different population question than their fixture established.

The refusal exposed the dependent population. This change supplies authority at each caller instead of recreating the old permissive default under `frozenset()`.

## Runtime closure receipt

Fresh one-use battleaxe root:

`/home/tsavo/remote/kobayashi-roster-closure-20260803-1506`

Suite result: `274 failed / 888 passed / 14 skipped / 2 warnings in 69.09s`, unpiped exit 1.

Row-identity comparison against the pre-refusal head:

- `R_roster_terminal=0`
- all 155 formerly-green invocations that began refusing now pass with explicit authority
- of 237 previously-red invocations whose first terminal moved to roster authority, 49 now pass outright and 107 reach a deeper non-roster terminal
- the other 81 previously-red semantic rows are 80 unchanged after normalizing reporter prefixes/object addresses and one intentionally earlier off-population terminal: a pandas source opening pytest is outside the enrolled pandas population
- 85 unrelated pre-existing failures remain unrelated

The headline is not “392 regressions.” The constructor refusal revealed 155 previously-green invocations that had been succeeding about a question nobody asked, plus 237 existing reds whose earlier terminal masked their original one.

Three authority categories were audited rather than inferred per test:

- 211 synthetic/authenticated dependency graphs -> authenticated distribution name
- 15 CPython-only graphs -> explicit empty roster
- 11 graph-free memo/prefix paths -> explicit empty roster; zero of these reached an off-population terminal

Four callers outside the original package sweep were then discriminated independently:

- source-property installed pytest slice: green with authenticated pytest authority
- synthetic reporter distribution: green with `graph.distribution_name`
- stdlib `re` import-member slice: green with explicit empty authority
- installed-pytest first-auth BinOp slice: roster authority closes, then a deeper named `Try._construct_sugar` gap appears for a dotted exception type in `_pytest/raises.py`

That last result is discovery beneath the fixed entrance, not a roster regression. This PR does not write that sugar.

## Static closure

Repo-wide AST scan after the bindings:

- `populate_source_derived_resource_refs`: 62 direct calls, 1 without session — the deliberate manager refusal tooth
- `SourceResolutionSession`: 121 direct constructions, 3 without roster — two monkeypatched-constructor bypass rows tracked by #7252 plus the constructor tooth
- `walk_session_for`: 13 direct calls, 1 without roster — the constructor tooth
- `session_or_new`: 14 direct calls, 1 `None` without roster — the constructor tooth

No production caller remains statically unauthoritative.

## Focused checks

- constructor and manager authority teeth: `8 passed in 0.67s`, exit 0
- four off-package roster discriminators: `3 passed, 1 deeper non-roster terminal in 8.15s`, exit 1; `R_roster_terminal=0`
- Black 26.5.1 over all 53 changed Python files: clean
- focused `py_compile`: exit 0
- `git diff --check`: exit 0

## History and tree preflight

- head: `4fccc6f3c06019abfa067f95e288f2e71d4ca38d`
- direct parent and merge-base: `6c66f8a12cdfbf5c5b784b4b192faf15fc8e1252`
- ahead/behind main: `1/0`
- range: exactly one caller commit; retired PR head `e1740485110a4da209432bde7cdf0e5d7e6593d3` is absent
- scope: 53 files, `+771/-188`, zero deleted files
- `.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.json` is present in the branch tree and retains SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`

## Not claiming

This does not claim the remaining 274 suite failures are roster defects, does not claim every deeper terminal is correct without its own triage, does not repair the newly exposed pytest `Try` gap, and does not resolve the monkeypatched-constructor bypass tracked in #7252.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require explicit `SourceResolutionSession` with enrolled distributions across all resolution call sites
> - Every call to `populate_source_derived_resource_refs`, `resolve_import_binding`, `resolve_source_visible_frame`, and related APIs now requires a `SourceResolutionSession` with an explicit `enrolled_distributions` set rather than relying on a default or implicit session.
> - `ResolvedPythonObjectV1.from_value` gains a required `session` parameter and forwards it to `resolve_import_binding`.
> - Test helpers across dozens of test modules are updated to construct and pass appropriately enrolled sessions — either with the distribution under test or with an empty frozenset for stdlib-only scenarios.
> - Several test files introduce local `_session_enrolling_graph` or `_session_for` factory helpers to reduce repetition and ensure consistent session enrollment.
> - Behavioral Change: passing no session to `populate_source_derived_resource_refs` now raises `TypeError` with message `'session construction requires an enrolled distribution roster'` instead of the previous `MissingEnrolledDistributionRoster` exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fccc6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->