### PR TITLE
Preserve universe construction panics at the full-tree mint

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2623,6 +2623,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     try:
                         def_memento, rows = _tree.function_contract_rows(fn, file_rel)
                     except SugarNotWritten as gap:
+                        # A full-tree mint has no later construction entrance:
+                        # turning this product terminal into an enumeration gap
+                        # lets the Rust fold downgrade it to a diagnostic and
+                        # seal incomplete IR.  Let the existing typed-loud RPC
+                        # membrane carry the structured panic instead.  A
+                        # targeted seek is different: it may still construct an
+                        # applied callee after its abstract universe refused.
+                        if not seek:
+                            raise
                         gaps.append(
                             {
                                 "memento": _tree.function_def_memento(

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_universe_panic_refusal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_universe_panic_refusal.py
@@ -1,0 +1,76 @@
+"""Full-tree universe mint must not downgrade product panics to gaps.
+
+The targeted ``seek=true`` universe door may retain an abstract gap while it
+tries an applied call-site construction (``test_dig_with_args`` owns that
+composition law).  The full-tree ``seek=false`` mint has no such second
+construction: converting ``SugarNotWritten`` to a gap lets Rust turn it into a
+diagnostic and seal an incomplete ``ir-document``.  This tooth pins the other
+arm at the real JSON-RPC membrane.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sugar_lift_py_tests import lift_rpc, tree_enumerate
+from sugar_source_tree.panic import SugarNotWritten
+
+
+def test_full_tree_universe_scan_preserves_sugar_not_written_as_typed_loud(
+    tmp_path, monkeypatch
+) -> None:
+    """Removing the no-seek rethrow must recreate a successful empty result."""
+
+    subject = tmp_path / "subject.py"
+    subject.write_text("def subject():\n    return 1\n", encoding="utf-8")
+    panic = SugarNotWritten(
+        blame=SimpleNamespace(filename="subject.py", line=2, col=4),
+        owner="CallSiteValue.attribute",
+        observed="undecided receiver runtime type or member semantics: CallSiteValue.bytes",
+        requested="a source-authenticated attribute success or exceptional exit",
+        fix=(
+            "carry receiver-type and member testimony to the attribute floor; "
+            "do not guess AttributeError or invent a completed projection"
+        ),
+    )
+
+    def refuse_contract_rows(_fn, _file_rel):
+        raise panic
+
+    request = {
+        "jsonrpc": "2.0",
+        "id": 17,
+        "method": "sugar.enumerate",
+        "params": {
+            "level": "universe",
+            "workspace_root": str(tmp_path),
+            "at": {"file": subject.name},
+            "seek": False,
+        },
+    }
+    requests = iter([request])
+    sent = []
+    monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", None)
+    monkeypatch.setattr(lift_rpc, "_BOUND_CALL_CONTRACT_REFS", None)
+    monkeypatch.setattr(tree_enumerate, "function_contract_rows", refuse_contract_rows)
+    monkeypatch.setattr(lift_rpc, "_recv", lambda: next(requests, None))
+    monkeypatch.setattr(lift_rpc, "_send", sent.append)
+
+    lift_rpc._serve()
+
+    assert len(sent) == 1, sent
+    response = sent[0]
+    assert "result" not in response, response
+    assert response["error"]["code"] == -32001
+    assert response["error"]["data"] == {
+        "kind": "typed-loud",
+        "exception_type": "SugarNotWritten",
+        "stage": "dispatch",
+        "diagnostic": {
+            "owner": panic.owner,
+            "observed": panic.observed,
+            "requested": panic.requested,
+            "fix": panic.fix,
+        },
+    }
+    assert "subject.py:2:4" in response["error"]["message"]


### PR DESCRIPTION
## Law

It constructs, or it panics when we have not written the sugar yet. A mint that seals `ir=[]` over a discarded `SugarNotWritten` breaks that law at the attested boundary.

## Cause

This is an entrance-specific membrane repair. In the Python `sugar.enumerate` universe loop, a product `SugarNotWritten` was caught and converted into an ordinary enumeration gap. The full-tree Rust mint then folded that gap into diagnostics and continued, allowing an empty row set to look clean even though the product had named the missing construct, coordinate, observed shape, requested construction, and fix.

Two deliberate changes composed into the defect:

- `88370ec9` introduced tolerant per-function universe enumeration.
- `a42524ee` / #6222 introduced the Rust diagnostic fold for full-tree mint.

Neither distinguished ordinary enumeration absence from a product construction panic. The mechanics were deliberate; the classification was accidental.

The loud path already exists: `_serve` serializes an uncaught `SourceTreePanic` as a typed-loud JSON-RPC error, and the Rust enumerate transport refuses that error. This change removes only the misclassified catch at the full-tree entrance.

## Repair boundary

- `seek=false` full-tree mint: re-raise `SugarNotWritten` so the existing typed-loud membrane carries the refusal.
- `seek=true` targeted dig: retain gap-and-continue. A symbolic abstract call can have no universe until the call-site cue substitutes arguments and constructs the applied callee. Removing the catch globally would break this lawful path; `test_dig_with_args.py::test_applied_dig_fires_even_when_the_abstract_universe_is_a_gap` is the control.

The vendor-member constructions remain deliberately separate and unimplemented: `hashlib` `digest_size` and `UUID` `bytes` still refuse as `CallSiteValue.attribute`.

## Exact evidence

Measured on branch head `119a4ecbc6b3bbf8d3f7f704cd8377e3df9f00fb`, direct parent/current main `b5e34a56b9be04d4588cf8f4d4f65f3c0a6a46a6`:

- Authenticated battleaxe focused teeth: **2/2 passed** under CPython 3.12.13 and pandas 3.0.3.
  - full-tree universe panic reaches typed-loud JSON-RPC refusal
  - targeted applied dig still constructs after an abstract universe gap
- Discrimination twin: deleting only the `seek=false` rethrow makes the new tooth fail with a successful `nodes=[]` result; restoring it returns 2/2 green.
- Scale: exactly **2 showcase scripts change verdict**, both from swallowed diagnostics/empty rows to typed-loud `SugarNotWritten` refusal:
  - `examples/hashlib-md5-digest-size/run-logo-receipt.sh`
  - `examples/uuid-bytes-length/run-logo-receipt.sh`
- Scale receipt: `/tmp/keaton-full-tree-universe-scale-119a4ecb.json`, SHA-256 `877429c2dcf676f92b0c519caeff43b34410f815752f7ce126fdf6ef4498ca07`.
- Direct script logs independently show both scripts exiting 1 at the typed-loud `CallSiteValue.attribute` terminal.

This does **not** make the showcase suite green. Other retained showcase terminals and two scale-instrument import failures remain distinct findings.

## Census impact

The pandas construction census does not traverse this universe/Rust diagnostic fold. Source-path proof: `control_effect_recensus` delegates to `recensus_enumerate_consumer` requesting only `functions`, `context-manager-resolutions`, and `facts`; that path contains zero universe-level or Rust `fold_enumerate_source_tree` references. The sealed 477 first-terminal receipt is therefore unaffected by this change. This is source-path proof, not a fresh corpus census.

Closes #7253.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `SugarNotWritten` panics during full-tree universe mint when `seek` is false
> - In [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/7269/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335), the `_handle_enumerate` handler now re-raises `SugarNotWritten` instead of converting it to an enumeration gap when `seek=False`.
> - When `seek=True`, the existing behavior is unchanged: the exception is recorded as a gap and iteration continues.
> - A new test in [`test_enumerate_universe_panic_refusal.py`](https://github.com/TSavo/sugar/pull/7269/files#diff-6c85abbebe2b0f00448a353af1999cd041f1d4f1ef6ed964673c7775d3ed17d3) verifies that a `universe`-level enumerate with `seek=False` returns a typed-loud error response (code `-32001`) rather than a success result.
> - Behavioral Change: `sugar.enumerate` requests at `universe` level with `seek=False` will now surface errors that were previously silently swallowed as gaps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 119a4ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Full-tree universe scans now correctly report `SugarNotWritten` errors as typed JSON-RPC errors instead of returning incomplete successful results.
  * Targeted scans continue to represent the condition as a gap and proceed.

* **Tests**
  * Added regression coverage validating error codes, diagnostics, exception details, dispatch stage, and source location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->