### PR TITLE
Publish battleaxe artifact manifests host-readable

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -594,6 +594,7 @@ for b in $needs; do
   printf '{"name":"%s","sha256":"%s"}' "$b" "$sum" >>"$manifest_tmp";
 done;
 printf ']}' >>"$manifest_tmp";
+chmod 0644 "$manifest_tmp";
 mv -f -- "$manifest_tmp" "$manifest";
 manifest_tmp="";
 trap - EXIT HUP INT TERM;

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -344,11 +344,19 @@ unset WRITER_BLOCK_MARKER
 rm -f "$writer_out/required-artifacts.json"
 writer_script="$(sugar_bx_artifact_build_script \
   first release "$writer_workspace" "$writer_out")"
+case "$writer_script" in
+  *'chmod 0644 "$manifest_tmp";'*'mv -f -- "$manifest_tmp" "$manifest";'*) ;;
+  *) fail "manifest publication does not set host-readable mode before atomic rename" ;;
+esac
 WRITER_PAYLOAD_ROOT="$tmp/writer-payloads" bash -c "$writer_script"
 python3 - "$writer_out" <<'PY'
-import hashlib, json, pathlib, sys
+import hashlib, json, pathlib, stat, sys
 root = pathlib.Path(sys.argv[1])
-manifest = json.loads((root / "required-artifacts.json").read_text())
+manifest_path = root / "required-artifacts.json"
+assert stat.S_IMODE(manifest_path.stat().st_mode) == 0o644, oct(
+    stat.S_IMODE(manifest_path.stat().st_mode)
+)
+manifest = json.loads(manifest_path.read_text())
 assert len(manifest["artifacts"]) == 1, manifest
 item = manifest["artifacts"][0]
 assert item["name"] == "first", item


### PR DESCRIPTION
## Outcome

Publish `required-artifacts.json` as mode `0644` before its atomic rename, so the root-running managed artifact builder leaves a manifest that the invoking battleaxe host user can read, quarantine, and reset.

Closes #7254.

## Root cause

#7219 fixed a real defect: it replaced an in-place `>`/`>>` manifest writer with `mktemp` plus same-filesystem atomic `mv`, preserving the prior manifest across a killed writer. The former direct redirect inherited umask `022` and published `0644`. `mktemp` creates `0600`, and `mv` preserves that mode.

The managed image has no `USER`, so `sugar_bx_build_artifacts_docker` runs as root while `/out` is a bind mount of a `tsavo:tsavo 0775` host directory. That made the resulting trio inconsistent:

- binary: `root:root 0755`
- metadata: `root:root 0644`
- manifest: `root:root 0600`

The atomicity repair therefore introduced a host-readability defect in the same writer. Both modes were individually plausible, which let the regression hide as recurring instrument noise.

## Measured blast radius

Read-only audit of `/home/tsavo/remote/sugar-bcargo-*/artifacts/required-artifacts.json` found:

- 32 manifests total
- 32 root-owned
- 23 mode `0600` and unreadable to the normal runner
- 9 mode `0644`

This change prevents new poisoned manifests. It does **not** chmod, delete, or otherwise repair those 23 existing residues. A checkout owner/operator must select a fresh `BCARGO_REMOTE_ROOT` or explicitly remove that checkout's ephemeral `artifacts/` directory as the normal host user before reuse. No bulk cleanup is part of this PR.

## Repair

Set `0644` on the staging manifest before `mv -f`. The order is load-bearing: chmod-after-rename would create a published `0600` window and weaken the atomic contract #7219 established.

Running the container as the host UID is deliberately rejected here. The managed image and mounted tool/cache layout use `/root`; changing execution identity would be a broad environment migration for a one-file mode defect.

## Teeth

- Red first: the Docker execution contract refused because the generated writer did not set host-readable mode before rename.
- Green: the generated script is required to place `chmod 0644 "$manifest_tmp"` before the atomic `mv`.
- Green: successful publication asserts the actual final mode is exactly `0644`.
- Existing atomicity arm remains green: a TERM after the first artifact leaves the prior final manifest byte-identical and leaves zero staging residue.
- Live cross-UID battleaxe proof from fresh root `/home/tsavo/remote/sugar-bcargo-kujan-7254-mode`: container-root publication produced `root:root 0644`; the host `tsavo` SSH session read and parsed it with `artifacts=1`, exit 0.
- `tests/sugarbin_docker_exec.sh "$PWD"`: PASS.
- `bash -n` and `git diff --check`: exit 0.

## Predicted impact

`Epsilon R(root-owned-unreadable-required-artifacts)`: new publications stop adding offenders. The pre-existing population remains 23 until separately reset; this PR does not claim that historical `R` is zero.

## Non-claims

No CAS shelf behavior changes. No container UID migration. No bulk chmod or cleanup. No claim that old poisoned checkouts repair themselves.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set battleaxe artifact manifest file permissions to 0644 before atomic rename
> Before renaming the temporary manifest to its final path in [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7271/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc), a `chmod 0644` step is added so the published manifest is host-readable. The integration test in [sugarbin_docker_exec.sh](https://github.com/TSavo/sugar/pull/7271/files#diff-dd07889f0744ddb1e6ea24d617d74078943ffb624914227169d92a4b12d3165c) is extended to assert both that the writer script includes the `chmod` and that the on-disk manifest has mode 0644.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb07ef1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->