### PR TITLE
Route showcase subscripts through operation-owned doors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py
@@ -1067,11 +1067,18 @@ class CallSiteValue(FloorValue):
     def subscript_with(self, operation, ctx):
         """Subscript on a callsite result (revealed after binary dig progress).
 
-        Same dig-or-symbolic totalizer as binary_operator_with.
+        Dig when the body floors; otherwise retain this callsite's symbolic
+        term. The operation owns the submission door -- the deleted central
+        dispatcher must never be rediscovered here.
         """
-        return self._dig_or_symbolic_redispatch(
-            operation, ctx, owner_suffix="callsite subscript receiver"
+        from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+
+        floor = self._dig_floor_or_none(
+            ctx,
+            owner=f"{operation.owner} callsite subscript receiver",
         )
+        receiver: FloorValue = floor if floor is not None else SymbolicValue(self.term)
+        return operation.submit(receiver, ctx)
 
     def project_sequence_with(self, operation, ctx):
         """``a, b = f(...)``: unpack of a callsite result.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/subscript_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/subscript_operation.py
@@ -85,7 +85,6 @@ class SubscriptOperation:
         del ctx
         from sugar_lift_py_tests.floor import SymbolicValue
         from sugar_lift_py_tests.ir import ctor
-        from sugar_lift_py_tests.sugar.floor_terms import floor_to_term
 
         return Complete(
             SymbolicValue(
@@ -93,7 +92,7 @@ class SubscriptOperation:
                     "py.subscript",
                     [
                         receiver.term,
-                        floor_to_term(self.index, owner=f"{self.owner} index"),
+                        self.index.to_term(owner=f"{self.owner} index"),
                     ],
                 )
             )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/subscript_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/subscript_operation.py
@@ -30,6 +30,10 @@ class SubscriptOperation:
     blame: object
     use_occurrence: object | None = None
 
+    def submit(self, receiver: Any, ctx: object) -> Outcome:
+        """Ask the receiver to answer this subscript demand."""
+        return receiver.subscript_with(self, ctx)
+
     def subscript_string(self, receiver, ctx: object) -> Outcome:
         from sugar_lift_py_tests.floor import (
             Bv32Value,

--- a/implementations/python/sugar-lift-py-tests/tests/test_showcase_operation_entrances.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_showcase_operation_entrances.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
 from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
 from sugar_lift_py_tests.ir import ctor, make_var
 from sugar_lift_py_tests.operations.subscript_operation import SubscriptOperation
@@ -33,3 +34,61 @@ def test_symbolic_subscript_projects_its_index_through_the_owned_term_door() -> 
     assert isinstance(outcome, Complete)
     assert outcome.value.term == ctor("py.subscript", [receiver.term, index.term])
     assert index.owners == ["symbolic-subscript index"]
+
+
+class _RecordingSubmittedOperation:
+    owner = "callsite-subscript"
+
+    def __init__(self) -> None:
+        self.answer = object()
+        self.submissions: list[tuple[object, object]] = []
+
+    def submit(self, receiver, ctx):
+        self.submissions.append((receiver, ctx))
+        return self.answer
+
+
+def test_callsite_subscript_redispatches_through_operation_owned_submit() -> None:
+    callsite = CallSiteValue(
+        "pandas.perform_operation",
+        (),
+        (),
+        make_var("pandas-callsite"),
+        None,
+    )
+    operation = _RecordingSubmittedOperation()
+    ctx = object()
+
+    answer = callsite.subscript_with(operation, ctx)
+
+    assert answer is operation.answer
+    assert len(operation.submissions) == 1
+    receiver, submitted_ctx = operation.submissions[0]
+    assert isinstance(receiver, SymbolicValue)
+    assert receiver.term == callsite.term
+    assert submitted_ctx is ctx
+
+
+class _RecordingSubscriptReceiver:
+    def __init__(self) -> None:
+        self.subscripts: list[tuple[object, object]] = []
+
+    def subscript_with(self, operation, ctx):
+        self.subscripts.append((operation, ctx))
+        return Complete(self)
+
+
+def test_subscript_operation_submits_itself_to_the_receiver_port() -> None:
+    operation = SubscriptOperation(
+        index=_RecordingTermIndex(),
+        owner="operation-submit",
+        blame="operation-submit-site",
+    )
+    receiver = _RecordingSubscriptReceiver()
+    ctx = object()
+
+    outcome = operation.submit(receiver, ctx)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value is receiver
+    assert receiver.subscripts == [(operation, ctx)]

--- a/implementations/python/sugar-lift-py-tests/tests/test_showcase_operation_entrances.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_showcase_operation_entrances.py
@@ -1,0 +1,35 @@
+"""Showcase regressions must walk the live operation-owned entrances."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.ir import ctor, make_var
+from sugar_lift_py_tests.operations.subscript_operation import SubscriptOperation
+from sugar_lift_py_tests.outcome import Complete
+
+
+class _RecordingTermIndex:
+    def __init__(self) -> None:
+        self.term = make_var("index")
+        self.owners: list[str] = []
+
+    def to_term(self, *, owner: str):
+        self.owners.append(owner)
+        return self.term
+
+
+def test_symbolic_subscript_projects_its_index_through_the_owned_term_door() -> None:
+    """The subscript operation must not rediscover the deleted floor shim."""
+    index = _RecordingTermIndex()
+    receiver = SymbolicValue(make_var("items"))
+    operation = SubscriptOperation(
+        index=index,
+        owner="symbolic-subscript",
+        blame="symbolic-subscript-site",
+    )
+
+    outcome = operation.subscript_symbolic(receiver, None)
+
+    assert isinstance(outcome, Complete)
+    assert outcome.value.term == ctor("py.subscript", [receiver.term, index.term])
+    assert index.owners == ["symbolic-subscript index"]


### PR DESCRIPTION
## What changed

This keeps two distinct wrong-entrance repairs as two commits:

1. Symbolic subscript construction now asks the index owner directly through `index.to_term(owner=...)` instead of rediscovering the retired `floor_terms.floor_to_term` shim.
2. Callsite subscript construction now preserves the dig-or-symbolic receiver choice and submits through the operation-owned `submit` door; `SubscriptOperation.submit` in turn reaches the receiver's `subscript_with` port.

## Why

Keaton's exact showcase remeasurement at `e75fcdc99b` found both causes still live because neither commit was on main:

- 3/3 stale `floor_terms` import rows
- 1/1 dead `pandas.perform_operation` import row

These constructs existed behind doors the live paths did not walk through.

Predicted impact:

- `Epsilon R_stale_floor_terms_wrong_entrance = -3`
- `Epsilon R_dead_perform_operation_wrong_entrance = -1`

A post-merge showcase remeasurement remains the authority for observed Delta R.

## Teeth

Executed through a verified-fresh Battleaxe root,
`/home/tsavo/remote/sugar-bcargo-hockney-0214968eef`, on branch head
`0214968eefcbd971bb7ab9ac24bb67bca1e9d714` over main
`ab7124ac2447f5af846ae37f1ffa053318d1c976`.

Authenticated environment: CPython 3.12.13, pandas 3.0.3, 1,421-file corpus.

```
3 passed in 0.81s
```

The teeth assert the entrances themselves, not merely symptom clearance:

- `index.to_term` is called exactly once with owner `symbolic-subscript index`.
- The callsite invokes operation-owned `submit` exactly once with the projected `SymbolicValue` and original context.
- `SubscriptOperation.submit` reaches the receiver port with the exact operation object and context.

## Non-claims

This does not claim all showcase failures construct or that the 31-row in-scope frontier is otherwise reduced. The NumPy row currently has a `ReceiverFieldStoreStateSugar` first terminal and only encounters `perform_operation` secondarily; this PR does not claim that first terminal clears. Reattribution or exposure of a deeper terminal is discovery, not regression.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route showcase subscript dispatch through operation-owned `submit` entrance
> - `CallSiteValue.subscript_with` now selects a receiver (dug floor or `SymbolicValue(self.term)`) and delegates to `operation.submit(receiver, ctx)` instead of the central `_dig_or_symbolic_redispatch` helper.
> - `SubscriptOperation` gains a `submit(receiver, ctx)` method that forwards to `receiver.subscript_with(self, ctx)`, making operations active participants in dispatch.
> - `SubscriptOperation.subscript_symbolic` now calls `self.index.to_term(owner=...)` directly instead of using a module-level `floor_to_term` conversion.
> - New tests in [`test_showcase_operation_entrances.py`](https://github.com/TSavo/sugar/pull/7274/files#diff-2ab54125eead06c550f2d8f91a6255bf6cde10a4541a0ba1348c0c06d8dd9a3c) cover all three changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0214968.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscript handling when concrete values are available, with symbolic fallback support.
  * Ensured subscript operations are correctly submitted through their receivers.
  * Improved call-site redispatch behavior for subscript requests.

* **Tests**
  * Added coverage for symbolic subscripting, call-site redispatch, receiver submission, and successful operation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->