### PR TITLE
Bind demand-table enumeration test roster authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -164,6 +164,8 @@ def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(
         workspace_root=corpus,
         file_rel="b.py",
         contract_refs=refs,
+        distribution="tiny-corpus",
+        source_workspace_root=corpus,
     )
     assert isinstance(row, dict)
     assert "category" in row


### PR DESCRIPTION
Pass the fixture distribution explicitly to context-manager-resolutions enumeration. This preserves the zero-walk assertion after roster authority became mandatory. Battleaxe fresh-root evidence on current main: 11 passed, exit 0, 0.95s. CAS publish/negative arms remain separate and unmeasured.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `distribution` and `source_workspace_root` arguments to demand-table enumeration test
> Updates `test_cold_process_with_prebuilt_table_performs_zero_corpus_walks` in [test_prebuilt_demand_table.py](https://github.com/TSavo/sugar/pull/7284/files#diff-d0bfca5fa44601c91de7ce0dbb42184e1b0666656cddfb459faefc7145e54460) to pass `distribution="tiny-corpus"` and `source_workspace_root=corpus` as keyword arguments to `measure_file_via_enumerate`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d83500.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->