### PR TITLE
Preserve runtime to_string results in equality claims

### DIFF
--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs
@@ -1615,7 +1615,7 @@ fn constraint_gap(reason: impl Into<String>) -> ! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FloatWidthScope, TemporalPlan, TemporalScope};
+    use crate::{FactoryAuditLog, FloatWidthScope, TemporalPlan, TemporalScope};
 
     #[test]
     fn raw_if_let_guard_constraint_is_typed_effect_not_factory_gap() {
@@ -1870,6 +1870,90 @@ mod tests {
                 "scan terminal assertion should ground both sides to 10, got {arg:?}"
             );
         }
+    }
+
+    #[test]
+    fn runtime_to_string_method_result_reaches_relation_through_method_owner() {
+        let expr: Expr = syn::parse_str(
+            r#"assert_eq!("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8", my_uuid.to_string())"#,
+        )
+        .expect("parse UUID to_string assertion");
+        let mut scope = TemporalScope::new("uuid-to-string-relation", TemporalPlan::default());
+        scope.record_let_binding(
+            "my_uuid",
+            syn::parse_str(r#"Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8").unwrap()"#)
+                .expect("parse UUID binding"),
+        );
+        let audits = FactoryAuditLog::default();
+        let float_widths = FloatWidthScope::new();
+
+        let entry = assertion_entry_with_audits(&expr, &scope, &float_widths, Some(&audits))
+            .expect("runtime to_string must reach the generic method-result relation");
+
+        let Formula::Atomic { name, args } = entry.atom.as_ref() else {
+            panic!("expected UUID to_string equality, got {:?}", entry.atom);
+        };
+        assert_eq!(name, "=");
+        assert_eq!(args.len(), 2);
+        let Term::Ctor {
+            name: method,
+            args: method_args,
+        } = args[1].as_ref()
+        else {
+            panic!(
+                "expected generic to_string method result, got {:?}",
+                args[1]
+            );
+        };
+        assert_eq!(method, "method:to_string");
+        assert_eq!(method_args.len(), 1);
+        assert!(
+            audits.borrow().iter().any(|audit| {
+                audit.requested_role == "Term"
+                    && audit.selected == Some("method")
+                    && audit.site.contains("to_string")
+            }),
+            "runtime to_string must be constructed by the generic method owner; audits={:?}",
+            audits.borrow()
+        );
+    }
+
+    #[test]
+    fn panic_freedom_relation_gate_still_refuses_unreplayed_iterator_consumption() {
+        let mut plan = TemporalPlan::default();
+        plan.mut_locals.insert("iter".to_string());
+        plan.iterators.insert("iter".to_string());
+        plan.versioned.insert("iter".to_string());
+        let scope = TemporalScope::new("panic-freedom-relation-gate", plan);
+        let lhs: Expr = syn::parse_str("iter.next()").expect("parse iterator terminal");
+        let direct_effect = crate::panic_freedom_expr_callsite_effect(&lhs, &scope)
+            .expect("unreplayed iterator consumption must carry a panic-freedom effect");
+        let expr: Expr =
+            syn::parse_str("assert_eq!(iter.next(), Some(1))").expect("parse relation");
+        let audits = FactoryAuditLog::default();
+        let float_widths = FloatWidthScope::new();
+
+        let effect = match assertion_entry_with_audits(&expr, &scope, &float_widths, Some(&audits))
+        {
+            Err(effect) => effect,
+            Ok(_) => panic!("panic-freedom relation gate must refuse before constructing a term"),
+        };
+
+        assert_eq!(effect.reason(), direct_effect.reason());
+        assert!(
+            effect.reason().contains("unknown iterator consumption"),
+            "gate must retain the named iterator-consumption refusal: {}",
+            effect.reason()
+        );
+        assert!(
+            !audits.borrow().iter().any(|audit| {
+                audit.requested_role == "Term"
+                    && audit.selected == Some("method")
+                    && audit.site.contains("next")
+            }),
+            "a gated iterator terminal must not reach the generic method owner; audits={:?}",
+            audits.borrow()
+        );
     }
 
     #[test]

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/factory.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/factory.rs
@@ -646,6 +646,20 @@ pub(crate) fn build_term_frag(frag: &SourceFragment, fcx: &SugarBuildCtx) -> Box
     )
 }
 
+/// Fragment-facing query for the source-determined Display-value territory owned by
+/// `ToStringTermSugar`. The raw `Expr` projection stays at the factory boundary so the
+/// recognizer does not grow a second AST entrance.
+pub(crate) fn has_source_determined_display_value_frag(
+    frag: &SourceFragment,
+    fcx: &SugarBuildCtx,
+) -> bool {
+    crate::sugar::format::has_source_determined_display_value(
+        frag.as_expr()
+            .expect("has_source_determined_display_value_frag: non-expr fragment"),
+        fcx,
+    )
+}
+
 /// Fragment-based variant of `build_composite`. The `as_expr()` escape lives HERE
 /// (inside `factory.rs`, ratchet-excluded) so recognize bodies that call this stay clean.
 /// Used by transparent-passthrough recognizers that return a child Sugar directly.

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs
@@ -238,6 +238,53 @@ fn stable_binding_init<'a>(name: &str, fcx: &'a SugarBuildCtx) -> Option<&'a Exp
     fcx.scope().stable_let_binding_for_term(name)
 }
 
+/// Whether Display formatting is owned by the source-determined format-value floor.
+///
+/// This is the recognizer-side boundary for `.to_string()`: closed literal/format
+/// shapes stay with `ToStringTermSugar`; runtime call/method receivers decline so the
+/// already-registered generic method term can preserve their result identity. Returning
+/// `false` never fabricates a value and never converts a format effect into success.
+pub(crate) fn has_source_determined_display_value(expr: &Expr, fcx: &SugarBuildCtx) -> bool {
+    match strip_refs_groups(expr) {
+        Expr::Lit(ExprLit { lit, .. }) => reconstruct_lit(lit)
+            .ok()
+            .flatten()
+            .and_then(|value| value.render(&Spec::display()).ok().flatten())
+            .is_some(),
+        Expr::Unary(unary) if matches!(unary.op, syn::UnOp::Neg(_)) => {
+            has_source_determined_display_value(&unary.expr, fcx)
+        }
+        Expr::Binary(binary) if is_fmt_arith_op(&binary.op) => {
+            has_source_determined_display_value(&binary.left, fcx)
+                && has_source_determined_display_value(&binary.right, fcx)
+        }
+        Expr::Macro(mac)
+            if macro_is(mac, "format_args")
+                || macro_is(mac, "format")
+                || macro_is(mac, "concat") =>
+        {
+            true
+        }
+        Expr::MethodCall(call) if call.method == "to_string" && call.args.is_empty() => {
+            has_source_determined_display_value(&call.receiver, fcx)
+        }
+        Expr::Path(path) if path.qself.is_none() => path
+            .path
+            .get_ident()
+            .and_then(|ident| {
+                let name = ident.to_string();
+                if fcx.resolving_bound_path(&name) {
+                    return None;
+                }
+                let child_fcx = fcx.with_bound_path(&name);
+                stable_binding_init(&name, fcx)
+                    .map(|init| has_source_determined_display_value(init, &child_fcx))
+            })
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
 enum FormatTemplateBody {
     Literal(String),
     LiteralString(SugarBody<LiteralStringFloor>),

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/to_string.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/to_string.rs
@@ -6,7 +6,9 @@
 use sugar_ir_symbolic::str_const;
 
 use crate::sugar::factory::SugarBuildCtx;
-use crate::sugar::factory::{FormatValueFloor, SugarBody};
+use crate::sugar::factory::{
+    has_source_determined_display_value_frag, FormatValueFloor, SugarBody,
+};
 use crate::sugar::format::display_format_value_floor;
 use crate::sugar::source_fragment::SourceFragment;
 use crate::{Desugared, Outcome, Sugar, SugarCtx};
@@ -41,6 +43,9 @@ pub(crate) fn recognize(frag: &SourceFragment, fcx: &SugarBuildCtx) -> Option<Bo
         return None;
     }
     let receiver = srg.call_receiver()?;
+    if !has_source_determined_display_value_frag(&receiver, fcx) {
+        return None;
+    }
     Some(Box::new(ToStringTermSugar {
         receiver: SugarBody::format_value_frag(&receiver, fcx),
     }))
@@ -82,17 +87,23 @@ mod tests {
 
     #[test]
     fn from_src_recognizes_to_string_method() {
-        let expr: Expr = syn::parse_str("x.to_string()").expect("parses");
+        let expr: Expr = syn::parse_str("42.to_string()").expect("parses");
         let frag = SourceFragment::expr(&expr, "<test>");
         assert_eq!(frag.observed(), "MethodCall");
         let scope = TemporalScope::new("from-src-test", TemporalPlan::default());
         let options = LiftOptions::default();
         let let_inits = BTreeMap::new();
         let fcx = SugarBuildCtx::new(&scope, &options, &let_inits);
-        // positive: bare to_string() with no args must recognize
+        // positive: source-determined to_string() with no args must recognize
         assert!(
             recognize(&frag, &fcx).is_some(),
-            "to_string() with no args must recognize"
+            "literal to_string() with no args must recognize"
+        );
+        // negative: an unknown runtime receiver belongs to generic MethodSugar.
+        let runtime_receiver: Expr = syn::parse_str("x.to_string()").expect("parses");
+        assert!(
+            recognize(&SourceFragment::expr(&runtime_receiver, "<test>"), &fcx).is_none(),
+            "unknown to_string receiver must decline to generic method construction"
         );
         // negative: different method must not recognize
         let clone_expr: Expr = syn::parse_str("x.clone()").expect("parses");

--- a/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
+++ b/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
@@ -7714,7 +7714,7 @@ fn t() {
 }
 
 #[test]
-fn direct_method_call_result_string_assertion_uses_euf_callsite_key() {
+fn direct_method_call_result_string_assertion_uses_method_owner_and_euf_callsite_key() {
     let src = r#"
 struct Name;
 
@@ -7731,9 +7731,42 @@ fn string_call_result() {
     let out = lift_file(&parse(src), "tests/fmt.rs");
     assert_eq!(out.seen, 1);
     assert_eq!(out.lifted, 1, "warnings: {:?}", out.warnings);
-    // #2813: a single opaque string callsite only proves panic-freedom support.
-    // It has no substantive sibling constraint, so it must not be counted as a claim.
-    assert_support_only_warranted(&out, &["method:to_string#panic_callsite"]);
+    assert_warranted_decl_count(&out, 1);
+    let relation = warranted_decl_with_name(&out, "method:to_string#euf");
+    let operands = inv_operands(relation);
+    assert_eq!(operands.len(), 1);
+    let Formula::Atomic { name, args } = operands[0].as_ref() else {
+        panic!("expected method-result equality, got {:?}", operands[0]);
+    };
+    assert_eq!(name, "=");
+    assert_eq!(args.len(), 2);
+    assert!(
+        matches!(args[0].as_ref(), Term::Ctor { name, .. } if name == "method:to_string"),
+        "runtime to_string must retain its generic method owner: {:?}",
+        args[0]
+    );
+    assert!(
+        matches!(
+            args[1].as_ref(),
+            Term::Const {
+                value: ConstValue::String(value),
+                sort,
+            } if value == "hello" && sort.name == "String"
+        ),
+        "runtime to_string equality must retain its asserted string result: {:?}",
+        args[1]
+    );
+    assert!(
+        out.assertion_facts.iter().any(|fact| {
+            fact.kind == AssertionFactKind::Warranted
+                && fact.claim_count == 0
+                && fact
+                    .contract_name
+                    .contains("method:to_string#panic_callsite")
+        }),
+        "runtime to_string must retain its panic-support fact: {:?}",
+        out.assertion_facts
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Finding

`ToStringTermSugar` recognized every zero-argument `.to_string()` call. For a runtime receiver such as a bound `Uuid`, it forced the receiver through `FormatValueFloor`, which reduced the already-constructed value to `RuntimeFormatArgument` before the registered generic `MethodSugar` could construct `method:to_string`. The panic-freedom relation gate was not the blocker.

## Repair

The recognizer now keeps only source-determined formatting territory: literals, supported arithmetic, format-producing macros, nested source-determined `.to_string()`, and stable bindings to those shapes. Runtime receivers decline at that shared door and reach the existing generic method-result construction. No new UUID sugar, name dispatch, or equality mechanism is added.

The integration tooth now authenticates both outputs separately: one claim-bearing `method:to_string` equality with its asserted string result, and the existing support-only `method:to_string#panic_callsite` fact.

## Teeth

Authenticated on battleaxe at exact head `287e66929e5a585a504e57546e157301ce9e11d8`:

- 11/11 `sugar::constraint::tests` green, including exact `method:to_string` ownership and the forced iterator panic-freedom refusal.
- 3/3 `sugar::to_string::tests` green, including literal ownership and runtime-receiver decline.
- 1/1 assertion-lift integration tooth green, authenticating the substantive method-result equality and retaining panic support.
- `cargo fmt --all -- --check` exits 0.

Total focused evidence: 15/15.

A direct already-built-binary semantic overlay exposed the next terminal: the bad UUID twin now refuses as `unsatisfied` on contradictory `method:to_string` results. The official showcase entrance remains **UNMEASURED** because `sugarbin` hit the known uncreatable rebuild-lock PID path (`holder_pid=unknown`); this PR does not claim showcase discharge. The overlay also exposed a separate false-green defect: all 29 good consistency rows are refused as vacuous while `run.sh` prints PASS. That defect is filed separately and is not weakened here.

## Scope

Predicted effect: the UUID method-result terminal moves from the wrong `FormatValueFloor` gate to the existing generic method owner. This is not a claim that the showcase passes, that its 29 good rows are substantive, or that bitflags/itertools descendants are repaired. No files or tests were deleted; no skips or xfails were added.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve runtime `to_string()` results as generic method terms in equality claims
> - The `to_string` recognizer now declines receivers whose `Display` value is not source-determined (e.g. runtime variables), letting them fall through to the generic method term path instead of being dropped.
> - Adds `has_source_determined_display_value` in [format.rs](https://github.com/TSavo/sugar/pull/7281/files#diff-8759331bfb713a7e5cb3ada18515ab66317e302e777cdb97c86605670dd90755) to classify receivers: literals, unary negation, binary arithmetic, format macros, and chained `.to_string()` on source-determined receivers all qualify.
> - Renames and updates the integration test in [assertion_lift.rs](https://github.com/TSavo/sugar/pull/7281/files#diff-2c8837d05110630c1a0380aef547a0a1d50da4d06b0b09e591425a91aefcb328) to assert that a runtime `.to_string()` call produces a `method:to_string` EUF relation with the correct equality structure.
> - Behavioral Change: `x.to_string()` where `x` is a runtime value no longer matches the `ToStringTermSugar` recognizer; it now produces a generic method owner term instead of being silently unhandled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 287e669.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `.to_string()` expressions by accepting only values whose display output can be determined safely.
  - Unknown or runtime-dependent values are now rejected instead of being incorrectly transformed.

- **Tests**
  - Added coverage for method ownership, generated string results, audit tracking, and panic-safety behavior.
  - Expanded validation for supported literals, expressions, formatting operations, and variable bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->