### PR TITLE
Migrate python-bind to source enumeration

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_rpc.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_rpc.py
@@ -2,11 +2,21 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import traceback
+from pathlib import Path
 from typing import Any
 
-from .bind_lifter import lift_paths
+from .bind_lifter import _iter_python_files, lift_paths
+from .rpc import (
+    ENUMERATE_RPC_METHOD,
+    _degenerate_file_memento,
+    _enumerate_result,
+    _memento_matches,
+    _resolved_under_root,
+)
+from .source_oracle import SourceUnavailable, path_source
 
 VERSION = "0.1.0"
 SURFACE = "python-bind"
@@ -37,7 +47,7 @@ def kit_declaration_result() -> dict[str, Any]:
             "methods": [
                 {"name": "initialize", "required": True},
                 {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
-                {"name": "lift", "required": True},
+                {"name": ENUMERATE_RPC_METHOD, "required": True},
                 {"name": "shutdown", "required": False},
             ]
         },
@@ -74,6 +84,8 @@ def dispatch(request: dict[str, Any]) -> dict[str, Any]:
         return {"jsonrpc": "2.0", "id": msg_id, "result": initialize_result()}
     if method == KIT_DECLARATION_RPC_METHOD:
         return {"jsonrpc": "2.0", "id": msg_id, "result": kit_declaration_result()}
+    if method == ENUMERATE_RPC_METHOD:
+        return _enumerate(msg_id, params)
     if method == "lift":
         return _lift(msg_id, params)
     if method == "shutdown":
@@ -108,6 +120,121 @@ def _lift(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
             "diagnostics": result.diagnostics,
         },
     }
+
+
+def _enumerate(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Construct python-bind IR through the SourceTree enumeration door.
+
+    This producer is per-file independent: ``lift_paths`` carries no mutable
+    cross-file registry, and its package re-export map is derived from the
+    workspace root on every call.  The Rust fold therefore reproduces the
+    retired whole-population lift by sealing ``source_files`` and demanding
+    ``universe`` once for every sealed file.
+    """
+    level = params.get("level")
+    root = Path(str(params.get("workspace_root", "."))).resolve()
+    at = params.get("at") if isinstance(params.get("at"), dict) else None
+    seek = bool(params.get("seek", False))
+
+    if level == "parameter-contract-link-units":
+        return {"jsonrpc": "2.0", "id": msg_id, "result": {"rows": []}}
+
+    if level == "source_files":
+        nodes: list[dict[str, Any]] = []
+        gaps: list[dict[str, Any]] = []
+        for file_path in sorted(_iter_python_files(root)):
+            rel_path = os.path.relpath(file_path, root).replace(os.sep, "/")
+            try:
+                _source, _filename, cid = path_source(str(file_path))
+            except SourceUnavailable as unavailable:
+                gaps.append(
+                    {
+                        "memento": _degenerate_file_memento(rel_path),
+                        "reason": str(unavailable),
+                    }
+                )
+                continue
+            memento = _degenerate_file_memento(rel_path, cid)
+            if seek and at is not None and not _memento_matches(memento, at):
+                continue
+            nodes.append({"memento": memento, "audit": None, "payload": None})
+        return _enumerate_result(msg_id, nodes, gaps)
+
+    if level == "universe":
+        rel_path = at.get("file") if at else None
+        if not isinstance(rel_path, str) or not rel_path:
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": at,
+                        "reason": "sugar.enumerate level='universe' requires `at.file`",
+                    }
+                ],
+            )
+        full_path = _resolved_under_root(root, rel_path)
+        if full_path is None:
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": at,
+                        "reason": f"path '{rel_path}' escapes workspace root '{root}'",
+                    }
+                ],
+            )
+        try:
+            _source, _filename, cid = path_source(str(full_path))
+        except SourceUnavailable as unavailable:
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": _degenerate_file_memento(rel_path),
+                        "reason": str(unavailable),
+                    }
+                ],
+            )
+        memento = _degenerate_file_memento(rel_path, cid)
+        if at is not None and not _memento_matches(memento, at):
+            return _enumerate_result(
+                msg_id,
+                [],
+                [
+                    {
+                        "memento": memento,
+                        "reason": (
+                            f"source identity for '{rel_path}' no longer matches "
+                            "the sealed source_files census"
+                        ),
+                    }
+                ],
+            )
+
+        options_value = params.get("options")
+        options = options_value if isinstance(options_value, dict) else {}
+        layer = str(options.get("layer") or "library-bindings")
+        file_result = lift_paths(str(root), [rel_path], layer=layer)
+        nodes = [
+            {"memento": memento, "audit": row, "payload": None}
+            for row in file_result.ir
+        ]
+        gaps = [
+            {"memento": memento, "reason": json.dumps(diagnostic, sort_keys=True)}
+            for diagnostic in file_result.diagnostics
+        ]
+        return _enumerate_result(msg_id, nodes, gaps)
+
+    return _error(
+        msg_id,
+        -32602,
+        f"sugar.enumerate: level {level!r} is not served by surface "
+        f"`{SURFACE}`; answering an unowned level with an empty census would "
+        "be a false zero",
+    )
 
 
 def _send(obj: dict[str, Any]) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_bind_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_bind_enumerate_rpc.py
@@ -1,0 +1,118 @@
+"""The python-bind surface constructs through ``sugar.enumerate`` only.
+
+The promotion proof is deliberately whole-population: folding per-file
+``universe`` rows over the sealed ``source_files`` census must reproduce the
+retired handler's whole-population result.  A per-file/per-file comparison is
+not sufficient evidence for a lift migration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sugar_lift_python_source.bind_rpc import (
+    ENUMERATE_RPC_METHOD,
+    dispatch,
+    kit_declaration_result,
+)
+from sugar_lift_python_source.source_oracle import path_source
+
+
+def _enumerate(root: Path, level: str, *, at: dict | None = None) -> dict:
+    params: dict = {"level": level, "workspace_root": str(root)}
+    if at is not None:
+        params["at"] = at
+    return dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": ENUMERATE_RPC_METHOD,
+            "params": params,
+        }
+    )
+
+
+def _write_population(root: Path) -> None:
+    (root / "alpha.py").write_text(
+        "# concept: alpha\ndef alpha(x: int) -> int:\n    return x\n",
+        encoding="utf-8",
+    )
+    (root / "beta.py").write_text(
+        "# concept: beta\ndef beta(y: int) -> int:\n    return y\n",
+        encoding="utf-8",
+    )
+
+
+def test_bind_declaration_advertises_enumerate_and_retires_lift() -> None:
+    names = {method["name"] for method in kit_declaration_result()["rpc"]["methods"]}
+
+    assert ENUMERATE_RPC_METHOD in names
+    assert "lift" not in names
+
+
+def test_bind_source_files_seals_the_whole_python_population(tmp_path: Path) -> None:
+    _write_population(tmp_path)
+    (tmp_path / "notes.txt").write_text("not source", encoding="utf-8")
+
+    result = _enumerate(tmp_path, "source_files")["result"]
+
+    assert [node["memento"]["file"] for node in result["nodes"]] == [
+        "alpha.py",
+        "beta.py",
+    ]
+    assert result["gaps"] == []
+    _source, _filename, alpha_cid = path_source(str(tmp_path / "alpha.py"))
+    assert result["nodes"][0]["memento"]["source_cid"] == alpha_cid
+
+
+def test_bind_population_fold_equals_whole_population_legacy(tmp_path: Path) -> None:
+    """The true migration contract: population legacy == enumerated fold."""
+    _write_population(tmp_path)
+
+    census = _enumerate(tmp_path, "source_files")["result"]
+    folded = [
+        node["audit"]
+        for file_node in census["nodes"]
+        for node in _enumerate(tmp_path, "universe", at=file_node["memento"])["result"][
+            "nodes"
+        ]
+    ]
+    legacy = dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "lift",
+            "params": {"workspace_root": str(tmp_path), "source_paths": ["."]},
+        }
+    )["result"]["ir"]
+
+    assert len(legacy) == 2, "the promotion control must carry real claim mass"
+    assert folded == legacy
+
+
+def test_bind_universe_refuses_a_stale_source_identity(tmp_path: Path) -> None:
+    _write_population(tmp_path)
+    alpha = _enumerate(tmp_path, "source_files")["result"]["nodes"][0]["memento"]
+    (tmp_path / "alpha.py").write_text(
+        "# concept: changed\ndef alpha(x: int) -> int:\n    return x + 1\n",
+        encoding="utf-8",
+    )
+
+    result = _enumerate(tmp_path, "universe", at=alpha)["result"]
+
+    assert result["nodes"] == []
+    assert len(result["gaps"]) == 1
+    assert "source identity" in result["gaps"][0]["reason"]
+
+
+def test_bind_declares_no_parameter_contract_link_units(tmp_path: Path) -> None:
+    response = _enumerate(tmp_path, "parameter-contract-link-units")
+
+    assert response["result"] == {"rows": []}
+
+
+def test_bind_refuses_an_unowned_enumeration_level(tmp_path: Path) -> None:
+    response = _enumerate(tmp_path, "facts")
+
+    assert response["error"]["code"] == -32602
+    assert "false zero" in response["error"]["message"]

--- a/implementations/python/sugar-lift-python-source/tests/test_bind_lifter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_bind_lifter.py
@@ -21,7 +21,11 @@ from sugar_lift_python_source.bind_lifter import (
     _public_reexport_map,
     lift_source,
 )
-from sugar_lift_python_source.bind_rpc import dispatch, initialize_result
+from sugar_lift_python_source.bind_rpc import (
+    ENUMERATE_RPC_METHOD,
+    dispatch,
+    initialize_result,
+)
 from sugar_lift_py_tests.canonicalizer import blake3_512_of
 from sugar_lift_py_tests.op_cid import local_op_cid
 from sugar_lift_python_source.canonical import cid_of_json
@@ -842,7 +846,7 @@ def test_bind_rpc_kit_declaration_returns_python_bind_surface() -> None:
     assert required_by_name == {
         "initialize": True,
         KIT_DECLARATION_RPC_METHOD: True,
-        "lift": True,
+        ENUMERATE_RPC_METHOD: True,
         "shutdown": False,
     }
     assert result["proofResolution"] == {"strategy": "pip"}


### PR DESCRIPTION
## Summary

Migrate the `python-bind` producer from the retired `lift` kit entrance to `sugar.enumerate`.

The new door:

- seals the complete Python file population through `path_source`;
- serves each demanded file through the existing `lift_paths(..., layer="library-bindings")` construction;
- authenticates the demanded file against its sealed source CID;
- declares the truthful empty parameter-contract-link-unit population; and
- refuses unowned levels loudly instead of returning a false empty census.

This is the one proven-mechanical door in the 24-row retired-lift showcase group. The other producer migrations are governed by #7261 and are not included here.

## Promotion proof

Per #7261, the control is **whole-population legacy versus per-file enumerate over the sealed population**, never per-file versus per-file.

The fixture contains two source files and the whole-population legacy result contains exactly 2 IR rows. Folding `universe` once for each memento returned by `source_files` produces exact row-for-row equality with those 2 legacy rows.

Before implementation, the new test module refused during collection because `bind_rpc` had no `ENUMERATE_RPC_METHOD` (exit 2). After implementation, **all six planted teeth collected and ran: 6/6 passed**. This collection count is explicit so a green five-test run cannot masquerade as full discrimination.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | exact whole-population construction equality |
| `mandatory_panics` | 0 | no sugar or panic semantics changed |
| `suppressed_descendants` | 0 | no suppression path changed |
| `typed_effects` | 0 | no effect semantics changed |
| `silent` | 0 | floor: must stay 0 |

Showcase entrance prediction: the 2 historical `python-bind` retired-lift rows should leave that entrance cause. This is an epsilon from the historical authenticated triage, not a current measured delta. Showcase semantics remain unmeasured until the post-land run.

## Validation

Pinned source tree: `5d30803848288b6de93428f733895ab4f9cfc95b`.

- `python -m pytest .../test_bind_enumerate_rpc.py -q`: 6 passed; all six tests collected and executed.
- Fresh post-commit check over the migration file plus unaffected bind tests: 62 passed, 2 deselected, exit 0.
- Black 26.5.1: all 3 changed files unchanged, exit 0.
- The two deselected decorator tests were not convenient exclusions: a separate detached worktree at unchanged main `5d30803848` reproduced both failures, 2/2, with the same `_ConceptCitationRefusal` NameError terminal before this branch existed.

Battleaxe is **unmeasured**. Its CAS verifier refused before pytest executed and reported a diagnosis now being repaired separately; this PR does not claim the shelf cell was corrupt or root-owned, and no remote test number is inferred from that refusal.

## Floors preserved

- No test deleted or detector weakened.
- The retired `lift` handler remains internal only as the promotion-proof control; it is no longer advertised as a kit method.
- Source identity is minted through the existing oracle and stale identity is a named gap.
- Unknown enumeration levels refuse by name; no fabricated zero.
- No current showcase result, showcase semantic outcome, or corpus-wide residual delta is claimed.

Closes neither #7261 nor the four real-translation doors it governs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate python-bind RPC from `lift` to `sugar.enumerate` with source file and universe levels
> - Replaces the advertised `lift` RPC method with `sugar.enumerate` in [bind_rpc.py](https://github.com/TSavo/sugar/pull/7262/files#diff-71297b0f62b12999e4e9ec41aa618f0281559df9c15ef81223a5ac93aeca7521).
> - `level='source_files'` iterates Python files under `workspace_root`, attaches source content IDs via degenerate file mementos, and supports seek/at filtering with gaps for unavailable sources.
> - `level='universe'` validates a file path against `workspace_root`, checks memento freshness, runs `lift_paths`, and returns per-row IR nodes with diagnostics as gaps.
> - `level='parameter-contract-link-units'` returns empty rows; unknown levels return a `-32602` error.
> - New tests in [test_bind_enumerate_rpc.py](https://github.com/TSavo/sugar/pull/7262/files#diff-86b1f96931fd0d84e7f0a402791b09725de1247ffc814ae58a0888d782bca2a8) cover all levels, stale memento rejection, and the kit declaration change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d338a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enumeration support for Python source files and universes through the RPC interface.
  * Added source-file census results, including unavailable-source reporting.
  * Added validation for workspace boundaries and stale source identities.
  * Updated the kit declaration to advertise enumeration and retire the legacy lift method.

* **Bug Fixes**
  * Unsupported enumeration levels now return clear invalid-parameter errors.

* **Tests**
  * Added coverage for enumeration behavior, validation, compatibility, and empty contract results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->