### PR TITLE
Migrate build witness to source enumeration

### DIFF
--- a/implementations/python/sugar-build-witness/src/sugar_build_witness/lift_lsp.py
+++ b/implementations/python/sugar-build-witness/src/sugar_build_witness/lift_lsp.py
@@ -5,9 +5,11 @@ import base64
 import json
 import os
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional
 
-from sugar_lift_py_tests.canonicalizer import encode_jcs
+from sugar_lift_py_tests.canonicalizer import blake3_512_of, encode_jcs
 from sugar_lift_py_tests.ir import (
     ContractDecl,
     declarations_to_value,
@@ -20,6 +22,7 @@ from .witness import (
     DEFAULT_MANIFEST,
     BuildWitness,
     build_witness_memento,
+    load_build_witness_plan,
     run_build_witness,
     witness_body,
     write_witness_package,
@@ -29,6 +32,20 @@ KIT_ID = "build-witness"
 KIT_VERSION = "0.1.0"
 KIT_DECLARATION_RPC_METHOD = "sugar.plugin.kit_declaration"
 RESOLVE_WITNESS_RPC_METHOD = "sugar.plugin.resolve_witness"
+ENUMERATE_RPC_METHOD = "sugar.enumerate"
+
+
+@dataclass(frozen=True)
+class _PopulationContext:
+    root: Path
+    anchor: str
+    sealed_cids: tuple[tuple[str, str], ...]
+
+    def cid_for(self, rel_path: str) -> str | None:
+        return dict(self.sealed_cids).get(rel_path)
+
+
+_POPULATION_CONTEXTS: dict[str, _PopulationContext] = {}
 
 
 def build_witness_proofir_provenance(bundle_cid: str, manifest_cid: str) -> dict:
@@ -97,72 +114,65 @@ def _recv() -> Optional[dict]:
         return None
 
 
+def _build_ir_document(ws: str, manifest_path: str = DEFAULT_MANIFEST) -> dict:
+    """The one build-witness construction, shared by legacy proof and adapter."""
+    if not os.path.isfile(os.path.join(ws, manifest_path)):
+        return {
+            "kind": "ir-document",
+            "ir": [],
+            "witness_mementos": [],
+            "implications": [],
+            "diagnostics": [],
+            "warnings": [{"message": "build-witness.json not found"}],
+        }
+    w = run_build_witness(ws, manifest_path)
+    package_dir = os.path.join(ws, ".sugar", "witnesses")
+    write_witness_package(w, package_dir)
+    decls = [
+        ContractDecl(
+            name=f"build-witness:{w.cid}::repo-script-cid-equals-distributed-script-cid",
+            inv=eq(str_const(w.repo_script_cid), str_const(w.distributed_script_cid)),
+        )
+    ]
+    for out in w.outputs:
+        decls.append(
+            ContractDecl(
+                name=(
+                    f"build-witness:{w.cid}"
+                    f"::distributed-output-cid-equals-rebuilt-output-cid::{out['distributed']}"
+                ),
+                inv=eq(str_const(out["distributedCid"]), str_const(out["rebuiltCid"])),
+            )
+        )
+    memento = build_witness_memento(w)
+    ir = json.loads(encode_jcs(declarations_to_value(decls)))
+    for member in ir:
+        if member.get("kind") == "contract" and member.get("name", "").startswith(
+            f"build-witness:{w.cid}"
+        ):
+            member["proofirProvenance"] = build_witness_proofir_provenance(
+                w.cid, w.manifest_cid
+            )
+            member["evidence"] = build_witness_evidence(w)
+    ir = ir + [memento]
+    return {
+        "kind": "ir-document",
+        "ir": ir,
+        "witness_mementos": [memento],
+        "implications": [],
+        "diagnostics": [],
+        "warnings": [],
+    }
+
+
 def handle_lift(msg_id: Any, params: dict) -> None:
     ws = str(params.get("workspace_root", "."))
-    manifest_path = DEFAULT_MANIFEST
-    if not os.path.isfile(os.path.join(ws, manifest_path)):
-        _send(
-            {
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {
-                    "kind": "ir-document",
-                    "ir": [],
-                    "witness_mementos": [],
-                    "implications": [],
-                    "diagnostics": [],
-                    "warnings": [{"message": "build-witness.json not found"}],
-                },
-            }
-        )
-        return
     try:
-        w = run_build_witness(ws, manifest_path)
-        package_dir = os.path.join(ws, ".sugar", "witnesses")
-        write_witness_package(w, package_dir)
-        decls = [
-            ContractDecl(
-                name=f"build-witness:{w.cid}::repo-script-cid-equals-distributed-script-cid",
-                inv=eq(
-                    str_const(w.repo_script_cid), str_const(w.distributed_script_cid)
-                ),
-            )
-        ]
-        for out in w.outputs:
-            decls.append(
-                ContractDecl(
-                    name=(
-                        f"build-witness:{w.cid}"
-                        f"::distributed-output-cid-equals-rebuilt-output-cid::{out['distributed']}"
-                    ),
-                    inv=eq(
-                        str_const(out["distributedCid"]), str_const(out["rebuiltCid"])
-                    ),
-                )
-            )
-        memento = build_witness_memento(w)
-        ir = json.loads(encode_jcs(declarations_to_value(decls)))
-        for member in ir:
-            if member.get("kind") == "contract" and member.get("name", "").startswith(
-                f"build-witness:{w.cid}"
-            ):
-                member["proofirProvenance"] = build_witness_proofir_provenance(
-                    w.cid, w.manifest_cid
-                )
-                member["evidence"] = build_witness_evidence(w)
-        ir = ir + [memento]
         _send(
             {
                 "jsonrpc": "2.0",
                 "id": msg_id,
-                "result": {
-                    "kind": "ir-document",
-                    "ir": ir,
-                    "witness_mementos": [memento],
-                    "implications": [],
-                    "diagnostics": [],
-                    "warnings": [],
-                },
+                "result": _build_ir_document(ws),
             }
         )
     except Exception as e:
@@ -175,6 +185,263 @@ def handle_lift(msg_id: Any, params: dict) -> None:
                 "error": {
                     "code": -32603,
                     "message": str(e),
+                    "data": traceback.format_exc(),
+                },
+            }
+        )
+
+
+def _file_memento(rel_path: str, source_cid: str | None = None) -> dict[str, Any]:
+    return {
+        "kind": "source-memento",
+        "file": rel_path,
+        "function_name": "",
+        "span": None,
+        "param_names": [],
+        "source_cid": source_cid,
+        "template_cid": None,
+    }
+
+
+def _enumerate_result(
+    msg_id: Any, nodes: list[dict[str, Any]], gaps: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {"nodes": nodes, "gaps": gaps},
+    }
+
+
+def _enumerate_error(msg_id: Any, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": -32602, "message": message},
+    }
+
+
+def _sealed_input_cid(root: Path, rel_path: str) -> str:
+    full_path = (root / rel_path).resolve(strict=True)
+    try:
+        full_path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(
+            f"build-witness input '{rel_path}' escapes workspace root '{root}'"
+        ) from exc
+    if not full_path.is_file():
+        raise FileNotFoundError(
+            f"build-witness input '{rel_path}' is not a file required by the manifest"
+        )
+    return blake3_512_of(full_path.read_bytes())
+
+
+def _prepare_population(root: Path) -> tuple[_PopulationContext | None, list[dict]]:
+    manifest_file = root / DEFAULT_MANIFEST
+    if not manifest_file.is_file():
+        _POPULATION_CONTEXTS.pop(str(root), None)
+        return None, []
+
+    plan = load_build_witness_plan(str(root), DEFAULT_MANIFEST)
+    sealed: list[tuple[str, str]] = []
+    gaps: list[dict] = []
+    for rel_path in plan.authenticated_input_paths:
+        try:
+            cid = _sealed_input_cid(root, rel_path)
+        except (OSError, ValueError) as exc:
+            gaps.append({"memento": _file_memento(rel_path), "reason": str(exc)})
+            continue
+        sealed.append((rel_path, cid))
+
+    if gaps:
+        _POPULATION_CONTEXTS.pop(str(root), None)
+        return None, gaps
+    context = _PopulationContext(
+        root=root,
+        anchor=plan.manifest_path,
+        sealed_cids=tuple(sealed),
+    )
+    _POPULATION_CONTEXTS[str(root)] = context
+    return context, []
+
+
+def _population_drift(context: _PopulationContext) -> str | None:
+    for rel_path, sealed_cid in context.sealed_cids:
+        try:
+            observed_cid = _sealed_input_cid(context.root, rel_path)
+        except (OSError, ValueError) as exc:
+            return (
+                f"build-witness input '{rel_path}' cannot be authenticated against "
+                f"the sealed source_files census: {exc}"
+            )
+        if observed_cid != sealed_cid:
+            return (
+                f"build-witness input '{rel_path}' changed since the sealed "
+                f"source_files census: {sealed_cid} != {observed_cid}"
+            )
+    return None
+
+
+def handle_enumerate(msg_id: Any, params: dict) -> None:
+    """Project one whole-workspace witness at its sealed manifest anchor."""
+    level = str(params.get("level", ""))
+    root = Path(str(params.get("workspace_root", "."))).resolve()
+    at = params.get("at") if isinstance(params.get("at"), dict) else None
+
+    try:
+        if level == "parameter-contract-link-units":
+            _send({"jsonrpc": "2.0", "id": msg_id, "result": {"rows": []}})
+            return
+
+        if level == "source_files":
+            context, gaps = _prepare_population(root)
+            if context is None:
+                _send(_enumerate_result(msg_id, [], gaps))
+                return
+            seek = bool(params.get("seek", False))
+            nodes = [
+                {
+                    "memento": _file_memento(rel_path, cid),
+                    "audit": None,
+                    "payload": None,
+                }
+                for rel_path, cid in context.sealed_cids
+                if not seek
+                or at is None
+                or (
+                    at.get("file") == rel_path
+                    and (
+                        not (at.get("source_cid") or at.get("sourceCid"))
+                        or (at.get("source_cid") or at.get("sourceCid")) == cid
+                    )
+                )
+            ]
+            _send(_enumerate_result(msg_id, nodes, []))
+            return
+
+        if level == "universe":
+            rel_path = at.get("file") if at else None
+            if not isinstance(rel_path, str) or not rel_path:
+                _send(
+                    _enumerate_result(
+                        msg_id,
+                        [],
+                        [
+                            {
+                                "memento": at,
+                                "reason": (
+                                    "sugar.enumerate level='universe' requires at.file"
+                                ),
+                            }
+                        ],
+                    )
+                )
+                return
+            context = _POPULATION_CONTEXTS.get(str(root))
+            if context is None:
+                _send(
+                    _enumerate_result(
+                        msg_id,
+                        [],
+                        [
+                            {
+                                "memento": at,
+                                "reason": (
+                                    "build-witness universe requires a prepared "
+                                    "source_files census for this workspace"
+                                ),
+                            }
+                        ],
+                    )
+                )
+                return
+            sealed_cid = context.cid_for(rel_path)
+            if sealed_cid is None:
+                _send(
+                    _enumerate_result(
+                        msg_id,
+                        [],
+                        [
+                            {
+                                "memento": at,
+                                "reason": (
+                                    f"build-witness input '{rel_path}' is not a member "
+                                    "of the sealed source_files census"
+                                ),
+                            }
+                        ],
+                    )
+                )
+                return
+            requested_cid = at.get("source_cid") or at.get("sourceCid")
+            if requested_cid and requested_cid != sealed_cid:
+                _send(
+                    _enumerate_result(
+                        msg_id,
+                        [],
+                        [
+                            {
+                                "memento": at,
+                                "reason": (
+                                    f"build-witness input '{rel_path}' does not match "
+                                    "the sealed source_files identity"
+                                ),
+                            }
+                        ],
+                    )
+                )
+                return
+            drift = _population_drift(context)
+            if drift is not None:
+                _send(
+                    _enumerate_result(
+                        msg_id,
+                        [],
+                        [{"memento": at, "reason": drift}],
+                    )
+                )
+                return
+            if rel_path != context.anchor:
+                _send(_enumerate_result(msg_id, [], []))
+                return
+
+            document = _build_ir_document(str(root))
+            drift = _population_drift(context)
+            if drift is not None:
+                _send(
+                    _enumerate_result(
+                        msg_id,
+                        [],
+                        [{"memento": at, "reason": drift}],
+                    )
+                )
+                return
+            memento = _file_memento(context.anchor, sealed_cid)
+            nodes = [
+                {"memento": memento, "audit": row, "payload": None}
+                for row in document["ir"]
+            ]
+            _send(_enumerate_result(msg_id, nodes, []))
+            return
+
+        _send(
+            _enumerate_error(
+                msg_id,
+                f"sugar.enumerate: level {level!r} is not served by surface "
+                f"'{KIT_ID}'; answering an unowned level with an empty census "
+                "would be a false zero",
+            )
+        )
+    except Exception as exc:
+        import traceback
+
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {
+                    "code": -32603,
+                    "message": str(exc),
                     "data": traceback.format_exc(),
                 },
             }
@@ -263,7 +530,7 @@ def main() -> None:
                             "methods": [
                                 {"name": "initialize", "required": True},
                                 {"name": KIT_DECLARATION_RPC_METHOD, "required": True},
-                                {"name": "lift", "required": True},
+                                {"name": ENUMERATE_RPC_METHOD, "required": True},
                                 {"name": RESOLVE_WITNESS_RPC_METHOD, "required": False},
                                 {"name": "shutdown", "required": False},
                             ]
@@ -277,6 +544,8 @@ def main() -> None:
                     },
                 }
             )
+        elif method == ENUMERATE_RPC_METHOD:
+            handle_enumerate(mid, msg.get("params", {}))
         elif method == "lift":
             handle_lift(mid, msg.get("params", {}))
         elif method == RESOLVE_WITNESS_RPC_METHOD:

--- a/implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py
+++ b/implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py
@@ -55,6 +55,36 @@ class BuildWitness:
     cid: str
 
 
+@dataclass(frozen=True)
+class BuildWitnessPlan:
+    """The authenticated build inputs parsed once from the manifest door."""
+
+    manifest_path: str
+    manifest_cid: str
+    repo_script: str
+    distributed_script: str
+    sources: tuple[str, ...]
+    command: tuple[str, ...]
+    outputs: tuple[dict[str, str], ...]
+    toolchain: str
+    timeout_seconds: int
+
+    @property
+    def authenticated_input_paths(self) -> tuple[str, ...]:
+        """Every workspace file whose bytes the witness authenticates."""
+        return tuple(
+            sorted(
+                {
+                    self.manifest_path,
+                    self.repo_script,
+                    self.distributed_script,
+                    *self.sources,
+                    *(output["distributed"] for output in self.outputs),
+                }
+            )
+        )
+
+
 def _to_value(value: Any):
     if value is None:
         return vnull()
@@ -160,6 +190,32 @@ def _witness_value(w: BuildWitness) -> dict[str, Any]:
     }
 
 
+def load_build_witness_plan(
+    project_dir: str, manifest_path: str = DEFAULT_MANIFEST
+) -> BuildWitnessPlan:
+    """Parse the manifest at the one shared population/construction door."""
+    root = Path(project_dir)
+    manifest_rel = _safe_rel(manifest_path)
+    manifest = _read_manifest(root, manifest_rel)
+    return BuildWitnessPlan(
+        manifest_path=manifest_rel,
+        manifest_cid=_canonical_cid(manifest),
+        repo_script=_safe_rel(str(manifest["repoScript"])),
+        distributed_script=_safe_rel(str(manifest["distributedScript"])),
+        sources=tuple(_safe_rel(str(path)) for path in manifest.get("sources", [])),
+        command=tuple(str(part) for part in manifest["command"]),
+        outputs=tuple(
+            {
+                "distributed": _safe_rel(str(output["distributed"])),
+                "rebuilt": _safe_rel(str(output["rebuilt"])),
+            }
+            for output in manifest.get("outputs", [])
+        ),
+        toolchain=str(manifest.get("toolchain", "build")),
+        timeout_seconds=int(manifest.get("timeoutSeconds", 30)),
+    )
+
+
 def witness_body(w: BuildWitness) -> bytes:
     return _canonical_bytes(_witness_value(w))
 
@@ -168,25 +224,12 @@ def run_build_witness(
     project_dir: str, manifest_path: str = DEFAULT_MANIFEST
 ) -> BuildWitness:
     root = Path(project_dir)
-    manifest_rel = _safe_rel(manifest_path)
-    manifest = _read_manifest(root, manifest_rel)
-    repo_script = _safe_rel(str(manifest["repoScript"]))
-    distributed_script = _safe_rel(str(manifest["distributedScript"]))
-    sources = [_safe_rel(str(p)) for p in manifest.get("sources", [])]
-    command = [str(p) for p in manifest["command"]]
-    outputs = [
-        {
-            "distributed": _safe_rel(str(o["distributed"])),
-            "rebuilt": _safe_rel(str(o["rebuilt"])),
-        }
-        for o in manifest.get("outputs", [])
-    ]
+    plan = load_build_witness_plan(project_dir, manifest_path)
 
-    repo_script_cid = _file_cid(root, repo_script)
-    distributed_script_cid = _file_cid(root, distributed_script)
-    source_tree_cid = _tree_cid(root, sources)
-    manifest_cid = _canonical_cid(manifest)
-    toolchain_id = _toolchain_id(str(manifest.get("toolchain", "build")))
+    repo_script_cid = _file_cid(root, plan.repo_script)
+    distributed_script_cid = _file_cid(root, plan.distributed_script)
+    source_tree_cid = _tree_cid(root, plan.sources)
+    toolchain_id = _toolchain_id(plan.toolchain)
     failures: list[str] = []
 
     if repo_script_cid != distributed_script_cid:
@@ -195,13 +238,14 @@ def run_build_witness(
             f"repo {repo_script_cid} != distributed {distributed_script_cid}"
         )
 
+    outputs = list(plan.outputs)
     _clean_rebuild_outputs(root, outputs)
     proc = subprocess.run(
-        _expand_command(command),
+        _expand_command(list(plan.command)),
         cwd=root,
         capture_output=True,
         text=True,
-        timeout=int(manifest.get("timeoutSeconds", 30)),
+        timeout=plan.timeout_seconds,
     )
     if proc.returncode != 0:
         failures.append(
@@ -230,15 +274,15 @@ def run_build_witness(
 
     outcome = "passed" if not failures else "failed"
     draft = BuildWitness(
-        manifest_path=manifest_rel,
-        manifest_cid=manifest_cid,
-        repo_script=repo_script,
+        manifest_path=plan.manifest_path,
+        manifest_cid=plan.manifest_cid,
+        repo_script=plan.repo_script,
         repo_script_cid=repo_script_cid,
-        distributed_script=distributed_script,
+        distributed_script=plan.distributed_script,
         distributed_script_cid=distributed_script_cid,
         source_tree_cid=source_tree_cid,
         toolchain_id=toolchain_id,
-        command=tuple(command),
+        command=plan.command,
         outputs=tuple(output_rows),
         failures=tuple(failures),
         outcome=outcome,

--- a/implementations/python/sugar-build-witness/tests/test_build_witness.py
+++ b/implementations/python/sugar-build-witness/tests/test_build_witness.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +24,38 @@ out = pathlib.Path(sys.argv[3])
 out.parent.mkdir(parents=True, exist_ok=True)
 out.write_text(f"demo-lib\\nmessage={message}\\nversion={version}\\n", encoding="utf-8")
 """
+
+
+def _rpc_process(root: Path) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [sys.executable, "-m", "sugar_build_witness.lift_lsp"],
+        cwd=root,
+        env=os.environ.copy(),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _rpc_request(
+    proc: subprocess.Popen[str], method: str, params: dict, *, msg_id: int = 1
+) -> dict:
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    proc.stdin.write(
+        json.dumps({"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params})
+        + "\n"
+    )
+    proc.stdin.flush()
+    line = proc.stdout.readline()
+    assert line, proc.stderr.read() if proc.stderr is not None else "no RPC response"
+    return json.loads(line)
+
+
+def _close_rpc(proc: subprocess.Popen[str]) -> None:
+    _rpc_request(proc, "shutdown", {}, msg_id=999)
+    proc.wait(timeout=5)
 
 
 def _write_project(
@@ -169,3 +202,163 @@ def test_tampered_distributed_output_is_named_failure(tmp_path):
     assert any("output artifact CID mismatch" in f for f in w.failures)
     assert verdict == "REFUSED"
     assert "output artifact CID mismatch" in reason
+
+
+def test_build_witness_declaration_advertises_enumerate_and_retires_lift(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    proc = _rpc_process(tmp_path)
+    try:
+        reply = _rpc_request(proc, "sugar.plugin.kit_declaration", {})
+        methods = {row["name"] for row in reply["result"]["rpc"]["methods"]}
+        assert "sugar.enumerate" in methods
+        assert "lift" not in methods
+    finally:
+        _close_rpc(proc)
+
+
+def test_build_witness_source_files_seals_authenticated_input_population(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    proc = _rpc_process(tmp_path)
+    try:
+        reply = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {"level": "source_files", "workspace_root": str(tmp_path)},
+        )
+        nodes = reply["result"]["nodes"]
+        assert [node["memento"]["file"] for node in nodes] == [
+            "build-witness.json",
+            "dist/configure.py",
+            "dist/libdemo.txt",
+            "repo/configure.py",
+            "src/message.txt",
+            "src/version.txt",
+        ]
+        assert reply["result"]["gaps"] == []
+        assert all(node["memento"]["source_cid"] for node in nodes)
+    finally:
+        _close_rpc(proc)
+
+
+def test_build_witness_population_fold_equals_whole_population_legacy(
+    tmp_path: Path,
+) -> None:
+    """#7261 promotion proof: whole legacy == sealed per-file fold."""
+    _write_project(tmp_path)
+    proc = _rpc_process(tmp_path)
+    try:
+        legacy = _rpc_request(
+            proc,
+            "lift",
+            {"workspace_root": str(tmp_path), "source_paths": ["."]},
+        )["result"]["ir"]
+        census = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {"level": "source_files", "workspace_root": str(tmp_path)},
+        )["result"]
+        folded: list[dict] = []
+        non_empty: list[str] = []
+        for file_node in census["nodes"]:
+            memento = file_node["memento"]
+            universe = _rpc_request(
+                proc,
+                "sugar.enumerate",
+                {
+                    "level": "universe",
+                    "workspace_root": str(tmp_path),
+                    "at": memento,
+                },
+            )["result"]
+            assert universe["gaps"] == []
+            if universe["nodes"]:
+                non_empty.append(memento["file"])
+            folded.extend(node["audit"] for node in universe["nodes"])
+
+        assert len(legacy) == 3, "the promotion control must carry real claim mass"
+        assert non_empty == ["build-witness.json"]
+        assert folded == legacy
+    finally:
+        _close_rpc(proc)
+
+
+def test_build_witness_universe_requires_prepared_population(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    proc = _rpc_process(tmp_path)
+    try:
+        reply = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {
+                "level": "universe",
+                "workspace_root": str(tmp_path),
+                "at": {"file": "build-witness.json"},
+            },
+        )
+        assert reply["result"]["nodes"] == []
+        assert len(reply["result"]["gaps"]) == 1
+        assert "prepared source_files census" in reply["result"]["gaps"][0]["reason"]
+    finally:
+        _close_rpc(proc)
+
+
+def test_build_witness_universe_refuses_population_drift(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    proc = _rpc_process(tmp_path)
+    try:
+        census = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {"level": "source_files", "workspace_root": str(tmp_path)},
+        )["result"]
+        anchor = next(
+            node["memento"]
+            for node in census["nodes"]
+            if node["memento"]["file"] == "build-witness.json"
+        )
+        (tmp_path / "src" / "message.txt").write_text("changed\n", encoding="utf-8")
+
+        reply = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {
+                "level": "universe",
+                "workspace_root": str(tmp_path),
+                "at": anchor,
+            },
+        )["result"]
+        assert reply["nodes"] == []
+        assert len(reply["gaps"]) == 1
+        assert "src/message.txt" in reply["gaps"][0]["reason"]
+        assert "sealed source_files census" in reply["gaps"][0]["reason"]
+    finally:
+        _close_rpc(proc)
+
+
+def test_build_witness_enumeration_refuses_false_empty_levels(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    proc = _rpc_process(tmp_path)
+    try:
+        link_units = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {
+                "level": "parameter-contract-link-units",
+                "workspace_root": str(tmp_path),
+            },
+        )
+        assert link_units["result"] == {"rows": []}
+
+        unknown = _rpc_request(
+            proc,
+            "sugar.enumerate",
+            {"level": "facts", "workspace_root": str(tmp_path)},
+        )
+        assert unknown["error"]["code"] == -32602
+        assert "false zero" in unknown["error"]["message"]
+    finally:
+        _close_rpc(proc)


### PR DESCRIPTION
## Summary

Migrate the `build-witness` producer from the retired `lift` kit entrance to `sugar.enumerate` under the promotion contract in #7261.

This is a real whole-workspace translation, not an advertisement-only patch:

- `BuildWitnessPlan` is now the single manifest parser and owner of the authenticated input population.
- `source_files` seals the manifest-owned input closure once and caches its CIDs for the RPC session.
- `build-witness.json` is the sole anchor for the whole-workspace witness package.
- Per-file `universe` demands are empty for sibling inputs; the manifest anchor projects the one legacy witness package.
- Every authenticated input is checked against the sealed census before and after construction. Drift or an unprepared population is a named gap.
- Unowned levels refuse loudly; parameter-contract link units truthfully return `rows=[]`.

The internal legacy handler remains only as the promotion control and is no longer advertised as a kit method.

## Why the triage changed

Initial triage rated build-witness the hardest remaining door because the public handler exposed only a whole-workspace operation and no source-tree/anchor contract.

Closer inspection established two facts that materially bounded it:

1. the build manifest already owns the exact file population the witness authenticates—manifest, repository/distributed scripts, declared sources, and distributed outputs; and
2. the pytest witness kit already demonstrates the lawful one-anchor projection for a whole-package witness.

That did not make this mechanical. It made the real translation finite: one manifest-owned population, one anchor, and one exact whole-population equivalence proof. Rust function-contract and Python verify still require population-wide index/registry translation.

## Promotion proof

The #7261 control is **whole-population legacy versus per-file enumerate over a prepared population context**.

The fixture seals 6 authenticated input files. Whole-workspace legacy emits exactly 3 IR rows: two contracts plus the signed witness memento. Folding `universe` across all 6 sealed file mementos emits rows at exactly one anchor, `build-witness.json`, and produces exact row-for-row equality with those 3 legacy rows.

Before implementation, all 6 planted migration teeth collected and failed, exit 1: the declaration advertised `lift` and each enumerate request returned the old `None` response. After implementation, all 6 collected and passed.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | exact whole-population legacy/fold equality |
| `mandatory_panics` | 0 | no witness proof meaning changed |
| `suppressed_descendants` | 0 | no suppression path changed |
| `typed_effects` | 0 | no effect semantics changed |
| `silent` | 0 | floor: must stay 0 |

Historical showcase entrance prediction: the single `build-witness` retired-lift row should leave that entrance cause. This is an epsilon from the authenticated historical triage, not a current measured delta.

## Validation

Pinned source tree and merge base: `c10ec233fac6bc1a0cf53b682bb6cfcab89efa70`.

- CPython 3.12.13, migration discrimination: 6 collected, 6 passed.
- Full build-witness focused file: 11 passed, exit 0.
- Black 26.5.1: all 3 changed files unchanged, exit 0.
- Promotion fixture: population=6, whole legacy rows=3, folded rows=3, non-empty anchors=1, exact equality.

The PATH CPython 3.14 attempt exited 143 without pytest output and is unmeasured; it is not included in any test claim. No battleaxe run or post-land showcase result is claimed.

## Floors preserved

- No test deleted or detector weakened.
- Counts are measured test output, not authored project state.
- Missing preparation, non-member inputs, stale CIDs, and population drift are loud gaps.
- Generated rebuilt outputs are not misrepresented as source inputs; the census contains only file bytes the existing witness authenticates.
- No build-witness showcase semantics, current residual delta, or behavior of the two remaining real-translation doors is claimed.

Closes neither #7261 nor the remaining rust-fn-contracts / python-verify migrations.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate build witness from `lift` RPC to `sugar.enumerate` source enumeration
> - Introduces a new `sugar.enumerate` RPC handler in [`lift_lsp.py`](https://github.com/TSavo/sugar/pull/7264/files#diff-435497958a6b7996adf513d50a94008eff0364a53173b17d128882fe866b5d42) replacing the advertised `lift` method. The server now seals a census of authenticated input files (blake3-512 CIDs) and serves IR documents under stable population verification.
> - Adds `BuildWitnessPlan` dataclass and `load_build_witness_plan` to [`witness.py`](https://github.com/TSavo/sugar/pull/7264/files#diff-ddff4193a3e15144d54da66d3e74258f5ffc031919bf33d709f71b0b5954095f), centralizing manifest parsing and authenticated input path enumeration.
> - `sugar.enumerate` supports three levels: `source_files` (returns file mementos with CIDs), `universe` (returns the full IR document, gated on a sealed population and drift check), and `parameter-contract-link-units` (returns empty rows).
> - Population drift detection re-hashes inputs on each `universe` request and reports gaps if files have changed since sealing.
> - Behavioral Change: the kit declaration now advertises `sugar.enumerate` instead of `lift`; `lift` is still accepted but no longer declared.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cac4a41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->