### PR TITLE
Route same-module managers through authenticated class door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1305,8 +1305,24 @@ def main() -> int:
                 flush=True,
             )
 
-            def tqdm(iterable, **_kwargs):
-                return iterable
+            class _NoProgress:
+                def __init__(self, iterable, **_kwargs):
+                    self._iterable = iterable
+
+                def __iter__(self):
+                    return iter(self._iterable)
+
+                def update(self, _count=1):
+                    del _count
+
+                def set_postfix(self, _postfix, **_kwargs):
+                    del _postfix, _kwargs
+
+                def close(self):
+                    pass
+
+            def tqdm(iterable, **kwargs):
+                return _NoProgress(iterable, **kwargs)
 
         live_done = 0
         live_panic = 0  # ConstructionPanic only (file-level kit panic)

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1298,10 +1298,15 @@ def main() -> int:
     if not args.aggregate_only:
         try:
             from tqdm import tqdm
-        except ImportError as error:  # pragma: no cover
-            raise SystemExit(
-                "tqdm is required: python3 -m pip install 'tqdm>=4.66'"
-            ) from error
+        except ImportError:  # pragma: no cover
+            print(
+                "RECENSUS: tqdm unavailable; proceeding without progress display",
+                file=sys.stderr,
+                flush=True,
+            )
+
+            def tqdm(iterable, **_kwargs):
+                return iterable
 
         live_done = 0
         live_panic = 0  # ConstructionPanic only (file-level kit panic)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1778,6 +1778,9 @@ def _populate_same_module_class_manager_uses(source_file, context, uses) -> None
         SourceDerivedContextManagerRefV1,
     )
     from sugar_lift_py_tests.floor import ObjectValue
+    from sugar_lift_py_tests.callable_application import CallableApplication
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Complete
     from sugar_lift_py_tests.temporal import builtin_name_temporal
     from sugar_source_tree.nodes import Call, ClassDef, Name
     from sugar_source_tree.panic import SugarNotWritten
@@ -1790,6 +1793,39 @@ def _populate_same_module_class_manager_uses(source_file, context, uses) -> None
     )
 
     reduce_ctx = ReduceContext(temporal=builtin_name_temporal())
+
+    def collect_application(call_sugar):
+        """Collect authenticated call actuals without re-entering Call.sugar()."""
+        def positional(index, values):
+            if index == len(call_sugar.args):
+                return keywords(0, values, ())
+            return call_sugar.args[index].desugar(reduce_ctx).and_then(
+                lambda value: value.project_operation_receiver_outcome(
+                    reduce_ctx, owner="same-module ClassDef positional actual"
+                ).and_then(
+                    lambda actual: positional(index + 1, values + (actual,))
+                )
+            )
+
+        def keywords(index, values, names):
+            if index == len(call_sugar.keywords):
+                return Complete(
+                    CallableApplication(values, names, call_sugar.site,
+                                        call_occurrence=call_sugar.call_occurrence)
+                )
+            name, argument = call_sugar.keywords[index]
+            return argument.desugar(reduce_ctx).and_then(
+                lambda value: value.project_operation_receiver_outcome(
+                    reduce_ctx, owner="same-module ClassDef keyword actual"
+                ).and_then(
+                    lambda actual: keywords(
+                        index + 1, values + (actual,), names + (name,)
+                    )
+                )
+            )
+
+        return positional(0, ())
+
     for _key, (coordinate, call, exit_face_id) in uses.items():
         if coordinate in context.source_derived_contract_refs:
             continue
@@ -1801,22 +1837,38 @@ def _populate_same_module_class_manager_uses(source_file, context, uses) -> None
         class_def = binds[0]
         target_symbol = f"python:local:{class_def.name}"
         try:
-            call_outcome = call.sugar().desugar(reduce_ctx)
-            call_value = getattr(call_outcome, "value", None)
-            if call_value is None or not hasattr(call_value, "force_floor"):
+            class_outcome = class_def.sugar().desugar(reduce_ctx)
+            class_value = getattr(class_outcome, "value", None)
+            if type(class_value) is not ClassDefinitionValue:
                 _install_local_derivation_gap(
                     context,
                     coordinate,
                     target_symbol,
-                    "non-manager-result",
-                    type(call_outcome).__name__,
+                    "class-definition-not-constructed",
+                    type(class_outcome).__name__,
                 )
                 continue
-            result = call_value.force_floor(
-                reduce_ctx,
-                owner="populate_same_module_class_manager",
-                project_callsite=False,
+            application = collect_application(call.sugar())
+            application_value = getattr(application, "value", None)
+            if application_value is None:
+                _install_local_derivation_gap(
+                    context, coordinate, target_symbol,
+                    "call-arguments-not-constructed", type(application).__name__
+                )
+                continue
+            result_outcome = class_value.callable_application_with(
+                application_value, reduce_ctx
             )
+            result = getattr(result_outcome, "value", None)
+            if result is not None and getattr(result, "defining_class", None) is not class_value:
+                _install_local_derivation_gap(
+                    context,
+                    coordinate,
+                    target_symbol,
+                    "class-definition-provenance-mismatch",
+                    "constructed receiver is not owned by authenticated class_def",
+                )
+                continue
         except (SugarNotWritten, TypeError) as exc:
             kind, detail = _populate_body_defect_kind_detail(exc)
             _install_local_derivation_gap(


### PR DESCRIPTION
## Summary

Same-module context-manager construction now adapts authenticated call arguments into `CallableApplication` and invokes the existing `ClassDefinitionValue.callable_application_with` door directly. The prior generic `call.sugar().desugar()` entrance, which produced `body=None`, is removed. Constructed receivers are required to carry `defining_class is class_value`; mismatches become a named derivation gap.

The census downstream effect is UNMEASURED. Three authenticated runs were lost during remote detached-process/bootstrap handling before a receipt arrived. Whether the readers.py, pytables.py, and stata.py missing-callsite-body terminals clear, and what appears behind them, remains unmeasured.

The census progress dependency is now optional: missing `tqdm` announces once on stderr and proceeds without display; it does not alter the measured population.

## Evidence and limits

- Base: current `origin/main` `647a888b015fbf4004d385b63a130bbf03e0fe6e`
- `py_compile` and `git diff --check` pass.
- No claim that the three files are complete or that terminals were removed.
- Remote detached-process lifetime is a separate infrastructure axis.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route same-module class manager construction through authenticated class definition
> - Refactors `_populate_same_module_class_manager_uses` in [manager_summary_derivation.py](https://github.com/TSavo/sugar/pull/7285/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to authenticate the `ClassDef` and call arguments before constructing instances, replacing the previous `force_floor`-based `Call.sugar()` path.
> - Desugars the class definition to a `ClassDefinitionValue`, builds a `CallableApplication` from positional and keyword actuals, then calls `callable_application_with` and verifies the result's `defining_class` matches the authenticated class.
> - Adds more specific gap kinds (`class-definition-not-constructed`, `call-arguments-not-constructed`, `class-definition-provenance-mismatch`) replacing the generic `non-manager-result`.
> - Also adds a `tqdm` shim in [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7285/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) so the script runs without a progress bar instead of exiting when `tqdm` is not installed.
> - Behavioral Change: same-module manager derivation may succeed or fail in different scenarios than before due to the new authentication and provenance verification steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e586e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->