### PR TITLE
Preserve nested BV32 operand sort authority

### DIFF
--- a/implementations/rust/sugar-ir-compiler-smt-lib/src/emitter.rs
+++ b/implementations/rust/sugar-ir-compiler-smt-lib/src/emitter.rs
@@ -2175,6 +2175,16 @@ fn collect_free_vars_term_ctx_adt(
                     collect_free_vars_string_term(&args[0], out, bound);
                     return;
                 }
+                // A nested BV32 constructor is its operands' sort authority.
+                // In the bitflags shape the tree sits below `method:bits`, so
+                // the formula-level direct-equality shortcut never sees it.
+                // Re-enter the existing BV32 collector at the constructor
+                // boundary rather than defaulting its associated-const vars to
+                // Int in the generic recursion.
+                if is_bv32_ctor_name(name) && term_renders_as_bv32(term) {
+                    collect_free_vars_term_bv32_result(term, out, bound);
+                    return;
+                }
             }
             // A monadic tester/selector (`adt.is_some(r)`, `opt:some#0(r)`) in
             // TERM position (a guarded-split guard/branch, #3445 Part 1 slice 2)
@@ -2604,7 +2614,7 @@ fn is_bv32_ctor_name(name: &str) -> bool {
     name.starts_with("bv32.")
 }
 
-fn term_renders_as_bv32(term: &Term) -> bool {
+pub(crate) fn term_renders_as_bv32(term: &Term) -> bool {
     let subst = std::collections::HashMap::new();
     emit_bv32_term(term, &subst).is_some()
 }

--- a/implementations/rust/sugar-ir-compiler-smt-lib/src/lib.rs
+++ b/implementations/rust/sugar-ir-compiler-smt-lib/src/lib.rs
@@ -101,7 +101,21 @@ fn validate_term(term: &sugar_ir_types::IrTerm) -> Result<(), String> {
             Ok(())
         }
         sugar_ir_types::IrTerm::Const { .. } => Ok(()),
-        sugar_ir_types::IrTerm::Ctor { args, .. } => args.iter().try_for_each(validate_term),
+        sugar_ir_types::IrTerm::Ctor { name, args } => {
+            if name.starts_with("bv32.") {
+                // The BV renderer validates the complete typed subtree,
+                // including Bool-valued conditions nested inside bv32.ite.
+                // Do not separately walk those condition ctors as value terms.
+                if emitter::term_renders_as_bv32(term) {
+                    return Ok(());
+                }
+                return Err(format!(
+                    "{name}: BV32 constructor could not render its operand shape; \
+                     refusing rather than weakening to a generic uninterpreted function"
+                ));
+            }
+            args.iter().try_for_each(validate_term)
+        }
         sugar_ir_types::IrTerm::Lambda { body, .. } => validate_term(body),
         sugar_ir_types::IrTerm::Let { body, .. } => validate_term(body),
     }
@@ -355,6 +369,68 @@ mod tests {
         assert!(
             !out.to_lowercase().contains("error"),
             "z3 must not error on a well-sorted script:\n{out}\n--- script ---\n{script}"
+        );
+    }
+
+    #[test]
+    fn nested_bv32_owner_preserves_associated_const_operand_sort() {
+        // bitflags showcase shape:
+        //   (Flags::A | Flags::B).bits() == 3
+        //
+        // BvBinOpSugar has already constructed the receiver as `bv32.or`.
+        // That constructor is the exact sort authority for both associated-
+        // const operands even though the BV tree is nested under method:bits.
+        let z3 = which_z3().expect("z3 required for nested BV32 sort check");
+        let inv = eq(
+            ctor(
+                "method:bits",
+                vec![ctor("bv32.or", vec![var("Flags::A"), var("Flags::B")])],
+            ),
+            serde_json::json!({
+                "kind": "const",
+                "value": 3,
+                "sort": {"kind": "primitive", "name": "Int"}
+            }),
+        );
+        let parts = fixture_compile_asserted_to_parts(&inv).expect("compile");
+        let script = format!("{}{}", parts.preamble, parts.body);
+        assert!(
+            script.contains("(declare-const |Flags::A| (_ BitVec 32))")
+                && script.contains("(declare-const |Flags::B| (_ BitVec 32))"),
+            "bv32.or must carry BV32 authority to its associated-const operands:\n{script}"
+        );
+        assert!(
+            script.contains("(declare-fun |method:bits| ((_ BitVec 32)) Int)"),
+            "method:bits must consume the constructed BV32 receiver:\n{script}"
+        );
+        assert!(
+            script.contains("(bvor |Flags::A| |Flags::B|)"),
+            "BvBinOpSugar's bv32.or owner must remain native bvor:\n{script}"
+        );
+        let out = run_z3(&z3, &script);
+        assert!(
+            !out.to_lowercase().contains("error"),
+            "nested BV32 authority must produce a well-sorted solver script:\n{out}\n--- script ---\n{script}"
+        );
+    }
+
+    #[test]
+    fn unrenderable_bv32_ctor_refuses_instead_of_falling_back_to_euf() {
+        let inv = eq(
+            ctor("bv32.or", vec![string_const("not-a-bitvector"), var("rhs")]),
+            serde_json::json!({
+                "kind": "const",
+                "value": 3,
+                "sort": {"kind": "primitive", "name": "Int"}
+            }),
+        );
+        let err = fixture_compile_asserted_to_parts(&inv)
+            .expect_err("an unrenderable bv32 ctor must refuse, never become a generic EUF");
+        let msg = err.to_string();
+        assert!(msg.contains("bv32.or"), "refusal must name the ctor: {msg}");
+        assert!(
+            msg.contains("could not render") && msg.contains("refusing rather than weakening"),
+            "refusal must name the rendering failure and the no-EUF law: {msg}"
         );
     }
 


### PR DESCRIPTION
## What changed

Nested `bv32.*` constructors now carry their existing BV32 sort authority into free-variable collection even when they sit below an outer constructor such as `method:bits`. The compiler boundary also refuses a malformed BV32 constructor whose operand shape cannot render, instead of letting it fall through to generic EUF emission.

## Why

The bitflags shape nests `bv32.or(Flags::A, Flags::B)` under `method:bits`. The generic nested traversal defaulted `Flags::A` and `Flags::B` to `Int` even though `bvor` requires BV32 operands. Separately, an unrenderable `bv32.or` could become `(declare-fun bv32.or (Int Int) Int)`, accepting a string-derived operand as a syntactically valid but semantically meaningless uninterpreted function.

The fix preserves the existing native BV32 owner rather than inventing a second sorter, and rejects malformed typed constructors before emission.

## Scope and evidence

- Restacked from Keaton's exact one-commit head `1b3488f61a12a2e825ab1f62766790b5ebbb6b86` onto main `49f730e4a944df1a61914d627690d659fb58347b` as one commit.
- Exactly two files changed: `emitter.rs` and its crate-level tests in `lib.rs`; no files or tests deleted and no taxonomy/residual bucket added.
- Two discrimination teeth: nested associated-constant operands are BV32 and well-sorted; malformed BV32/string operands refuse rather than weakening to EUF.
- Keaton reported the full SMT-LIB crate suite 157/157 on the original exact head. Fresh battleaxe control on restacked head `d229e63870f92211ead16db6cca2a9ce8b2af035`: 157 passed, 0 failed, 0 ignored, 0 measured, 0 filtered out; both new teeth executed.
- Closing-account JSON remains present with SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

Predicted epsilon: the two bitflags SMT terminals move from ill-sorted/meaningless emission to native BV32 authority or a named refusal. No broader showcase verdict is claimed.
