### PR TITLE
Authenticate filesystem CAS shelf identity separately from local builds

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -623,17 +623,22 @@ mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_B
   local build_script
   build_script="$(sugar_bx_artifact_build_script "$needs" "$profile")"
   local shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2,readonly"
+  local shelf_read_only=1
   local name
   if [[ "$provision_artifacts" == 1 ]]; then
     for name in ${SUGAR_BX_ENV_NAMES[@]+"${SUGAR_BX_ENV_NAMES[@]}"}; do
       [[ "$name" != SUGAR_BINARY_PUBLISH || ${!name:-0} != 1 ]] \
-        || shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2"
+        || {
+          shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2"
+          shelf_read_only=0
+        }
     done
   fi
   local -a docker_args=(docker run --rm
     --workdir /workspace/sugar
     --env SUGAR_BINARY_ALLOW_BUILD=0
     --env SUGAR_BINARY_PUBLISH=0
+    --env "SUGAR_BINARY_SHELF_READ_ONLY=$shelf_read_only"
     --env CARGO_TARGET_DIR=/managed-target
     --env SUGAR_BINARY_TARGET_ROOT=/managed-target
     --env "SUGAR_BX_MOUNT_PROOF=$SUGAR_BX_MOUNT_PROOF"
@@ -681,8 +686,11 @@ sugar_bx_run_docker() {
   fi
   local name arg command=""
   for name in ${SUGAR_BX_ENV_NAMES[@]+"${SUGAR_BX_ENV_NAMES[@]}"}; do
+    # Transport-owned mount authority cannot be forged by a payload env.
+    [[ "$name" != SUGAR_BINARY_SHELF_READ_ONLY ]] || continue
     [[ ${!name+x} == x ]] && docker_args+=(--env "$name=${!name}")
   done
+  docker_args+=(--env SUGAR_BINARY_SHELF_READ_ONLY=1)
   docker_args+=("$image" "$@")
   for arg in "${docker_args[@]}"; do command+=" $(sugar_bx_quote "$arg")"; done
   sugar_bx_ssh "exec${command}"

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -626,7 +626,7 @@ shelf_exercise_note_log() {
   reporter="$repo_root/tools/shelf_exercise_report.py"
   [[ -f "$reporter" ]] || return 0
   case "$msg" in
-    crime=unevictable-shelf-*|crime=private-filesystem-shelf-*|crime=cas-address-payload-mismatch*|crime=corrupt-shelf-cell*|crime=uncreatable-filesystem-shelf-*|crime=private-shared-cache-cell*)
+    crime=unevictable-shelf-*|crime=private-filesystem-shelf-*|crime=cas-address-payload-mismatch*|crime=corrupt-shelf-cell*|crime=uncreatable-filesystem-shelf-*|crime=private-shared-cache-cell*|crime=shelf-manifest-*|crime=read-only-shelf-recovery*)
       op=crime
       outcome=crime
       crime="${msg%% *}"
@@ -833,6 +833,101 @@ for key, value in expected.items():
 with open(path, "rb") as f: actual = hashlib.sha256(f.read()).hexdigest()
 if data.get("sha256") != actual:
     print("sugarbin: artifact checksum mismatch", file=sys.stderr); raise SystemExit(1)
+PY
+}
+
+# Filesystem-CAS membership is intentionally narrower than local build
+# identity. The cell is addressed by h(payload), while its manifest carries
+# stable source/platform/target/profile authority. Full cargo/rustc -Vv output
+# remains strict for local targets and mutable cache cells, but diagnostic host
+# OS residue cannot make identical bytes invalid at their content address.
+verify_filesystem_shelf_artifact() {
+  local binary_path="$1" stamp="$2" identity="$3" content_key="$4" cell="$5"
+  local manifest actual_key
+  manifest="$(artifact_manifest_path "$binary_path")"
+  [[ -f "$binary_path" && -x "$binary_path" ]] || return 1
+  [[ -f "$manifest" ]] || {
+    log "crime=shelf-manifest-parse-failed owner=bin/sugarbin cell=$cell path=$manifest error=missing-manifest replacement=republish the CAS cell from an authenticated artifact"
+    return 1
+  }
+
+  actual_key="$(blake3_512_file "$binary_path")" || return 1
+  if [[ "$actual_key" != "$content_key" ]]; then
+    log "crime=cas-address-payload-mismatch owner=bin/sugarbin cell=$cell address=$content_key payload=$actual_key replacement=evict the CAS cell; a content-addressed shelf cannot host p under h≠h(p)"
+    return 1
+  fi
+
+  python3 - "$manifest" "$binary_path" "$cell" "$bin_name" "$package" \
+    "$stamp" "$identity" "$(platform_key)" "$target_triple" "$profile" <<'PY'
+import hashlib
+import json
+import sys
+
+manifest, path, cell, binary, package, stamp, identity, platform, target, profile = sys.argv[1:]
+try:
+    with open(manifest, encoding="utf-8") as source:
+        data = json.load(source)
+except Exception as error:
+    print(
+        "sugarbin: crime=shelf-manifest-parse-failed "
+        f"owner=bin/sugarbin cell={cell} path={manifest} "
+        f"error={type(error).__name__}:{error} "
+        "replacement=republish the CAS cell from an authenticated artifact",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+expected = {
+    "schema": 1,
+    "binary": binary,
+    "package": package,
+    "sourceStamp": stamp,
+    "buildIdentity": identity,
+    "platform": platform,
+    "targetTriple": target,
+    "profile": profile,
+    "features": [],
+    "built": True,
+    "executed": False,
+}
+for field, expected_value in expected.items():
+    observed = data.get(field)
+    if observed != expected_value:
+        print(
+            "sugarbin: crime=shelf-manifest-identity-mismatch "
+            f"owner=bin/sugarbin cell={cell} field={field} "
+            f"expected={expected_value!r} observed={observed!r} "
+            "replacement=republish the CAS cell for the requested stable identity",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+# These fields are provenance retained for diagnosis, not CAS membership.
+# Absence is still a malformed manifest; differing verbose text is lawful.
+for field in ("rustc", "cargo"):
+    observed = data.get(field)
+    if not isinstance(observed, str) or not observed:
+        print(
+            "sugarbin: crime=shelf-manifest-identity-mismatch "
+            f"owner=bin/sugarbin cell={cell} field={field} "
+            f"expected='non-empty diagnostic provenance' observed={observed!r} "
+            "replacement=republish the CAS cell with complete provenance",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+with open(path, "rb") as payload:
+    actual_sha256 = hashlib.sha256(payload.read()).hexdigest()
+expected_sha256 = data.get("sha256")
+if expected_sha256 != actual_sha256:
+    print(
+        "sugarbin: crime=shelf-manifest-checksum-mismatch "
+        f"owner=bin/sugarbin cell={cell} path={path} "
+        f"expected={expected_sha256!r} observed={actual_sha256} "
+        "replacement=republish the manifest for these content-addressed bytes",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 PY
 }
 
@@ -1367,16 +1462,22 @@ PY
 }
 
 evict_shelf_cell() {
-  # Mechanism (not a comment): remove a regenerable stamp-keyed cell so resolve
-  # can rebuild. Fail-closed verify stays strict; recovery is eviction+rebuild.
+  # Recovery authority is supplied by the transport. A read-only bind is not
+  # an ownership failure and must never be narrated as root-owned corruption.
   local cell="$1" candidate="${2:-}" manifest="${3:-}"
+  if [[ "${SUGAR_BINARY_SHELF_READ_ONLY:-0}" == 1 ]]; then
+    [[ -z "$candidate" ]] || rm -f "$candidate" 2>/dev/null || true
+    [[ -z "$manifest" ]] || rm -f "$manifest" 2>/dev/null || true
+    log "crime=read-only-shelf-recovery owner=bin/sugarbin cell=$cell illegal shape=the authenticated shelf cell needs recovery but the transport mounted the shelf read-only replacement=repair or republish the cell through a writable shelf publisher; do not diagnose mount policy as corruption or ownership"
+    return 2
+  fi
   log "evicting regenerable shelf cell: $cell"
   rm -rf "$cell" 2>/dev/null || true
   [[ -z "$candidate" ]] || rm -f "$candidate" 2>/dev/null || true
   [[ -z "$manifest" ]] || rm -f "$manifest" 2>/dev/null || true
-  # Root-owned cells may survive unprivileged rm; leave a loud breadcrumb.
+  # A writable shelf cell that survives removal is a real mode/ownership arm.
   if [[ -d "$cell" ]]; then
-    log "crime=unevictable-shelf-cell owner=bin/sugarbin cell=$cell replacement=remove as a privileged operator (sudo rm -rf cell) then rebuild; peer runners cannot heal root-owned cells"
+    log "crime=unevictable-shelf-cell owner=bin/sugarbin cell=$cell illegal shape=a writable shelf cell survived peer eviction replacement=repair its parent/cell modes through finalize_peer_evictable_shelf_cell, then rebuild"
     return 2
   fi
   return 0
@@ -1552,6 +1653,9 @@ pull_from_filesystem_shelf() {
   fi
   if filesystem_shelf_complete "$cell" "$shelf_name" \
     && ! filesystem_shelf_cell_is_peer_evictable "$cell" "$shelf_name"; then
+    if [[ "${SUGAR_BINARY_SHELF_READ_ONLY:-0}" == 1 ]]; then
+      evict_shelf_cell "$cell" || return $?
+    fi
     # Readable but peer-unevictable (classic root-owned 0755): do not serve as a
     # healthy hit. Try finalize heal; if that fails, miss → rebuild path.
     if ! finalize_peer_evictable_shelf_cell "$cell" "$shelf_name"; then
@@ -1571,23 +1675,17 @@ pull_from_filesystem_shelf() {
   chmod 0755 "$candidate_dir" "$tmp"
   chmod 0644 "$manifest"
   mv -f "$tmp" "$candidate"
-  # CAS membership: payload at address h must satisfy h(payload) = address.
-  local actual_key
-  if ! actual_key="$(blake3_512_file "$candidate")"; then
-    rm -f "$candidate" "$manifest" 2>/dev/null || true
-    return 1
-  fi
-  if [[ "$actual_key" != "$content_key" ]]; then
-    log "crime=cas-address-payload-mismatch owner=bin/sugarbin cell=$cell address=$content_key payload=$actual_key replacement=evict the CAS cell; a content-addressed shelf cannot host p under h≠h(p)"
+  if ! verify_filesystem_shelf_artifact \
+    "$candidate" "$stamp" "$identity" "$content_key" "$cell"; then
+    # Named verifier refusal: remove a writable regenerable cell, or refuse by
+    # read-only recovery authority without mislabeling the cell.
     evict_shelf_cell "$cell" "$candidate" "$manifest" || return $?
     return 1
   fi
-  if ! verify_artifact_manifest "$candidate" "$stamp" "$identity" "filesystem shelf artifact"; then
-    # Strict check failed: do not serve. Evict regenerable cell → miss → rebuild.
-    log "crime=corrupt-shelf-cell owner=bin/sugarbin cell=$cell replacement=evict cell and rebuild from declared inputs"
-    evict_shelf_cell "$cell" "$candidate" "$manifest" || return $?
-    return 1
-  fi
+  # The shelf manifest retains publisher provenance. The mutable local cache
+  # and target require testimony for the current cargo/rustc environment, so
+  # mint that testimony only after CAS and stable identity authenticate.
+  write_artifact_manifest "$candidate" "$stamp" "$identity"
   log "phase=resolve-hit source=filesystem-shelf bin=$bin_name name=$shelf_name content=$(_stamp_short "$content_key")… stamp=$(_stamp_short "$stamp")…"
   materialize_cached_artifact "$candidate" "$stamp" "$identity"
 }

--- a/docs/superpowers/plans/2026-08-03-cas-shelf-verifier.md
+++ b/docs/superpowers/plans/2026-08-03-cas-shelf-verifier.md
@@ -1,0 +1,147 @@
+# CAS Shelf Verifier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make filesystem-CAS verification accept byte-identical cross-OS artifacts while preserving source and payload refusals and naming read-only recovery honestly.
+
+**Architecture:** Keep the existing local artifact verifier strict. Add a shelf-only verifier that owns payload-address and stable-manifest authentication, and carry an explicit read-only transport fact from the battleaxe Docker mount to recovery.
+
+**Tech Stack:** Bash, embedded Python 3, BLAKE3, SHA-256, Docker bind mounts.
+
+## Global Constraints
+
+- Never delete, chmod, or rewrite the live battleaxe shelf cell.
+- Wrong source stamp and wrong payload remain loud, named refusals.
+- Local target/cache verification remains strict over Cargo and Rust identity.
+- `cargo -Vv` host OS residue is not filesystem-CAS payload identity.
+
+---
+
+### Task 1: Pin the shelf-verification arms
+
+**Files:**
+- Create: `tests/sugarbin_shelf_manifest_identity.sh`
+- Modify: `tests/sugarbin_shelf_content_addressed.sh`
+
+**Interfaces:**
+- Consumes: `bin/sugarbin`, a temporary shelf, fixed source stamp, and fake Cargo/Rust executables.
+- Produces: end-to-end cross-OS, wrong-source, wrong-payload, and local-strict testimony.
+
+- [ ] **Step 1: Write the failing contract**
+
+Build and publish a temporary executable with Cargo OS `Ubuntu 24.4`. Clear
+only the temporary target/cache, change the fake Cargo OS to `Debian 12`, and
+resolve with builds disabled. Assert a shelf hit and zero build calls. Plant a
+wrong manifest `sourceStamp` and a wrong gzipped payload in separate copies and
+assert their distinct named crimes.
+
+- [ ] **Step 2: Verify RED**
+
+Run `bash tests/sugarbin_shelf_manifest_identity.sh "$PWD"`.
+
+Expected: the cross-OS arm exits nonzero after `artifact identity mismatch:
+cargo`; the present recovery reason is also too broad.
+
+- [ ] **Step 3: Pin the one-door call**
+
+Extend `tests/sugarbin_shelf_content_addressed.sh` to require the shelf-only
+verifier and forbid the filesystem-shelf candidate from using the strict local
+verifier.
+
+### Task 2: Split CAS membership from local build identity
+
+**Files:**
+- Modify: `bin/sugarbin`
+- Test: `tests/sugarbin_shelf_manifest_identity.sh`
+- Test: `tests/sugarbin_shelf_content_addressed.sh`
+
+**Interfaces:**
+- Consumes: candidate path, source stamp, build identity, CAS key, and cell.
+- Produces: `verify_filesystem_shelf_artifact` with named status and crimes.
+
+- [ ] **Step 1: Implement the minimal verifier**
+
+Recompute BLAKE3, compare the CAS address, parse the manifest, verify SHA-256
+and stable fields, and emit `crime=shelf-manifest-parse-failed` or
+`crime=shelf-manifest-identity-mismatch field=<field>`. Exclude only diagnostic
+`rustc` and `cargo` strings. Leave `verify_artifact_manifest` unchanged.
+
+- [ ] **Step 2: Route only filesystem-shelf reads through it**
+
+Replace the duplicated address check and strict verifier call in
+`pull_from_filesystem_shelf`. On refusal, remove only temporary materialization
+and enter the existing recovery path.
+
+- [ ] **Step 3: Verify GREEN**
+
+Run all three commands:
+
+```bash
+bash tests/sugarbin_shelf_manifest_identity.sh "$PWD"
+bash tests/sugarbin_shelf_content_addressed.sh "$PWD"
+bash tests/sugarbin_artifact_manifest.sh "$PWD"
+```
+
+Expected: all pass; the final command proves local target/cache strictness.
+
+### Task 3: Name read-only recovery separately
+
+**Files:**
+- Modify: `bin/lib/sugar-bx.sh`
+- Modify: `bin/sugarbin`
+- Test: `tests/sugarbin_shelf_manifest_identity.sh`
+- Test: `tests/sugarbin_shelf_peer_evictable.sh`
+
+**Interfaces:**
+- Consumes: `SUGAR_BINARY_SHELF_READ_ONLY=1` from a read-only Docker bind.
+- Produces: `crime=read-only-shelf-recovery`; writable unevictability retains `crime=unevictable-shelf-cell`.
+
+- [ ] **Step 1: Add the failing read-only arm**
+
+Invoke recovery with `SUGAR_BINARY_SHELF_READ_ONLY=1` and a planted mismatch.
+Assert the read-only crime and that the cell remains. Invoke without the fact
+against a non-removable fixture and assert the ownership/mode crime remains.
+
+- [ ] **Step 2: Carry mount authority and implement refusal**
+
+Set the environment fact in both battleaxe Docker paths whenever the shelf
+mount is read-only, and `0` only for the existing publication-enabled path.
+Check it before attempting eviction.
+
+- [ ] **Step 3: Verify GREEN and hygiene**
+
+Run:
+
+```bash
+bash tests/sugarbin_shelf_manifest_identity.sh "$PWD"
+bash tests/sugarbin_shelf_peer_evictable.sh "$PWD"
+bash -n bin/sugarbin bin/lib/sugar-bx.sh tests/sugarbin_shelf_manifest_identity.sh
+git diff --check
+```
+
+Expected: every command exits zero.
+
+### Task 4: Bank and publish
+
+**Files:**
+- Modify: only the files named above and the design/plan documents.
+
+**Interfaces:**
+- Consumes: focused receipts and current `origin/main`.
+- Produces: one clean branch and pull request linked to #7260.
+
+- [ ] **Step 1: Commit the focused repair**
+
+Record all focused receipts and explicit non-claims in the commit message.
+
+- [ ] **Step 2: Preflight against current main**
+
+Verify remote head, parent/merge-base, branch-tree scope, zero deletions, no
+foreign commits, and the sealed closing-account digest.
+
+- [ ] **Step 3: Push and open the PR**
+
+State that no live shelf cell was mutated, broad battleaxe/package scale is
+unmeasured until landing, and #6982 moved payload addressing but left
+build-specific identity in the CAS manifest.
+

--- a/docs/superpowers/plans/2026-08-03-cas-shelf-verifier.md
+++ b/docs/superpowers/plans/2026-08-03-cas-shelf-verifier.md
@@ -27,7 +27,7 @@
 - Consumes: `bin/sugarbin`, a temporary shelf, fixed source stamp, and fake Cargo/Rust executables.
 - Produces: end-to-end cross-OS, wrong-source, wrong-payload, and local-strict testimony.
 
-- [ ] **Step 1: Write the failing contract**
+- [x] **Step 1: Write the failing contract**
 
 Build and publish a temporary executable with Cargo OS `Ubuntu 24.4`. Clear
 only the temporary target/cache, change the fake Cargo OS to `Debian 12`, and
@@ -35,14 +35,14 @@ resolve with builds disabled. Assert a shelf hit and zero build calls. Plant a
 wrong manifest `sourceStamp` and a wrong gzipped payload in separate copies and
 assert their distinct named crimes.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
 Run `bash tests/sugarbin_shelf_manifest_identity.sh "$PWD"`.
 
 Expected: the cross-OS arm exits nonzero after `artifact identity mismatch:
 cargo`; the present recovery reason is also too broad.
 
-- [ ] **Step 3: Pin the one-door call**
+- [x] **Step 3: Pin the one-door call**
 
 Extend `tests/sugarbin_shelf_content_addressed.sh` to require the shelf-only
 verifier and forbid the filesystem-shelf candidate from using the strict local
@@ -59,20 +59,20 @@ verifier.
 - Consumes: candidate path, source stamp, build identity, CAS key, and cell.
 - Produces: `verify_filesystem_shelf_artifact` with named status and crimes.
 
-- [ ] **Step 1: Implement the minimal verifier**
+- [x] **Step 1: Implement the minimal verifier**
 
 Recompute BLAKE3, compare the CAS address, parse the manifest, verify SHA-256
 and stable fields, and emit `crime=shelf-manifest-parse-failed` or
 `crime=shelf-manifest-identity-mismatch field=<field>`. Exclude only diagnostic
 `rustc` and `cargo` strings. Leave `verify_artifact_manifest` unchanged.
 
-- [ ] **Step 2: Route only filesystem-shelf reads through it**
+- [x] **Step 2: Route only filesystem-shelf reads through it**
 
 Replace the duplicated address check and strict verifier call in
 `pull_from_filesystem_shelf`. On refusal, remove only temporary materialization
 and enter the existing recovery path.
 
-- [ ] **Step 3: Verify GREEN**
+- [x] **Step 3: Verify GREEN**
 
 Run all three commands:
 
@@ -96,19 +96,19 @@ Expected: all pass; the final command proves local target/cache strictness.
 - Consumes: `SUGAR_BINARY_SHELF_READ_ONLY=1` from a read-only Docker bind.
 - Produces: `crime=read-only-shelf-recovery`; writable unevictability retains `crime=unevictable-shelf-cell`.
 
-- [ ] **Step 1: Add the failing read-only arm**
+- [x] **Step 1: Add the failing read-only arm**
 
 Invoke recovery with `SUGAR_BINARY_SHELF_READ_ONLY=1` and a planted mismatch.
 Assert the read-only crime and that the cell remains. Invoke without the fact
 against a non-removable fixture and assert the ownership/mode crime remains.
 
-- [ ] **Step 2: Carry mount authority and implement refusal**
+- [x] **Step 2: Carry mount authority and implement refusal**
 
 Set the environment fact in both battleaxe Docker paths whenever the shelf
 mount is read-only, and `0` only for the existing publication-enabled path.
 Check it before attempting eviction.
 
-- [ ] **Step 3: Verify GREEN and hygiene**
+- [x] **Step 3: Verify GREEN and hygiene**
 
 Run:
 
@@ -130,7 +130,7 @@ Expected: every command exits zero.
 - Consumes: focused receipts and current `origin/main`.
 - Produces: one clean branch and pull request linked to #7260.
 
-- [ ] **Step 1: Commit the focused repair**
+- [x] **Step 1: Commit the focused repair**
 
 Record all focused receipts and explicit non-claims in the commit message.
 
@@ -144,4 +144,3 @@ foreign commits, and the sealed closing-account digest.
 State that no live shelf cell was mutated, broad battleaxe/package scale is
 unmeasured until landing, and #6982 moved payload addressing but left
 build-specific identity in the CAS manifest.
-

--- a/docs/superpowers/specs/2026-08-03-cas-shelf-verifier-design.md
+++ b/docs/superpowers/specs/2026-08-03-cas-shelf-verifier-design.md
@@ -1,0 +1,62 @@
+# CAS Shelf Verification Design
+
+## Problem
+
+The filesystem shelf addresses binary cells by the BLAKE3-512 digest of the
+decompressed payload, but reuses the strict local-build manifest verifier when
+reading those cells. That verifier includes the complete `cargo -Vv` and
+`rustc -Vv` strings. A cell built on Ubuntu 24.4 and consumed in the managed
+Debian 12 image therefore reports corruption even when the Cargo commit,
+source stamp, payload address, and payload SHA-256 all match.
+
+Recovery then attempts to evict the cell through a deliberately read-only
+Docker bind and reports the surviving path as root-owned/unevictable. The host
+cell is actually peer-readable and peer-evictable. Both terminals name the
+wrong cause.
+
+## Why content addressing did not finish the migration
+
+#6982 moved binary bytes from a source-stamp path to `cas/h(payload)`, but kept
+one build-environment-specific artifact manifest inside that payload cell. The
+address became content-derived while verification still treated diagnostic
+build-environment strings as membership. Identical payloads produced under two
+host OS strings still collide in one CAS cell and one manifest. The migration
+split the address but not the two meanings carried by the manifest.
+
+## Design
+
+Keep `verify_artifact_manifest` strict for local targets, build outputs, and
+the mutable local cache. Add one filesystem-CAS verifier for shelf reads. It
+authenticates:
+
+- BLAKE3-512 of decompressed bytes equals the cell content key;
+- SHA-256 equals the manifest;
+- schema, binary, package, source stamp, build identity, platform, target
+  triple, profile, features, built, and executed fields match;
+- diagnostic `rustc` and `cargo` strings are present but do not define CAS
+  membership.
+
+Manifest parse failure and stable-field mismatch receive named terminals.
+Payload-address mismatch remains the existing CAS crime. No failure is called
+byte corruption unless payload bytes fail a byte-integrity check.
+
+The battleaxe transport also declares when the shelf bind is read-only.
+Recovery checks that declaration before attempting eviction and reports a
+read-only recovery refusal. A writable shelf that genuinely cannot remove a
+cell retains the peer-ownership/mode refusal.
+
+## Discrimination
+
+An end-to-end temporary shelf contract proves four arms:
+
+1. Same source/platform/target/profile and identical payload, with only the
+   `cargo -Vv` OS line changed, resolves from the CAS shelf without rebuilding.
+2. A planted wrong source stamp refuses by the manifest-identity field name.
+3. A planted payload under the wrong CAS address refuses by the address/payload
+   crime.
+4. A planted manifest mismatch under a declared read-only shelf refuses as
+   read-only recovery; a writable private cell remains the ownership/mode arm.
+
+The test also proves that the strict local verifier still rejects Cargo
+identity drift. No existing shelf cell is deleted, chmodded, or rewritten.
+

--- a/docs/superpowers/specs/2026-08-03-cas-shelf-verifier-design.md
+++ b/docs/superpowers/specs/2026-08-03-cas-shelf-verifier-design.md
@@ -40,10 +40,19 @@ Manifest parse failure and stable-field mismatch receive named terminals.
 Payload-address mismatch remains the existing CAS crime. No failure is called
 byte corruption unless payload bytes fail a byte-integrity check.
 
+After shelf authentication, the mutable local cache remints its manifest with
+the current diagnostic Cargo/Rust provenance before strict local
+materialization. The shelf retains publisher provenance; the local target does
+not pretend the publisher environment is the current execution environment.
+
 The battleaxe transport also declares when the shelf bind is read-only.
 Recovery checks that declaration before attempting eviction and reports a
 read-only recovery refusal. A writable shelf that genuinely cannot remove a
 cell retains the peer-ownership/mode refusal.
+
+Both new refusal families remain crimes in the shelf-exercise receipt. More
+accurate reason names must not turn an exercised refusal into apparent clean
+silence.
 
 ## Discrimination
 
@@ -59,4 +68,3 @@ An end-to-end temporary shelf contract proves four arms:
 
 The test also proves that the strict local verifier still rejects Cargo
 identity drift. No existing shelf cell is deleted, chmodded, or rewritten.
-

--- a/tests/shelf_exercise_report.sh
+++ b/tests/shelf_exercise_report.sh
@@ -90,6 +90,18 @@ python3 "$tool" event --output "$tmp/crime.json" --op crime --outcome crime \
 v="$(verdict_of --receipt "$tmp/crime.json" --advisory)"
 [[ "$v" == "SHELF_EXERCISED_CRIME" ]] || fail "crime receipt should be EXERCISED_CRIME, got $v"
 
+# Named shelf-verifier and recovery crimes remain instrumented after the
+# generic corrupt/ownership terminals split. A more truthful reason must not
+# disappear from the shelf-exercise receipt.
+for named_crime in shelf-manifest-identity-mismatch read-only-shelf-recovery; do
+  cat >"$tmp/named-crime.log" <<LOG
+sugarbin: crime=$named_crime owner=bin/sugarbin cell=/cache/cas/x/sugar
+LOG
+  v="$(verdict_of --log "$tmp/named-crime.log" --advisory)"
+  [[ "$v" == "SHELF_EXERCISED_CRIME" ]] || fail \
+    "$named_crime log should be EXERCISED_CRIME, got $v"
+done
+
 # --- Twin 5: log of the 2026-08-01 failed recensus shape → NEVER_TOUCHED ---
 # Identity/sourceStamp only; no filesystem shelf lines (the real failure mode).
 cat >"$tmp/recensus-early-death.log" <<'LOG'

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -92,6 +92,7 @@ line="$(tail -1 "$tmp/docker.log")"
 [[ "$build_line" == *"'$core_ref'"* && "$build_line" == *"bin/sugarbin"* ]] || fail "artifact was not resolved inside managed core: $build_line"
 [[ "$build_line" == *"dst=/root/.cache/sugar/binaries"* ]] || fail "managed builder omitted persistent verified cache"
 [[ "$build_line" == *"dst=/root/.cache/sugar/binary-shelf-v2,readonly"* ]] || fail "ordinary managed resolution shelf is missing or writable"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_SHELF_READ_ONLY=1'"* ]] || fail "ordinary managed resolution did not carry read-only shelf authority"
 [[ "$build_line" == *"'--env' 'SUGAR_BINARY_ALLOW_BUILD=0'"* ]] || fail "ordinary managed resolution retained an implicit build fallback"
 [[ "$build_line" == *"CARGO_TARGET_DIR=/managed-target"* ]] || fail "managed builder reused ambient Cargo target"
 [[ "$build_line" == *"SUGAR_BINARY_TARGET_ROOT=/managed-target"* ]] || fail "managed manifest root diverges from Cargo target"
@@ -119,6 +120,7 @@ line="$(tail -1 "$tmp/docker.log")"
 [[ "$line" == *"src=C:"* ]] || fail "WSL bind source was not translated"
 [[ "$line" == *"dst=/opt/sugar/bin,readonly"* ]] || fail "artifact mount not read-only"
 [[ "$line" == *"dst=/root/.cache/sugar/binary-shelf-v2,readonly"* ]] || fail "managed task cannot consume exact shelf payloads"
+[[ "$line" == *"'--env' 'SUGAR_BINARY_SHELF_READ_ONLY=1'"* ]] || fail "managed task did not carry read-only shelf authority"
 [[ "$line" == *"required-artifacts.json,readonly"* ]] || fail "stamp mount not read-only"
 [[ "$line" != *"--env' 'SUGAR_BIN="* ]] || fail "orchestrator forged SUGAR_BIN before manifest verification"
 [[ "$entrypoint" == *'export SUGAR_BIN=/opt/sugar/bin/sugar'* ]] || fail "entrypoint does not inject verified sugar"
@@ -127,6 +129,16 @@ line="$(tail -1 "$tmp/docker.log")"
 [[ "$line" != *docker.sock* ]] || fail "Docker socket leaked into task"
 [[ "$line" != *"--network' 'none"* ]] || fail "ad-hoc Docker command was forced offline"
 [[ "$(wc -l <"$tmp/docker.log" | tr -d ' ')" == 2 ]] || fail "managed build/task count wrong"
+
+# Shelf mount authority belongs to the transport, never to caller-forwarded
+# environment. A payload cannot turn the read-only task mount into writable
+# recovery authority by forwarding a contradictory value.
+: >"$tmp/docker.log"
+SUGAR_BINARY_SHELF_READ_ONLY=0 run run --host bx --env docker:core \
+  --env SUGAR_BINARY_SHELF_READ_ONLY -- sh -c 'echo authority' >/dev/null
+line="$(tail -1 "$tmp/docker.log")"
+[[ "$line" == *"'--env' 'SUGAR_BINARY_SHELF_READ_ONLY=1'"* ]] || fail "task lost transport-owned read-only shelf authority"
+[[ "$line" != *"'--env' 'SUGAR_BINARY_SHELF_READ_ONLY=0'"* ]] || fail "task forwarded forged writable shelf authority"
 
 : >"$tmp/docker.log"
 run build --host bx --env docker:core --profile debug --needs sugar >/dev/null
@@ -144,6 +156,7 @@ build_line="$(head -1 "$tmp/docker.log")"
 [[ "$build_line" == *"'--env' 'SUGAR_BINARY_REQUIRE_PUBLISH=1'"* ]] || fail "explicit managed publisher did not require a complete shelf cell"
 [[ "$build_line" != *"SUGAR_BINARY_PUBLISH=0 bin/sugarbin"* ]] || fail "managed build script overrode explicit publish authority"
 [[ "$build_line" == *"dst=/root/.cache/sugar/binary-shelf-v2"* && "$build_line" != *"dst=/root/.cache/sugar/binary-shelf-v2,readonly"* ]] || fail "explicit managed publisher did not receive the writable shelf"
+[[ "$build_line" == *"'--env' 'SUGAR_BINARY_SHELF_READ_ONLY=0'"* ]] || fail "explicit managed publisher retained read-only shelf authority"
 : >"$tmp/docker.log"
 
 status=0

--- a/tests/sugarbin_shelf_content_addressed.sh
+++ b/tests/sugarbin_shelf_content_addressed.sh
@@ -53,10 +53,14 @@ grep -Fq 'read_filesystem_shelf_stamp_ref' <<<"$pull_body" || {
   echo 'pull does not resolve stamp→content ref' >&2
   exit 1
 }
-grep -Fq 'cas-address-payload-mismatch' <<<"$pull_body" || {
-  echo 'pull does not enforce h(payload)=address' >&2
+grep -Fq 'verify_filesystem_shelf_artifact' <<<"$pull_body" || {
+  echo 'pull does not route through the filesystem-CAS verifier' >&2
   exit 1
 }
+if grep -Fq 'verify_artifact_manifest "$candidate" "$stamp" "$identity" "filesystem shelf artifact"' <<<"$pull_body"; then
+  echo 'filesystem shelf still routes through strict local-build verification' >&2
+  exit 1
+fi
 
 # --- dynamic: two payloads → two CAS addresses; stamp is not the address ---
 if ! command -v b3sum >/dev/null 2>&1; then
@@ -114,3 +118,8 @@ printf '%s\n' "$key_a" >"$ref2"
 }
 
 echo 'PASS: R_shelf_content_addressed_cell — address is h(payload); stamp is ref only'
+
+# End-to-end discrimination belongs to this enrolled contract: a separate
+# filesystem-CAS verifier accepts diagnostic host drift but still rejects
+# wrong source authority and wrong payload bytes.
+"$repo/tests/sugarbin_shelf_manifest_identity.sh" "$repo"

--- a/tests/sugarbin_shelf_manifest_identity.sh
+++ b/tests/sugarbin_shelf_manifest_identity.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Filesystem-CAS membership is payload + stable source/platform/target/profile,
+# not diagnostic cargo/rustc host residue. Local materializations stay strict.
+set -euo pipefail
+
+repo="${1:?usage: sugarbin_shelf_manifest_identity.sh REPO_ROOT}"
+tmp_root="${SUGARBIN_EXEC_TMPDIR:-$repo/.sugar/test-tmp}"
+mkdir -p "$tmp_root"
+tmp="$(mktemp -d "$tmp_root/sugarbin-shelf-manifest.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/target/release" "$tmp/cache" "$tmp/shelf"
+: >"$tmp/cargo.log"
+printf '%s\n' 'Ubuntu 24.4' >"$tmp/cargo-os"
+
+cat >"$tmp/bin/rustc" <<'SH'
+#!/usr/bin/env bash
+cat <<'EOF'
+rustc 1.96.0 (fake 2026-01-01)
+binary: rustc
+commit-hash: fake
+host: x86_64-unknown-linux-gnu
+release: 1.96.0
+LLVM version: 22.0.0
+EOF
+SH
+cat >"$tmp/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == -vV ]]; then
+  cat <<EOF
+cargo 1.96.0 (fake 2026-01-01)
+release: 1.96.0
+commit-hash: fake-cargo-commit
+commit-date: 2026-01-01
+host: x86_64-unknown-linux-gnu
+libgit2: 1.9.0
+libcurl: 8.12.0
+ssl: OpenSSL 3.5.0
+os: $(cat "$SUGARBIN_FAKE_CARGO_OS_FILE") [64-bit]
+EOF
+  exit 0
+fi
+printf '%s\n' "$*" >>"$SUGARBIN_FAKE_CARGO_LOG"
+binary=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == --bin ]]; then binary="$2"; shift 2; else shift; fi
+done
+mkdir -p "$CARGO_TARGET_DIR/release"
+cat >"$CARGO_TARGET_DIR/release/$binary" <<EOF
+#!/usr/bin/env bash
+printf '%s\\n' 'stable-payload:$binary'
+EOF
+chmod +x "$CARGO_TARGET_DIR/release/$binary"
+SH
+chmod +x "$tmp/bin/rustc" "$tmp/bin/cargo"
+
+export PATH="$tmp/bin:$PATH"
+export SUGARBIN_FAKE_CARGO_LOG="$tmp/cargo.log"
+export SUGARBIN_FAKE_CARGO_OS_FILE="$tmp/cargo-os"
+export SUGAR_BINARY_CARGO="$tmp/bin/cargo"
+export SUGAR_BINARY_TARGET_ROOT="$tmp/target"
+export SUGAR_BINARY_CACHE_DIR="$tmp/cache"
+export SUGAR_BINARY_SHELF_ROOT="$tmp/shelf"
+export SUGAR_BINARY_SOURCE_STAMP="blake3-512_$(printf 'a%.0s' {1..128})"
+export SUGAR_BINARY_NO_SHELF=0
+export SUGAR_BINARY_PUBLISH=1
+
+clear_materialization() {
+  rm -rf "$tmp/target" "$tmp/cache"
+  mkdir -p "$tmp/target/release" "$tmp/cache"
+}
+
+clone_shelf() {
+  local destination="$1"
+  rm -rf "$destination"
+  cp -a "$tmp/published-shelf" "$destination"
+}
+
+resolve_without_build() {
+  SUGAR_BINARY_ALLOW_BUILD=0 SUGAR_BINARY_NO_SELF_HEAL=1 \
+    "$repo/bin/sugarbin" --bin sugar
+}
+
+# Publish one byte-stable artifact under the Ubuntu diagnostic string.
+published="$("$repo/bin/sugarbin" --bin sugar)"
+[[ "$($published)" == stable-payload:sugar ]]
+[[ "$(wc -l <"$tmp/cargo.log" | tr -d ' ')" == 1 ]]
+cp -a "$tmp/shelf" "$tmp/published-shelf"
+published_manifest="$tmp/published-manifest.json"
+published_binary="$tmp/published-sugar"
+cp "$tmp/target/release/sugar.sugarbin.json" "$published_manifest"
+cp "$tmp/target/release/sugar" "$published_binary"
+chmod +x "$published_binary"
+
+# Positive arm: same source/platform/target/profile and identical payload under
+# the same cargo commit, but different host-OS residue, is a filesystem-CAS hit.
+printf '%s\n' 'Debian 12' >"$tmp/cargo-os"
+clear_materialization
+: >"$tmp/cargo.log"
+set +e
+cross_os_path="$(resolve_without_build 2>"$tmp/cross-os.err")"
+cross_os_status=$?
+set -e
+if [[ "$cross_os_status" != 0 ]]; then
+  echo 'byte-identical cross-OS filesystem-CAS resolve refused' >&2
+  cat "$tmp/cross-os.err" >&2
+  exit 1
+fi
+[[ "$($cross_os_path)" == stable-payload:sugar ]]
+[[ ! -s "$tmp/cargo.log" ]] || {
+  echo 'cross-OS CAS hit rebuilt the byte-identical payload' >&2
+  exit 1
+}
+grep -Fq 'phase=resolve-hit source=filesystem-shelf' "$tmp/cross-os.err"
+# Materialization mints current local testimony; strict local verification is
+# still meaningful after a shelf hit.
+grep -Fq 'os: Debian 12 [64-bit]' "$tmp/target/release/sugar.sugarbin.json"
+
+# Strict-local twin: the Ubuntu manifest cannot be blessed as a Debian local
+# target merely because its bytes are valid shelf content.
+clear_materialization
+cp "$published_binary" "$tmp/target/release/sugar"
+cp "$published_manifest" "$tmp/target/release/sugar.sugarbin.json"
+chmod +x "$tmp/target/release/sugar"
+set +e
+SUGAR_BINARY_NO_SHELF=1 SUGAR_BINARY_ALLOW_BUILD=0 SUGAR_BINARY_NO_SELF_HEAL=1 \
+  "$repo/bin/sugarbin" --bin sugar >"$tmp/local-strict.out" 2>"$tmp/local-strict.err"
+local_strict_status=$?
+set -e
+[[ "$local_strict_status" != 0 ]] || {
+  echo 'strict local verifier accepted cargo host-OS drift' >&2
+  exit 1
+}
+grep -Fq 'artifact identity mismatch: cargo' "$tmp/local-strict.err"
+
+# Lying twin 1: stable source authority remains part of shelf membership.
+clone_shelf "$tmp/wrong-source-shelf"
+export SUGAR_BINARY_SHELF_ROOT="$tmp/wrong-source-shelf"
+python3 - "$SUGAR_BINARY_SHELF_ROOT" <<'PY'
+import json
+import pathlib
+import sys
+
+manifests = list(pathlib.Path(sys.argv[1]).glob("cas/*/sugar/sugar.sugarbin.json"))
+assert len(manifests) == 1, manifests
+data = json.loads(manifests[0].read_text(encoding="utf-8"))
+data["sourceStamp"] = "blake3-512_" + "b" * 128
+manifests[0].write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+clear_materialization
+set +e
+resolve_without_build >"$tmp/wrong-source.out" 2>"$tmp/wrong-source.err"
+wrong_source_status=$?
+set -e
+[[ "$wrong_source_status" != 0 ]] || {
+  echo 'wrong-source shelf manifest was accepted' >&2
+  exit 1
+}
+grep -Fq 'crime=shelf-manifest-identity-mismatch' "$tmp/wrong-source.err"
+grep -Fq 'field=sourceStamp' "$tmp/wrong-source.err"
+
+# Lying twin 2: bytes under h' != h(payload) remain a CAS-address refusal.
+clone_shelf "$tmp/wrong-payload-shelf"
+export SUGAR_BINARY_SHELF_ROOT="$tmp/wrong-payload-shelf"
+wrong_payload_cell="$(find "$SUGAR_BINARY_SHELF_ROOT/cas" -type f -name sugar.gz -print -quit)"
+printf '#!/usr/bin/env bash\nprintf "wrong-payload\\n"\n' | gzip -9 >"$wrong_payload_cell"
+clear_materialization
+set +e
+resolve_without_build >"$tmp/wrong-payload.out" 2>"$tmp/wrong-payload.err"
+wrong_payload_status=$?
+set -e
+[[ "$wrong_payload_status" != 0 ]] || {
+  echo 'payload under the wrong CAS address was accepted' >&2
+  exit 1
+}
+grep -Fq 'crime=cas-address-payload-mismatch' "$tmp/wrong-payload.err"
+
+# Recovery authority arm: the transport says this shelf is read-only. A stable
+# manifest refusal must not attempt eviction or misreport ownership.
+clone_shelf "$tmp/read-only-shelf"
+export SUGAR_BINARY_SHELF_ROOT="$tmp/read-only-shelf"
+read_only_cell="$(find "$SUGAR_BINARY_SHELF_ROOT/cas" -type f -name sugar.sugarbin.json -print -quit)"
+python3 - "$read_only_cell" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+data["sourceStamp"] = "blake3-512_" + "c" * 128
+path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+read_only_cell_dir="$(dirname "$read_only_cell")"
+clear_materialization
+set +e
+SUGAR_BINARY_SHELF_READ_ONLY=1 resolve_without_build \
+  >"$tmp/read-only.out" 2>"$tmp/read-only.err"
+read_only_status=$?
+set -e
+[[ "$read_only_status" != 0 ]] || {
+  echo 'read-only shelf mismatch was accepted' >&2
+  exit 1
+}
+grep -Fq 'crime=read-only-shelf-recovery' "$tmp/read-only.err"
+[[ -d "$read_only_cell_dir" ]] || {
+  echo 'declared read-only shelf cell was evicted' >&2
+  exit 1
+}
+
+echo 'PASS: filesystem CAS authenticates stable identity, payload, and recovery authority'

--- a/tools/shelf_exercise_report.py
+++ b/tools/shelf_exercise_report.py
@@ -104,12 +104,16 @@ _LOG_EXERCISE = (
     re.compile(r"sugarbin:\s*prebuilt cache hit\b"),
     re.compile(r"sugarbin:\s*prebuilt cache rejected\b"),
 )
-# Crimes that mean the shelf path was entered and refused.
-_LOG_CRIME = re.compile(
-    r"sugarbin:\s*crime=(?:unevictable-shelf-|private-filesystem-shelf-|"
+# Crimes that mean the shelf path was entered and refused. This fragment owns
+# both recognition and reason extraction so adding a truthful terminal cannot
+# silently disappear from one side of the receipt.
+_SHELF_CRIME_NAME = (
+    r"(?:unevictable-shelf-|private-filesystem-shelf-|"
     r"cas-address-payload-mismatch|corrupt-shelf-cell|"
-    r"uncreatable-filesystem-shelf-|private-shared-cache-cell)"
+    r"uncreatable-filesystem-shelf-|private-shared-cache-cell|"
+    r"shelf-manifest-|read-only-shelf-recovery)"
 )
+_LOG_CRIME = re.compile(rf"sugarbin:\s*crime={_SHELF_CRIME_NAME}")
 # Evidence the binary resolve path ran at all (so NEVER_TOUCHED is claimable).
 _LOG_RESOLVE = (
     re.compile(r"sugarbin:\s*phase=resolve-start\b"),
@@ -274,9 +278,7 @@ def classify_log(text: str) -> tuple[str, list[str]]:
 
     # Extract crime= tags for the reason line.
     crime_tags = re.findall(
-        r"sugarbin:\s*(crime=(?:unevictable-shelf-|private-filesystem-shelf-|"
-        r"cas-address-payload-mismatch|corrupt-shelf-cell|"
-        r"uncreatable-filesystem-shelf-|private-shared-cache-cell)[^\s]*)",
+        rf"sugarbin:\s*(crime={_SHELF_CRIME_NAME}[^\s]*)",
         text,
     )
 


### PR DESCRIPTION
## Summary

A battleaxe binary shelf cell was reported first as `crime=corrupt-shelf-cell` and then as `crime=unevictable-shelf-cell`. Direct inspection proved both reasons wrong: the host cell is uid 1001, peer-readable, byte-valid, and addressed by the exact BLAKE3-512 of its decompressed payload. The path under `/root` is the read-only Docker bind destination, not a root-owned host shelf.

The actual mismatch was diagnostic build provenance. The cell manifest recorded Cargo 1.96.0 on Ubuntu 24.4; the current managed image has the same Cargo version and commit on Debian 12. Payload BLAKE3 and SHA-256 both match.

This PR:

- adds a filesystem-CAS verifier that authenticates `h(payload)`, manifest SHA-256, and stable source, binary, package, platform, target, profile, feature, and execution fields;
- retains non-empty Cargo and Rust diagnostic provenance without treating host OS text as CAS membership;
- leaves the strict local target and mutable-cache verifier unchanged;
- remints current local diagnostic testimony only after the shelf payload and stable identity authenticate;
- carries transport-owned `SUGAR_BINARY_SHELF_READ_ONLY` authority from both Docker paths and refuses recovery before mutation on a read-only bind;
- prevents payload environment forwarding from forging writable shelf authority; and
- keeps every new named refusal visible as `SHELF_EXERCISED_CRIME`.

## Why #6982 did not hold

#6982 moved payload bytes to `cas/h(payload)` but left one build-environment-specific manifest in that cell and continued to verify it with the strict local-build verifier. The address became content-derived while diagnostic host text still decided membership. Identical payloads produced under two OS strings therefore collided lawfully at one CAS address and were then rejected unlawfully. This change splits those two meanings instead of repeating the narrower #6969/#6973 verifier toggle.

## Discrimination

The new temporary-shelf contract was red before implementation with `artifact identity mismatch: cargo`, followed by false corruption and eviction. It is green at this head and proves all arms:

1. Same source/platform/target/profile, same Cargo commit, identical payload, Ubuntu-to-Debian diagnostic drift: filesystem-shelf hit, zero second Cargo builds.
2. Strict local target with the foreign diagnostic manifest: refuses on `cargo`.
3. Planted wrong source: `crime=shelf-manifest-identity-mismatch field=sourceStamp`.
4. Planted wrong payload under the prior address: `crime=cas-address-payload-mismatch`.
5. Planted mismatch with read-only transport authority: `crime=read-only-shelf-recovery`, cell preserved.
6. Caller-forwarded read-only=0 cannot override the transport-owned read-only=1 fact; the explicit publisher receives read-only=0 with a writable mount.

## Validation

Pinned base: `f8457732f8abc68e8b10de8e388ea7a195226a84`. Exact head: `688af6027e2591d6d1f316a3810e0fc18772ac8c`.

- `bash tests/sugarbin_shelf_immutability.sh "$PWD"`: PASS, including 8-resolver single-flight, dead-winner reclaim, CAS/source/payload/recovery twins, shelf-exercise receipt, and demand-table artifact.
- `bash tests/sugarbin_docker_exec.sh "$PWD"`: PASS.
- `bash tests/sugarbin_artifact_manifest.sh "$PWD"`: PASS; strict local verification preserved.
- `python3 -m pytest tests/test_sugarbin_shell_tier.py -q`: 7 passed.
- `bash -n`, `py_compile`, and `git diff --check`: exit 0.
- Closing-account SHA-256 remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Predicted Epsilon R and floors

- `R_false_corrupt_shelf_reason`: 1 -> 0 for stable-manifest mismatch.
- `R_false_unevictable_shelf_reason`: 1 -> 0 for read-only recovery.
- Wrong source and wrong payload floors remain loud.
- Local target/cache identity remains strict.
- No file, test, or shelf artifact deleted.

No live battleaxe shelf cell was read, chmodded, rewritten, evicted, or deleted by this work. No post-land battleaxe measurement, pytest verdict for the two blocked agents, non-binary artifact migration, or broad package-suite result is claimed. Those measurements become available only after the repair lands.

Closes #7260. Related evidence: #7254.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate filesystem CAS shelf identity separately from local builds
> - Introduces `verify_filesystem_shelf_artifact` in [sugarbin](https://github.com/TSavo/sugar/pull/7265/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) to validate shelf artifacts by BLAKE3-512 CAS address and stable manifest identity fields, tolerating cargo/rustc host string differences across OS builds.
> - Adds `SUGAR_BINARY_SHELF_READ_ONLY` to control shelf mount authority: writable only for explicit publishers (`SUGAR_BINARY_PUBLISH=1`), read-only for all other docker runs including task execution.
> - Filters `SUGAR_BINARY_SHELF_READ_ONLY` from caller-provided environment in `sugar_bx_run_docker` to prevent payload forging, then unconditionally appends the correct value.
> - `evict_shelf_cell` now refuses to delete shelf cells when `SUGAR_BINARY_SHELF_READ_ONLY=1`, emitting a named `read-only-shelf-recovery` crime instead.
> - Extends `classify_log` in [shelf_exercise_report.py](https://github.com/TSavo/sugar/pull/7265/files#diff-6de961f9f89dd3d7f66e96093f194e5dcad258f4795ad40577e09bc8b96ac5cc) to recognize `shelf-manifest-*` and `read-only-shelf-recovery*` crime tags as `SHELF_EXERCISED_CRIME` verdicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 688af60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->