### PR TITLE
Route captured callback mutation through temporal refusal

### DIFF
--- a/implementations/rust/sugar-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/lib.rs
@@ -5354,24 +5354,28 @@ impl TemporalScope {
     }
 
     pub(crate) fn temporal_rewrite_expr_for(&self, name: &str) -> Option<Expr> {
-        if self.alias_deref_mutation_needs_refusal(name) {
+        if self.temporal_rewrite_needs_refusal(name) {
             return None;
         }
         self.temporal_rewrite.borrow().expr_for(name)
     }
 
     pub(crate) fn temporal_rewrite_term_for(&self, name: &str) -> Option<Rc<Term>> {
-        if self.alias_deref_mutation_needs_refusal(name) {
+        if self.temporal_rewrite_needs_refusal(name) {
             return None;
         }
         self.temporal_rewrite.borrow().term_for(name)
     }
 
     pub(crate) fn temporal_rewrite_index_expr_for(&self, name: &str, index: usize) -> Option<Expr> {
-        if self.alias_deref_mutation_needs_refusal(name) {
+        if self.temporal_rewrite_needs_refusal(name) {
             return None;
         }
         self.temporal_rewrite.borrow().expr_for_index(name, index)
+    }
+
+    fn temporal_rewrite_needs_refusal(&self, name: &str) -> bool {
+        self.alias_deref_mutation_needs_refusal(name) || self.is_temporally_unstable_read(name)
     }
 
     pub(crate) fn unknown_iterator_consumption_reason(&self, name: &str) -> Option<String> {
@@ -22032,6 +22036,50 @@ mod lifter_key_tests {
             plan.alias_deref_mutated.contains("x"),
             "inline deref mutation must poison the base local, got {:?}",
             plan.alias_deref_mutated
+        );
+    }
+
+    #[test]
+    fn temporal_plan_seats_sorted_by_cached_key_captured_mutation_at_shared_owner() {
+        let f: syn::ItemFn = syn::parse_str(
+            r#"
+            fn sorted_by_cached_key_ncalls() {
+                let mut ncalls = 0;
+                let sorted = [3, 4, 1, 2]
+                    .iter()
+                    .cloned()
+                    .sorted_by_cached_key(|&x| {
+                        ncalls += 1;
+                        x.to_string()
+                    });
+                let collected: Vec<_> = sorted.collect();
+                assert_eq!(collected, vec![1, 2, 3, 4]);
+                assert_eq!(ncalls, 4);
+            }
+            "#,
+        )
+        .expect("test function parses");
+
+        let plan = temporal_plan_for_stmts(&f.block.stmts, &BTreeSet::new());
+
+        assert!(
+            plan.temporally_unstable.contains("ncalls"),
+            "sorted_by_cached_key captured mutation must be seated at the shared temporal owner: {:?}",
+            plan.temporally_unstable
+        );
+
+        let mut scope = TemporalScope::new("itertools::sorted_by_cached_key_ncalls", plan);
+        for stmt in f.block.stmts.iter().take(3) {
+            if let Stmt::Local(local) = stmt {
+                record_simple_value_binding(&mut scope, local);
+                scope.dispatch_temporal_rewrite_local(local);
+            }
+            advance_temporal_scope_for_stmt(stmt, &mut scope);
+        }
+        assert!(scope.is_temporally_unstable_read("ncalls"));
+        assert!(
+            scope.temporal_rewrite_expr_for("ncalls").is_none(),
+            "the shared temporal projection door must not serve the stale initializer for an unstable capture"
         );
     }
 

--- a/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
+++ b/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
@@ -32204,7 +32204,6 @@ fn while_loop_counter_read_replays_exact_bound() {
 // the call -- a post-call read lifts the initial literal, refuting a true assertion. The
 // read must REFUSE (temporally unstable). Refuse-only.
 #[test]
-#[ignore = "assertion_lift frontier: mutable-alias-state (#3026)"]
 fn closure_capture_mut_local_post_closure_read_refuses_not_false_refutation() {
     let src = r#"
         #[test]
@@ -32225,6 +32224,71 @@ fn closure_capture_mut_local_post_closure_read_refuses_not_false_refutation() {
             .iter()
             .any(|r| r.contains("temporally unstable post-loop read")),
         "a closure-captured mutated local read after the call must REFUSE: {:?}",
+        out.skip_reasons
+    );
+}
+
+#[test]
+fn sorted_by_cached_key_captured_mutation_reaches_temporal_refusal() {
+    let src = r#"
+        #[test]
+        fn sorted_by_cached_key_ncalls_4_exact_row() {
+            let mut ncalls = 0;
+            let sorted = [3, 4, 1, 2].iter().cloned().sorted_by_cached_key(|&x| {
+                ncalls += 1;
+                x.to_string()
+            });
+            let collected: Vec<_> = sorted.collect();
+            assert_eq!(collected, vec![1, 2, 3, 4]);
+            assert_eq!(ncalls, 4);
+        }
+    "#;
+    let out = lift_file(&parse(src), "examples/itertools-showcase/good/src/lib.rs");
+    let dump = format!("{:?}", out.decls);
+    assert!(
+        !(dump.contains("Int(0)") && dump.contains("Int(4)")),
+        "captured callback mutation must not seal the stale `0 == 4`: {dump}"
+    );
+    assert!(
+        out.skip_reasons.iter().any(|reason| {
+            reason.contains("temporally unstable post-loop read of `ncalls`")
+                && matches!(
+                    sugar_lift_rust_tests::refusal_disposition(reason),
+                    sugar_lift_rust_tests::Disposition::TerminalEffect
+                )
+        }),
+        "sorted_by_cached_key must reach the shared temporal captured-mutation refusal with exact owner `ncalls`: {:?}",
+        out.skip_reasons
+    );
+}
+
+#[test]
+fn sorted_by_cached_key_read_only_capture_does_not_over_refuse() {
+    let src = r#"
+        #[test]
+        fn sorted_by_cached_key_read_only() {
+            let offset = 1;
+            let sorted = [3, 4, 1, 2]
+                .iter()
+                .cloned()
+                .sorted_by_cached_key(|&x| x + offset);
+            let _: Vec<_> = sorted.collect();
+            assert_eq!(offset, 1);
+        }
+    "#;
+    let out = lift_file(&parse(src), "coretests/loop/closure_readonly.rs");
+    assert!(
+        out.skip_reasons.iter().all(|reason| {
+            !(reason.contains("temporally unstable post-loop read") && reason.contains("offset"))
+        }),
+        "a read-only callback capture must stay outside the mutation refusal: {:?}",
+        out.skip_reasons
+    );
+    assert!(
+        out.assertions_lifted >= 1,
+        "the read-only capture remains a constructed literal assertion: lifted={} refused={} skips={:?}",
+        out.assertions_lifted,
+        out.assertions_refused,
         out.skip_reasons
     );
 }


### PR DESCRIPTION
## Summary

Route temporally unstable closure captures through the one shared temporal projection door before any expression, term, or index projection can serve a stale initializer.

The live itertools row mutates `ncalls` inside `sorted_by_cached_key`. The temporal plan already owned that fact, but `temporal_rewrite_expr_for` still returned `0`, so the assertion sealed the false conjunction `1=1 AND 0=4`. The projection door now declines all temporally unstable reads, allowing the existing bound-path owner to emit the named `temporally unstable post-loop read of ncalls` refusal.

This does not add callback-cardinality semantics and does not special-case `sorted_by_cached_key`. A read-only callback twin still constructs, and the pre-existing ignored `.inspect` captured-mutation tooth is now active.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | 0 | no new construction semantics; a stale projection is removed |
| `mandatory_panics` | 0 | no construction-panic path changes |
| `suppressed_descendants` | 0 | no descendant suppression added |
| `typed_effects` | +1 | the itertools `ncalls` read reaches its existing temporal refusal |
| `silent` | 0 | floor: the false `0=4` testimony becomes loud |

Focused axis: `R_false_refutation(sorted_by_cached_key_ncalls)` is predicted 1 -> 0. Callback-cardinality construction remains unclaimed.

## Validation

Revalidated after restack onto base `d88435c09fe4f603a6bcaaf5866de2d4f16fa730`; head `260b2f0cbcf86d25231338ff35e1583f0546d34c`.

- RED before repair: shared projection-door tooth, 0 passed / 1 failed, exit 101; the door served the stale initializer.
- RED before repair: callback discrimination family, unsafe arm alone failed with `1=1 AND 0=4`; plan-owner and read-only arms passed.
- `../../bin/bcargo test -p sugar-lift-rust-tests --test assertion_lift closure_capture -- --nocapture`: 2 passed / 0 failed, exit 0.
- `../../bin/bcargo test -p sugar-lift-rust-tests sorted_by_cached_key_ -- --nocapture`: 3 passed / 0 failed, exit 0.
- `cargo fmt --all -- --check`: exit 0.
- `git diff --check HEAD^`: exit 0.

The full itertools showcase was launched through `bin/brun`, but it never reached execution: `sugarbin` looped reclaiming a stale/missing `rust_test_assertions_rpc` rebuild-lock PID (`heartbeat_age_s=999999`). I stopped only that invocation. This is explicitly no showcase verdict.

## Floors preserved

- `silent=0`: stale initializer testimony is refused by name.
- No default value, callback-method allowlist, or second mutation predicate.
- No test deleted for green; one ignored regression tooth was activated.
- No claim that callback cardinality is constructed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse temporal rewrite for captured callback mutations via `temporal_rewrite_needs_refusal`
> - Adds a new `temporal_rewrite_needs_refusal` helper on `TemporalScope` that returns true if a name has either an alias-deref mutation or a temporally unstable read, centralizing the refusal predicate.
> - Updates `temporal_rewrite_expr_for`, `temporal_rewrite_term_for`, and `temporal_rewrite_index_expr_for` to use this unified predicate, so all three now return `None` for temporally unstable reads (e.g. variables mutated inside a `.sorted_by_cached_key` callback).
> - Enables the previously ignored `closure_capture_mut_local_post_closure_read_refuses_not_false_refutation` test and adds two new integration tests covering the mutating-capture and read-only-capture cases.
> - Behavioral Change: names that are temporally unstable reads now cause temporal rewrite getters to refuse, where previously only alias-deref mutation triggered refusal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 260b2f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->