### PR TITLE
Keep authenticated demand derivation alive across CAS publication refusal

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1213,7 +1213,16 @@ def main() -> int:
                 f"RECENSUS DEMAND_TABLE wrote path={write_path} "
                 f"contentCid={table.content_cid}"
             )
-            publish_demand_table(table, write_path)
+            try:
+                publish_demand_table(table, write_path)
+            except DemandTableArtifactRefusal as refuse:
+                # Derivation is authenticated product input; CAS publication
+                # is only a sharing optimisation. Keep the local table, but
+                # never claim it was published or install it as a cache hit.
+                _narrate(
+                    "RECENSUS DEMAND_TABLE CAS publication refused after "
+                    f"successful derivation; continuing locally: {refuse}"
+                )
             if temporary_path is not None:
                 temporary_path.unlink(missing_ok=True)
             refs = install_prebuilt_demand_table(table, root=workspace_root)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -514,7 +514,11 @@ def validate_shared_demand_table(payload: dict, *, expected_content_key: str) ->
 
 
 def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
-    """Pull #6464's exact table read-only; never build or publish one."""
+    """Resolve the shared table, deriving authentically on a CAS miss.
+
+    A miss is slow but honest: the authenticated producer is the fallback.
+    Corrupt/private-shelf errors remain loud refusals and never fall through.
+    """
     import json
     import os
     import subprocess
@@ -544,6 +548,38 @@ def pull_shared_demand_table(repo_root: Path, output: Path) -> dict:
         check=False,
         env=environment,
     )
+    if completed.returncode == 1:
+        print(
+            "python-demand-table CAS miss: "
+            f"requested semantic key={SHARED_DEMAND_TABLE_CONTENT_KEY}; "
+            "falling back to authenticated derivation",
+            file=sys.stderr,
+            flush=True,
+        )
+        from .authenticated_pytest import authenticated_pandas_corpus
+        from .prebuilt_demand_table import (
+            mint_prebuilt_demand_table,
+            write_prebuilt_demand_table,
+        )
+
+        table = mint_prebuilt_demand_table(authenticated_pandas_corpus())
+        payload = {
+            "contentKey": table.semantic_identity.content_key,
+            "rows": list(table.rows),
+            "authentication": {
+                "python": AUTHENTICATED_RUNTIME,
+                "pandas": table.corpus_pin.version,
+                "authenticatedCorpusManifestCid": table.corpus_pin.aggregate_hash,
+            },
+            "identity": {
+                "corpusManifestCid": table.corpus_pin.aggregate_hash,
+                "fileCount": table.corpus_pin.file_count,
+            },
+        }
+        output.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+        return validate_shared_demand_table(
+            payload, expected_content_key=table.semantic_identity.content_key,
+        )
     if completed.returncode != 0 or not output.is_file():
         raise DemandTableRefusal(
             "the exact shared python-demand-table is unavailable; await its "

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -118,6 +118,7 @@ class PrebuiltDemandTableV1:
             "schema": self.schema,
             "corpusPin": self.corpus_pin.as_dict(),
             "rows": list(self.rows),
+            "semanticIdentity": self.semantic_identity.as_dict(),
         }
 
     def to_json_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Correct the prebuilt demand-table payload content CID: mint now hashes `table.preimage()`, the exact method validator authenticates. Semantic identity remains a separate field.
- Treat CAS publication refusal after a successful authenticated derivation as loud but non-fatal: do not install or claim a published artifact; continue with the locally derived table.
- On the legacy shared-table consumer, report the requested semantic key and fall back to authenticated derivation on a CAS miss.

## Evidence

- Fresh main base: `f6fd5bb88cd8a909cabdae43b8773fd13ca57212`.
- Authenticated battleaxe tooth: `test_validator_accepts_current_table`, 1 passed, 10 deselected, exit 0, CPython 3.12.13 / pandas 3.0.3.
- This tooth exercises the invariant that mint output and validator recomputation agree; it previously caught the divergent preimage.
- `python -m py_compile` passed for all changed modules.
- `tools/showcase_bulk_refuse_class.py` remains present.
- Closing-account digest remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Non-claims

The publish-then-resolve and changed-key-miss cache arms are not yet measured on battleaxe. No cache hit, zero-walk, or negative-arm number is claimed here. Existing PR checks were green without exercising the authenticated content-CID invariant; the battleaxe tooth is the evidence for that invariant.
