### PR TITLE
Construct dependency cache identity and design refusal meaning identity

### DIFF
--- a/docs/superpowers/plans/2026-08-03-dependency-artifact-cache-coherence.md
+++ b/docs/superpowers/plans/2026-08-03-dependency-artifact-cache-coherence.md
@@ -1,0 +1,78 @@
+# Dependency Artifact Cache Construction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rehydrate dependency-artifact cache inputs through the one lawful graph constructor, making independent cached graph fields unrepresentable.
+
+**Architecture:** Disable direct field allocation, route distribution and stdlib input variants through one constructor, and persist only primitive distribution file inputs in `dep-graph-v4`. Cache refusal invalidates one seat and executes the existing authenticated miss path.
+
+**Tech Stack:** Python 3.12, frozen dataclasses, pickle cache, logging, pytest.
+
+## Global Constraints
+
+- No separate coherence predicate over `artifact_kind` and `distribution_name`.
+- Cache v4 stores exactly schema and primitive recorded-file inputs.
+- The miss path must perform real authenticated reconstruction; never return an empty or default graph.
+- Lawful graph fields and artifact CID remain unchanged.
+- The 94 off-population rows are not attributed to this defect.
+- No battleaxe, census, pandas walk, or broad pytest run.
+
+---
+
+### Task 1: Prove the missing construction boundary
+
+**Files:**
+- Test: `implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py`
+
+**Interfaces:**
+- Consumes: current direct `DependencyArtifactGraph(...)` field initializer.
+- Produces: red constructor and poisoned-cache teeth.
+
+- [x] Write a direct-allocation tooth whose caught exception type must be named `DependencyArtifactConstructionError`.
+- [x] Write a poisoned-v4 tooth that wraps and executes the real `_read_recorded_installation`, then asserts a non-empty rebuilt distribution graph, exact-seat invalidation evidence, and a clean replacement seat.
+- [x] Run the two teeth unpiped; require failures for the missing construction boundary and the cache projection path, not collection or census errors.
+
+### Task 2: Install one graph construction path
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py`
+
+**Interfaces:**
+- Consumes: closed distribution/stdlib input variants containing authenticated files and diagnostic paths.
+- Produces: `_construct_from_authenticated_inputs(...) -> DependencyArtifactGraph` and named `DependencyArtifactConstructionError` for direct allocation.
+
+- [x] Disable the dataclass-generated public initializer and make direct field allocation raise `DependencyArtifactConstructionError`.
+- [x] Add closed distribution and stdlib input variants.
+- [x] Move METADATA identity, module projection, CID derivation, and final allocation into `_construct_from_authenticated_inputs`.
+- [x] Route live distribution and stdlib intake through that method without altering lawful output fields.
+- [x] Run the constructor tooth unpiped and require green.
+
+### Task 3: Persist and rehydrate inputs only
+
+**Files:**
+- Modify: `implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py`
+- Test: `implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py`
+
+**Interfaces:**
+- Consumes: primitive v4 file rows.
+- Produces: constructed graph or visible exact-seat refusal returning `None`.
+
+- [x] Write v4 seats with only `schema` and primitive `files` rows.
+- [x] Require exact payload and file-row keys; construct every `AuthenticatedArtifactFileV1` before graph construction.
+- [x] Preserve visible refusal, exact-seat invalidation, and requested-vs-derived CID authentication.
+- [x] Run constructor, coherent-hit, poisoned-seat, and v3-successor teeth unpiped and require green.
+
+### Task 4: Verify, publish, and open the PR
+
+**Files:**
+- Verify all files above.
+
+**Interfaces:**
+- Consumes: complete corrected diff based on `dfdd436b2c5d5c757a48019c62f06df04372c6ed`.
+- Produces: pushed corrected branch and draft PR to main.
+
+- [x] Run the full cache-authority file locally and selected real stdlib constructor consumers, unpiped.
+- [ ] Run Black check and `git diff --check`.
+- [ ] Commit only the four scoped files.
+- [ ] Push a corrected branch without overwriting the superseded remote history.
+- [ ] Open a draft PR with root cause, invariant, red/green evidence, exact test scope, and the explicit nonclaim about 94 rows.

--- a/docs/superpowers/plans/2026-08-03-dependency-artifact-cache-coherence.md
+++ b/docs/superpowers/plans/2026-08-03-dependency-artifact-cache-coherence.md
@@ -12,6 +12,8 @@
 
 - No separate coherence predicate over `artifact_kind` and `distribution_name`.
 - Cache v4 stores exactly schema and primitive recorded-file inputs.
+- A cache candidate is selected only after live bytes derive its artifact CID;
+  filesystem stat metadata is not an authentication key.
 - The miss path must perform real authenticated reconstruction; never return an empty or default graph.
 - Lawful graph fields and artifact CID remain unchanged.
 - The 94 off-population rows are not attributed to this defect.
@@ -60,6 +62,8 @@
 - [x] Write v4 seats with only `schema` and primitive `files` rows.
 - [x] Require exact payload and file-row keys; construct every `AuthenticatedArtifactFileV1` before graph construction.
 - [x] Preserve visible refusal, exact-seat invalidation, and requested-vs-derived CID authentication.
+- [x] Remove the stat-fingerprint front door and prove an equal-stat byte
+      mutation cannot serve a stale graph.
 - [x] Run constructor, coherent-hit, poisoned-seat, and v3-successor teeth unpiped and require green.
 
 ### Task 4: Verify, publish, and open the PR

--- a/docs/superpowers/specs/2026-08-03-dependency-artifact-cache-coherence-design.md
+++ b/docs/superpowers/specs/2026-08-03-dependency-artifact-cache-coherence-design.md
@@ -1,0 +1,111 @@
+# Dependency Artifact Cache Construction Design
+
+## Goal
+
+Make a cached dependency-artifact graph rehydrate through the same constructor
+as live intake. The cache persists constructor inputs, not a graph projection,
+so independent `artifact_kind` and `distribution_name` fields cannot exist in a
+cache seat.
+
+This closes #7215. It does not explain the 94 off-population dependency rows: a
+cold-cache census reproduced those rows with coherent newly written seats.
+
+## Finding
+
+The v3 payload carries enough information to reconstruct lawfully. Every
+recorded file retains its relative seat, full bytes, and content CID, including
+the distribution METADATA preimage. Those inputs determine the distribution
+name and version, artifact CID, module projection, and fixed
+`artifact_kind="distribution"`.
+
+The defect is that v3 also pickles the already-constructed file objects and the
+derived graph fields. Unpickling bypasses `AuthenticatedArtifactFileV1`'s
+constructor, while `_load_authenticate_disk_cache()` directly allocates a graph
+from independent derived fields. The seat is a redundant input/output mixture,
+not a missing-preimage artifact.
+
+## One construction path
+
+`DependencyArtifactGraph` will not expose its dataclass-generated field
+initializer. A direct attempt to allocate one from graph fields raises named
+`DependencyArtifactConstructionError` and directs the caller to authenticated
+intake.
+
+One internal graph constructor consumes a closed input variant:
+
+- distribution input: ordered `(AuthenticatedArtifactFileV1, diagnostic_path)`
+  pairs;
+- stdlib input: the same file pairs plus the requested module name.
+
+The constructor derives the variant's fields. For distribution input it parses
+the single retained METADATA file, derives name/version, fixes kind to
+`distribution`, projects modules from retained Python source, and derives the
+artifact CID. For stdlib input it fixes kind and runtime identity from the
+running interpreter and requires the requested module in the projection. No
+constructor accepts an independent kind/name pair.
+
+Live distribution intake, live stdlib intake, and cache rehydration all call
+this constructor. Cache diagnostic paths are retained relative seats; live
+paths remain their installed coordinates. Diagnostic paths do not contribute
+to graph identity.
+
+## Cache schema v4
+
+A v4 payload has exactly two keys:
+
+```text
+schema = dep-graph-v4
+files = [{source_seat, content_cid, content}, ...]
+```
+
+The loader reconstructs each `AuthenticatedArtifactFileV1` from the primitive
+row, firing its content-CID constructor law, then supplies the resulting input
+files to the shared distribution constructor. Name, version, artifact CID,
+modules, and artifact kind are never deserialized.
+
+Extra keys, including the old `artifact_kind` and `distribution_name`, make the
+stored input schema invalid. A v3 seat is likewise invalid for the v4 reader.
+
+## Refusal and recovery
+
+Any malformed input row, schema mismatch, constructor refusal, or mismatch
+between the requested cache key and the constructor-derived CID:
+
+1. records warning event `dependency-artifact-cache-refused` with the requested
+   artifact CID, named reason, and invalidation result;
+2. deletes exactly `_artifact_disk_cache_path(artifact_cid)`;
+3. returns `None` to the existing cache-miss branch.
+
+The existing branch reads the installed distribution and constructs it through
+the same constructor. No empty or default graph exists. A failure of live
+authenticated intake remains fatal.
+
+## Discrimination teeth
+
+1. **Constructor tooth:** use a real coherent graph's fields to attempt direct
+   allocation with `artifact_kind="stdlib"` and
+   `distribution_name="pandas"`. It must raise
+   `DependencyArtifactConstructionError` by name. Current main accepts the
+   pair when given the module-private authority token.
+2. **Coherent cache tooth:** a production-written v4 seat survives a cold
+   process table and is served without invoking live installation intake or
+   recording a refusal.
+3. **Poisoned cache tooth:** remove the retained METADATA input from an otherwise
+   exact v4 seat. The shared graph constructor refuses it by its existing
+   METADATA rule; the loader records and invalidates the exact seat, then
+   `authenticate()` invokes the real installation reader, constructs a
+   non-empty lawful distribution graph, and writes a clean v4 replacement.
+   This proves constructor refusal and miss execution, not merely skip behavior.
+4. **Schema successor tooth:** a v3 seat is visibly invalidated and rebuilt as
+   v4.
+
+## Identity and scope
+
+For lawful inputs, all public graph fields and artifact CIDs remain identical.
+The change removes cache authority over derived fields; it does not rename or
+reinterpret them. Focused twins compare the complete observable graph before
+and after cold rehydration.
+
+Only `dependency_artifact.py`, its cache-authority tests, and these design/plan
+receipts change. No census, pandas walk, broad test run, or battleaxe lease is
+part of this shot.

--- a/docs/superpowers/specs/2026-08-03-dependency-artifact-cache-coherence-design.md
+++ b/docs/superpowers/specs/2026-08-03-dependency-artifact-cache-coherence-design.md
@@ -49,6 +49,13 @@ this constructor. Cache diagnostic paths are retained relative seats; live
 paths remain their installed coordinates. Diagnostic paths do not contribute
 to graph identity.
 
+The cache may only be selected after live intake has content-addressed the
+recorded bytes. A path plus `(mtime_ns, size)` fingerprint is not authenticated
+content identity: two different equal-size byte strings can carry the same
+stat metadata and select a stale graph without reading either one. That warm
+front door is removed rather than widened with another metadata field. The
+artifact CID derived from constructor inputs is the only cache key.
+
 ## Cache schema v4
 
 A v4 payload has exactly two keys:
@@ -87,9 +94,9 @@ authenticated intake remains fatal.
    `distribution_name="pandas"`. It must raise
    `DependencyArtifactConstructionError` by name. Current main accepts the
    pair when given the module-private authority token.
-2. **Coherent cache tooth:** a production-written v4 seat survives a cold
-   process table and is served without invoking live installation intake or
-   recording a refusal.
+2. **Coherent cache tooth:** after live intake derives the content identity, a
+   production-written v4 seat survives a cold process table and is served
+   without recording a refusal.
 3. **Poisoned cache tooth:** remove the retained METADATA input from an otherwise
    exact v4 seat. The shared graph constructor refuses it by its existing
    METADATA rule; the loader records and invalidates the exact seat, then
@@ -98,6 +105,9 @@ authenticated intake remains fatal.
    This proves constructor refusal and miss execution, not merely skip behavior.
 4. **Schema successor tooth:** a v3 seat is visibly invalidated and rebuilt as
    v4.
+5. **Stat-collision tooth:** two equal-size source preimages are forced to the
+   same mtime. The second authentication must address the second bytes rather
+   than serving the first graph through metadata coincidence.
 
 ## Identity and scope
 

--- a/docs/superpowers/specs/2026-08-03-refusal-semantic-identity-design.md
+++ b/docs/superpowers/specs/2026-08-03-refusal-semantic-identity-design.md
@@ -1,0 +1,260 @@
+# Refusal Vocabulary Semantic Identity Design
+
+**Issue:** #7226
+
+**Design pin:** `a5534eb0084bccd12c4d88575e6e3e69360d286b`
+
+**Scope:** design only; this document does not authorize implementation or census migration
+
+## Problem
+
+The refusal-vocabulary census currently identifies each source occurrence as
+
+```text
+path + sha256(normalized whole line) + duplicate ordinal
+```
+
+The line number is display-only, but the identity still belongs to source text rather
+than to the refusal the source constructs. A repair that preserves the refusal while
+changing an identifier, constructor entrance, or line boundary can therefore create a
+false vanished row plus a false new row.
+
+That is the wrong answer to the only semantic question the ledger needs to answer:
+did this refusal meaning remain present in the statically inspected source, or did it
+genuinely disappear?
+
+The current census was measured at the design pin with:
+
+```text
+python tools/check-lift-refusal-vocabulary.py
+```
+
+The unpiped exit code was `0`. It reported 2,423 occurrences across 195 files,
+including 2,269 `lift-output-backlog` occurrences. This is a static source census; it
+does not prove runtime reachability.
+
+## Measured sensitivity boundary
+
+Hockney measured three distinct sensitivity classes before this design:
+
+| Change | Current key result | Measured population |
+| --- | --- | --- |
+| whitespace within a line | no rekey and no classification movement | Black 26.5.1 reformatted 47 scanned-package Python files |
+| identifier or call-shape change | rekeys surviving meaning | `self.site` to `site`; direct `RaiseEffect(...)` to `RaiseEffect.for_builtin(...)` |
+| line joining or splitting | rekeys surviving meaning | a 366-file sweep joined a two-line `CacheRefuse` into one line, producing net `-1` |
+
+The pinned comparison contained 105 new and 11 stale rows. Exhaustive history
+authenticated three new rows and three stale rows as the two sides of spelling-only
+churn. Thus 3/105 new rows (2.9%) and 3/11 stale rows (27.3%) are confirmed identity
+noise. This does not claim that the remaining 102 new rows are semantically novel.
+
+The replacement identity must therefore be invariant under all three measured
+non-semantic transformations: whitespace changes, identifier/call-entrance rewrites
+that construct the same refusal, and line joining or splitting.
+
+## Law
+
+Refusal meaning is constructed once by the owner that constructs the refusal. The
+census may project that identity; it may not recreate it from spelling, AST shape, or
+line layout.
+
+Source location is evidence about where the meaning is seated. It is not the meaning.
+The successor schema therefore separates two nouns:
+
+- `meaningCid`: what refusal was constructed;
+- `seat`: where the source census observed that meaning.
+
+Changing a seat without changing `meaningCid` is a move. Reducing the multiplicity of
+a `meaningCid` is a genuine semantic disappearance from the static population.
+
+## `RefusalMeaningV1`
+
+Every executable refusal occurrence must project a canonical preimage owned by its
+construction type:
+
+```json
+{
+  "schema": "refusal-meaning/v1",
+  "language": "python",
+  "constructorKind": "RaiseEffect",
+  "structuralKey": {"...": "producer-owned canonical fields"}
+}
+```
+
+`meaningCid` is minted by the repository's existing canonical content-CID constructor
+over this preimage; schema v2 does not introduce another hash or canonicalization
+profile. Its required properties are:
+
+1. `constructorKind` names the typed construction result, not the spelling of the
+   entrance used to obtain it.
+2. `structuralKey` is nonempty and is emitted by that constructor's owner.
+3. The key contains the fields that distinguish refusal meanings and excludes source
+   formatting, local identifier spelling, constructor call spelling, path, line, and
+   column.
+4. Display fields such as `exception_name` may travel beside the key, but a display
+   name alone cannot authenticate type identity. For a `RaiseEffect`, the owner
+   projects its authenticated exception-type/effect testimony and its existing
+   structural refusal key. Both direct construction and `for_builtin` must reach that
+   same projection after they construct the same value.
+5. Classification (`speaker`, `wire_marker`, `reason`, and `replacement`) is payload
+   compared under an identity. It is not part of `meaningCid`; otherwise a
+   classification change would masquerade as removal plus addition.
+
+The census does not contain per-constructor rules. A Python or Rust construction owner
+must expose the projection at its existing authoritative door. The language frontend
+may locate that owner using the repository's existing source construction and binding
+machinery, but it must not define a second table saying that two spellings are
+equivalent.
+
+If an executable `refus*` occurrence cannot be joined to one constructed owner and one
+nonempty structural key, the entire census refuses with an
+`UnownedRefusalMeaning` row naming language, path, span, and observed shape. It never
+falls back to normalized text.
+
+## `RefusalSeatV1`
+
+Every semantic occurrence also records source provenance:
+
+```json
+{
+  "schema": "refusal-seat/v1",
+  "meaningCid": "<content CID>",
+  "language": "python",
+  "path": "<repository-relative path>",
+  "owner": "<authenticated enclosing owner>",
+  "locus": "<authenticated source locus>",
+  "line": 123
+}
+```
+
+The seat is retained for diagnostics, review, and repair routing. None of its fields is
+hashed into `meaningCid`. A path move, helper extraction, identifier rename, or line
+join can therefore change the seat while preserving the meaning.
+
+The ledger is a multiset, not a set. Comparison for each `meaningCid` is:
+
+1. pair exact old/new seats first;
+2. deterministically pair remaining old/new seats as moves;
+3. report unmatched old seats as vanished multiplicity;
+4. report unmatched new seats as added multiplicity.
+
+Two equal refusal meanings at different seats therefore remain two occurrences. A
+reorder or relocation does not manufacture churn; removal of either one reduces the
+multiplicity and stays loud.
+
+## Prose and non-executable vocabulary
+
+Comments, docstrings, documentation strings, and other non-executable vocabulary do
+not construct a refusal and must not be laundered into `RefusalMeaningV1`. They remain
+in a separate `refusal-lexical/v1` inventory with lexical identity and source seats.
+
+The lexical inventory preserves the vocabulary-removal ratchet but makes no claim
+about semantic identity or runtime reachability. Its new/stale rows are never combined
+with semantic additions, semantic disappearances, or semantic moves.
+
+An executable occurrence cannot be put into the prose inventory merely because its
+owner is unresolved. Unresolved executable identity refuses the run by name. Likewise,
+an unparseable scanned Python or Rust file refuses the run; it is not scanned as raw
+text and it does not disappear from the denominator.
+
+## Schema-v2 output
+
+The successor census carries four separately conserved collections:
+
+- semantic meanings keyed by `meaningCid`;
+- semantic seats referencing those meanings;
+- lexical/prose occurrences;
+- named instrument refusals, which make the census unmeasured rather than becoming a
+  fourth occurrence class.
+
+Summary output reports semantic additions, semantic disappearances, seat moves,
+classification changes, and lexical changes separately. A semantic `vanished` row
+means the observed multiplicity of a constructed refusal meaning decreased. A moved
+seat is never printed as vanished plus new.
+
+## Migration
+
+Migration is a dual-run, not an in-place census rewrite.
+
+1. Freeze schema v1 at the design pin.
+2. Run v1 and v2 over the same exact git tree.
+3. Emit a migration mapping from every v1 occurrence key to exactly one v2 semantic
+   seat or lexical occurrence.
+4. Require exact conservation:
+   - v1 rows: exactly 2,423;
+   - mapped v2 semantic seats plus lexical occurrences: exactly 2,423;
+   - missing rows: zero;
+   - multiply mapped rows: zero;
+   - unowned executable occurrences: zero;
+   - unparseable scanned files: zero;
+   - classification payload changes introduced solely by migration: zero.
+5. Compare the dual-run result against the three authenticated churn examples. They
+   must become seat moves with stable `meaningCid`, not vanish/new pairs.
+6. Only after all conservation conditions hold may a later, separately authorized
+   implementation retire schema v1.
+
+The number 2,423 is a hard gate bound to the design pin. A changed main tree requires a
+new pinned measurement and an explicit migration-gate update; an implementation may
+not silently bless a different denominator.
+
+## Required discrimination twins
+
+Every sensitivity class needs both a preserving arm and a genuinely changing arm:
+
+1. **Whitespace:** formatting within a line preserves `meaningCid`; any changed display
+   span is at most a seat move. Removing the refusal decreases semantic multiplicity.
+2. **Identifier:** `self.site` to a bound local `site` preserves `meaningCid`; changing
+   the producer-owned structural key creates a new meaning.
+3. **Constructor entrance:** direct `RaiseEffect(...)` to
+   `RaiseEffect.for_builtin(...)` preserves `meaningCid` when both construct the same
+   effect; constructing a different authenticated exception/effect meaning creates a
+   new key.
+4. **Line joining/splitting:** joining or splitting one `CacheRefuse` construction
+   preserves one meaning and one occurrence; adding a second semantic refusal raises
+   multiplicity to two.
+5. **Genuine removal:** deleting a semantic refusal leaves an unmatched old seat and
+   reports one vanished meaning occurrence.
+6. **Duplicate multiplicity:** two equal meanings remain count two across reorder or
+   relocation; deleting one reports count one, never zero and never a deduplicated
+   pass.
+7. **Prose separation:** editing prose can move a lexical row without changing the
+   semantic ledger; an executable refusal cannot escape into the lexical partition.
+8. **Unowned and unparseable:** a source-visible executable refusal without an
+   authenticated owner, and an unparseable scanned file, each refuse by name. A
+   well-owned, parseable twin completes.
+
+## Cost
+
+The migration requires language-aware source ownership for Python and Rust, a schema
+v2 census and comparator, owner-provided meaning projections, an exact v1-to-v2
+mapping for all 2,423 rows, and dual-run receipts. The prose split must also preserve
+the current speaker and wire-marker classifications.
+
+This is deliberately more work than changing the hash input. The cost buys one
+definition of refusal meaning, owned by construction, instead of a growing set of
+syntax equivalence rules in the instrument.
+
+## Rejected alternatives
+
+### AST normalization
+
+Canonicalizing AST nodes, alpha-renaming identifiers, or teaching the census that
+`RaiseEffect(...)` and `RaiseEffect.for_builtin(...)` are equivalent is rejected. It
+creates a second semantic definition beside the constructor. It will drift on the
+next unanticipated rewrite, which is the same disease as two ways of knowing one
+thing.
+
+### Runtime-only construction identity
+
+Recording only refusal objects observed during execution is honest about every object
+it sees, but it is coverage-bound. Unreached source would vanish from the census even
+when the refusal remained present. Runtime testimony may corroborate the static
+ledger, but it cannot replace this static census alone.
+
+## Result
+
+Schema v2 buys a ledger in which spelling-preserving repairs stop manufacturing
+progress and regressions. A seat move says where code went. A semantic addition says a
+new refusal meaning appeared. A semantic disappearance says the statically observed
+multiplicity of a refusal meaning genuinely decreased. The instrument can then answer
+that question directly instead of requiring a manual history investigation.

--- a/docs/superpowers/specs/2026-08-03-refusal-semantic-identity-design.md
+++ b/docs/superpowers/specs/2026-08-03-refusal-semantic-identity-design.md
@@ -43,6 +43,13 @@ Hockney measured three distinct sensitivity classes before this design:
 | identifier or call-shape change | rekeys surviving meaning | `self.site` to `site`; direct `RaiseEffect(...)` to `RaiseEffect.for_builtin(...)` |
 | line joining or splitting | rekeys surviving meaning | a 366-file sweep joined a two-line `CacheRefuse` into one line, producing net `-1` |
 
+The 47-file result was true of that Black sweep and false as a general claim of
+source-rewrite invariance. It happened to change whitespace only within lines. The
+roughly eight-times-larger 366-file sweep also joined lines and exposed the third
+sensitivity class. Thus zero movement in the first sweep authenticates only the
+within-line-whitespace boundary; it is not evidence that normalized-text identity
+survives arbitrary formatting or source-layout changes.
+
 The pinned comparison contained 105 new and 11 stale rows. Exhaustive history
 authenticated three new rows and three stale rows as the two sides of spelling-only
 churn. Thus 3/105 new rows (2.9%) and 3/11 stale rows (27.3%) are confirmed identity

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from email.parser import BytesParser
 import importlib.machinery
 import importlib.metadata
+import logging
 import os
 from pathlib import Path, PurePosixPath
 import sys
@@ -27,7 +28,16 @@ class DependencyArtifactAuthenticationError(Exception):
     """The selected installed artifact cannot be authenticated exactly."""
 
 
-_ARTIFACT_INTAKE_AUTHORITY = object()
+class DependencyArtifactConstructionError(DependencyArtifactAuthenticationError):
+    """A graph allocation bypassed its authenticated input constructor."""
+
+
+class DependencyArtifactCacheInputError(DependencyArtifactAuthenticationError):
+    """A disk seat does not encode dependency graph constructor inputs."""
+
+
+_LOG = logging.getLogger(__name__)
+_DEPENDENCY_ARTIFACT_CACHE_SCHEMA = "dep-graph-v4"
 
 # The authenticated-graph memo is CONTENT-ADDRESSED, and that is the whole
 # reason it may be process-global (#6266's distinction, applied here).
@@ -168,25 +178,109 @@ def _load_authenticate_disk_cache(
 
         with path.open("rb") as stream:
             payload = pickle.load(stream)
-        if not isinstance(payload, dict) or payload.get("schema") != "dep-graph-v3":
-            return None
-        graph = DependencyArtifactGraph(
-            artifact_kind=payload["artifact_kind"],
-            distribution_name=payload["distribution_name"],
-            distribution_version=payload["distribution_version"],
-            distribution_artifact_cid=payload["distribution_artifact_cid"],
-            files=tuple(payload["files"]),
-            modules=MappingProxyType(dict(payload["modules"])),
-            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
+        inputs = _decode_dependency_artifact_cache_inputs(payload)
+        graph = DependencyArtifactGraph._construct_from_authenticated_inputs(inputs)
+    except Exception as exc:
+        _refuse_authenticate_disk_cache(
+            artifact_cid=artifact_cid,
+            path=path,
+            reason=f"{type(exc).__name__}: {exc}",
         )
-    except Exception:
         return None
-    # ``__post_init__`` already recomputed the CID from the retained bytes; this
-    # pins that the recomputed CID is the one that was ASKED for, so a payload
-    # parked at the wrong seat cannot answer a question it does not address.
+    # Construction re-derived the CID from the retained inputs. Pin that it is
+    # the CID that was ASKED for, so a payload parked at a wrong seat cannot
+    # answer a question it does not address.
     if graph.distribution_artifact_cid != artifact_cid:
+        _refuse_authenticate_disk_cache(
+            artifact_cid=artifact_cid,
+            path=path,
+            reason=(
+                "parked artifact CID mismatch: "
+                f"payload={graph.distribution_artifact_cid}"
+            ),
+        )
         return None
     return graph
+
+
+def _decode_dependency_artifact_cache_inputs(
+    payload: object,
+) -> "_DistributionGraphInputs":
+    """Construct distribution inputs from the cache's primitive wire form."""
+    if not isinstance(payload, dict) or set(payload) != {"schema", "files"}:
+        raise DependencyArtifactCacheInputError(
+            "dependency artifact cache input has an invalid key set"
+        )
+    if payload["schema"] != _DEPENDENCY_ARTIFACT_CACHE_SCHEMA:
+        raise DependencyArtifactCacheInputError(
+            "disk cache schema mismatch: "
+            f"expected={_DEPENDENCY_ARTIFACT_CACHE_SCHEMA} "
+            f"actual={payload['schema']}"
+        )
+    rows = payload["files"]
+    if not isinstance(rows, list):
+        raise DependencyArtifactCacheInputError(
+            "dependency artifact cache files must be a list"
+        )
+    located: list[tuple[AuthenticatedArtifactFileV1, str]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict) or set(row) != {
+            "source_seat",
+            "content_cid",
+            "content",
+        }:
+            raise DependencyArtifactCacheInputError(
+                f"dependency artifact cache file {index} has an invalid key set"
+            )
+        source_seat = row["source_seat"]
+        content_cid = row["content_cid"]
+        content = row["content"]
+        if not isinstance(source_seat, str) or not source_seat:
+            raise DependencyArtifactCacheInputError(
+                f"dependency artifact cache file {index} has an invalid source seat"
+            )
+        if not isinstance(content_cid, str) or not content_cid.startswith(
+            "blake3-512:"
+        ):
+            raise DependencyArtifactCacheInputError(
+                f"dependency artifact cache file {index} has an invalid content CID"
+            )
+        if not isinstance(content, bytes):
+            raise DependencyArtifactCacheInputError(
+                f"dependency artifact cache file {index} has non-byte content"
+            )
+        located.append(
+            (
+                AuthenticatedArtifactFileV1(
+                    source_seat=source_seat,
+                    content_cid=content_cid,
+                    content=content,
+                ),
+                source_seat,
+            )
+        )
+    return _DistributionGraphInputs(tuple(located))
+
+
+def _refuse_authenticate_disk_cache(
+    *,
+    artifact_cid: str,
+    path: Path,
+    reason: str,
+) -> None:
+    """Make one rejected cache seat visible, then make it absent."""
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        invalidated = False
+    else:
+        invalidated = not path.exists()
+    _LOG.warning(
+        "dependency-artifact-cache-refused " "artifact_cid=%s reason=%s invalidated=%s",
+        artifact_cid,
+        reason,
+        invalidated,
+    )
 
 
 def _store_authenticate_disk_cache(
@@ -197,18 +291,18 @@ def _store_authenticate_disk_cache(
         import pickle
         import tempfile
 
-        # MappingProxyType is not pickleable; store plain dict modules.
         payload = {
-            # v3 projects recorded .pyi defining source as modules.  A v2 seat
-            # for the same artifact CID is byte-authentic but semantically
-            # incomplete, so it must never answer this reader.
-            "schema": "dep-graph-v3",
-            "artifact_kind": graph.artifact_kind,
-            "distribution_name": graph.distribution_name,
-            "distribution_version": graph.distribution_version,
-            "distribution_artifact_cid": graph.distribution_artifact_cid,
-            "files": graph.files,
-            "modules": dict(graph.modules),
+            # v4 persists constructor INPUTS only. Identity, kind, CID, and
+            # module projection are re-derived through graph construction.
+            "schema": _DEPENDENCY_ARTIFACT_CACHE_SCHEMA,
+            "files": [
+                {
+                    "source_seat": item.source_seat,
+                    "content_cid": item.content_cid,
+                    "content": item.content,
+                }
+                for item in graph.files
+            ],
         }
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_name = tempfile.mkstemp(
@@ -536,6 +630,20 @@ PythonObjectResolutionV1 = ResolvedPythonObjectV1 | PythonObjectResolutionGapV1
 
 
 @dataclass(frozen=True)
+class _DistributionGraphInputs:
+    located: tuple[tuple[AuthenticatedArtifactFileV1, str], ...]
+
+
+@dataclass(frozen=True)
+class _StdlibGraphInputs:
+    located: tuple[tuple[AuthenticatedArtifactFileV1, str], ...]
+    requested_module_name: str
+
+
+_DependencyArtifactGraphInputs = _DistributionGraphInputs | _StdlibGraphInputs
+
+
+@dataclass(frozen=True, init=False)
 class DependencyArtifactGraph:
     artifact_kind: Literal["distribution", "stdlib"]
     distribution_name: str
@@ -543,17 +651,63 @@ class DependencyArtifactGraph:
     distribution_artifact_cid: str
     files: tuple[AuthenticatedArtifactFileV1, ...]
     modules: Mapping[str, AuthenticatedModuleSourceV1]
-    _intake_authority: object = field(repr=False, compare=False)
 
-    def __post_init__(self) -> None:
-        if self._intake_authority is not _ARTIFACT_INTAKE_AUTHORITY:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise DependencyArtifactConstructionError(
+            "DependencyArtifactGraph cannot be allocated from graph fields; "
+            "construct it from authenticated artifact inputs"
+        )
+
+    @classmethod
+    def _construct_from_authenticated_inputs(
+        cls, inputs: _DependencyArtifactGraphInputs
+    ) -> "DependencyArtifactGraph":
+        """The only allocation path from authenticated artifact testimony."""
+        located = inputs.located
+        files = tuple(item for item, _ in located)
+        records = [
+            {"path": item.source_seat, "contentCid": item.content_cid} for item in files
+        ]
+        if records != sorted(records, key=lambda item: item["path"]):
             raise DependencyArtifactAuthenticationError(
-                "dependency artifact graph was not minted by SourceOracle intake"
+                "artifact files must be canonically ordered"
             )
-        if self.artifact_kind == "distribution":
+        files_by_seat = {item.source_seat: item for item in files}
+        if len(files_by_seat) != len(files):
+            raise DependencyArtifactAuthenticationError(
+                "distribution artifact contains duplicate file seats"
+            )
+
+        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        for item, diagnostic_path in located:
+            relative = PurePosixPath(item.source_seat)
+            module_name = _module_name(relative)
+            if module_name is None:
+                continue
+            try:
+                source = item.content.decode("utf-8")
+            except UnicodeError as exc:
+                raise DependencyArtifactAuthenticationError(
+                    f"recorded Python module {module_name} is not parseable UTF-8 source"
+                ) from exc
+            _require_parseable_module_source(
+                source, path=diagnostic_path, module_name=module_name
+            )
+            if module_name in modules:
+                raise DependencyArtifactAuthenticationError(
+                    f"distribution contains duplicate module seat {module_name}"
+                )
+            modules[module_name] = AuthenticatedModuleSourceV1(
+                module_name=module_name,
+                source_seat=relative.as_posix(),
+                source_cid=item.content_cid,
+                source=source,
+            )
+
+        if isinstance(inputs, _DistributionGraphInputs):
             metadata_files = [
                 item
-                for item in self.files
+                for item in files
                 if item.source_seat.endswith(".dist-info/METADATA")
             ]
             if len(metadata_files) != 1:
@@ -561,68 +715,50 @@ class DependencyArtifactGraph:
                     "distribution graph must retain one METADATA preimage"
                 )
             metadata = BytesParser().parsebytes(metadata_files[0].content)
-            if (
-                metadata.get("Name") != self.distribution_name
-                or metadata.get("Version") != self.distribution_version
-            ):
+            name = metadata.get("Name")
+            version = metadata.get("Version")
+            if not isinstance(name, str) or not name or not version:
                 raise DependencyArtifactAuthenticationError(
-                    "distribution identity does not match its METADATA preimage"
+                    "installed distribution lacks name or version metadata"
                 )
-        elif self.artifact_kind != "stdlib":
-            raise DependencyArtifactAuthenticationError(
-                "dependency artifact graph has an unknown intake kind"
+            artifact_kind: Literal["distribution", "stdlib"] = "distribution"
+            distribution_name = name
+            distribution_version = str(version)
+            artifact_preimage_kind = "python-dependency-artifact"
+        elif isinstance(inputs, _StdlibGraphInputs):
+            if inputs.requested_module_name not in modules:
+                raise DependencyArtifactAuthenticationError(
+                    "requested stdlib module is not projected from authenticated source"
+                )
+            artifact_kind = "stdlib"
+            distribution_name = f"{sys.implementation.name}-stdlib"
+            distribution_version = (
+                sys.implementation.cache_tag or sys.version.split()[0]
             )
-        records = [
-            {"path": item.source_seat, "contentCid": item.content_cid}
-            for item in self.files
-        ]
-        if records != sorted(records, key=lambda item: item["path"]):
-            raise DependencyArtifactAuthenticationError(
-                "artifact files must be canonically ordered"
+            artifact_preimage_kind = "python-stdlib-artifact"
+        else:
+            raise DependencyArtifactConstructionError(
+                "dependency artifact graph inputs have an unknown variant"
             )
-        expected = cid_of_json(
+
+        artifact_cid = cid_of_json(
             {
-                "kind": (
-                    "python-dependency-artifact"
-                    if self.artifact_kind == "distribution"
-                    else "python-stdlib-artifact"
-                ),
+                "kind": artifact_preimage_kind,
                 "schemaVersion": "1",
-                "distributionName": self.distribution_name,
-                "distributionVersion": self.distribution_version,
+                "distributionName": distribution_name,
+                "distributionVersion": distribution_version,
                 "files": records,
             }
         )
-        if expected != self.distribution_artifact_cid:
-            raise DependencyArtifactAuthenticationError(
-                "distribution artifact CID does not match its file preimage"
-            )
-        files_by_seat = {item.source_seat: item for item in self.files}
-        if len(files_by_seat) != len(self.files):
-            raise DependencyArtifactAuthenticationError(
-                "distribution artifact contains duplicate file seats"
-            )
-        for module_name, module in self.modules.items():
-            recorded = files_by_seat.get(module.source_seat)
-            if (
-                module_name != module.module_name
-                or module_name != _module_name(PurePosixPath(module.source_seat))
-                or recorded is None
-                or recorded.content_cid != module.source_cid
-            ):
-                raise DependencyArtifactAuthenticationError(
-                    "module source is not projected from the artifact file manifest"
-                )
-        expected_modules = {
-            name
-            for item in self.files
-            for name in [_module_name(PurePosixPath(item.source_seat))]
-            if name is not None
-        }
-        if set(self.modules) != expected_modules:
-            raise DependencyArtifactAuthenticationError(
-                "artifact module projection is incomplete or contains invented modules"
-            )
+
+        graph = object.__new__(cls)
+        object.__setattr__(graph, "artifact_kind", artifact_kind)
+        object.__setattr__(graph, "distribution_name", distribution_name)
+        object.__setattr__(graph, "distribution_version", distribution_version)
+        object.__setattr__(graph, "distribution_artifact_cid", artifact_cid)
+        object.__setattr__(graph, "files", files)
+        object.__setattr__(graph, "modules", MappingProxyType(modules))
+        return graph
 
     @staticmethod
     def _distribution_seat_key(
@@ -669,8 +805,8 @@ class DependencyArtifactGraph:
     @staticmethod
     def _read_recorded_installation(
         distribution: importlib.metadata.Distribution,
-    ) -> tuple[list[tuple[AuthenticatedArtifactFileV1, str]], str, str, str]:
-        """Read and content-address the installation; mint its artifact CID.
+    ) -> list[tuple[AuthenticatedArtifactFileV1, str]]:
+        """Read and content-address the graph constructor's file inputs.
 
         This is the half that CANNOT be memoized across content change: it is
         what establishes which bytes are on disk right now. Unchanged-install
@@ -705,33 +841,7 @@ class DependencyArtifactGraph:
                     str(path),
                 )
             )
-        metadata_files = [
-            item
-            for item, _ in located
-            if item.source_seat.endswith(".dist-info/METADATA")
-        ]
-        if len(metadata_files) != 1:
-            raise DependencyArtifactAuthenticationError(
-                "installed distribution must contain one recorded METADATA file"
-            )
-        metadata = BytesParser().parsebytes(metadata_files[0].content)
-        name = metadata.get("Name")
-        version = metadata.get("Version")
-        if not isinstance(name, str) or not name or not version:
-            raise DependencyArtifactAuthenticationError(
-                "installed distribution lacks name or version metadata"
-            )
-        preimage = {
-            "kind": "python-dependency-artifact",
-            "schemaVersion": "1",
-            "distributionName": name,
-            "distributionVersion": version,
-            "files": [
-                {"path": item.source_seat, "contentCid": item.content_cid}
-                for item, _ in located
-            ],
-        }
-        return located, name, str(version), cid_of_json(preimage)
+        return located
 
     @classmethod
     def _remember_fingerprint(
@@ -770,9 +880,11 @@ class DependencyArtifactGraph:
                     _AUTHENTICATE_GRAPH_CACHE[parked_cid] = disk
                     cls._remember_fingerprint(seat_key, fingerprint, disk)
                     return disk
-        located, name, version, artifact_cid = cls._read_recorded_installation(
-            distribution
+        located = cls._read_recorded_installation(distribution)
+        constructed = cls._construct_from_authenticated_inputs(
+            _DistributionGraphInputs(tuple(located))
         )
+        artifact_cid = constructed.distribution_artifact_cid
         if _AUTHENTICATE_CACHE_ENABLED:
             cached = _AUTHENTICATE_GRAPH_CACHE.get(artifact_cid)
             if cached is not None:
@@ -783,39 +895,7 @@ class DependencyArtifactGraph:
                 _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = disk
                 cls._remember_fingerprint(seat_key, fingerprint, disk)
                 return disk
-        authenticated_files = [item for item, _ in located]
-        modules: dict[str, AuthenticatedModuleSourceV1] = {}
-        for item, path in located:
-            relative = PurePosixPath(item.source_seat)
-            module_name = _module_name(relative)
-            if module_name is None:
-                continue
-            try:
-                source = item.content.decode("utf-8")
-            except UnicodeError as exc:
-                raise DependencyArtifactAuthenticationError(
-                    f"recorded Python module {module_name} is not parseable UTF-8 source"
-                ) from exc
-            _require_parseable_module_source(source, path=path, module_name=module_name)
-            if module_name in modules:
-                raise DependencyArtifactAuthenticationError(
-                    f"distribution contains duplicate module seat {module_name}"
-                )
-            modules[module_name] = AuthenticatedModuleSourceV1(
-                module_name=module_name,
-                source_seat=relative.as_posix(),
-                source_cid=item.content_cid,
-                source=source,
-            )
-        graph = cls(
-            artifact_kind="distribution",
-            distribution_name=name,
-            distribution_version=version,
-            distribution_artifact_cid=artifact_cid,
-            files=tuple(authenticated_files),
-            modules=MappingProxyType(modules),
-            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
-        )
+        graph = constructed
         if _AUTHENTICATE_CACHE_ENABLED:
             _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = graph
             _store_authenticate_disk_cache(graph)
@@ -862,59 +942,28 @@ class DependencyArtifactGraph:
             if source_path.name == "__init__.py"
             else [source_path]
         )
-        authenticated_files: list[AuthenticatedArtifactFileV1] = []
-        modules: dict[str, AuthenticatedModuleSourceV1] = {}
+        located: list[tuple[AuthenticatedArtifactFileV1, str]] = []
         for candidate in paths:
             relative = PurePosixPath(candidate.relative_to(root).as_posix())
             try:
                 content, _seat, content_cid = dependency_artifact_file(str(candidate))
-                source = content.decode("utf-8")
-                projected = _module_name(relative) or module_name
-                _require_parseable_module_source(
-                    source, path=str(candidate), module_name=projected
-                )
             except (
                 SourceUnavailable,
-                UnicodeError,
-                DependencyArtifactAuthenticationError,
                 ValueError,
             ) as exc:
                 raise DependencyArtifactAuthenticationError(
                     f"cannot authenticate stdlib source {relative}"
                 ) from exc
-            authenticated_files.append(
-                AuthenticatedArtifactFileV1(relative.as_posix(), content_cid, content)
-            )
-            projected_name = _module_name(relative)
-            if projected_name is not None:
-                modules[projected_name] = AuthenticatedModuleSourceV1(
-                    projected_name, relative.as_posix(), content_cid, source
+            located.append(
+                (
+                    AuthenticatedArtifactFileV1(
+                        relative.as_posix(), content_cid, content
+                    ),
+                    str(candidate),
                 )
-        if module_name not in modules:
-            raise DependencyArtifactAuthenticationError(
-                "requested stdlib module is not projected from authenticated source"
             )
-        runtime_version = sys.implementation.cache_tag or sys.version.split()[0]
-        name = f"{sys.implementation.name}-stdlib"
-        records = [
-            {"path": item.source_seat, "contentCid": item.content_cid}
-            for item in authenticated_files
-        ]
-        preimage = {
-            "kind": "python-stdlib-artifact",
-            "schemaVersion": "1",
-            "distributionName": name,
-            "distributionVersion": runtime_version,
-            "files": records,
-        }
-        return cls(
-            artifact_kind="stdlib",
-            distribution_name=name,
-            distribution_version=runtime_version,
-            distribution_artifact_cid=cid_of_json(preimage),
-            files=tuple(authenticated_files),
-            modules=MappingProxyType(modules),
-            _intake_authority=_ARTIFACT_INTAKE_AUTHORITY,
+        return cls._construct_from_authenticated_inputs(
+            _StdlibGraphInputs(tuple(located), module_name)
         )
 
 

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -68,16 +68,6 @@ _AUTHENTICATE_GRAPH_CACHE: dict[str, "DependencyArtifactGraph"] = {}
 # verdict, never a graph. Paying full price is always a legal answer.
 _AUTHENTICATE_CACHE_ENABLED = True
 
-# Warm re-auth front door: install seat → (mtime fingerprint, graph).
-# NOT a path-keyed graph cache. Returns a content-addressed graph only when
-# every recorded file's (mtime_ns, size) still matches the fingerprint taken
-# at authentication. An edit that moves mtime is a miss → full re-hash → new
-# artifact CID. Identity remains content-addressed; this only avoids re-reading
-# ~67MB of pandas bytes to recompute h(p) when p did not move.
-_AUTHENTICATE_BY_INSTALLATION_FINGERPRINT: dict[
-    str, tuple[str, "DependencyArtifactGraph"]
-] = {}
-
 
 def _require_parseable_module_source(
     source: str, *, path: str, module_name: str
@@ -111,60 +101,6 @@ def _artifact_disk_cache_path(artifact_cid: str) -> Path:
     """
     digest = artifact_cid.removeprefix("blake3-512:")[:32]
     return _cache_root() / "dependency-artifact-graphs" / f"{digest}.pkl"
-
-
-def _fingerprint_disk_cache_path(seat_key: str, fingerprint: str) -> Path:
-    """On-disk seat for install-fingerprint → artifact CID."""
-    digest = blake3_512_of(f"{seat_key}\n{fingerprint}".encode("utf-8")).removeprefix(
-        "blake3-512:"
-    )[:32]
-    return _cache_root() / "dependency-artifact-fingerprints" / f"{digest}.json"
-
-
-def _load_artifact_cid_for_fingerprint(seat_key: str, fingerprint: str) -> str | None:
-    path = _fingerprint_disk_cache_path(seat_key, fingerprint)
-    if not path.is_file():
-        return None
-    try:
-        import json
-
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(payload, dict) or payload.get("schema") != "dep-fp-v1":
-            return None
-        cid = payload.get("distribution_artifact_cid")
-        return cid if isinstance(cid, str) and cid.startswith("blake3-512:") else None
-    except Exception:
-        return None
-
-
-def _store_fingerprint_disk_cache(
-    seat_key: str, fingerprint: str, artifact_cid: str
-) -> None:
-    path = _fingerprint_disk_cache_path(seat_key, fingerprint)
-    try:
-        import json
-        import tempfile
-
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "schema": "dep-fp-v1",
-            "distribution_artifact_cid": artifact_cid,
-        }
-        fd, tmp_name = tempfile.mkstemp(
-            dir=str(path.parent), prefix=".fp-", suffix=".json"
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as stream:
-                json.dump(payload, stream, separators=(",", ":"))
-            Path(tmp_name).replace(path)
-        except Exception:
-            try:
-                Path(tmp_name).unlink(missing_ok=True)
-            except OSError:
-                pass
-            raise
-    except Exception:
-        return
 
 
 def _load_authenticate_disk_cache(
@@ -761,56 +697,14 @@ class DependencyArtifactGraph:
         return graph
 
     @staticmethod
-    def _distribution_seat_key(
-        distribution: importlib.metadata.Distribution,
-    ) -> str:
-        path = getattr(distribution, "_path", None)
-        if path is not None:
-            return str(Path(path).resolve())
-        return str(Path(distribution.locate_file("")).resolve())
-
-    @staticmethod
-    def _installation_fingerprint(
-        distribution: importlib.metadata.Distribution,
-    ) -> str:
-        """Cheap install identity: every recorded file's (seat, mtime, size).
-
-        Not a content hash — a change detector. Editing an installed module
-        moves mtime/size; the fingerprint moves; the warm front door misses.
-        """
-        files = distribution.files
-        if files is None:
-            raise DependencyArtifactAuthenticationError(
-                "installed distribution has no recorded file manifest"
-            )
-        parts: list[str] = []
-        for recorded in sorted(files, key=lambda item: str(item)):
-            relative = PurePosixPath(str(recorded))
-            if relative.is_absolute():
-                raise DependencyArtifactAuthenticationError(
-                    "distribution manifest contains an absolute file seat"
-                )
-            path = Path(distribution.locate_file(recorded))
-            try:
-                stat = path.stat()
-            except OSError as exc:
-                raise DependencyArtifactAuthenticationError(
-                    f"cannot stat recorded distribution file {relative}"
-                ) from exc
-            parts.append(
-                f"{relative.as_posix()}:{int(stat.st_mtime_ns)}:{int(stat.st_size)}"
-            )
-        return blake3_512_of("\n".join(parts).encode("utf-8"))
-
-    @staticmethod
     def _read_recorded_installation(
         distribution: importlib.metadata.Distribution,
     ) -> list[tuple[AuthenticatedArtifactFileV1, str]]:
         """Read and content-address the graph constructor's file inputs.
 
         This is the half that CANNOT be memoized across content change: it is
-        what establishes which bytes are on disk right now. Unchanged-install
-        warm path skips this via ``_installation_fingerprint`` first.
+        what establishes which bytes are on disk right now. Every authentication
+        reads it before consulting a memo keyed by the resulting content CID.
         """
         files = distribution.files
         if files is None:
@@ -844,42 +738,10 @@ class DependencyArtifactGraph:
         return located
 
     @classmethod
-    def _remember_fingerprint(
-        cls,
-        seat_key: str | None,
-        fingerprint: str | None,
-        graph: "DependencyArtifactGraph",
-    ) -> None:
-        if seat_key is None or fingerprint is None or not _AUTHENTICATE_CACHE_ENABLED:
-            return
-        _AUTHENTICATE_BY_INSTALLATION_FINGERPRINT[seat_key] = (fingerprint, graph)
-        _store_fingerprint_disk_cache(
-            seat_key, fingerprint, graph.distribution_artifact_cid
-        )
-
-    @classmethod
     def authenticate(
         cls, distribution: importlib.metadata.Distribution
     ) -> "DependencyArtifactGraph":
         """Hash every recorded installed file and publish authenticated modules."""
-        seat_key: str | None = None
-        fingerprint: str | None = None
-        if _AUTHENTICATE_CACHE_ENABLED:
-            # Warm front door (process then disk): if no recorded file moved
-            # (mtime/size), return the content-addressed graph already proven
-            # for this install seat. Mutation that moves mtime is a miss.
-            seat_key = cls._distribution_seat_key(distribution)
-            fingerprint = cls._installation_fingerprint(distribution)
-            prior = _AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.get(seat_key)
-            if prior is not None and prior[0] == fingerprint:
-                return prior[1]
-            parked_cid = _load_artifact_cid_for_fingerprint(seat_key, fingerprint)
-            if parked_cid is not None:
-                disk = _load_authenticate_disk_cache(parked_cid)
-                if disk is not None:
-                    _AUTHENTICATE_GRAPH_CACHE[parked_cid] = disk
-                    cls._remember_fingerprint(seat_key, fingerprint, disk)
-                    return disk
         located = cls._read_recorded_installation(distribution)
         constructed = cls._construct_from_authenticated_inputs(
             _DistributionGraphInputs(tuple(located))
@@ -888,18 +750,15 @@ class DependencyArtifactGraph:
         if _AUTHENTICATE_CACHE_ENABLED:
             cached = _AUTHENTICATE_GRAPH_CACHE.get(artifact_cid)
             if cached is not None:
-                cls._remember_fingerprint(seat_key, fingerprint, cached)
                 return cached
             disk = _load_authenticate_disk_cache(artifact_cid)
             if disk is not None:
                 _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = disk
-                cls._remember_fingerprint(seat_key, fingerprint, disk)
                 return disk
         graph = constructed
         if _AUTHENTICATE_CACHE_ENABLED:
             _AUTHENTICATE_GRAPH_CACHE[artifact_cid] = graph
             _store_authenticate_disk_cache(graph)
-            cls._remember_fingerprint(seat_key, fingerprint, graph)
         return graph
 
     @classmethod
@@ -979,7 +838,6 @@ def clear_top_level_authentication_caches() -> None:
     global _PACKAGES_DISTRIBUTIONS_CACHE
     _PACKAGES_DISTRIBUTIONS_CACHE = None
     _TOP_LEVEL_GRAPH_CACHE.clear()
-    _AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
 
 
 def _packages_distributions() -> Mapping[str, list[str]]:

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import csv
 import dataclasses
 import importlib.metadata
+import pickle
 import sys
 from pathlib import Path
 
@@ -423,7 +424,173 @@ def test_disk_memo_survives_a_cold_process_table(tmp_path):
     assert _observable(from_disk) == _observable(warm)
 
 
-# -- twin 6: the value is not mutable, so a writer cannot leak -----------------
+# -- twin 6: cache seats retain inputs; the constructor owns graph fields ------
+
+
+def test_graph_fields_cannot_directly_construct_an_incoherent_pair(tmp_path):
+    """No caller, including the cache, may allocate a graph from derived fields."""
+    distribution = _install(tmp_path / "project", implementation_source=_IMPL_A)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    with pytest.raises(da.DependencyArtifactAuthenticationError) as refused:
+        DependencyArtifactGraph(
+            artifact_kind="stdlib",
+            distribution_name="pandas",
+            distribution_version=graph.distribution_version,
+            distribution_artifact_cid=graph.distribution_artifact_cid,
+            files=graph.files,
+            modules=graph.modules,
+        )
+
+    assert type(refused.value).__name__ == "DependencyArtifactConstructionError"
+
+
+def test_disk_cache_persists_only_primitive_constructor_inputs(tmp_path):
+    """A cache seat has no authority to remember a graph's derived fields."""
+    distribution = _install(tmp_path / "project", implementation_source=_IMPL_A)
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    seat = da._artifact_disk_cache_path(graph.distribution_artifact_cid)
+
+    with seat.open("rb") as stream:
+        payload = pickle.load(stream)
+
+    assert set(payload) == {"schema", "files"}
+    assert payload["schema"] == "dep-graph-v4"
+    assert payload["files"]
+    assert all(
+        set(row) == {"source_seat", "content_cid", "content"}
+        and isinstance(row["source_seat"], str)
+        and isinstance(row["content_cid"], str)
+        and isinstance(row["content"], bytes)
+        for row in payload["files"]
+    )
+
+
+def test_coherent_disk_graph_is_served_without_refusal(tmp_path, monkeypatch, caplog):
+    """Primitive cached inputs rehydrate without consulting live installation."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    warm = DependencyArtifactGraph.authenticate(distribution)
+    seat = da._artifact_disk_cache_path(warm.distribution_artifact_cid)
+
+    da._AUTHENTICATE_GRAPH_CACHE.clear()
+    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
+    da._TOP_LEVEL_GRAPH_CACHE.clear()
+
+    def forbidden_rebuild(_distribution):
+        raise AssertionError("coherent disk hit rebuilt")
+
+    monkeypatch.setattr(
+        DependencyArtifactGraph,
+        "_read_recorded_installation",
+        staticmethod(forbidden_rebuild),
+    )
+    served = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+
+    assert _observable(served) == _observable(warm)
+    assert seat.is_file()
+    assert "dependency-artifact-cache-refused" not in caplog.text
+
+
+def test_unconstructible_cache_inputs_miss_and_execute_authenticated_rebuild(
+    tmp_path, monkeypatch, caplog
+):
+    """Constructor refusal means absent; intake executes and never returns empty."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    warm = DependencyArtifactGraph.authenticate(distribution)
+    seat = da._artifact_disk_cache_path(warm.distribution_artifact_cid)
+    primitive_files = [
+        {
+            "source_seat": item.source_seat,
+            "content_cid": item.content_cid,
+            "content": item.content,
+        }
+        for item in warm.files
+        if not item.source_seat.endswith(".dist-info/METADATA")
+    ]
+    with seat.open("wb") as stream:
+        pickle.dump(
+            {
+                "schema": "dep-graph-v4",
+                "files": primitive_files,
+            },
+            stream,
+            protocol=pickle.HIGHEST_PROTOCOL,
+        )
+
+    real_read = DependencyArtifactGraph._read_recorded_installation
+    reads = 0
+
+    def counted_real_read(selected_distribution):
+        nonlocal reads
+        reads += 1
+        return real_read(selected_distribution)
+
+    monkeypatch.setattr(
+        DependencyArtifactGraph,
+        "_read_recorded_installation",
+        staticmethod(counted_real_read),
+    )
+    da._AUTHENTICATE_GRAPH_CACHE.clear()
+    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
+    da._TOP_LEVEL_GRAPH_CACHE.clear()
+
+    served = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+
+    assert served.artifact_kind == "distribution"
+    assert served.distribution_name == warm.distribution_name
+    assert served.distribution_artifact_cid == warm.distribution_artifact_cid
+    assert served.files
+    assert served.modules
+    assert reads == 1
+    assert "dependency-artifact-cache-refused" in caplog.text
+    assert warm.distribution_artifact_cid in caplog.text
+    assert "DependencyArtifactAuthenticationError" in caplog.text
+    assert "distribution graph must retain one METADATA preimage" in caplog.text
+    assert "invalidated=True" in caplog.text
+    assert seat.is_file()
+    with seat.open("rb") as stream:
+        replacement = pickle.load(stream)
+    assert set(replacement) == {"schema", "files"}
+    assert replacement["schema"] == "dep-graph-v4"
+
+
+def test_previous_cache_schema_is_refused_invalidated_and_rebuilt(tmp_path, caplog):
+    """A byte-authentic v3 seat cannot answer the relationship-aware v4 reader."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_A)
+    warm = DependencyArtifactGraph.authenticate(distribution)
+    seat = da._artifact_disk_cache_path(warm.distribution_artifact_cid)
+    with seat.open("rb") as stream:
+        payload = pickle.load(stream)
+    assert payload["schema"] == da._DEPENDENCY_ARTIFACT_CACHE_SCHEMA
+    payload["schema"] = "dep-graph-v3"
+    with seat.open("wb") as stream:
+        pickle.dump(payload, stream, protocol=pickle.HIGHEST_PROTOCOL)
+
+    da._AUTHENTICATE_GRAPH_CACHE.clear()
+    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
+    da._TOP_LEVEL_GRAPH_CACHE.clear()
+    rebuilt = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+
+    assert _observable(rebuilt) == _observable(warm)
+    assert "dependency-artifact-cache-refused" in caplog.text
+    assert warm.distribution_artifact_cid in caplog.text
+    assert "disk cache schema mismatch" in caplog.text
+    assert seat.is_file()
+    with seat.open("rb") as stream:
+        replacement = pickle.load(stream)
+    assert replacement["schema"] == "dep-graph-v4"
+
+
+# -- twin 7: the value is not mutable, so a writer cannot leak -----------------
 
 
 def test_a_served_graph_cannot_be_written_into(tmp_path):
@@ -473,7 +640,6 @@ def test_bite_a_forged_graph_cannot_be_minted_or_served(tmp_path):
             distribution_artifact_cid="blake3-512:" + "0" * 128,
             files=graph.files,
             modules=graph.modules,
-            _intake_authority=da._ARTIFACT_INTAKE_AUTHORITY,
         )
     with pytest.raises(da.DependencyArtifactAuthenticationError):
         DependencyArtifactGraph(
@@ -483,5 +649,4 @@ def test_bite_a_forged_graph_cannot_be_minted_or_served(tmp_path):
             distribution_artifact_cid=graph.distribution_artifact_cid,
             files=graph.files,
             modules=graph.modules,
-            _intake_authority=object(),
         )

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_cache_authority.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import csv
 import dataclasses
 import importlib.metadata
+import os
 import pickle
 import sys
 from pathlib import Path
@@ -153,7 +154,6 @@ def _isolated_memos(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
     monkeypatch.setattr(da, "_AUTHENTICATE_GRAPH_CACHE", {})
     monkeypatch.setattr(da, "_AUTHENTICATE_CACHE_ENABLED", True)
-    monkeypatch.setattr(da, "_AUTHENTICATE_BY_INSTALLATION_FINGERPRINT", {})
     monkeypatch.setattr(da, "_PACKAGES_DISTRIBUTIONS_CACHE", None)
     monkeypatch.setattr(da, "_TOP_LEVEL_GRAPH_CACHE", {})
     yield
@@ -177,6 +177,30 @@ def test_mutating_the_installation_invalidates_the_cached_graph(tmp_path):
 
     assert second.modules["example_pkg.implementation"].source == _IMPL_B
     assert second.distribution_artifact_cid != first.distribution_artifact_cid
+
+
+def test_equal_stat_metadata_cannot_hide_changed_installation_bytes(tmp_path):
+    """A stat-identical mutation must not satisfy content authentication."""
+    root = tmp_path / "project"
+    distribution = _install(root, implementation_source=_IMPL_B)
+    implementation_path = root / "example_pkg" / "implementation.py"
+    fixed_mtime_ns = 1_700_000_000_000_000_000
+    os.utime(implementation_path, ns=(fixed_mtime_ns, fixed_mtime_ns))
+
+    first = DependencyArtifactGraph.authenticate(distribution)
+
+    replacement = "def build(value):\n    return value + 2\n"
+    assert len(replacement) == len(_IMPL_B)
+    _mutate(root, replacement)
+    os.utime(implementation_path, ns=(fixed_mtime_ns, fixed_mtime_ns))
+    second = DependencyArtifactGraph.authenticate(
+        importlib.metadata.Distribution.at(distribution._path)
+    )
+    truth = _uncached(importlib.metadata.Distribution.at(distribution._path))
+
+    assert second.distribution_artifact_cid == truth.distribution_artifact_cid
+    assert second.distribution_artifact_cid != first.distribution_artifact_cid
+    assert second.modules["example_pkg.implementation"].source == replacement
 
 
 def test_bite_the_path_keyed_memo_serves_the_stale_graph(tmp_path):
@@ -412,9 +436,8 @@ def test_disk_memo_survives_a_cold_process_table(tmp_path):
     warm = DependencyArtifactGraph.authenticate(distribution)
 
     # Simulate a new process: every process-local table is empty; only the
-    # content-addressed (and fingerprint→CID) disk seats remain.
+    # content-addressed disk seat remains.
     da._AUTHENTICATE_GRAPH_CACHE.clear()
-    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
     da._TOP_LEVEL_GRAPH_CACHE.clear()
     from_disk = DependencyArtifactGraph.authenticate(
         importlib.metadata.Distribution.at(distribution._path)
@@ -467,29 +490,34 @@ def test_disk_cache_persists_only_primitive_constructor_inputs(tmp_path):
 
 
 def test_coherent_disk_graph_is_served_without_refusal(tmp_path, monkeypatch, caplog):
-    """Primitive cached inputs rehydrate without consulting live installation."""
+    """Authenticated content identity selects and rehydrates primitive inputs."""
     root = tmp_path / "project"
     distribution = _install(root, implementation_source=_IMPL_A)
     warm = DependencyArtifactGraph.authenticate(distribution)
     seat = da._artifact_disk_cache_path(warm.distribution_artifact_cid)
 
     da._AUTHENTICATE_GRAPH_CACHE.clear()
-    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
     da._TOP_LEVEL_GRAPH_CACHE.clear()
 
-    def forbidden_rebuild(_distribution):
-        raise AssertionError("coherent disk hit rebuilt")
+    real_read = DependencyArtifactGraph._read_recorded_installation
+    reads = 0
+
+    def counted_real_read(selected_distribution):
+        nonlocal reads
+        reads += 1
+        return real_read(selected_distribution)
 
     monkeypatch.setattr(
         DependencyArtifactGraph,
         "_read_recorded_installation",
-        staticmethod(forbidden_rebuild),
+        staticmethod(counted_real_read),
     )
     served = DependencyArtifactGraph.authenticate(
         importlib.metadata.Distribution.at(distribution._path)
     )
 
     assert _observable(served) == _observable(warm)
+    assert reads == 1
     assert seat.is_file()
     assert "dependency-artifact-cache-refused" not in caplog.text
 
@@ -535,7 +563,6 @@ def test_unconstructible_cache_inputs_miss_and_execute_authenticated_rebuild(
         staticmethod(counted_real_read),
     )
     da._AUTHENTICATE_GRAPH_CACHE.clear()
-    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
     da._TOP_LEVEL_GRAPH_CACHE.clear()
 
     served = DependencyArtifactGraph.authenticate(
@@ -574,7 +601,6 @@ def test_previous_cache_schema_is_refused_invalidated_and_rebuilt(tmp_path, capl
         pickle.dump(payload, stream, protocol=pickle.HIGHEST_PROTOCOL)
 
     da._AUTHENTICATE_GRAPH_CACHE.clear()
-    da._AUTHENTICATE_BY_INSTALLATION_FINGERPRINT.clear()
     da._TOP_LEVEL_GRAPH_CACHE.clear()
     rebuilt = DependencyArtifactGraph.authenticate(
         importlib.metadata.Distribution.at(distribution._path)

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -682,7 +682,7 @@ def test_recorded_source_seat_cannot_be_relabelled_as_invented_module(
 
     with pytest.raises(
         DependencyArtifactAuthenticationError,
-        match="module source is not projected",
+        match="cannot be allocated from graph fields",
     ):
         replace(graph, modules=MappingProxyType({"invented.module": invented}))
 


### PR DESCRIPTION
## Summary

- Specify issue #7226 as a two-level meaningCid and seat ledger. The design records the measured sensitivity boundary, eight discrimination twins, and an exact 2,423-row dual-run conservation gate; it does not implement or migrate that census.
- Persist dependency-artifact cache constructor inputs only and rehydrate them through the one graph constructor, making independent artifact-kind and distribution-name pairs unconstructible.
- Make invalid cache seats visibly refuse, invalidate the exact seat, and execute authenticated rebuild rather than returning an empty or default graph.
- Remove the filesystem-stat warm front door. A deterministic equal-size, equal-mtime mutation proved that it could return a stale graph without reading the changed bytes; cache selection now follows live content-derived artifact identity.

## Evidence

Measured on branch b472647f30e5b4530b5982a06772408ee0ce44f3 over main 699a6ec960fac849af8841d169367496378f60ff:

- bin/bpytest over the complete cache-authority file plus three stdlib constructor consumers: 29 passed, exit 0, authenticated CPython 3.12.13.
- bin/brun Black check over both changed Python files: exit 0.
- git diff --check: exit 0.
- Equal-stat tooth: exit 1 before removing the stat-keyed front door for a stale artifact CID; green in the 29-node authenticated run after the change.

A prior direct local pytest invocation printed passing output and then exited 143. That result was discarded; exit 143 is the local enforcement process terminating forbidden direct pytest. Every banked test result above ran through bpytest or brun.

## Scope and nonclaims

The cache gap is real on its own merits and is not implicated in the 94 off-population rows; a cold-cache census already disproved that attribution. No corpus census or cache performance delta is claimed. The meaningCid document is design only, and the 2,423 count remains a migration gate bound to its stated design pin.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce single constructor path for `DependencyArtifactGraph` and introduce cache schema v4
> - `DependencyArtifactGraph.__init__` now raises `DependencyArtifactConstructionError`; the only valid construction path is via `_construct_from_authenticated_inputs`, which re-derives identity, kind, modules, and CID from primitive inputs.
> - Cache schema v4 persists only primitive file inputs (`source_seat`, `content_cid`, `content`) rather than derived/serialized graph fields; the stat-metadata fingerprint warm-path is removed.
> - `_load_authenticate_disk_cache` now decodes v4 payloads strictly via `_decode_dependency_artifact_cache_inputs`, and on any decode failure or CID mismatch calls `_refuse_authenticate_disk_cache` to log a structured warning, delete the seat, and return a cache miss.
> - Adds design specs for cache coherence and refusal semantic identity (`RefusalMeaningV1`/`RefusalSeatV1`) in [docs/superpowers/specs/](https://github.com/TSavo/sugar/pull/7277/files#diff-78d1a73d8bd36dd94566831365dc6d33d06a17ca223bd3888d051feeddb2b4db).
> - Risk: existing v3 cache seats are refused and invalidated on next access, forcing a rebuild from live authentication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8847405.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->