### PR TITLE
Publish derived demand tables to the CAS shelf

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -100,6 +100,7 @@ import os
 import platform
 import subprocess
 import sys
+import tempfile
 import time
 from collections import Counter
 from pathlib import Path
@@ -1109,6 +1110,30 @@ def main() -> int:
         write_prebuilt_demand_table,
     )
 
+    def publish_demand_table(table, path: Path) -> None:
+        """Publish the derived payload through the authenticated CAS door."""
+        repo_root = Path(__file__).resolve().parents[4]
+        completed = subprocess.run(
+            [
+                str(repo_root / "bin" / "sugarbin"),
+                "artifact", "publish", "--kind", "python-demand-table",
+                "--content-key", table.content_cid, "--input", str(path),
+                "--runtime", "cpython-3.12.13",
+            ],
+            cwd=repo_root, capture_output=True, text=True, check=False,
+        )
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()[:800]
+            raise DemandTableArtifactRefusal(
+                "python-demand-table CAS publication refused: "
+                f"contentCid={table.content_cid} exit={completed.returncode} "
+                f"detail={detail}"
+            )
+        _narrate(
+            "RECENSUS DEMAND_TABLE published CAS "
+            f"contentCid={table.content_cid} runtime=cpython-3.12.13"
+        )
+
     pin_identity = {
         "distribution": observed_pin.distribution,
         "version": observed_pin.version,
@@ -1175,12 +1200,22 @@ def main() -> int:
             if write_path is None and args.out_dir is not None:
                 # Default artifact next to board outputs so shards can find it.
                 write_path = Path(args.out_dir) / "provisional-demand-table.json"
-            if write_path is not None:
-                write_prebuilt_demand_table(table, write_path)
-                _narrate(
-                    f"RECENSUS DEMAND_TABLE wrote path={write_path} "
-                    f"contentCid={table.content_cid}"
+            temporary_path = None
+            if write_path is None:
+                handle = tempfile.NamedTemporaryFile(
+                    prefix="python-demand-table-", suffix=".json", delete=False
                 )
+                temporary_path = Path(handle.name)
+                handle.close()
+                write_path = temporary_path
+            write_prebuilt_demand_table(table, write_path)
+            _narrate(
+                f"RECENSUS DEMAND_TABLE wrote path={write_path} "
+                f"contentCid={table.content_cid}"
+            )
+            publish_demand_table(table, write_path)
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
             refs = install_prebuilt_demand_table(table, root=workspace_root)
             return refs, table.content_cid
 


### PR DESCRIPTION
After successful demand-table derivation, serialize to a temporary or requested path and publish through bin/sugarbin artifact publish using the computed payload CID and authenticated cpython-3.12.13 runtime. Publication refusal is loud and prevents the run from banking an uncacheable result. Existing prebuilt load path remains unchanged and resolves with zero corpus walk. Focused evidence: py_compile exit 0. The prebuilt pytest invocation exited 143 before producing test output and is unmeasured. Legacy hardcoded key filed separately as #7272.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish derived demand tables to the CAS shelf via sugarbin
> - `_derive_and_maybe_write` in [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7273/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) now always writes a demand table to disk, using a `NamedTemporaryFile` when no explicit write path is configured.
> - A new `publish_demand_table` helper invokes the `sugarbin` CLI to publish the demand table as a `python-demand-table` artifact to CAS using the table's content CID.
> - On non-zero exit from `sugarbin`, the helper raises `DemandTableArtifactRefusal` with trimmed stderr/stdout detail instead of silently proceeding.
> - Risk: derivation phases that previously succeeded without a write path will now fail if CAS publication is refused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 304bfb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->