### PR TITLE
Project equality operands through operation receiver authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/equality_op_sugar.py
@@ -78,7 +78,17 @@ class EqualityOpSugar(ConstructedTermSugar):
 
     def apply_reduced(self, left, right, ctx: object = None) -> Outcome:
         """Apply equality/refinement to operands already evaluated once."""
-        return _equals_and_refine(left, right, self.site, ctx, self.left_coordinate)
+        return _equals_and_refine(
+            left.project_operation_receiver(
+                ctx, owner="EqualityOpSugar left operation receiver"
+            ),
+            right.project_operation_receiver(
+                ctx, owner="EqualityOpSugar right operation receiver"
+            ),
+            self.site,
+            ctx,
+            self.left_coordinate,
+        )
 
 
 def _finite_equality_face(value, peer, *, matches: bool):

--- a/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_compare_exceptional_exit_producer.py
@@ -12,7 +12,13 @@ import pytest
 
 from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
-from sugar_lift_py_tests.floor import CallSiteValue, NoneValue, SymbolicValue, TermValue
+from sugar_lift_py_tests.floor import (
+    CallSiteValue,
+    FloorValue,
+    NoneValue,
+    SymbolicValue,
+    TermValue,
+)
 from sugar_lift_py_tests.formal_parameter import FormalParameterCoordinateV1
 from sugar_lift_py_tests.ir import PrimitiveSort, ctor, make_var
 from sugar_lift_py_tests.outcome import Complete
@@ -80,6 +86,23 @@ class _ValueSugar(ConstructedTermSugar):
             (str_const(type(self.value).__name__),),
             symbol_kind="coordinate",
         )
+
+
+class _OperationReceiverProjectionProbe(FloorValue):
+    """Record the exact operation-receiver door without changing equality."""
+
+    def __init__(self, label: str, calls: list[tuple], projected: TermValue) -> None:
+        self.label = label
+        self.calls = calls
+        self.projected = projected
+
+    def project_operation_receiver(self, ctx: object, *, owner: str):
+        self.calls.append((self.label, ctx, owner))
+        return self.projected
+
+    def equals(self, other, site):
+        peer = other.projected if isinstance(other, type(self)) else other
+        return self.projected.equals(peer, site)
 
 
 def _repo_root() -> Path:
@@ -437,6 +460,26 @@ def test_ground_decided_equality_still_completes() -> None:
     assert isinstance(outcome, Complete)
     assert not isinstance(outcome, ExitSet)
     assert isinstance(outcome.value, FalseBoolLiteralSugar)
+
+
+def test_equality_projects_both_operation_receivers_with_exact_owners() -> None:
+    calls: list[tuple] = []
+    ctx = object()
+    left = _OperationReceiverProjectionProbe("left", calls, TermValue(1))
+    right = _OperationReceiverProjectionProbe("right", calls, TermValue(1))
+
+    outcome = EqualityOpSugar(
+        _ValueSugar(left),
+        _ValueSugar(right),
+        "compare-site",
+    ).desugar(ctx)
+
+    assert calls == [
+        ("left", ctx, "EqualityOpSugar left operation receiver"),
+        ("right", ctx, "EqualityOpSugar right operation receiver"),
+    ]
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, TrueBoolLiteralSugar)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Finding

EqualityOpSugar already owns equality semantics, but apply_reduced bypassed the operation-receiver projection that ComparisonOpSugar applies. Raw callsite operands therefore reached equals without the existing source-backed receiver authority.

## Change

- Project both evaluated operands through project_operation_receiver before equality dispatch.
- Pin the left and right owner strings independently.
- Keep the native and bodyless result-type authority class out of this change; #7263 carries that ruling request.

## Instrument

The focused tooth records the exact calls, in order:

- left with owner EqualityOpSugar left operation receiver
- right with owner EqualityOpSugar right operation receiver

It then proves ordinary ground equality still completes. A panic-disappeared-only assertion would pass against suppression; this tooth requires the intended door.

## Authenticated evidence

At e1f365d7cf0e9121427251172f9b9e6d7f21a367, direct parent and merge-base current main 1f0d317051ed4f8333852ea4075ef2a17aad6a9d:

- bin/bpytest through a fresh battleaxe root
- CPython 3.12.13
- pandas 3.0.3 / 1421
- 1 passed in 1.09s

## Scope and non-claim

This establishes reattribution, not construction. Projection may expose a deeper opaque native call, and this PR does not claim full construction. If rows reattribute and halt somewhere new, that new terminal is the finding. Imported Python targets are not classified from spelling alone; source-frame enrollment remains authority.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project equality operands through `project_operation_receiver` before comparison in `EqualityOpSugar`
> In `EqualityOpSugar.apply_reduced`, both the left and right operands are now passed through `project_operation_receiver` (with explicit owner strings `'EqualityOpSugar left operation receiver'` and `'EqualityOpSugar right operation receiver'`) before being handed to `_equals_and_refine`. A new test verifies the exact call sequence and that the result is `Complete` with a `TrueBoolLiteralSugar` value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1f365d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->