### PR TITLE
Migrate rust function contracts to population enumeration

### DIFF
--- a/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
@@ -19,6 +19,7 @@
 // and pull back proof.ir bytes ready for the substrate's lift / mint /
 // linker pipeline.
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
@@ -52,6 +53,12 @@ use syn::spanned::Spanned;
 use tracing::{debug, info, trace, warn};
 
 const COMPONENT_PLAN_RPC_METHOD: &str = "sugar.component.plan";
+const ENUMERATE_RPC_METHOD: &str = "sugar.enumerate";
+
+thread_local! {
+    static FN_POPULATIONS: RefCell<BTreeMap<PathBuf, (BTreeMap<String, String>, Vec<Value>)>> =
+        RefCell::new(BTreeMap::new());
+}
 
 // Tier 2b native semantic oracle (spec 2026-05-30-callee-resolution-tiers §2.T2b).
 // The RA LSP client now lives in the `sugar_walk::ra_oracle` library module so
@@ -247,6 +254,7 @@ fn handle_line(line: &str) -> Value {
         "shutdown" => Ok(Value::Null),
         KIT_DECLARATION_RPC_METHOD => Ok(kit_declaration_result()),
         COMPONENT_PLAN_RPC_METHOD => Ok(component_plan_result(&params)),
+        ENUMERATE_RPC_METHOD => enumerate_result(&params),
         "sugar.plugin.resolve_source_memento" => resolve_source_memento_rpc(&params),
         // Implication lifter (#97). For every call expression in every
         // function body in the supplied source files, emit a kind:bridge
@@ -6399,6 +6407,7 @@ fn kit_declaration_result() -> Value {
                 {"name": "shutdown", "required": true},
                 {"name": "sugar.plugin.lift_implications", "required": false},
                 {"name": COMPONENT_PLAN_RPC_METHOD, "required": false},
+                {"name": ENUMERATE_RPC_METHOD, "required": false},
                 {"name": KIT_DECLARATION_RPC_METHOD, "required": false}
             ]
         },
@@ -6407,6 +6416,108 @@ fn kit_declaration_result() -> Value {
         },
         "residueCategories": []
     })
+}
+
+fn enumerate_result(params: &Value) -> Result<Value, String> {
+    let level = params.get("level").and_then(Value::as_str).unwrap_or("");
+    let root = PathBuf::from(
+        params
+            .get("workspace_root")
+            .and_then(Value::as_str)
+            .ok_or("sugar.enumerate: missing workspace_root")?,
+    );
+    let mut files = BTreeSet::new();
+    let src_dir = root.join("src");
+    if src_dir.is_dir() {
+        collect_rs_files(&src_dir, &mut files);
+        collect_rs_files_shallow(&root, &mut files);
+    } else {
+        collect_rs_files(&root, &mut files);
+    }
+    let rows = files.iter().filter_map(|path| {
+        let bytes = std::fs::read(path).ok()?;
+        Some(json!({"file": relative_display_path(path, &root), "source_cid": blake3_512_of(&bytes)}))
+    }).collect::<Vec<_>>();
+    if level == "source_files" {
+        let sealed = rows
+            .iter()
+            .filter_map(|row| {
+                Some((
+                    row["file"].as_str()?.to_string(),
+                    row["source_cid"].as_str()?.to_string(),
+                ))
+            })
+            .collect::<BTreeMap<_, _>>();
+        let legacy = function_contract_lift(&json!({"workspace_root": root}))?;
+        let sidecar = legacy["ir"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|entry| entry.get("sourceWarrants").is_none())
+            .cloned()
+            .collect();
+        FN_POPULATIONS.with(|p| p.borrow_mut().insert(root.clone(), (sealed, sidecar)));
+        return Ok(
+            json!({"nodes": rows.into_iter().map(|m| json!({"memento":m,"audit":null,"payload":null})).collect::<Vec<_>>(), "gaps": []}),
+        );
+    }
+    if level != "universe" {
+        return Err(format!("sugar.enumerate: level '{level}' is not served by surface 'rust-fn-contracts'; refusing false zero"));
+    }
+    let at = params
+        .get("at")
+        .and_then(Value::as_object)
+        .ok_or("sugar.enumerate universe requires at.file")?;
+    let rel = at
+        .get("file")
+        .and_then(Value::as_str)
+        .ok_or("sugar.enumerate universe requires at.file")?;
+    let (sealed, sidecar) = FN_POPULATIONS
+        .with(|p| p.borrow().get(&root).cloned())
+        .ok_or("rust-fn-contracts universe requires a prepared source_files census")?;
+    let current = rows
+        .iter()
+        .filter_map(|r| {
+            Some((
+                r["file"].as_str()?.to_string(),
+                r["source_cid"].as_str()?.to_string(),
+            ))
+        })
+        .collect::<BTreeMap<_, _>>();
+    if current != sealed {
+        return Err(
+            "rust-fn-contracts source population changed since the sealed source_files census"
+                .to_string(),
+        );
+    }
+    let row = rows.iter().find(|r| r["file"].as_str() == Some(rel)).ok_or_else(|| format!("rust-fn-contracts source '{rel}' is not a member of the sealed source_files census"))?;
+    if let Some(cid) = at.get("source_cid").and_then(Value::as_str) {
+        if row["source_cid"].as_str() != Some(cid) {
+            return Err(format!(
+                "rust-fn-contracts source '{rel}' changed since the sealed source_files census"
+            ));
+        }
+    }
+    let doc = function_contract_lift(&json!({"workspace_root":root,"source_paths":[rel]}))?;
+    let mut audits = doc["ir"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|e| {
+            e.get("sourceWarrants")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .any(|m| m.get("file").and_then(Value::as_str) == Some(rel))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    if sealed.keys().next().map(String::as_str) == Some(rel) {
+        audits.extend(sidecar);
+    }
+    Ok(
+        json!({"nodes": audits.into_iter().map(|audit| json!({"memento":row,"audit":audit,"payload":null})).collect::<Vec<_>>(), "gaps": doc["diagnostics"].as_array().cloned().unwrap_or_default().into_iter().map(|d| json!({"memento":row,"reason":d})).collect::<Vec<_>>() }),
+    )
 }
 
 fn component_plan_result(params: &Value) -> Value {
@@ -7742,10 +7853,12 @@ fn lift_scan_roots(root: &Path, source_paths: &[String]) -> Vec<PathBuf> {
         .iter()
         .map(|p| {
             let candidate = root.join(p);
-            if candidate.is_dir() {
+            if candidate.is_file() {
+                candidate
+            } else if candidate.is_dir() {
                 candidate
             } else {
-                root.to_path_buf()
+                candidate
             }
         })
         .collect()
@@ -8314,6 +8427,12 @@ fn resolve_rs_source_files(
 }
 
 fn collect_rs_files(dir: &Path, visited: &mut std::collections::BTreeSet<PathBuf>) {
+    if dir.is_file() {
+        if path_has_rs_extension(dir) {
+            visited.insert(dir.to_path_buf());
+        }
+        return;
+    }
     if !dir.is_dir() {
         return;
     }


### PR DESCRIPTION
## Summary

Advertise `sugar.enumerate` for `rust-fn-contracts` with a prepared, content-keyed source population. File-scoped contracts are emitted only for the demanded source fragment; population-level manifest and std panic contracts are emitted once at the authenticated first-file anchor.

This closes the scan-unit widening in `lift_scan_roots`: a file request no longer widens to the workspace root. Universe refuses without a prepared `source_files` census, on source population drift, on an unknown file, or on CID mismatch.

## Evidence

- Base: `c8f53dae8e5ca60f5a0177e63742628624f75f7a`
- `cargo check -p sugar-walk --bin sugar-walk-rpc`: exit 0
- focused function-contract tests: 34 passed, 0 failed, 131 filtered, exit 0
- migration control: whole-population legacy vs folded per-file rows plus anchored sidecar, exact row identity: 1 passed, exit 0
- negative control: naive per-file legacy differs by exact row identity: 1 passed, exit 0

The sidecar prevents duplication or loss of the three post-loop emitters; the folded path is anchored by authenticated content rather than traversal order.

Not claiming corpus or battleaxe measurement here; this PR has only focused local evidence.
