### PR TITLE
Require substantive showcase discharge before PASS

### DIFF
--- a/examples/bitflags-showcase/run.sh
+++ b/examples/bitflags-showcase/run.sh
@@ -36,6 +36,23 @@ done
 
 pyget() { python3 "$REPO/tools/showcase/json_get.py" "$1" "$2"; }
 
+require_substantive_statuses() {
+  python3 - "$REPO" "$1" "$2" <<'PY'
+import sys
+
+repo, path, suite = sys.argv[1:]
+sys.path.insert(0, repo)
+from tools.showcase.durable_consistency import require_substantive_discharge
+from tools.showcase.json_get import load_receipt
+
+statuses = require_substantive_discharge(
+    load_receipt(path).get("rows", []),
+    suite=suite,
+)
+print(",".join(statuses))
+PY
+}
+
 write_lying_discharge() {
   local script="$1"
   cat > "$script" <<'SH'
@@ -62,7 +79,7 @@ run_suite() {
   local prove_json="$dir/.prove.json"
   ( cd "$dir" && "$SUGAR" prove . --json ) > "$prove_json" 2>/dev/null || true
 
-  local consistency_status witness_status
+  local consistency_status substantive_status witness_status
   consistency_status="$(pyget "$prove_json" "
 ','.join([r.get('status') for r in d.get('rows', []) if (r.get('property', '') or '').startswith('consistency:') and 'witness-package' not in (r.get('property', '') or '')]) or 'MISSING'
 ")"
@@ -73,7 +90,8 @@ next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get(
   echo "   prove witness-package status: $witness_status"
 
   if [ "$expect_consistency" = "DISCHARGE" ]; then
-    echo "$consistency_status" | grep -qv 'unsatisfied' || { echo "FAIL[$suite]: expected consistency discharge, got $consistency_status"; exit 1; }
+    substantive_status="$(require_substantive_statuses "$prove_json" "$suite")"
+    echo "   prove substantive consistency statuses: $substantive_status"
   else
     echo "$consistency_status" | grep -q 'unsatisfied' || { echo "FAIL[$suite]: expected consistency refusal, got $consistency_status"; exit 1; }
   fi
@@ -112,6 +130,7 @@ sys.path.insert(0, repo)
 from tools.showcase.durable_consistency import (
     check_durable_consistency,
     is_witness_package_row,
+    require_substantive_discharge,
 )
 from tools.showcase.json_get import load_receipt
 
@@ -119,6 +138,11 @@ receipt = load_receipt(path)
 rows = receipt.get("rows", [])
 consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
+)
+substantive = (
+    require_substantive_discharge(rows, suite=suite)
+    if expect_consistency == "DISCHARGE"
+    else []
 )
 witness = [
     r.get("status")
@@ -138,6 +162,8 @@ verified = any(
 if not verified:
     raise SystemExit(f"FAIL[{suite}]: witness dimension did not verify")
 print(f"   durable consistency statuses: {','.join(consistency)}")
+if substantive:
+    print(f"   durable substantive consistency statuses: {','.join(substantive)}")
 print(f"   durable witness statuses: {','.join(witness)}")
 print("   durable witness dimension: verified")
 PY

--- a/examples/forall-loop-showcase/run.sh
+++ b/examples/forall-loop-showcase/run.sh
@@ -36,6 +36,23 @@ done
 
 pyget() { python3 "$REPO/tools/showcase/json_get.py" "$1" "$2"; }
 
+require_substantive_statuses() {
+  python3 - "$REPO" "$1" "$2" <<'PY'
+import sys
+
+repo, path, suite = sys.argv[1:]
+sys.path.insert(0, repo)
+from tools.showcase.durable_consistency import require_substantive_discharge
+from tools.showcase.json_get import load_receipt
+
+statuses = require_substantive_discharge(
+    load_receipt(path).get("rows", []),
+    suite=suite,
+)
+print(",".join(statuses))
+PY
+}
+
 write_lying_discharge() {
   local script="$1"
   cat > "$script" <<'SH'
@@ -62,7 +79,7 @@ run_suite() {
   local prove_json="$dir/.prove.json"
   ( cd "$dir" && "$SUGAR" prove . --json ) > "$prove_json" 2>/dev/null || true
 
-  local consistency_status witness_status
+  local consistency_status substantive_status witness_status
   consistency_status="$(pyget "$prove_json" "
 ','.join([r.get('status') for r in d.get('rows', []) if (r.get('property', '') or '').startswith('consistency:') and 'witness-package' not in (r.get('property', '') or '')]) or 'MISSING'
 ")"
@@ -73,7 +90,8 @@ next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get(
   echo "   prove witness-package status: $witness_status"
 
   if [ "$expect_consistency" = "DISCHARGE" ]; then
-    echo "$consistency_status" | grep -qv 'unsatisfied' || { echo "FAIL[$suite]: expected consistency discharge, got $consistency_status"; exit 1; }
+    substantive_status="$(require_substantive_statuses "$prove_json" "$suite")"
+    echo "   prove substantive consistency statuses: $substantive_status"
   else
     echo "$consistency_status" | grep -q 'unsatisfied' || { echo "FAIL[$suite]: expected consistency refusal, got $consistency_status"; exit 1; }
   fi
@@ -112,6 +130,7 @@ sys.path.insert(0, repo)
 from tools.showcase.durable_consistency import (
     check_durable_consistency,
     is_witness_package_row,
+    require_substantive_discharge,
 )
 from tools.showcase.json_get import load_receipt
 
@@ -119,6 +138,11 @@ receipt = load_receipt(path)
 rows = receipt.get("rows", [])
 consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
+)
+substantive = (
+    require_substantive_discharge(rows, suite=suite)
+    if expect_consistency == "DISCHARGE"
+    else []
 )
 witness = [
     r.get("status")
@@ -138,6 +162,8 @@ verified = any(
 if not verified:
     raise SystemExit(f"FAIL[{suite}]: witness dimension did not verify")
 print(f"   durable consistency statuses: {','.join(consistency)}")
+if substantive:
+    print(f"   durable substantive consistency statuses: {','.join(substantive)}")
 print(f"   durable witness statuses: {','.join(witness)}")
 print("   durable witness dimension: verified")
 PY

--- a/examples/num-integer-showcase/run.sh
+++ b/examples/num-integer-showcase/run.sh
@@ -36,6 +36,23 @@ done
 
 pyget() { python3 "$REPO/tools/showcase/json_get.py" "$1" "$2"; }
 
+require_substantive_statuses() {
+  python3 - "$REPO" "$1" "$2" <<'PY'
+import sys
+
+repo, path, suite = sys.argv[1:]
+sys.path.insert(0, repo)
+from tools.showcase.durable_consistency import require_substantive_discharge
+from tools.showcase.json_get import load_receipt
+
+statuses = require_substantive_discharge(
+    load_receipt(path).get("rows", []),
+    suite=suite,
+)
+print(",".join(statuses))
+PY
+}
+
 write_lying_discharge() {
   local script="$1"
   cat > "$script" <<'SH'
@@ -62,7 +79,7 @@ run_suite() {
   local prove_json="$dir/.prove.json"
   ( cd "$dir" && "$SUGAR" prove . --json ) > "$prove_json" 2>/dev/null || true
 
-  local consistency_status witness_status
+  local consistency_status substantive_status witness_status
   consistency_status="$(pyget "$prove_json" "
 ','.join([r.get('status') for r in d.get('rows', []) if (r.get('property', '') or '').startswith('consistency:') and 'witness-package' not in (r.get('property', '') or '')]) or 'MISSING'
 ")"
@@ -73,7 +90,8 @@ next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get(
   echo "   prove witness-package status: $witness_status"
 
   if [ "$expect_consistency" = "DISCHARGE" ]; then
-    echo "$consistency_status" | grep -qv 'unsatisfied' || { echo "FAIL[$suite]: expected consistency discharge, got $consistency_status"; exit 1; }
+    substantive_status="$(require_substantive_statuses "$prove_json" "$suite")"
+    echo "   prove substantive consistency statuses: $substantive_status"
   else
     echo "$consistency_status" | grep -q 'unsatisfied' || { echo "FAIL[$suite]: expected consistency refusal, got $consistency_status"; exit 1; }
   fi
@@ -112,6 +130,7 @@ sys.path.insert(0, repo)
 from tools.showcase.durable_consistency import (
     check_durable_consistency,
     is_witness_package_row,
+    require_substantive_discharge,
 )
 from tools.showcase.json_get import load_receipt
 
@@ -119,6 +138,11 @@ receipt = load_receipt(path)
 rows = receipt.get("rows", [])
 consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
+)
+substantive = (
+    require_substantive_discharge(rows, suite=suite)
+    if expect_consistency == "DISCHARGE"
+    else []
 )
 witness = [
     r.get("status")
@@ -138,6 +162,8 @@ verified = any(
 if not verified:
     raise SystemExit(f"FAIL[{suite}]: witness dimension did not verify")
 print(f"   durable consistency statuses: {','.join(consistency)}")
+if substantive:
+    print(f"   durable substantive consistency statuses: {','.join(substantive)}")
 print(f"   durable witness statuses: {','.join(witness)}")
 print("   durable witness dimension: verified")
 PY

--- a/examples/semver-showcase/run.sh
+++ b/examples/semver-showcase/run.sh
@@ -36,6 +36,23 @@ done
 
 pyget() { python3 "$REPO/tools/showcase/json_get.py" "$1" "$2"; }
 
+require_substantive_statuses() {
+  python3 - "$REPO" "$1" "$2" <<'PY'
+import sys
+
+repo, path, suite = sys.argv[1:]
+sys.path.insert(0, repo)
+from tools.showcase.durable_consistency import require_substantive_discharge
+from tools.showcase.json_get import load_receipt
+
+statuses = require_substantive_discharge(
+    load_receipt(path).get("rows", []),
+    suite=suite,
+)
+print(",".join(statuses))
+PY
+}
+
 write_lying_discharge() {
   local script="$1"
   cat > "$script" <<'SH'
@@ -62,7 +79,7 @@ run_suite() {
   local prove_json="$dir/.prove.json"
   ( cd "$dir" && "$SUGAR" prove . --json ) > "$prove_json" 2>/dev/null || true
 
-  local consistency_status witness_status
+  local consistency_status substantive_status witness_status
   consistency_status="$(pyget "$prove_json" "
 ','.join([r.get('status') for r in d.get('rows', []) if (r.get('property', '') or '').startswith('consistency:') and 'witness-package' not in (r.get('property', '') or '')]) or 'MISSING'
 ")"
@@ -73,7 +90,8 @@ next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get(
   echo "   prove witness-package status: $witness_status"
 
   if [ "$expect_consistency" = "DISCHARGE" ]; then
-    echo "$consistency_status" | grep -qv 'unsatisfied' || { echo "FAIL[$suite]: expected consistency discharge, got $consistency_status"; exit 1; }
+    substantive_status="$(require_substantive_statuses "$prove_json" "$suite")"
+    echo "   prove substantive consistency statuses: $substantive_status"
   else
     echo "$consistency_status" | grep -q 'unsatisfied' || { echo "FAIL[$suite]: expected consistency refusal, got $consistency_status"; exit 1; }
   fi
@@ -112,6 +130,7 @@ sys.path.insert(0, repo)
 from tools.showcase.durable_consistency import (
     check_durable_consistency,
     is_witness_package_row,
+    require_substantive_discharge,
 )
 from tools.showcase.json_get import load_receipt
 
@@ -119,6 +138,11 @@ receipt = load_receipt(path)
 rows = receipt.get("rows", [])
 consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
+)
+substantive = (
+    require_substantive_discharge(rows, suite=suite)
+    if expect_consistency == "DISCHARGE"
+    else []
 )
 witness = [
     r.get("status")
@@ -138,6 +162,8 @@ verified = any(
 if not verified:
     raise SystemExit(f"FAIL[{suite}]: witness dimension did not verify")
 print(f"   durable consistency statuses: {','.join(consistency)}")
+if substantive:
+    print(f"   durable substantive consistency statuses: {','.join(substantive)}")
 print(f"   durable witness statuses: {','.join(witness)}")
 print("   durable witness dimension: verified")
 PY

--- a/examples/url-showcase/run.sh
+++ b/examples/url-showcase/run.sh
@@ -36,6 +36,23 @@ done
 
 pyget() { python3 "$REPO/tools/showcase/json_get.py" "$1" "$2"; }
 
+require_substantive_statuses() {
+  python3 - "$REPO" "$1" "$2" <<'PY'
+import sys
+
+repo, path, suite = sys.argv[1:]
+sys.path.insert(0, repo)
+from tools.showcase.durable_consistency import require_substantive_discharge
+from tools.showcase.json_get import load_receipt
+
+statuses = require_substantive_discharge(
+    load_receipt(path).get("rows", []),
+    suite=suite,
+)
+print(",".join(statuses))
+PY
+}
+
 write_lying_discharge() {
   local script="$1"
   cat > "$script" <<'SH'
@@ -62,7 +79,7 @@ run_suite() {
   local prove_json="$dir/.prove.json"
   ( cd "$dir" && "$SUGAR" prove . --json ) > "$prove_json" 2>/dev/null || true
 
-  local consistency_status witness_status
+  local consistency_status substantive_status witness_status
   consistency_status="$(pyget "$prove_json" "
 ','.join([r.get('status') for r in d.get('rows', []) if (r.get('property', '') or '').startswith('consistency:') and 'witness-package' not in (r.get('property', '') or '')]) or 'MISSING'
 ")"
@@ -73,7 +90,8 @@ next((r.get('status') for r in d.get('rows', []) if 'witness-package' in (r.get(
   echo "   prove witness-package status: $witness_status"
 
   if [ "$expect_consistency" = "DISCHARGE" ]; then
-    echo "$consistency_status" | grep -qv 'unsatisfied' || { echo "FAIL[$suite]: expected consistency discharge, got $consistency_status"; exit 1; }
+    substantive_status="$(require_substantive_statuses "$prove_json" "$suite")"
+    echo "   prove substantive consistency statuses: $substantive_status"
   else
     echo "$consistency_status" | grep -q 'unsatisfied' || { echo "FAIL[$suite]: expected consistency refusal, got $consistency_status"; exit 1; }
   fi
@@ -112,6 +130,7 @@ sys.path.insert(0, repo)
 from tools.showcase.durable_consistency import (
     check_durable_consistency,
     is_witness_package_row,
+    require_substantive_discharge,
 )
 from tools.showcase.json_get import load_receipt
 
@@ -119,6 +138,11 @@ receipt = load_receipt(path)
 rows = receipt.get("rows", [])
 consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
+)
+substantive = (
+    require_substantive_discharge(rows, suite=suite)
+    if expect_consistency == "DISCHARGE"
+    else []
 )
 witness = [
     r.get("status")
@@ -138,6 +162,8 @@ verified = any(
 if not verified:
     raise SystemExit(f"FAIL[{suite}]: witness dimension did not verify")
 print(f"   durable consistency statuses: {','.join(consistency)}")
+if substantive:
+    print(f"   durable substantive consistency statuses: {','.join(substantive)}")
 print(f"   durable witness statuses: {','.join(witness)}")
 print("   durable witness dimension: verified")
 PY

--- a/tools/showcase/durable_consistency.py
+++ b/tools/showcase/durable_consistency.py
@@ -13,7 +13,10 @@ Prove and durable verify must use the SAME consistency law for the good twin:
 
 Historically durable required *every* consistency row `discharged`, while prove
 only forbade `unsatisfied`. Under #2813 lone-EUF vacuity that made good twins
-pass prove and fail durable on the same receipt.
+pass prove and fail durable on the same receipt.  That transport-level parity
+law remains available through ``check_durable_consistency``.  A showcase that
+claims PASS has the stronger obligation enforced by
+``require_substantive_discharge``: nonempty product testimony, all discharged.
 """
 
 from __future__ import annotations
@@ -30,6 +33,37 @@ VACUOUS_MARKERS = (
 def is_consistency_row(row: Mapping[str, Any]) -> bool:
     prop = row.get("property") or ""
     return prop.startswith("consistency:") and "witness-package" not in prop
+
+
+def is_substantive_consistency_row(row: Mapping[str, Any]) -> bool:
+    """Return whether a consistency row asserts a product relation.
+
+    Panic-callsite rows are support testimony: they remain present and may
+    honestly refuse as vacuous, but they cannot sustain a showcase PASS.
+    """
+    prop = str(row.get("property") or "")
+    return is_consistency_row(row) and "#panic_callsite#" not in prop
+
+
+def require_substantive_discharge(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    suite: str,
+) -> list[str]:
+    """Require a nonempty substantive population whose every row discharged."""
+    substantive = [row for row in rows if is_substantive_consistency_row(row)]
+    statuses = [str(row.get("status") or "") for row in substantive]
+    if not substantive:
+        raise SystemExit(
+            f"FAIL[{suite}]: no substantive consistency rows; "
+            "PASS requires a nonempty substantive population"
+        )
+    if any(status != "discharged" for status in statuses):
+        raise SystemExit(
+            f"FAIL[{suite}]: expected substantive consistency rows all discharged, "
+            f"got {statuses}"
+        )
+    return statuses
 
 
 def is_witness_package_row(row: Mapping[str, Any]) -> bool:

--- a/tools/showcase_bulk_refuse_class.py
+++ b/tools/showcase_bulk_refuse_class.py
@@ -31,6 +31,7 @@ from tools.showcase.durable_consistency import (  # noqa: E402
     check_durable_consistency,
     classify_refuse_reasons,
     is_consistency_row,
+    require_substantive_discharge,
 )
 from tools.showcase.json_get import load_receipt  # noqa: E402
 
@@ -77,6 +78,43 @@ def analyze_receipt(path: Path) -> dict[str, object]:
 
 
 def self_test() -> None:
+    # A real num-integer-shaped good wall is not a discharge: substantive
+    # rows reached the verifier, but every one refused as vacuous.
+    num_integer_vacuous = [
+        {
+            "property": f"consistency:method:gcd#euf#row-{index}::assertion",
+            "status": "refused",
+            "reason": "consistency check vacuous: single constraint has no sibling",
+        }
+        for index in range(20)
+    ]
+    try:
+        require_substantive_discharge(
+            num_integer_vacuous,
+            suite="num-integer-good",
+        )
+        raise AssertionError("20/20 vacuous substantive rows must not pass")
+    except SystemExit as e:
+        assert "substantive consistency rows all discharged" in str(e)
+
+    # A nonempty substantive population whose every member discharged passes.
+    substantive_discharge = [
+        {
+            "property": "consistency:method:all_equal#euf#row::assertion",
+            "status": "discharged",
+            "reason": "solver returned sat",
+        },
+        {
+            "property": "consistency:method:all_equal#panic_callsite#euf#row::assertion",
+            "status": "refused",
+            "reason": "consistency check vacuous: support-only panic row",
+        },
+    ]
+    assert require_substantive_discharge(
+        substantive_discharge,
+        suite="itertools-good",
+    ) == ["discharged"]
+
     # Good: substantive + honest vacuous refuse → aligned OK, old law fails.
     mixed = [
         {


### PR DESCRIPTION
## What changed

The bitflags, forall-loop, num-integer, semver, and url showcase scripts now require a nonempty population of substantive consistency rows and require every substantive row to be discharged before they may print PASS. Panic-callsite support rows remain present and may remain vacuous-refused, but can no longer sustain a PASS.

The shared durable-consistency module now exposes the strict PASS predicate separately from its older transport-parity predicate. That preserves the lawful vacuity transport while closing the success-shaped-empty door at the five vulnerable scripts. The retired java-forall-loop script is intentionally unchanged even though it imports the permissive legacy policy; revival must migrate it explicitly. UUID remains separately tracked by #7282.

## Why

The e75 showcase audit originally reported 15 passes. Reach testimony corrected that to 14, and substantive-row testimony corrected it again to 12: num-integer had 20/20 consistency rows vacuous-refused and semver had 27/27 vacuous-refused while both scripts printed PASS. The product did not regress across 15 -> 14 -> 12; the instruments became less flattering. These two showcases have never verified substantive claims and will now fail honestly.

This is the same absence-collapsed-into-success class as a skip counted as PASS and zero parsed witness lines reported as No tests. Here attendance and rows existed, but none of the substantive rows discharged. Vacuity refusal remains intact; the lie was the PASS.

## Teeth and evidence

- Exact head: 92eaa71ca4214ef114596251f9f1b52a90737f6a, one commit over 647a888b015fbf4004d385b63a130bbf03e0fe6e.
- Fresh-root battleaxe brun self-test: exit 0. A real num-integer-shaped nonempty 20-row all-vacuous wall refuses; one discharged substantive row plus a vacuous panic-callsite support row passes.
- Local focused self-test: exit 0.
- bash syntax: 5/5 scripts pass.
- No files or tests deleted; no skips or xfails added.

The attempted full num-integer showcase is explicitly UNMEASURED: rust-cargo-test-witness stalled for 120 seconds without a response frame before the new gate, exit 1. This PR does not claim a current end-to-end showcase verdict; it claims the focused refusal/pass contract and predicts the two historical false greens become honest reds once the entrance reaches them.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require substantive showcase discharge before PASS in consistency checks
> - Adds `require_substantive_discharge` to [`tools/showcase/durable_consistency.py`](https://github.com/TSavo/sugar/pull/7283/files#diff-95f301f457fd4a5c303624473dac3fdffe614c7dbb3d6734a2da11d3a55c7f10), which selects non-panic-callsite consistency rows and exits with an error if the set is empty or any row is not `discharged`.
> - Adds `is_substantive_consistency_row` helper to exclude rows whose property contains `#panic_callsite#` from consistency checks.
> - Replaces the previous lax `grep`-based `unsatisfied` check in the DISCHARGE branch of each showcase `run.sh` with a call to `require_substantive_statuses`, which invokes `require_substantive_discharge` and prints results.
> - Extends `tools/showcase_bulk_refuse_class.py` self-tests to validate `require_substantive_discharge` for vacuous (all-refused) and valid (mixed discharged/panic) populations.
> - Behavioral Change: DISCHARGE now fails hard if substantive consistency rows are empty or any are not `discharged`, rather than passing when `unsatisfied` is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14e1359.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->