### PR TITLE
Refuse cargo witness child silence by name

### DIFF
--- a/implementations/rust/sugar-lift-rust-cargo-test-witness/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-cargo-test-witness/src/lib.rs
@@ -289,6 +289,55 @@ fn witnesses_from_parsed(
     out
 }
 
+fn stdout_testifies_zero_tests(stdout: &str) -> bool {
+    let counts: Vec<usize> = stdout
+        .lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("running ")?
+                .strip_suffix(" tests")?
+                .parse()
+                .ok()
+        })
+        .collect();
+    !counts.is_empty() && counts.iter().all(|count| *count == 0)
+}
+
+fn witnesses_from_cargo_run(
+    success: bool,
+    exit_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+    cc: &str,
+    rc: &str,
+    code_files: &[String],
+) -> Result<Vec<Witness>, String> {
+    let parsed = parse_cargo_test_output(stdout);
+    if !parsed.is_empty() {
+        // A failing test makes cargo exit nonzero while still producing honest
+        // per-test testimony. Preserve those rows; only a child failure with no
+        // test testimony is an execution failure.
+        return Ok(witnesses_from_parsed(&parsed, cc, rc, code_files));
+    }
+    if !success {
+        return Err(format!(
+            "cargo test failed before producing test testimony: exitCode={} stdout={stdout:?} stderr={stderr:?}",
+            exit_code
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "signal".to_string())
+        ));
+    }
+    if stdout_testifies_zero_tests(stdout) {
+        return Ok(Vec::new());
+    }
+    Err(format!(
+        "cargo test produced no test-population testimony: exitCode={} stdout={stdout:?} stderr={stderr:?}",
+        exit_code
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "signal".to_string())
+    ))
+}
+
 /// Run the project's tests ONCE and content-address EACH test as its own witness.
 /// `--no-fail-fast` so a failing test does not suppress later test binaries (which
 /// would change the test SET and break bundle reproduction). stdout is parsed for
@@ -306,8 +355,16 @@ pub fn run_suite_witnesses(
         .output()
         .map_err(|e| format!("spawn `cargo test`: {e}"))?;
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed = parse_cargo_test_output(&stdout);
-    Ok(witnesses_from_parsed(&parsed, &cc, &rc, code_files))
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    witnesses_from_cargo_run(
+        output.status.success(),
+        output.status.code(),
+        &stdout,
+        &stderr,
+        &cc,
+        &rc,
+        code_files,
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/implementations/rust/sugar-lift-rust-cargo-test-witness/src/tests.rs
+++ b/implementations/rust/sugar-lift-rust-cargo-test-witness/src/tests.rs
@@ -65,6 +65,56 @@ fn parser_ignores_non_test_lines() {
     assert!(parsed.is_empty());
 }
 
+#[test]
+fn failed_child_without_test_rows_refuses_with_exit_and_stderr() {
+    let error = witnesses_from_cargo_run(
+        false,
+        Some(101),
+        "",
+        "error[E0308]: mismatched types",
+        CC,
+        RC,
+        &["src/lib.rs".to_string()],
+    )
+    .unwrap_err();
+
+    assert!(error.contains("cargo test failed before producing test testimony"));
+    assert!(error.contains("exitCode=101"));
+    assert!(error.contains("error[E0308]: mismatched types"));
+}
+
+#[test]
+fn successful_zero_test_run_remains_an_honest_empty_suite() {
+    let witnesses = witnesses_from_cargo_run(
+        true,
+        Some(0),
+        "running 0 tests\n\ntest result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n",
+        "",
+        CC,
+        RC,
+        &["src/lib.rs".to_string()],
+    )
+    .unwrap();
+
+    assert!(witnesses.is_empty());
+}
+
+#[test]
+fn successful_output_without_test_population_testimony_refuses() {
+    let error = witnesses_from_cargo_run(
+        true,
+        Some(0),
+        "Finished test profile target(s)",
+        "",
+        CC,
+        RC,
+        &["src/lib.rs".to_string()],
+    )
+    .unwrap_err();
+
+    assert!(error.contains("cargo test produced no test-population testimony"));
+}
+
 // ------- PER-TEST BODY SHAPE -------
 
 #[test]


### PR DESCRIPTION
## What this fixes

`run_suite_witnesses` ignored the `cargo test` process exit status and stderr. A compile failure could therefore produce zero parsed test rows and be emitted as an empty successful witness suite: “No tests” over a subject that never ran.

The existing JSON-RPC `Err` door now carries the child failure without adding a transport or taxonomy:

- parsed per-test rows remain authoritative even when a failing test makes Cargo exit nonzero;
- nonzero exit with zero rows refuses by name with `exitCode`, stdout, and stderr;
- exit-zero empty is lawful only when stdout explicitly testifies `running 0 tests`;
- exit-zero silence without population testimony refuses.

The load-bearing discrimination is that absence must be attested, not inferred. A genuinely empty suite says so; silence is unmeasured. This is the same class as unknown-versus-empty enrollment and the showcase completion-witness fix in #7276.

## Preflight

- Exact head: `028b22c3fd72a7037073b615a997ebd1005b6b0c`
- Parent and merge-base: current main `669b1d644b11e5bf98e6050fec787078d2b4d85e`
- Exactly one commit, ahead 1 / behind 0
- Exactly two modified files, no deletions
- Existing `Err` JSON-RPC path retained; no new category, kind, label, taxonomy, residual bucket, runner, or CI-capacity change
- Closing-account SHA-256 remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`
- `git diff --check` clean

## Evidence

Authenticated battleaxe crate tests: 26/26 passed.

The end-to-end itertools confirmation remains infrastructure-unmeasured because the managed container currently derives filesystem-shelf staging under the `/root` read-only bind. That does not weaken the crate-level proof and is being repaired separately under #7254.

## Delta / epsilon

Predicted movement: compile/pre-test child failures and unattested zero-output runs move from success-shaped empty witness sets to named refusal. Honest failing-test rows and attested zero-test suites remain unchanged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse cargo test child silence by returning errors when no test-population testimony is produced
> - `run_suite_witnesses` in [lib.rs](https://github.com/TSavo/sugar/pull/7278/files#diff-3ada30a0c1c6369c38e7f0612bcb0ceee2e81586333469d9f0bd9ce4ae4ea4d9) now captures stderr in addition to stdout and delegates result interpretation to a new `witnesses_from_cargo_run` helper.
> - `witnesses_from_cargo_run` returns an error (including exit code and captured stdio) when cargo fails without producing per-test rows, and returns an error when cargo succeeds but produces no test-population testimony at all.
> - Successful runs where stdout reports zero tests still return an empty witness set (honest zero-test suites are preserved).
> - Behavioral Change: previously, `run_suite_witnesses` could silently return an empty set on failure; it now returns an explicit error in those cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 028b22c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->