### PR TITLE
Refresh refusal vocabulary after earned additions

### DIFF
--- a/tools/lift_refusal_vocabulary_census.json
+++ b/tools/lift_refusal_vocabulary_census.json
@@ -2,7 +2,7 @@
   "identity": "path + normalized text digest + duplicate ordinal; line is display only",
   "issue": "#3632",
   "law": "REFUSE is the verifier verb; lift outputs are reduced meaning or typed effects.",
-  "lift_output_backlog": 2269,
+  "lift_output_backlog": 2288,
   "occurrences": [
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/discharge_cli.py:523c0ad6c899be9b:1",
@@ -26,7 +26,7 @@
     },
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/lift_lsp.py:23fb4681f32f03df:1",
-      "line": 38,
+      "line": 55,
       "path": "implementations/python/sugar-build-witness/src/sugar_build_witness/lift_lsp.py",
       "reason": "witness builder reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -36,7 +36,7 @@
     },
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py:387495c1a847b274:1",
-      "line": 303,
+      "line": 347,
       "path": "implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py",
       "reason": "witness builder reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -46,7 +46,7 @@
     },
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py:c00e8507b151e816:1",
-      "line": 314,
+      "line": 358,
       "path": "implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py",
       "reason": "witness builder reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -56,7 +56,7 @@
     },
     {
       "key": "implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py:df6fb2c960db5d05:1",
-      "line": 299,
+      "line": 343,
       "path": "implementations/python/sugar-build-witness/src/sugar_build_witness/witness.py",
       "reason": "witness builder reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -136,7 +136,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:c6148629b10bd3d9:1",
-      "line": 557,
+      "line": 556,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -146,7 +146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py:cbbc07efb9f468e8:1",
-      "line": 488,
+      "line": 487,
       "path": "implementations/python/sugar-lift-py-pytest-witness/src/sugar_pytest_witness/lift_lsp.py",
       "reason": "pytest witness kit reads or reports prove-side verifier verdicts",
       "replacement": "keep verifier status vocabulary; do not use as lift output name",
@@ -316,7 +316,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:6d00f42e323dd52e:1",
-      "line": 300,
+      "line": 304,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -326,7 +326,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:76f002a1c742454d:1",
-      "line": 336,
+      "line": 340,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -336,7 +336,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:9ed74bff44bac48b:1",
-      "line": 341,
+      "line": 345,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -346,7 +346,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:ae7b4ed98193ab1d:1",
-      "line": 508,
+      "line": 512,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -356,7 +356,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:b42acd18a59455bb:1",
-      "line": 542,
+      "line": 546,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -366,7 +366,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py:cee7ba4291859b61:1",
-      "line": 460,
+      "line": 462,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/authenticated_pytest.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -386,7 +386,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:0b7c9a18c8e2c816:1",
-      "line": 450,
+      "line": 431,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -406,7 +406,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:25aa667ae594a8d1:1",
-      "line": 430,
+      "line": 411,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -416,7 +416,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:26a0b53a42f92ef5:1",
-      "line": 496,
+      "line": 477,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -426,7 +426,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:283cdffb594c5f12:1",
-      "line": 403,
+      "line": 387,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -436,7 +436,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:294f9425d7d9f5cf:1",
-      "line": 360,
+      "line": 346,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -446,7 +446,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:326c0b4c42e5b5f9:1",
-      "line": 490,
+      "line": 471,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -456,7 +456,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:341864487ff003a9:1",
-      "line": 518,
+      "line": 499,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -466,7 +466,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:3473dc4bd868b8b7:1",
-      "line": 224,
+      "line": 216,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -476,7 +476,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:38e38a3a648904b6:1",
-      "line": 290,
+      "line": 278,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -486,7 +486,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:38e38a3a648904b6:2",
-      "line": 409,
+      "line": 392,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -496,7 +496,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:3927d82403a9bb57:1",
-      "line": 232,
+      "line": 224,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -506,7 +506,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:40117616bf74d2d5:1",
-      "line": 265,
+      "line": 255,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -516,7 +516,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:43aa4b68e6b4a8fb:1",
-      "line": 459,
+      "line": 438,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -525,18 +525,8 @@
       "wire_marker": "internal-only"
     },
     {
-      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:4448e268d2f50c0b:1",
-      "line": 404,
-      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "\"one or more files refused functionsClean \"",
-      "wire_marker": "internal-only"
-    },
-    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:48a20294ad00d461:1",
-      "line": 475,
+      "line": 452,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -546,7 +536,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:4e8c936eccc7840a:1",
-      "line": 401,
+      "line": 385,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -556,7 +546,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:581137087253295c:1",
-      "line": 521,
+      "line": 502,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -566,7 +556,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:58aa1f6abe9357cf:1",
-      "line": 233,
+      "line": 225,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -576,7 +566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:633a476b97638d1e:1",
-      "line": 387,
+      "line": 371,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -586,7 +576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:72ad8f2ba476753d:1",
-      "line": 262,
+      "line": 252,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -596,7 +586,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:735de78bb41f600f:1",
-      "line": 322,
+      "line": 310,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -606,7 +596,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:73df118d5befa157:1",
-      "line": 273,
+      "line": 263,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -616,7 +606,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:73df118d5befa157:2",
-      "line": 417,
+      "line": 400,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -626,7 +616,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:83d5f03ba6dba388:1",
-      "line": 530,
+      "line": 511,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -636,7 +626,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:854defb7c9a65a3d:1",
-      "line": 226,
+      "line": 218,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -646,7 +636,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:89597a77e94d5303:1",
-      "line": 259,
+      "line": 249,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -656,7 +646,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:89597a77e94d5303:2",
-      "line": 287,
+      "line": 275,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -666,7 +656,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:89fe49eb35beae41:1",
-      "line": 515,
+      "line": 496,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -675,8 +665,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:8af9d873f7460955:1",
+      "line": 388,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"one or more files refused functionsClean \" \"(would be tautological clean%)\"",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:8ece1870c43e4aa1:1",
-      "line": 523,
+      "line": 504,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -686,7 +686,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:956ed26fd4ffb517:1",
-      "line": 513,
+      "line": 494,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -696,7 +696,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:a0fdc662aa26237d:1",
-      "line": 280,
+      "line": 268,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -706,7 +706,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:a50994cbec55ac99:1",
-      "line": 468,
+      "line": 445,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -716,7 +716,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:b4d63447cf23b44f:1",
-      "line": 410,
+      "line": 393,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -726,7 +726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:b776c0ed73d667ae:1",
-      "line": 225,
+      "line": 217,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -736,7 +736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:c44c29efcee4ad36:1",
-      "line": 391,
+      "line": 375,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -746,7 +746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:c9c788cf647344c9:1",
-      "line": 516,
+      "line": 497,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -756,7 +756,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:d134a7d7c852b17d:1",
-      "line": 421,
+      "line": 404,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -776,7 +776,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:d96fbe437717da53:1",
-      "line": 278,
+      "line": 266,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -786,7 +786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:df3badb48c22a691:1",
-      "line": 291,
+      "line": 279,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -796,7 +796,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:e0aa298aa7a7379f:1",
-      "line": 388,
+      "line": 372,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -806,7 +806,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:f18b6e0253bce21f:1",
-      "line": 267,
+      "line": 257,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -816,7 +816,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:fa072040e89ee659:1",
-      "line": 429,
+      "line": 410,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -826,7 +826,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py:fb242528bd026be2:1",
-      "line": 296,
+      "line": 284,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/c4/board_function_facts.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -946,7 +946,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py:aa9fae34782a4b03:1",
-      "line": 177,
+      "line": 185,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/demand_table_identity.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -976,7 +976,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:4d6dfc932785abc9:1",
-      "line": 284,
+      "line": 282,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -986,7 +986,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:5b6a49ad296497cf:1",
-      "line": 266,
+      "line": 264,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -996,7 +996,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:69c525740c848874:1",
-      "line": 340,
+      "line": 337,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1006,7 +1006,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:6f37f5208a9cb3dd:1",
-      "line": 307,
+      "line": 304,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1016,7 +1016,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:70ab45bc61822f20:1",
-      "line": 409,
+      "line": 406,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1026,7 +1026,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:8113597c30466169:1",
-      "line": 341,
+      "line": 338,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1036,7 +1036,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:95968d355e3c72a6:1",
-      "line": 384,
+      "line": 381,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1046,7 +1046,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:a397c6ec06cd75da:1",
-      "line": 322,
+      "line": 319,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1066,7 +1066,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:d8a3f899b66a652d:1",
-      "line": 400,
+      "line": 397,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1076,7 +1076,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py:f3d7104e7e87f773:1",
-      "line": 272,
+      "line": 270,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/desugar_axis.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1326,7 +1326,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:04768a62b9348346:1",
-      "line": 969,
+      "line": 967,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1336,7 +1336,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:0a60b9e9283c560b:1",
-      "line": 929,
+      "line": 927,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1346,7 +1346,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:151e94d813ebdcb4:1",
-      "line": 920,
+      "line": 918,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1376,7 +1376,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:3ef2b63bf4085cb7:1",
-      "line": 951,
+      "line": 949,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1386,7 +1386,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:47ca32290ca83d0d:1",
-      "line": 926,
+      "line": 924,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1396,7 +1396,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:52a4a4cf224c64da:1",
-      "line": 909,
+      "line": 907,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1406,7 +1406,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:7e6c839fad846b5f:1",
-      "line": 991,
+      "line": 989,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1416,7 +1416,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:b4ef46960d398f7a:1",
-      "line": 962,
+      "line": 960,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1426,7 +1426,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:c20dae017f95487e:1",
-      "line": 923,
+      "line": 921,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1436,7 +1436,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:1",
-      "line": 932,
+      "line": 930,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1446,7 +1446,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:2",
-      "line": 937,
+      "line": 935,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1456,7 +1456,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:3",
-      "line": 945,
+      "line": 943,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1466,7 +1466,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:4",
-      "line": 952,
+      "line": 950,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1476,7 +1476,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:5",
-      "line": 957,
+      "line": 955,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1486,7 +1486,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d0f289d1ced31436:6",
-      "line": 965,
+      "line": 963,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1496,7 +1496,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:d753c45130bb14e1:1",
-      "line": 990,
+      "line": 988,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1506,7 +1506,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:e9e27e8fd5e4ebc8:1",
-      "line": 917,
+      "line": 915,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1516,7 +1516,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:f587884b31c4c7b3:1",
-      "line": 914,
+      "line": 912,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1536,7 +1536,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py:f90d6079fcab7b08:1",
-      "line": 989,
+      "line": 987,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/call_site_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1566,7 +1566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:014ed6ca2eb38b70:1",
-      "line": 1015,
+      "line": 1011,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1576,7 +1576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:014ed6ca2eb38b70:2",
-      "line": 1035,
+      "line": 1031,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1586,7 +1586,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:014ed6ca2eb38b70:3",
-      "line": 1057,
+      "line": 1053,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1596,7 +1596,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:097a6f3b9574f919:1",
-      "line": 786,
+      "line": 782,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1606,7 +1606,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:0c4a488cb49b6fb9:1",
-      "line": 1034,
+      "line": 1030,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1616,7 +1616,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:1f3d5ea80364c8b5:1",
-      "line": 604,
+      "line": 600,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1626,7 +1626,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:222287dae6537994:1",
-      "line": 788,
+      "line": 784,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1636,7 +1636,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:223fedce4813d3cd:1",
-      "line": 1033,
+      "line": 1029,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1646,7 +1646,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:2be5be2ae1d38edf:1",
-      "line": 760,
+      "line": 756,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1656,7 +1656,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:6f8e1bc8d785f4a8:1",
-      "line": 1138,
+      "line": 1134,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1666,7 +1666,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:77199514ecd31f4c:1",
-      "line": 1118,
+      "line": 1114,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1676,7 +1676,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:79e1af0c73cca3c6:1",
-      "line": 1006,
+      "line": 1002,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1686,7 +1686,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8400f9d7c8e3699a:1",
-      "line": 1199,
+      "line": 1195,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1696,7 +1696,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8b57d4a8c516d4cb:1",
-      "line": 1016,
+      "line": 1012,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1706,7 +1706,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8b57d4a8c516d4cb:2",
-      "line": 1036,
+      "line": 1032,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1716,7 +1716,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:8b57d4a8c516d4cb:3",
-      "line": 1058,
+      "line": 1054,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1726,7 +1726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:9085c0f961c575f9:1",
-      "line": 1013,
+      "line": 1009,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1736,7 +1736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:9ca6e3b40ba1c89b:1",
-      "line": 1210,
+      "line": 1204,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1746,7 +1746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:9f8fb782071e5eff:1",
-      "line": 1014,
+      "line": 1010,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1756,7 +1756,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:1",
-      "line": 1200,
+      "line": 1209,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1766,7 +1766,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:2",
-      "line": 1215,
+      "line": 1214,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1776,17 +1776,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:3",
-      "line": 1220,
-      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "self._refuse_ordering_meaning(",
-      "wire_marker": "internal-only"
-    },
-    {
-      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:b392f5da7c480d6a:4",
-      "line": 1225,
+      "line": 1219,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1796,7 +1786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:bad65eb6fc982e50:1",
-      "line": 984,
+      "line": 980,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1806,7 +1796,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:bd6f605a6726dc83:1",
-      "line": 1054,
+      "line": 1050,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1816,7 +1806,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:be2d66f5d5448455:1",
-      "line": 1132,
+      "line": 1128,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1826,7 +1816,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:c5bd1246ec562325:1",
-      "line": 722,
+      "line": 718,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1836,7 +1826,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:d23f6b298ecf0095:1",
-      "line": 1056,
+      "line": 1052,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1846,7 +1836,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:d70314f1281e99b2:1",
-      "line": 606,
+      "line": 602,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1856,12 +1846,22 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:ee82ebb15531dc06:1",
-      "line": 758,
+      "line": 754,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "\"\"\"Refuse lookup when source testimony decides neither outgoing edge.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py:fa96bec06923f1f8:1",
+      "line": 1196,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/floor_value.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "self._refuse_ordering_meaning(other, site, owner=owner, operator=operator)",
       "wire_marker": "internal-only"
     },
     {
@@ -1946,7 +1946,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:449ae530d9a1ba6e:1",
-      "line": 100,
+      "line": 99,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1956,7 +1956,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:646e7800f5893f01:1",
-      "line": 113,
+      "line": 112,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1966,7 +1966,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:88101b621c1ba63e:1",
-      "line": 70,
+      "line": 69,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1976,7 +1976,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:a7562b951727a20d:1",
-      "line": 245,
+      "line": 243,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1986,7 +1986,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:1",
-      "line": 122,
+      "line": 121,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -1996,7 +1996,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:2",
-      "line": 132,
+      "line": 131,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2006,7 +2006,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:3",
-      "line": 140,
+      "line": 139,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2016,7 +2016,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:4",
-      "line": 153,
+      "line": 152,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2026,7 +2026,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:5",
-      "line": 174,
+      "line": 173,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2036,7 +2036,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:6",
-      "line": 191,
+      "line": 189,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2046,7 +2046,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:7",
-      "line": 201,
+      "line": 199,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2056,7 +2056,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:8",
-      "line": 250,
+      "line": 248,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2066,7 +2066,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py:f675bca19fbd3be4:9",
-      "line": 265,
+      "line": 263,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/raise_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2106,7 +2106,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py:55fb783f8b4f40db:1",
-      "line": 185,
+      "line": 179,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/single_outcome_law.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2116,7 +2116,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py:02a79529f205debd:1",
-      "line": 889,
+      "line": 887,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2136,7 +2136,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py:c45c1c27b7a6bbe2:1",
-      "line": 164,
+      "line": 162,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/string_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2146,7 +2146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:1dca8e80578ea2e3:1",
-      "line": 493,
+      "line": 494,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2156,7 +2156,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:651f6d80c8419d84:1",
-      "line": 423,
+      "line": 424,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2166,7 +2166,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:7088ff30703d0b15:1",
-      "line": 292,
+      "line": 293,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2176,7 +2176,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:8cc50d540607ff56:1",
-      "line": 422,
+      "line": 423,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2186,7 +2186,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:9b4d57b0a72a9592:1",
-      "line": 452,
+      "line": 453,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2196,7 +2196,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:c422df5c1b61696b:1",
-      "line": 436,
+      "line": 437,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2216,7 +2216,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py:ebd7d649ff1ee053:1",
-      "line": 424,
+      "line": 425,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/symbolic_value.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2246,7 +2246,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:3425b04fdb7bd5bd:1",
-      "line": 607,
+      "line": 605,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2256,7 +2256,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:35f3e4ba5d60b6b4:1",
-      "line": 1748,
+      "line": 1750,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2266,7 +2266,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:4daf0549501d8b9c:1",
-      "line": 1660,
+      "line": 1662,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2276,7 +2276,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:c8e40750987fe993:1",
-      "line": 1714,
+      "line": 1716,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2286,7 +2286,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:c8e40750987fe993:2",
-      "line": 1756,
+      "line": 1758,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2296,7 +2296,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py:fae78461a067e48f:1",
-      "line": 1132,
+      "line": 1123,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/generator_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2346,7 +2346,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py:15073bbd52fe928d:1",
-      "line": 206,
+      "line": 203,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py",
       "reason": "IDD instrument code names an existing frontier or vocabulary row",
       "replacement": "keep until the named frontier row is retired by its owning migration",
@@ -2366,7 +2366,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py:356079d78bc76fef:1",
-      "line": 214,
+      "line": 211,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/builtin_closed_operation_instrument.py",
       "reason": "IDD instrument code names an existing frontier or vocabulary row",
       "replacement": "keep until the named frontier row is retired by its owning migration",
@@ -2376,7 +2376,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py:59710ed00feae821:1",
-      "line": 191,
+      "line": 189,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py",
       "reason": "IDD instrument code names an existing frontier or vocabulary row",
       "replacement": "keep until the named frontier row is retired by its owning migration",
@@ -2386,7 +2386,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py:90781b569bc76cc1:1",
-      "line": 194,
+      "line": 192,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py",
       "reason": "IDD instrument code names an existing frontier or vocabulary row",
       "replacement": "keep until the named frontier row is retired by its owning migration",
@@ -2406,7 +2406,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py:9252c1601584e790:2",
-      "line": 169,
+      "line": 167,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/idd/instrument_scan_scope.py",
       "reason": "IDD instrument code names an existing frontier or vocabulary row",
       "replacement": "keep until the named frontier row is retired by its owning migration",
@@ -2446,7 +2446,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py:09961c171f1219e0:1",
-      "line": 1361,
+      "line": 1360,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2456,7 +2456,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py:37dc335fa59b8e9d:1",
-      "line": 1166,
+      "line": 1169,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2486,7 +2486,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py:123afe61f95c8711:1",
-      "line": 2533,
+      "line": 2506,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2496,12 +2496,22 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py:f14d9df53d963944:1",
-      "line": 2546,
+      "line": 2519,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "# FunctionBindingMiss is named refuse (gap above); unfinished",
+      "wire_marker": "wire-protocol:rpc-dto"
+    },
+    {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py:f77a51a32018af76:1",
+      "line": 2632,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "# applied callee after its abstract universe refused.",
       "wire_marker": "wire-protocol:rpc-dto"
     },
     {
@@ -2516,7 +2526,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:21668c5aae4e776c:1",
-      "line": 335,
+      "line": 332,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2526,7 +2536,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:28b1af74dd98992f:1",
-      "line": 337,
+      "line": 334,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2546,7 +2556,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:4157ea11475d3e78:1",
-      "line": 341,
+      "line": 338,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2556,7 +2566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:4231ea48240f655c:1",
-      "line": 331,
+      "line": 328,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2586,7 +2596,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:58546381542848eb:1",
-      "line": 515,
+      "line": 512,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2626,7 +2636,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:6639b28578941d83:1",
-      "line": 484,
+      "line": 481,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2636,7 +2646,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:6639b28578941d83:2",
-      "line": 510,
+      "line": 507,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2646,7 +2656,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:6639b28578941d83:3",
-      "line": 551,
+      "line": 584,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2656,7 +2666,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:67f369a675678b25:1",
-      "line": 777,
+      "line": 809,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2676,7 +2686,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:79ff1c01b71dd967:1",
-      "line": 404,
+      "line": 401,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2686,7 +2696,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:86d79b609dc0c0f0:1",
-      "line": 388,
+      "line": 385,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2716,7 +2726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:9de429e19b194d6e:1",
-      "line": 403,
+      "line": 400,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2726,7 +2736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:9de429e19b194d6e:2",
-      "line": 456,
+      "line": 453,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2736,7 +2746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:a488d0d6eba73ac1:1",
-      "line": 342,
+      "line": 339,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2745,8 +2755,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:a6f4b2fd42942355:1",
+      "line": 520,
+      "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Corrupt/private-shelf errors remain loud refusals and never fall through.",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:b9eb397d2c04434f:1",
-      "line": 798,
+      "line": 830,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2766,7 +2786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:e26356181b8ea8da:1",
-      "line": 395,
+      "line": 392,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2786,7 +2806,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py:fc2ca3e0a20aa1e8:1",
-      "line": 457,
+      "line": 454,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2846,7 +2866,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:0ccc14caa49a9811:1",
-      "line": 1215,
+      "line": 1202,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2856,7 +2876,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:1fd0e343568c2ffd:1",
-      "line": 1113,
+      "line": 1102,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2876,7 +2896,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:5704e70627417bb5:1",
-      "line": 215,
+      "line": 213,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2886,7 +2906,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:637604514bc524a0:1",
-      "line": 253,
+      "line": 251,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2896,7 +2916,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:74f7df15f1d90137:1",
-      "line": 140,
+      "line": 138,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2906,7 +2926,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:877c3635ffe0adde:1",
-      "line": 1151,
+      "line": 1138,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2916,7 +2936,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:c5b1ad8a560dc1a6:1",
-      "line": 338,
+      "line": 334,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2926,7 +2946,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py:d1856b0d998ccf78:1",
-      "line": 609,
+      "line": 605,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/outcome/exit_set.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -2996,7 +3016,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:0b5985d13548f26e:1",
-      "line": 217,
+      "line": 221,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3006,7 +3026,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:1372a1203cdbcd79:1",
-      "line": 39,
+      "line": 42,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3016,7 +3036,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:1",
-      "line": 73,
+      "line": 76,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3026,7 +3046,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:2",
-      "line": 145,
+      "line": 149,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3036,7 +3056,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:3",
-      "line": 225,
+      "line": 229,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3046,7 +3066,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:4",
-      "line": 232,
+      "line": 236,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3056,7 +3076,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:5",
-      "line": 238,
+      "line": 242,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3066,7 +3086,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:6",
-      "line": 245,
+      "line": 251,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3076,7 +3096,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:7",
-      "line": 271,
+      "line": 277,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3086,7 +3106,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:372049189bc611df:8",
-      "line": 276,
+      "line": 282,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3096,7 +3116,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:38425ae473b3a954:1",
-      "line": 161,
+      "line": 165,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3106,7 +3126,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:3c7f44f9c26debaf:1",
-      "line": 236,
+      "line": 240,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3116,7 +3136,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:5cc5b034c9fcf94e:1",
-      "line": 249,
+      "line": 255,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3126,7 +3146,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py:c43f6ace2372766f:1",
-      "line": 43,
+      "line": 46,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3176,7 +3196,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py:630ce0604f1447b7:1",
-      "line": 260,
+      "line": 254,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/assign_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3216,7 +3236,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py:79d8e493db3bb466:1",
-      "line": 145,
+      "line": 143,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/bool_op_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3246,7 +3266,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py:90353a4441ceadc9:1",
-      "line": 267,
+      "line": 265,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3256,7 +3276,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py:912964f7d373d528:1",
-      "line": 294,
+      "line": 292,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comparison_op_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3266,7 +3286,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py:ad070fe5a08665b1:1",
-      "line": 181,
+      "line": 183,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3286,7 +3306,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py:bea61a3423aa2c50:2",
-      "line": 153,
+      "line": 152,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/delete_effect_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3476,7 +3496,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py:c5bd5f1b169a0198:1",
-      "line": 256,
+      "line": 258,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/if_exp_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3506,7 +3526,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py:a13950695d96a694:1",
-      "line": 233,
+      "line": 235,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/loop_recurrence_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3516,7 +3536,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py:26032a49a0853eb5:1",
-      "line": 224,
+      "line": 222,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3526,7 +3546,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py:cc790522d233713c:1",
-      "line": 186,
+      "line": 184,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/store_effect_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3536,7 +3556,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py:2c273edaff275c7c:1",
-      "line": 87,
+      "line": 88,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3546,7 +3566,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py:95521f0f92d8e128:1",
-      "line": 130,
+      "line": 131,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3556,7 +3576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py:ea69fdb81baa3154:1",
-      "line": 88,
+      "line": 89,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/subscript_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3566,7 +3586,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py:9c2080f840690fe3:1",
-      "line": 204,
+      "line": 195,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/try_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3696,7 +3716,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:13b666fe428cc124:1",
-      "line": 436,
+      "line": 434,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3706,7 +3726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:13b666fe428cc124:2",
-      "line": 652,
+      "line": 646,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3716,7 +3736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:2849c571ed835ff7:1",
-      "line": 327,
+      "line": 325,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3726,7 +3746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:3a16ae849bf31836:1",
-      "line": 449,
+      "line": 447,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3736,7 +3756,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:3a16ae849bf31836:2",
-      "line": 666,
+      "line": 660,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3746,7 +3766,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:42874e751b4ad31d:1",
-      "line": 620,
+      "line": 614,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3756,7 +3776,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:528baeae4085e7ca:1",
-      "line": 553,
+      "line": 547,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3766,7 +3786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:8a5e0a2e722421ff:1",
-      "line": 443,
+      "line": 441,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3776,7 +3796,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:9777334dbe6ea2a9:1",
-      "line": 448,
+      "line": 446,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3786,7 +3806,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:9777334dbe6ea2a9:2",
-      "line": 665,
+      "line": 659,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3796,7 +3816,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py:a9cbdf3c915862ed:1",
-      "line": 355,
+      "line": 353,
       "path": "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_effect_boundary_sugar.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3866,7 +3886,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py:c396e5a13b340b87:1",
-      "line": 1145,
+      "line": 1146,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -3876,7 +3896,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py:b9b6d4181fa5afd5:1",
-      "line": 299,
+      "line": 295,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4556,7 +4576,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:0553a9949395cd41:1",
-      "line": 3707,
+      "line": 3703,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4576,7 +4596,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:1673171b377490e8:1",
-      "line": 2553,
+      "line": 2549,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4586,7 +4606,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:1ea1d4d29dd68d6f:1",
-      "line": 3237,
+      "line": 3233,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4616,7 +4636,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:53eaeb8bde078c42:1",
-      "line": 2494,
+      "line": 2490,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4626,7 +4646,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:9412ef956d9669dc:1",
-      "line": 3473,
+      "line": 3469,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4636,7 +4656,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:a968c2eba845a3c9:1",
-      "line": 3475,
+      "line": 3471,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4656,7 +4676,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:bff2cd54205fddf8:1",
-      "line": 3463,
+      "line": 3459,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4676,7 +4696,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py:f2bc5070b6d703a6:1",
-      "line": 3718,
+      "line": 3714,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4686,7 +4706,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:1b2ca43f4358ed18:1",
-      "line": 859,
+      "line": 860,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4696,7 +4716,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:2af518ea5e2321d3:1",
-      "line": 676,
+      "line": 677,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4706,7 +4726,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:2ca0c0961ffe4388:1",
-      "line": 680,
+      "line": 681,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4716,7 +4736,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:469fa3ea564fc627:1",
-      "line": 683,
+      "line": 684,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4726,7 +4746,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:4e9a53fbeff54a09:1",
-      "line": 682,
+      "line": 683,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4756,7 +4776,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:ab3e2e00b9e65a9a:1",
-      "line": 673,
+      "line": 674,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4766,7 +4786,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:f17b99e33b4bc636:1",
-      "line": 707,
+      "line": 708,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4776,7 +4796,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py:ff8d7c67ee7b3ac9:1",
-      "line": 706,
+      "line": 707,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_protocol_construction.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4796,7 +4816,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:0bc688431d63f096:1",
-      "line": 2148,
+      "line": 2207,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4806,7 +4826,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:0d9315daa5f1315b:1",
-      "line": 1474,
+      "line": 1483,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4816,7 +4836,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:1946ce2a22d311ed:1",
-      "line": 2884,
+      "line": 2943,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4826,7 +4846,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:51190fab5a030c33:1",
-      "line": 2854,
+      "line": 2913,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4845,8 +4865,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:a21b4f4c0d48b565:1",
+      "line": 1295,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"supplied; refusing to infer an enrolled population from a path segment\"",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b1899d1ce1f39bdf:1",
-      "line": 2250,
+      "line": 2312,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4866,7 +4896,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b376f4cbc6f0ada9:1",
-      "line": 1586,
+      "line": 1595,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4876,7 +4906,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py:b4610bd089aa39f4:1",
-      "line": 1569,
+      "line": 1578,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -4912,6 +4942,26 @@
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "(``not``, equality, subscript, f-string parts). That refusal is not",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py:37ee712d35b21fda:1",
+      "line": 342,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"\"\"Return the caller's authoritative session; refuse unknown authority.",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py:6d49338c354cb38d:1",
+      "line": 57,
+      "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "and refuses; it is not permission for any owner to invent a roster.",
       "wire_marker": "internal-only"
     },
     {
@@ -5046,7 +5096,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:0ea9d3db9fed818c:1",
-      "line": 246,
+      "line": 248,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5056,7 +5106,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:a73ac5bc57ddf363:1",
-      "line": 243,
+      "line": 245,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5066,7 +5116,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:c4829d099c3b9db1:1",
-      "line": 456,
+      "line": 458,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5076,7 +5126,7 @@
     },
     {
       "key": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py:eae51ec3ab0e5a96:1",
-      "line": 500,
+      "line": 502,
       "path": "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/value_pins.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5586,7 +5636,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:215eef637af9edd2:1",
-      "line": 1611,
+      "line": 1614,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5596,7 +5646,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:5962e02588c357e8:1",
-      "line": 855,
+      "line": 858,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5606,7 +5656,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:6e245b1560265270:1",
-      "line": 764,
+      "line": 767,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5616,7 +5666,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:8ca21c4bce69537d:1",
-      "line": 783,
+      "line": 786,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5626,7 +5676,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:94ae1f20c0ecb1d4:1",
-      "line": 782,
+      "line": 785,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5636,7 +5686,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:ba6253a3338b129b:1",
-      "line": 815,
+      "line": 818,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5646,7 +5696,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py:e8b3c1a5422ae4d5:1",
-      "line": 781,
+      "line": 784,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5656,7 +5706,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py:09e8084ac43dc487:1",
-      "line": 159,
+      "line": 161,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/loop_recurrence.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5686,7 +5736,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:5ea9ab078e85df21:1",
-      "line": 7406,
+      "line": 7405,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5696,7 +5746,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:61d89ff95e22609b:1",
-      "line": 7405,
+      "line": 7404,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5706,7 +5756,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:81c4e60ad47fa407:1",
-      "line": 5417,
+      "line": 5418,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5716,7 +5766,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:8f560ad01639115f:1",
-      "line": 10845,
+      "line": 10844,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5736,7 +5786,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:acab81ce0a110325:1",
-      "line": 11594,
+      "line": 11593,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5746,7 +5796,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:b58fd98676fd6590:1",
-      "line": 9567,
+      "line": 9566,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5756,7 +5806,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:ca5b1d622d4c3c1a:1",
-      "line": 7298,
+      "line": 7297,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5776,7 +5826,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py:e88ffe25d18e5725:1",
-      "line": 5339,
+      "line": 5340,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5786,7 +5836,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:116b130b61766434:1",
-      "line": 55,
+      "line": 54,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5796,7 +5846,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:6fd8120daf6ceec6:1",
-      "line": 117,
+      "line": 116,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5806,7 +5856,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:8326e56ae05b594d:1",
-      "line": 115,
+      "line": 114,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5816,7 +5866,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:97d107d5b3fa2542:1",
-      "line": 114,
+      "line": 113,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -5826,7 +5876,7 @@
     },
     {
       "key": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py:b5142fbc575d5c9a:1",
-      "line": 122,
+      "line": 121,
       "path": "implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7606,7 +7656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:00c1ea334cb863ad:1",
-      "line": 8738,
+      "line": 9568,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7616,7 +7666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:01f2c62991873873:1",
-      "line": 8847,
+      "line": 9677,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7626,7 +7676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:02a88599a318f556:1",
-      "line": 7992,
+      "line": 8822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7636,7 +7686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:06ccd998b11dcf55:1",
-      "line": 7810,
+      "line": 8640,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7646,7 +7696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:0897ee0c7cf8f5f5:1",
-      "line": 3108,
+      "line": 3599,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7656,7 +7706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:09bc97bec1fcde1f:1",
-      "line": 515,
+      "line": 554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7666,7 +7716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:0c11991598d805bb:1",
-      "line": 7535,
+      "line": 8365,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7676,7 +7726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:0c19e2c67405c640:1",
-      "line": 3101,
+      "line": 3592,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7686,7 +7736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:0e7eff390e5f11d0:1",
-      "line": 7429,
+      "line": 8259,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7696,7 +7746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:0f8aa012da32bb46:1",
-      "line": 503,
+      "line": 542,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7706,7 +7756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:11daeefc03513447:1",
-      "line": 8683,
+      "line": 9513,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7716,7 +7766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:145e4fc26bc53766:1",
-      "line": 252,
+      "line": 254,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7726,7 +7776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:148bcafbf4169955:1",
-      "line": 8032,
+      "line": 8862,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7736,7 +7786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:151bbf7b7f448a2c:1",
-      "line": 7602,
+      "line": 8432,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7746,7 +7796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:15ec4b7675494093:1",
-      "line": 7627,
+      "line": 8457,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7756,7 +7806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:168d3213611ef260:1",
-      "line": 8678,
+      "line": 9508,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7766,7 +7816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:173871b5529841f2:1",
-      "line": 8017,
+      "line": 8847,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7776,7 +7826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:18c854128b190659:1",
-      "line": 3481,
+      "line": 3972,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7786,7 +7836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:1aead6354bfff76c:1",
-      "line": 6574,
+      "line": 7404,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7796,7 +7846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:1be009e2750c5849:1",
-      "line": 7031,
+      "line": 7861,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7806,7 +7856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:1c9c73a640decca1:1",
-      "line": 6875,
+      "line": 7705,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7816,7 +7866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:1e9367445933e494:1",
-      "line": 4334,
+      "line": 4825,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7826,7 +7876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:1f669a4867925235:1",
-      "line": 7604,
+      "line": 8434,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7836,7 +7886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:1fd62bb80330cbc9:1",
-      "line": 5863,
+      "line": 6372,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7846,7 +7896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2029a19d14ca57db:1",
-      "line": 8667,
+      "line": 9497,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7856,7 +7906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:204c5a40bece5671:1",
-      "line": 8311,
+      "line": 9141,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7866,7 +7916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:208ca7e859d02c12:1",
-      "line": 9174,
+      "line": 10004,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7876,7 +7926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:21545eb90cad5d53:1",
-      "line": 7205,
+      "line": 8035,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7886,7 +7936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:275093312fbf3631:1",
-      "line": 8714,
+      "line": 9544,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7896,7 +7946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:28c97874a02342e8:1",
-      "line": 6953,
+      "line": 7783,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7906,7 +7956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:298f0251d86bfdbe:1",
-      "line": 3255,
+      "line": 3746,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7916,7 +7966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:298f0251d86bfdbe:2",
-      "line": 4033,
+      "line": 4524,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7926,7 +7976,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2c8e8aa56e7196aa:1",
-      "line": 8647,
+      "line": 9477,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7936,7 +7986,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2cabb1845dbc307d:1",
-      "line": 8736,
+      "line": 9566,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7946,7 +7996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2d61fdd5bf0819a0:1",
-      "line": 8701,
+      "line": 9531,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7956,7 +8006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2e062f33e7a3f753:1",
-      "line": 7648,
+      "line": 8478,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7966,7 +8016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2e4f26c105ce27db:1",
-      "line": 4019,
+      "line": 4510,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7976,7 +8026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:2f52e2c611aa6d6f:1",
-      "line": 7580,
+      "line": 8410,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7986,7 +8036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:31fbccce2fd411cd:1",
-      "line": 7511,
+      "line": 8341,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -7996,7 +8046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:321591cd95fbb4e1:1",
-      "line": 8807,
+      "line": 9637,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8006,7 +8056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3352b923866ca687:1",
-      "line": 7082,
+      "line": 7912,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8016,7 +8066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3415fdadb9174cbd:1",
-      "line": 8319,
+      "line": 9149,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8026,7 +8076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:37497c778c78cf2b:1",
-      "line": 6945,
+      "line": 7775,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8036,7 +8086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:38c0d2112608fd43:1",
-      "line": 7931,
+      "line": 8761,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8046,7 +8096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:396ce19160de98c6:1",
-      "line": 3486,
+      "line": 3977,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8056,7 +8106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3b49d50d672f6910:1",
-      "line": 4447,
+      "line": 4938,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8066,7 +8116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3c5faaee4e1389d8:1",
-      "line": 509,
+      "line": 548,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8076,7 +8126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3c782258a058051a:1",
-      "line": 5865,
+      "line": 6374,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8086,7 +8136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3c782258a058051a:2",
-      "line": 5870,
+      "line": 6379,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8096,7 +8146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3d746a0fb2757bb1:1",
-      "line": 7952,
+      "line": 8782,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8106,7 +8156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3d9cd3fcb5c02879:1",
-      "line": 7589,
+      "line": 8419,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8116,7 +8166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3dc5eb55b0c358ba:1",
-      "line": 607,
+      "line": 646,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8126,7 +8176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:3f882c604fb224f6:1",
-      "line": 7457,
+      "line": 8287,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8136,7 +8186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:410f3f514c90a714:1",
-      "line": 7530,
+      "line": 8360,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8146,7 +8196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:411e4224dc5a7ef5:1",
-      "line": 7045,
+      "line": 7875,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8156,7 +8206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:411e4224dc5a7ef5:2",
-      "line": 7179,
+      "line": 8009,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8166,7 +8216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:411e4224dc5a7ef5:3",
-      "line": 7201,
+      "line": 8031,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8176,7 +8226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:41d13c7b74f95cf3:1",
-      "line": 4317,
+      "line": 4808,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8186,7 +8236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4258b9204214ebf6:1",
-      "line": 7432,
+      "line": 8262,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8196,7 +8246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:42d17044f6d70960:1",
-      "line": 8455,
+      "line": 9285,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8206,7 +8256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:45150935994e57c5:1",
-      "line": 5501,
+      "line": 6010,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8216,7 +8266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:46387bdf2146ce56:1",
-      "line": 8482,
+      "line": 9312,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8226,7 +8276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4677f9cb73c4bb36:1",
-      "line": 7041,
+      "line": 7871,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8236,7 +8286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:485bbfce70a57321:1",
-      "line": 8131,
+      "line": 8961,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8246,7 +8296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:490f36b2e927e9fa:1",
-      "line": 5868,
+      "line": 6377,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8256,7 +8306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4a373a5bf346b178:1",
-      "line": 7634,
+      "line": 8464,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8266,7 +8316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4ad40a401223ffc5:1",
-      "line": 3004,
+      "line": 3495,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8276,7 +8326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4ad40a401223ffc5:2",
-      "line": 4551,
+      "line": 5042,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8286,7 +8336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4caf52a4435e6e9a:1",
-      "line": 7750,
+      "line": 8580,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8296,7 +8346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:4f93eb313ba04ac3:1",
-      "line": 623,
+      "line": 662,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8306,7 +8356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:52954baed48c1c7c:1",
-      "line": 7870,
+      "line": 8700,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8316,7 +8366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:52cbed418c2653fc:1",
-      "line": 7862,
+      "line": 8692,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8326,7 +8376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:5400aeb4105abf49:1",
-      "line": 9153,
+      "line": 9983,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8336,7 +8386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:54f710fc18346249:1",
-      "line": 4622,
+      "line": 5113,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8346,7 +8396,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:55396a475fafa2d2:1",
-      "line": 3181,
+      "line": 3672,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8356,7 +8406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:5709917b3ccf9ec9:1",
-      "line": 7899,
+      "line": 8729,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8366,7 +8416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:58213abafb3949f3:1",
-      "line": 7619,
+      "line": 8449,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8376,7 +8426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:5aa5c002632cb10e:1",
-      "line": 7897,
+      "line": 8727,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8386,7 +8436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:5e32c56f1a5e6828:1",
-      "line": 3469,
+      "line": 3960,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8396,7 +8446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:5f1716407af17fee:1",
-      "line": 2936,
+      "line": 3427,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8406,7 +8456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:5f94955c13c2a950:1",
-      "line": 3100,
+      "line": 3591,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8416,7 +8466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6030d3728a826c11:1",
-      "line": 588,
+      "line": 627,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8426,7 +8476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:60b52502d9b81cf3:1",
-      "line": 7000,
+      "line": 7830,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8436,7 +8486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:64be959f0dbba82c:1",
-      "line": 7846,
+      "line": 8676,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8446,7 +8496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6833417870277c41:1",
-      "line": 8814,
+      "line": 9644,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8456,7 +8506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:69fbf2d82ca8a8b7:1",
-      "line": 8117,
+      "line": 8947,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8466,7 +8516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6aeb2a683edfb2d6:1",
-      "line": 8829,
+      "line": 9659,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8476,7 +8526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6ba6a3159c06e9f7:1",
-      "line": 4061,
+      "line": 4552,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8486,7 +8536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6c85a8280a8a1ee8:1",
-      "line": 7715,
+      "line": 8545,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8496,7 +8546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6cd2a4a558389cd8:1",
-      "line": 500,
+      "line": 539,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8506,7 +8556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6d918ad6a77e74a8:1",
-      "line": 6885,
+      "line": 7715,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8516,7 +8566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6dd778f47096540b:1",
-      "line": 7967,
+      "line": 8797,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8526,7 +8576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6ded4939158673cb:1",
-      "line": 7926,
+      "line": 8756,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8536,7 +8586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:6e02a5cd1c2a4a62:1",
-      "line": 8680,
+      "line": 9510,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8546,7 +8596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:705d55e882c1ad56:1",
-      "line": 606,
+      "line": 645,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8556,7 +8606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:70a7caea262064e4:1",
-      "line": 2954,
+      "line": 3445,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8566,7 +8616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:710cf2597369931c:1",
-      "line": 7686,
+      "line": 8516,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8576,7 +8626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:71b9b8de151d4d54:1",
-      "line": 8399,
+      "line": 9229,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8586,7 +8636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:72d608358239527e:1",
-      "line": 7656,
+      "line": 8486,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8596,7 +8646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:73325b5a6db2cfd5:1",
-      "line": 5500,
+      "line": 6009,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8606,7 +8656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:736b3b65efb8fe03:1",
-      "line": 7960,
+      "line": 8790,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8616,7 +8666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7470a521893f13b0:1",
-      "line": 3516,
+      "line": 4007,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8626,7 +8676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:75c11e60d744f22d:1",
-      "line": 7244,
+      "line": 8074,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8636,7 +8686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7638384fd55eae41:1",
-      "line": 7454,
+      "line": 8284,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8646,7 +8696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7719d3cbe83a8fa5:1",
-      "line": 7154,
+      "line": 7984,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8656,7 +8706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:77648f3c745de48f:1",
-      "line": 7839,
+      "line": 8669,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8666,7 +8716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7781e93feb0859ed:1",
-      "line": 2974,
+      "line": 3465,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8676,7 +8726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:78ef9457dde26ba2:1",
-      "line": 7691,
+      "line": 8521,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8686,7 +8736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7942852dcda56174:1",
-      "line": 8780,
+      "line": 9610,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8696,7 +8746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:79d84dd3fb2b2373:1",
-      "line": 580,
+      "line": 619,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8706,7 +8756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7a13a54557cf242b:1",
-      "line": 3474,
+      "line": 3965,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8716,7 +8766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7b673116a052da1a:1",
-      "line": 7720,
+      "line": 8550,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8726,7 +8776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7d9cc4e53e8f2d71:1",
-      "line": 8709,
+      "line": 9539,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8736,7 +8786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7daa9ed4aace6511:1",
-      "line": 7774,
+      "line": 8604,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8746,7 +8796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:7ef3eb80e68a5502:1",
-      "line": 4331,
+      "line": 4822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8756,7 +8806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:81b788f5893f3ed0:1",
-      "line": 578,
+      "line": 617,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8766,7 +8816,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:8213f6b3e83aead2:1",
-      "line": 6918,
+      "line": 7748,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8776,7 +8826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:8213f6b3e83aead2:2",
-      "line": 7889,
+      "line": 8719,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8786,7 +8836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:1",
-      "line": 4554,
+      "line": 5045,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8796,7 +8846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:2",
-      "line": 4562,
+      "line": 5053,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8806,7 +8856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:3",
-      "line": 4570,
+      "line": 5061,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8816,7 +8866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:4",
-      "line": 4578,
+      "line": 5069,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8826,7 +8876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:5",
-      "line": 4586,
+      "line": 5077,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8836,7 +8886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:6",
-      "line": 4594,
+      "line": 5085,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8846,7 +8896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:82d3b3d4944cbe24:7",
-      "line": 4602,
+      "line": 5093,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8856,7 +8906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:831ac057e9128fae:1",
-      "line": 8053,
+      "line": 8883,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8866,7 +8916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:8435320da7aa7811:1",
-      "line": 7916,
+      "line": 8746,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8876,7 +8926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:85744c0c075b54d9:1",
-      "line": 7678,
+      "line": 8508,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8886,7 +8936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:87bb0398af266726:1",
-      "line": 8728,
+      "line": 9558,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8896,7 +8946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:88ba9104405053e1:1",
-      "line": 7872,
+      "line": 8702,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8906,7 +8956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:89996bb92b129fd4:1",
-      "line": 8294,
+      "line": 9124,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8916,7 +8966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:8c1c11f757786b8e:1",
-      "line": 8477,
+      "line": 9307,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8925,8 +8975,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:8c2e5b939919fab6:1",
+      "line": 6890,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fn rust_test_assertions_enumeration_refuses_false_empty_levels() {",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:8c419dc8000e3c36:1",
-      "line": 7470,
+      "line": 8300,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8936,7 +8996,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:90c10bb355fdec9b:1",
-      "line": 7438,
+      "line": 8268,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8946,7 +9006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:91bfc4c85689c8a6:1",
-      "line": 611,
+      "line": 650,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8956,7 +9016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:1",
-      "line": 3152,
+      "line": 3643,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8966,7 +9026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:10",
-      "line": 3306,
+      "line": 3797,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8976,7 +9036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:11",
-      "line": 3317,
+      "line": 3808,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8986,7 +9046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:12",
-      "line": 3322,
+      "line": 3813,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -8996,7 +9056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:2",
-      "line": 3172,
+      "line": 3663,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9006,7 +9066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:3",
-      "line": 3177,
+      "line": 3668,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9016,7 +9076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:4",
-      "line": 3260,
+      "line": 3751,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9026,7 +9086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:5",
-      "line": 3264,
+      "line": 3755,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9036,7 +9096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:6",
-      "line": 3272,
+      "line": 3763,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9046,7 +9106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:7",
-      "line": 3277,
+      "line": 3768,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9056,7 +9116,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:8",
-      "line": 3282,
+      "line": 3773,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9066,7 +9126,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:928644cffea39124:9",
-      "line": 3298,
+      "line": 3789,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9076,7 +9136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:95ecbfc3255a3d8d:1",
-      "line": 3104,
+      "line": 3595,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9086,7 +9146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:96db15fd190864b0:1",
-      "line": 8660,
+      "line": 9490,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9096,7 +9156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:979371ab1937aa0f:1",
-      "line": 8743,
+      "line": 9573,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9106,7 +9166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:986c128c8ea68364:1",
-      "line": 7984,
+      "line": 8814,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9116,7 +9176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:98db74471efbef01:1",
-      "line": 7764,
+      "line": 8594,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9126,7 +9186,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:99017a019af7fad2:1",
-      "line": 8292,
+      "line": 9122,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9136,7 +9196,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:99b3e4897e4c0fe9:1",
-      "line": 3007,
+      "line": 3498,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9146,7 +9206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:99b3e4897e4c0fe9:2",
-      "line": 3105,
+      "line": 3596,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9156,7 +9216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:99f6e97a7daad50d:1",
-      "line": 6883,
+      "line": 7713,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9166,7 +9226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9a345f7fab453859:1",
-      "line": 8055,
+      "line": 8885,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9176,7 +9236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9adf8a724952b829:1",
-      "line": 7584,
+      "line": 8414,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9186,7 +9246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9bc79c06f30743a4:1",
-      "line": 8824,
+      "line": 9654,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9196,7 +9256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9cceb8584a937226:1",
-      "line": 6911,
+      "line": 7741,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9206,7 +9266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9d1e1c9054ca8edb:1",
-      "line": 6924,
+      "line": 7754,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9216,7 +9276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9dfdac128f0ed4ab:1",
-      "line": 7555,
+      "line": 8385,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9226,7 +9286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:9eda8153218d72e9:1",
-      "line": 6990,
+      "line": 7820,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9236,7 +9296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a018902c48ae87da:1",
-      "line": 7904,
+      "line": 8734,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9246,7 +9306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a039984bd9dad2d8:1",
-      "line": 7831,
+      "line": 8661,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9256,7 +9316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a08dda5f7e37ed3e:1",
-      "line": 8272,
+      "line": 9102,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9266,7 +9326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a0dfa22da7f46d1c:1",
-      "line": 7663,
+      "line": 8493,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9276,7 +9336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a2dc1a4ab47586e4:1",
-      "line": 7242,
+      "line": 8072,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9286,7 +9346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a3fc7ddd087cfeac:1",
-      "line": 7735,
+      "line": 8565,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9296,7 +9356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a54d2b9a1f16dc24:1",
-      "line": 8009,
+      "line": 8839,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9306,7 +9366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a5c80a74bd94a3df:1",
-      "line": 7962,
+      "line": 8792,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9316,7 +9376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a6e6cf1292093437:1",
-      "line": 7743,
+      "line": 8573,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9326,7 +9386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a86b083b4363a2aa:1",
-      "line": 3257,
+      "line": 3748,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9335,8 +9395,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a87c7ddcfafeced9:1",
+      "line": 6742,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "let root = unique_temp_dir(\"rust_test_assertions_universe_refuses_drift\");",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:a98fc2bba7554336:1",
-      "line": 6899,
+      "line": 7729,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9346,7 +9416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:ab53037683bb2555:1",
-      "line": 7547,
+      "line": 8377,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9356,7 +9426,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:aee14b5245e42386:1",
-      "line": 579,
+      "line": 618,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9366,7 +9436,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:af788cedb8dab5d2:1",
-      "line": 8661,
+      "line": 9491,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9376,7 +9446,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:afc90dd8dfc0a4a1:1",
-      "line": 4613,
+      "line": 5104,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9386,7 +9456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b030f5a537fa4634:1",
-      "line": 7800,
+      "line": 8630,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9396,7 +9466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b0a716fbfd846173:1",
-      "line": 8045,
+      "line": 8875,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9406,7 +9476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b128cdc74016d83f:1",
-      "line": 7557,
+      "line": 8387,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9416,7 +9486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b24bcc401aef24f3:1",
-      "line": 7483,
+      "line": 8313,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9426,7 +9496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b2ffd9912e45070e:1",
-      "line": 7779,
+      "line": 8609,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9436,7 +9506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b4c640438df07cba:1",
-      "line": 7507,
+      "line": 8337,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9446,7 +9516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b4e5bde19069a88c:1",
-      "line": 7688,
+      "line": 8518,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9456,7 +9526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b4fc5bd0f1dad52e:1",
-      "line": 7813,
+      "line": 8643,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9466,7 +9536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b567c8a14a76e485:1",
-      "line": 6891,
+      "line": 7721,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9476,7 +9546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b645fff3e7452937:1",
-      "line": 9032,
+      "line": 9862,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9486,7 +9556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b65ad1dd2ea5129a:1",
-      "line": 800,
+      "line": 842,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9496,7 +9566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b65ad1dd2ea5129a:2",
-      "line": 835,
+      "line": 877,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9506,7 +9576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b6d89c988d62e843:1",
-      "line": 6949,
+      "line": 7779,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9516,7 +9586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b7485afcb3845546:1",
-      "line": 8759,
+      "line": 9589,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9526,7 +9596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b7492853dbb0fd5e:1",
-      "line": 659,
+      "line": 698,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9536,7 +9606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b7a969867c5b0aa9:1",
-      "line": 8401,
+      "line": 9231,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9546,7 +9616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b7d458d07902147e:1",
-      "line": 7808,
+      "line": 8638,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9556,7 +9626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b804748e3a4495a6:1",
-      "line": 7629,
+      "line": 8459,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9566,7 +9636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b835d254ed293055:1",
-      "line": 7025,
+      "line": 7855,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9576,7 +9646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:b99153b40fc23f9f:1",
-      "line": 7994,
+      "line": 8824,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9586,7 +9656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:bc78701f48a3450f:1",
-      "line": 6970,
+      "line": 7800,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9596,7 +9666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:bd422ce4e3a98230:1",
-      "line": 601,
+      "line": 640,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9606,7 +9676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:bd64157dde5ef393:1",
-      "line": 3003,
+      "line": 3494,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9616,7 +9686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c106e2508db35984:1",
-      "line": 8423,
+      "line": 9253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9626,7 +9696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c29785555945b863:1",
-      "line": 3215,
+      "line": 3706,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9636,7 +9706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c323eaa7e210da9d:1",
-      "line": 6895,
+      "line": 7725,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9646,7 +9716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c3c6be2d155aa3ca:1",
-      "line": 7713,
+      "line": 8543,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9656,7 +9726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c5a2a5407c916b06:1",
-      "line": 6872,
+      "line": 7702,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9666,7 +9736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c6eb4589bac6c542:1",
-      "line": 8826,
+      "line": 9656,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9676,7 +9746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c7414bff7e750266:1",
-      "line": 6879,
+      "line": 7709,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9686,7 +9756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c7ff7cb3eac0edb2:1",
-      "line": 7480,
+      "line": 8310,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9696,7 +9766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c89decb7e7c30ac5:1",
-      "line": 7997,
+      "line": 8827,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9706,7 +9776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:c9e20539149f5017:1",
-      "line": 8095,
+      "line": 8925,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9716,7 +9786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:cc8cd2d05bb7c6dc:1",
-      "line": 608,
+      "line": 647,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9726,7 +9796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:cd8f2124add319b0:1",
-      "line": 7607,
+      "line": 8437,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9735,8 +9805,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:cf497462aaef5fce:1",
+      "line": 6858,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"target-contract preparation refused observed shape\".to_string(),",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d0f31e696b134ad6:1",
-      "line": 7183,
+      "line": 8013,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9746,7 +9826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d17601c5f2598259:1",
-      "line": 3182,
+      "line": 3673,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9756,7 +9836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d338264fc146889b:1",
-      "line": 7745,
+      "line": 8575,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9766,7 +9846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d377afa149971afa:1",
-      "line": 7560,
+      "line": 8390,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9776,7 +9856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d3d250568b7eb589:1",
-      "line": 9015,
+      "line": 9845,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9786,7 +9866,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d6ccea385d7c49e5:1",
-      "line": 4216,
+      "line": 4707,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9796,7 +9876,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d6fab892273ed3e8:1",
-      "line": 7499,
+      "line": 8329,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9806,7 +9886,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d7757a192c1551cd:1",
-      "line": 7585,
+      "line": 8415,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9816,7 +9896,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d7c67b8da1c0e44d:1",
-      "line": 8321,
+      "line": 9151,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9826,7 +9906,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d842bd1fdd896aec:1",
-      "line": 7924,
+      "line": 8754,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9836,7 +9916,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d8553a43ce511c1a:1",
-      "line": 9168,
+      "line": 9998,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9846,7 +9926,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:d94aeda6b62d1a87:1",
-      "line": 507,
+      "line": 546,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9856,7 +9936,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:da29f3bff3739773:1",
-      "line": 7875,
+      "line": 8705,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9866,7 +9946,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:da8e2ab7e6fa6d97:1",
-      "line": 4451,
+      "line": 4942,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9876,7 +9956,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:dda9147397c0169f:1",
-      "line": 8406,
+      "line": 9236,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9886,7 +9966,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e0df591923884403:1",
-      "line": 625,
+      "line": 664,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9896,16 +9976,6 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e0df591923884403:2",
-      "line": 2984,
-      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
-      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
-      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
-      "speaker": "lift-output-backlog",
-      "text": "Some(named_source_refusal_reason(",
-      "wire_marker": "internal-only"
-    },
-    {
-      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e0df591923884403:3",
       "line": 3475,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
@@ -9915,8 +9985,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e0df591923884403:3",
+      "line": 3966,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Some(named_source_refusal_reason(",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e11f2d89a8d0e320:1",
-      "line": 4309,
+      "line": 4800,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9926,7 +10006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e160b079a714bd2a:1",
-      "line": 7532,
+      "line": 8362,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9936,7 +10016,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e2569648dac29adb:1",
-      "line": 7772,
+      "line": 8602,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9946,7 +10026,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e5c6acc6d1851f8d:1",
-      "line": 3123,
+      "line": 3614,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9956,7 +10036,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e7c88fa4ab3aee90:1",
-      "line": 7572,
+      "line": 8402,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9966,7 +10046,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e7f341d9637238a0:1",
-      "line": 653,
+      "line": 692,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9976,7 +10056,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e81b104f77ac67e8:1",
-      "line": 7447,
+      "line": 8277,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9986,7 +10066,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e8280268392899e2:1",
-      "line": 8019,
+      "line": 8849,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -9996,7 +10076,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:e843128731195f12:1",
-      "line": 4328,
+      "line": 4819,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10006,7 +10086,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:eaabfd34a2c839e6:1",
-      "line": 477,
+      "line": 516,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10016,7 +10096,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:eacf25a18142ef16:1",
-      "line": 7152,
+      "line": 7982,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10026,7 +10106,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:ebc209c454c06c63:1",
-      "line": 7581,
+      "line": 8411,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10035,8 +10115,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:ebc8f6752f53fb57:1",
+      "line": 6891,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "let root = unique_temp_dir(\"rust_test_assertions_refuses_false_empty_levels\");",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:ed0a31bc245a9acd:1",
-      "line": 7478,
+      "line": 8308,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10046,7 +10136,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:ede135bd36398fcb:1",
-      "line": 5876,
+      "line": 6385,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10056,7 +10146,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:ee51e50284b15be3:1",
-      "line": 8711,
+      "line": 9541,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10066,7 +10156,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:eeb4896a2ea3d539:1",
-      "line": 7658,
+      "line": 8488,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10076,7 +10166,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:eebc8cab0a64526b:1",
-      "line": 4654,
+      "line": 5145,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10086,7 +10176,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f12254c9b7a8dd18:1",
-      "line": 8297,
+      "line": 9127,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10095,8 +10185,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f31190453d20da60:1",
+      "line": 6741,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fn rust_test_assertions_universe_refuses_population_drift() {",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f51c669c3bce16fe:1",
-      "line": 7509,
+      "line": 8339,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10106,7 +10206,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f6174ede3633f617:1",
-      "line": 7705,
+      "line": 8535,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10116,7 +10216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f61c527589604a56:1",
-      "line": 7841,
+      "line": 8671,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10126,7 +10226,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f6ea8cd61d24acda:1",
-      "line": 8655,
+      "line": 9485,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10136,7 +10236,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:1",
-      "line": 6901,
+      "line": 7731,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10146,7 +10246,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:2",
-      "line": 6916,
+      "line": 7746,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10156,7 +10256,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:3",
-      "line": 6962,
+      "line": 7792,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10166,7 +10266,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:4",
-      "line": 6972,
+      "line": 7802,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10176,7 +10276,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:5",
-      "line": 6982,
+      "line": 7812,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10186,7 +10286,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:6",
-      "line": 6992,
+      "line": 7822,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10196,7 +10296,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:7",
-      "line": 7002,
+      "line": 7832,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10206,7 +10306,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:8",
-      "line": 7012,
+      "line": 7842,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10216,7 +10316,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f72152dd68c5dabf:9",
-      "line": 7156,
+      "line": 7986,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10226,7 +10326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f76c4e0d4e445b2f:1",
-      "line": 21,
+      "line": 22,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10236,7 +10336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f7f1a069b7534e08:1",
-      "line": 8473,
+      "line": 9303,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10246,7 +10346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f9176f9b7c66a92b:1",
-      "line": 7522,
+      "line": 8352,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10256,7 +10356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f996714761e7569c:1",
-      "line": 257,
+      "line": 259,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10266,7 +10366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:f9ce74c517277c43:1",
-      "line": 3525,
+      "line": 4016,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10276,7 +10376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:fcc932b6ac279816:1",
-      "line": 3497,
+      "line": 3988,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10285,8 +10385,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:fce7e534266e5298:1",
+      "line": 6884,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "reason.contains(\"target-contract preparation refused\"),",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:fda829b667d260ea:1",
-      "line": 4546,
+      "line": 5037,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10296,7 +10406,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:fe7dca1f3e4a79ea:1",
-      "line": 8106,
+      "line": 8936,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -10306,7 +10416,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs:fec02991de54bf36:1",
-      "line": 7452,
+      "line": 8282,
       "path": "implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17216,7 +17326,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:0f61c8087d653e1c:1",
-      "line": 745,
+      "line": 779,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17226,7 +17336,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:12c4598d2354494d:1",
-      "line": 772,
+      "line": 806,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17236,7 +17346,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:14e1a7e0cbbd2f87:1",
-      "line": 1025,
+      "line": 1059,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17246,7 +17356,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:1e72f564e4243e8d:1",
-      "line": 1066,
+      "line": 1100,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17256,7 +17366,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:1e917174372010a1:1",
-      "line": 938,
+      "line": 972,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17266,7 +17376,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:20b3238e2d9f8ab6:1",
-      "line": 708,
+      "line": 742,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17276,7 +17386,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:2ef80be1c3812a3a:1",
-      "line": 284,
+      "line": 249,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17285,8 +17395,38 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:311eb63e4679c759:1",
+      "line": 63,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "/// `TermFloor` owner or refuse loudly; a guessed variable/source spelling cannot replace",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:353ceec1acb7efaf:1",
+      "line": 145,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"callsite child term construction refused: owner=CallsiteSugar; \\",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:353ceec1acb7efaf:2",
+      "line": 152,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"callsite child term construction refused: owner=CallsiteSugar; \\",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:3b8a8d5d1f035ca6:1",
-      "line": 1069,
+      "line": 1103,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17295,8 +17435,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:3dfa2f4d7293793a:1",
+      "line": 711,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fn unsupported_callsite_child_refuses_instead_of_minting_opaque_identity() {",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:3fd7af011aab0653:1",
-      "line": 1096,
+      "line": 1130,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17306,7 +17456,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:4479740af2202855:1",
-      "line": 798,
+      "line": 832,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17316,7 +17466,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:47a131e4f859840e:1",
-      "line": 285,
+      "line": 250,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17326,7 +17476,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:55beb00d1e8a916d:1",
-      "line": 852,
+      "line": 886,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17336,7 +17486,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:5a671a5ef634cc02:1",
-      "line": 524,
+      "line": 489,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17346,7 +17496,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:5b4df80bea5b6375:1",
-      "line": 1103,
+      "line": 1137,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17356,7 +17506,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:694c42c571529eb1:1",
-      "line": 272,
+      "line": 237,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17366,7 +17516,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:6a2636416724c53b:1",
-      "line": 811,
+      "line": 845,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17376,7 +17526,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:6fa69f5c8665401e:1",
-      "line": 279,
+      "line": 244,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17386,7 +17536,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:7b48932ef3c2cc40:1",
-      "line": 799,
+      "line": 833,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17396,7 +17546,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:86b8a3f11bb3c912:1",
-      "line": 589,
+      "line": 554,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17406,7 +17556,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:8a18ffa6454e051a:1",
-      "line": 869,
+      "line": 903,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17416,7 +17566,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:995505f427d26869:1",
-      "line": 933,
+      "line": 967,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17426,7 +17576,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:9be365d1cf26a2b1:1",
-      "line": 746,
+      "line": 780,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17446,7 +17596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:9f9a82aaceb5018c:1",
-      "line": 964,
+      "line": 998,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17486,7 +17636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:b6bde30b79979479:1",
-      "line": 765,
+      "line": 799,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17496,7 +17646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:baf5c385ce5894cb:1",
-      "line": 1121,
+      "line": 1155,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17506,7 +17656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:c94cf3e1079262ce:1",
-      "line": 1101,
+      "line": 1135,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17516,7 +17666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:c96d4b1f4da15045:1",
-      "line": 353,
+      "line": 318,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17536,7 +17686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:d41e13e49530b9ac:1",
-      "line": 762,
+      "line": 796,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17546,7 +17696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:d41e13e49530b9ac:2",
-      "line": 952,
+      "line": 986,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17556,7 +17706,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:d41e13e49530b9ac:3",
-      "line": 1083,
+      "line": 1117,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17566,7 +17716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:dc680e17630d7061:1",
-      "line": 280,
+      "line": 245,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17576,7 +17726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:e0fd7b455927b3a6:1",
-      "line": 577,
+      "line": 542,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17586,7 +17736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:e1057dc33fe0a6d2:1",
-      "line": 1093,
+      "line": 1127,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17596,7 +17746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:e7adc24eacbbd323:1",
-      "line": 1219,
+      "line": 1253,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17606,7 +17756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:ee49dbdfab8a479d:1",
-      "line": 963,
+      "line": 997,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17616,7 +17766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:f7d477a194529c1d:1",
-      "line": 628,
+      "line": 593,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17626,7 +17776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs:fcd5eae84faa4fd5:1",
-      "line": 1156,
+      "line": 1190,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/callsite.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17856,7 +18006,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs:01feeb5e9ff29595:1",
-      "line": 1876,
+      "line": 1960,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -17865,13 +18015,43 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs:12ee3dc9f0085e65:1",
+      "line": 1922,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "fn panic_freedom_relation_gate_still_refuses_unreplayed_iterator_consumption() {",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs:2dbc45701f027d3f:1",
+      "line": 1939,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "Ok(_) => panic!(\"panic-freedom relation gate must refuse before constructing a term\"),",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs:b99528494b720df0:1",
-      "line": 1906,
+      "line": 1990,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
       "speaker": "lift-output-backlog",
       "text": "panic!(\"unsafe `&mut *p` relation operand must refuse\");",
+      "wire_marker": "internal-only"
+    },
+    {
+      "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs:d2771e4f8cb0c1c5:1",
+      "line": 1945,
+      "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/constraint.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "\"gate must retain the named iterator-consumption refusal: {}\",",
       "wire_marker": "internal-only"
     },
     {
@@ -18036,7 +18216,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/factory.rs:ecd953de3c8773de:1",
-      "line": 834,
+      "line": 848,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/factory.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18406,7 +18586,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:063b7661e302b987:1",
-      "line": 3440,
+      "line": 3487,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18416,7 +18596,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:1b113f9d4ffafff5:1",
-      "line": 4379,
+      "line": 4426,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18426,7 +18606,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:332c806855d08548:1",
-      "line": 4322,
+      "line": 4369,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18436,7 +18616,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:34d85ebf1688cdf6:1",
-      "line": 3396,
+      "line": 3443,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18446,7 +18626,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:3aeba7d351eab30e:1",
-      "line": 3398,
+      "line": 3445,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18456,7 +18636,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:3aeba7d351eab30e:2",
-      "line": 3406,
+      "line": 3453,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18466,7 +18646,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:510d9176a5062b5b:1",
-      "line": 4333,
+      "line": 4380,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18476,7 +18656,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:5fcc44b8645c9445:1",
-      "line": 1316,
+      "line": 1363,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18486,7 +18666,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:60d30a3fa7d5e71c:1",
-      "line": 4318,
+      "line": 4365,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18496,7 +18676,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:668ace916149a45d:1",
-      "line": 3390,
+      "line": 3437,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18506,7 +18686,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:85313b9639fdbe1b:1",
-      "line": 3340,
+      "line": 3387,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18516,7 +18696,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:864d1fd247e6708f:1",
-      "line": 4253,
+      "line": 4300,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18536,7 +18716,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:8c01bf1eef8dea5c:1",
-      "line": 3401,
+      "line": 3448,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18546,7 +18726,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:9294f40358c31b37:1",
-      "line": 3433,
+      "line": 3480,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18556,7 +18736,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:9711a83ce972cc64:1",
-      "line": 1619,
+      "line": 1666,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18566,7 +18746,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:9bfca0e9c41e9486:1",
-      "line": 4380,
+      "line": 4427,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18576,7 +18756,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:9d5f9f0fce8aef47:1",
-      "line": 3450,
+      "line": 3497,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18586,7 +18766,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:a38323b7c182897c:1",
-      "line": 3436,
+      "line": 3483,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18596,7 +18776,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:a73ae751fe721cd3:1",
-      "line": 2628,
+      "line": 2675,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18606,7 +18786,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:ab7191b84a0f520c:1",
-      "line": 4349,
+      "line": 4396,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18616,7 +18796,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:ad1179600c82101d:1",
-      "line": 3272,
+      "line": 3319,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18626,7 +18806,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:afb37016ae4fadab:1",
-      "line": 3419,
+      "line": 3466,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18646,7 +18826,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:c3843992415ab501:1",
-      "line": 4231,
+      "line": 4278,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18656,7 +18836,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:cb891cea811e3f8b:1",
-      "line": 3371,
+      "line": 3418,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18666,7 +18846,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:d178256003025cf0:1",
-      "line": 4237,
+      "line": 4284,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -18676,7 +18856,7 @@
     },
     {
       "key": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs:e80a0d97266f96b2:1",
-      "line": 3415,
+      "line": 3462,
       "path": "implementations/rust/sugar-lift-rust-tests/src/sugar/format.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20486,7 +20666,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:021eaddad444e327:1",
-      "line": 14799,
+      "line": 14918,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20496,7 +20676,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:04cd4077cc5265a7:1",
-      "line": 7112,
+      "line": 7223,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20506,7 +20686,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:05b9b290fce2b1b7:1",
-      "line": 16226,
+      "line": 16345,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20516,7 +20696,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:06a19c58f62ffed2:1",
-      "line": 7679,
+      "line": 7790,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20526,7 +20706,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:08ce40913a4b353e:1",
-      "line": 17795,
+      "line": 17914,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20536,7 +20716,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:091fa2a83b558435:1",
-      "line": 8112,
+      "line": 8225,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20546,7 +20726,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:09778efbaafe198e:1",
-      "line": 17472,
+      "line": 17591,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20556,7 +20736,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0a878b9d1889df06:1",
-      "line": 7186,
+      "line": 7297,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20566,7 +20746,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:1",
-      "line": 12273,
+      "line": 12392,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20576,7 +20756,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:10",
-      "line": 16614,
+      "line": 16733,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20586,7 +20766,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:11",
-      "line": 16621,
+      "line": 16740,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20596,7 +20776,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:12",
-      "line": 16628,
+      "line": 16747,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20606,7 +20786,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:13",
-      "line": 16718,
+      "line": 16837,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20616,7 +20796,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:14",
-      "line": 16787,
+      "line": 16906,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20626,7 +20806,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:15",
-      "line": 16865,
+      "line": 16984,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20636,7 +20816,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:16",
-      "line": 16937,
+      "line": 17056,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20646,7 +20826,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:2",
-      "line": 15008,
+      "line": 15127,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20656,7 +20836,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:3",
-      "line": 15147,
+      "line": 15266,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20666,7 +20846,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:4",
-      "line": 15154,
+      "line": 15273,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20676,7 +20856,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:5",
-      "line": 15161,
+      "line": 15280,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20686,7 +20866,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:6",
-      "line": 15309,
+      "line": 15428,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20696,7 +20876,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:7",
-      "line": 15435,
+      "line": 15554,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20706,7 +20886,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:8",
-      "line": 15846,
+      "line": 15965,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20716,7 +20896,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0b1c55bed773ff77:9",
-      "line": 16060,
+      "line": 16179,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20726,7 +20906,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0c1b94d75bf7fa15:1",
-      "line": 7720,
+      "line": 7831,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20736,7 +20916,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0c83f3424841fdc2:1",
-      "line": 1454,
+      "line": 1462,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20746,7 +20926,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0cd44a1f26a01f61:1",
-      "line": 4633,
+      "line": 4641,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20756,7 +20936,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0e8360695ff9d764:1",
-      "line": 3464,
+      "line": 3472,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20766,7 +20946,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0ed5fe8aaaf10688:1",
-      "line": 7668,
+      "line": 7779,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20776,7 +20956,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0f4a4a2ccfb8fe37:1",
-      "line": 1509,
+      "line": 1517,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20786,7 +20966,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:0febba36e5d84c42:1",
-      "line": 9822,
+      "line": 9941,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20796,7 +20976,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:1044dc2f0a5f5ad6:1",
-      "line": 666,
+      "line": 674,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20806,7 +20986,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:12bd74802c16dfa6:1",
-      "line": 17798,
+      "line": 17917,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20816,7 +20996,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:16b67a569c955f16:1",
-      "line": 3864,
+      "line": 3872,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20826,7 +21006,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:17bd8d17f45b6ea5:1",
-      "line": 10367,
+      "line": 10486,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20836,7 +21016,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:19ecc9ff91aeee5d:1",
-      "line": 17317,
+      "line": 17436,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20846,7 +21026,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:1c4ee6723e5c9f85:1",
-      "line": 10328,
+      "line": 10447,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20856,7 +21036,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:1c7514f110e333ed:1",
-      "line": 5206,
+      "line": 5214,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20866,7 +21046,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:1d492f18098df21e:1",
-      "line": 12507,
+      "line": 12626,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20876,7 +21056,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:1dcd9453f5c4ecb6:1",
-      "line": 5402,
+      "line": 5410,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20886,7 +21066,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:1ec9d9123c9f67b4:1",
-      "line": 13494,
+      "line": 13613,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20896,7 +21076,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2206f642acbb5202:1",
-      "line": 15204,
+      "line": 15323,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20906,7 +21086,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:229729a87b5b1de5:1",
-      "line": 14939,
+      "line": 15058,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20916,7 +21096,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:23d22a7a903d58fb:1",
-      "line": 3364,
+      "line": 3372,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20926,7 +21106,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:265c4879bb916955:1",
-      "line": 17794,
+      "line": 17913,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20936,7 +21116,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2725936be3fcc480:1",
-      "line": 14767,
+      "line": 14886,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20946,7 +21126,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2740b11505be8fda:1",
-      "line": 14543,
+      "line": 14662,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20956,7 +21136,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:277f13510188663c:1",
-      "line": 16282,
+      "line": 16401,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20966,7 +21146,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:287cabec6f7f584c:1",
-      "line": 5266,
+      "line": 5274,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20976,7 +21156,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2cd7abe8c27b1bce:1",
-      "line": 7541,
+      "line": 7652,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20986,7 +21166,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2cd7abe8c27b1bce:2",
-      "line": 7590,
+      "line": 7701,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -20996,7 +21176,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2e7bbc12e07da9b6:1",
-      "line": 4437,
+      "line": 4445,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21006,7 +21186,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2f4812e04e267146:1",
-      "line": 10178,
+      "line": 10297,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21016,7 +21196,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:2fddb188e2b08bc2:1",
-      "line": 63,
+      "line": 70,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21025,8 +21205,18 @@
       "wire_marker": "internal-only"
     },
     {
+      "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:31f4c4169f7b7629:1",
+      "line": 6465,
+      "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
+      "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
+      "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
+      "speaker": "lift-output-backlog",
+      "text": "return Err(format!(\"sugar.enumerate: level '{level}' is not served by surface 'rust-fn-contracts'; refusing false zero\"));",
+      "wire_marker": "internal-only"
+    },
+    {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:34204af2144b60a5:1",
-      "line": 9911,
+      "line": 10030,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21036,7 +21226,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:3594993c87d7f0b2:1",
-      "line": 7207,
+      "line": 7318,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21046,7 +21236,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:3594993c87d7f0b2:2",
-      "line": 7218,
+      "line": 7329,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21056,7 +21246,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:359c7c425c702db9:1",
-      "line": 4364,
+      "line": 4372,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21066,7 +21256,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:386bc820a7f8c214:1",
-      "line": 17229,
+      "line": 17348,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21076,7 +21266,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:3987ce31b29750b9:1",
-      "line": 15191,
+      "line": 15310,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21086,7 +21276,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:3c2c1f0c13c87e49:1",
-      "line": 16444,
+      "line": 16563,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21096,7 +21286,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:4126543621a88012:1",
-      "line": 14887,
+      "line": 15006,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21106,7 +21296,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:41b11c9133404a9f:1",
-      "line": 17893,
+      "line": 18012,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21116,7 +21306,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:42e6cc967c56c6ab:1",
-      "line": 9037,
+      "line": 9156,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21126,7 +21316,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:42f6c4e295f8466c:1",
-      "line": 7099,
+      "line": 7210,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21136,7 +21326,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:4516d22dd7eab9bd:1",
-      "line": 5310,
+      "line": 5318,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21146,7 +21336,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:4680d73dcaa3c80c:1",
-      "line": 10387,
+      "line": 10506,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21156,7 +21346,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:46fe632a06bc766a:1",
-      "line": 4108,
+      "line": 4116,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21166,7 +21356,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:482265427ff2a6d4:1",
-      "line": 12488,
+      "line": 12607,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21176,7 +21366,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:4845af81b30d0958:1",
-      "line": 12908,
+      "line": 13027,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21186,7 +21376,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:48f48e1a2a84b7f3:1",
-      "line": 13547,
+      "line": 13666,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21196,7 +21386,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:4ebe3166106675fd:1",
-      "line": 10409,
+      "line": 10528,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21206,7 +21396,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:4f6df9b0a2139d6a:1",
-      "line": 9957,
+      "line": 10076,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21216,7 +21406,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:546376e7112acc7d:1",
-      "line": 17412,
+      "line": 17531,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21226,7 +21416,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:54d11a4c06133c32:1",
-      "line": 12505,
+      "line": 12624,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21236,7 +21426,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:56b58b915654d111:1",
-      "line": 14327,
+      "line": 14446,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21246,7 +21436,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:58ab901611223440:1",
-      "line": 15227,
+      "line": 15346,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21256,7 +21446,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:5a29d267cd8daed6:1",
-      "line": 17512,
+      "line": 17631,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21266,7 +21456,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:5afb9aa932a029c4:1",
-      "line": 17272,
+      "line": 17391,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21276,7 +21466,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:5afc8059016c8c65:1",
-      "line": 5442,
+      "line": 5450,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21286,7 +21476,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:5c31f5bdf1812007:1",
-      "line": 1400,
+      "line": 1408,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21296,7 +21486,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:5c4dff3b795debce:1",
-      "line": 7192,
+      "line": 7303,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21306,7 +21496,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:60fa07f1e41d10fe:1",
-      "line": 16198,
+      "line": 16317,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21316,7 +21506,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:61defbdfabfaea94:1",
-      "line": 10321,
+      "line": 10440,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21326,7 +21516,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:6370b011843e91b6:1",
-      "line": 17803,
+      "line": 17922,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21336,7 +21526,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:6720584fb63aa68f:1",
-      "line": 13544,
+      "line": 13663,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21346,7 +21536,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:68e6622ae25c8442:1",
-      "line": 5788,
+      "line": 5796,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21356,7 +21546,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:69bd709a6a4e0ce6:1",
-      "line": 13476,
+      "line": 13595,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21366,7 +21556,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:6a7c15fd87ed7a83:1",
-      "line": 16962,
+      "line": 17081,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21376,7 +21566,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:6a97ab5fed92fd29:1",
-      "line": 3585,
+      "line": 3593,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21386,7 +21576,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:6c728be8c17299cd:1",
-      "line": 665,
+      "line": 673,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21396,7 +21586,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:6f3dc2fa256f3797:1",
-      "line": 5265,
+      "line": 5273,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21406,7 +21596,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:70b48d178e6848ee:1",
-      "line": 10575,
+      "line": 10694,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21416,7 +21606,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:730a8ccaa61e35a1:1",
-      "line": 13505,
+      "line": 13624,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21426,7 +21616,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:73aaf92f586ca0cf:1",
-      "line": 13171,
+      "line": 13290,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21436,7 +21626,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:74fa40a2c44621c3:1",
-      "line": 17288,
+      "line": 17407,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21446,7 +21636,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:76b34dc13b7c00a6:1",
-      "line": 10139,
+      "line": 10258,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21456,7 +21646,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:77a9c801e20ed4d4:1",
-      "line": 16467,
+      "line": 16586,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21466,7 +21656,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:796f0d18722ada7b:1",
-      "line": 7176,
+      "line": 7287,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21476,7 +21666,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:7b5e7090624f2a3d:1",
-      "line": 577,
+      "line": 585,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21486,7 +21676,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:7cbd45cc34a1c9fd:1",
-      "line": 16883,
+      "line": 17002,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21496,7 +21686,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:7da34eb986fdf71f:1",
-      "line": 7182,
+      "line": 7293,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21506,7 +21696,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:7e6d12d10e02504f:1",
-      "line": 2290,
+      "line": 2298,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21516,7 +21706,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:7ee93683d4001739:1",
-      "line": 13999,
+      "line": 14118,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21526,7 +21716,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:7f65eafc70dc815b:1",
-      "line": 14622,
+      "line": 14741,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21536,7 +21726,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:8179e21554b0cab5:1",
-      "line": 17347,
+      "line": 17466,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21546,7 +21736,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:81c7c62933306945:1",
-      "line": 14857,
+      "line": 14976,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21556,7 +21746,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:8295adb977a2213f:1",
-      "line": 16007,
+      "line": 16126,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21566,7 +21756,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:83d41ee2d8a4557b:1",
-      "line": 7228,
+      "line": 7339,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21576,7 +21766,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:849933e9ec3b4e65:1",
-      "line": 16497,
+      "line": 16616,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21586,7 +21776,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:869a6a8cff8100de:1",
-      "line": 14739,
+      "line": 14858,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21596,7 +21786,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:873d717810983d53:1",
-      "line": 4082,
+      "line": 4090,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21606,7 +21796,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:87b1e294043cdf70:1",
-      "line": 554,
+      "line": 562,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21616,7 +21806,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:88d9a66d097985b7:1",
-      "line": 536,
+      "line": 544,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21626,7 +21816,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:897ad1c506ae1cfe:1",
-      "line": 5920,
+      "line": 5928,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21636,7 +21826,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:8e9148a785a2e964:1",
-      "line": 12489,
+      "line": 12608,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21646,7 +21836,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:8f527d438b5c0e3d:1",
-      "line": 17404,
+      "line": 17523,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21656,7 +21846,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:8fe2bc2b4681627c:1",
-      "line": 3434,
+      "line": 3442,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21666,7 +21856,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:90958038a664fe93:1",
-      "line": 5883,
+      "line": 5891,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21676,7 +21866,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:943ed94cce994197:1",
-      "line": 10343,
+      "line": 10462,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21686,7 +21876,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:949d0ba9800fe840:1",
-      "line": 16706,
+      "line": 16825,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21696,7 +21886,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:9753e8941da56ba5:1",
-      "line": 12387,
+      "line": 12506,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21706,7 +21896,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:98ece4979c073012:1",
-      "line": 9872,
+      "line": 9991,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21716,7 +21906,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:9a83697d775900c9:1",
-      "line": 295,
+      "line": 303,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21726,7 +21916,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:9ca7f11fdea0d9dd:1",
-      "line": 510,
+      "line": 518,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21736,7 +21926,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:9e18f7ae2defc696:1",
-      "line": 16472,
+      "line": 16591,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21746,7 +21936,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:9e83a7b540a5a53d:1",
-      "line": 3178,
+      "line": 3186,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21756,7 +21946,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:9f24c34e73c9c257:1",
-      "line": 10063,
+      "line": 10182,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21766,7 +21956,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a10321cab614d517:1",
-      "line": 1411,
+      "line": 1419,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21776,7 +21966,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a1a4a6eb4056609b:1",
-      "line": 7113,
+      "line": 7224,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21786,7 +21976,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a204a7d789ae4b4f:1",
-      "line": 17213,
+      "line": 17332,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21796,7 +21986,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a21d61e56a1eb5e1:1",
-      "line": 16900,
+      "line": 17019,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21806,7 +21996,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a6a623f21872b2f1:1",
-      "line": 4145,
+      "line": 4153,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21816,7 +22006,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a6aaaea681e20aad:1",
-      "line": 5949,
+      "line": 5957,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21826,7 +22016,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a82af57b7bf2c62c:1",
-      "line": 17854,
+      "line": 17973,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21836,7 +22026,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a842c0b8162264a3:1",
-      "line": 4816,
+      "line": 4824,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21846,7 +22036,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:a8fb6eb596cf2ba9:1",
-      "line": 16146,
+      "line": 16265,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21856,7 +22046,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ac256a04476d235e:1",
-      "line": 9761,
+      "line": 9880,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21866,7 +22056,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ad8b6ccf1af30ea1:1",
-      "line": 16346,
+      "line": 16465,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21876,7 +22066,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:aec8abbf45a58d9a:1",
-      "line": 16258,
+      "line": 16377,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21886,7 +22076,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:af2bfce888439a6b:1",
-      "line": 14649,
+      "line": 14768,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21896,7 +22086,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:af35a6528aa4cf4a:1",
-      "line": 3848,
+      "line": 3856,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21906,7 +22096,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:af90697f69ecdd31:1",
-      "line": 10331,
+      "line": 10450,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21916,7 +22106,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:b0283430f26a235d:1",
-      "line": 10292,
+      "line": 10411,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21926,7 +22116,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:bb51a1f8b5daad72:1",
-      "line": 10578,
+      "line": 10697,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21936,7 +22126,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:bbfa52236606a2f4:1",
-      "line": 14569,
+      "line": 14688,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21946,7 +22136,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:c09d85c0f7d9ca34:1",
-      "line": 7166,
+      "line": 7277,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21956,7 +22146,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:c125f165f4c05e1c:1",
-      "line": 16170,
+      "line": 16289,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21966,7 +22156,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:c2d02f9108519ae3:1",
-      "line": 13062,
+      "line": 13181,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21976,7 +22166,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:c4e332aca288ac86:1",
-      "line": 5824,
+      "line": 5832,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21986,7 +22176,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:c80ba7d2513e5da8:1",
-      "line": 5451,
+      "line": 5459,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -21996,7 +22186,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:cac7560e648b2185:1",
-      "line": 7203,
+      "line": 7314,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22006,7 +22196,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:cbefa5338e82feb7:1",
-      "line": 10403,
+      "line": 10522,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22016,7 +22206,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ce609c3f2f982e7f:1",
-      "line": 7504,
+      "line": 7615,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22026,7 +22216,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:cf3d758b4a454926:1",
-      "line": 17294,
+      "line": 17413,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22036,7 +22226,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:d8b1af12e9453361:1",
-      "line": 14595,
+      "line": 14714,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22046,7 +22236,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:d9608da8a308a4d6:1",
-      "line": 7718,
+      "line": 7829,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22056,7 +22246,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:d96bbff08b6ced48:1",
-      "line": 5900,
+      "line": 5908,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22066,7 +22256,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:d9c337784250d38b:1",
-      "line": 15989,
+      "line": 16108,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22076,7 +22266,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:daabf7d0c3b42f5c:1",
-      "line": 14151,
+      "line": 14270,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22086,7 +22276,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:db8c11a2c0b7fe60:1",
-      "line": 9786,
+      "line": 9905,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22096,7 +22286,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:dcf7a0530cefaf9f:1",
-      "line": 7103,
+      "line": 7214,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22106,7 +22296,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:dd6d63c470bd836d:1",
-      "line": 15964,
+      "line": 16083,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22116,7 +22306,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ddb295f50cd95170:1",
-      "line": 14682,
+      "line": 14801,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22126,7 +22316,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:dfcbff3b55ea251d:1",
-      "line": 17464,
+      "line": 17583,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22136,7 +22326,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e173b1a8c12c6dbd:1",
-      "line": 7451,
+      "line": 7562,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22146,7 +22336,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e17f2f84af33e670:1",
-      "line": 7085,
+      "line": 7196,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22156,7 +22346,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e4d5c28c26dfa65e:1",
-      "line": 12163,
+      "line": 12282,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22166,7 +22356,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e56f07d16f5cc9b4:1",
-      "line": 4255,
+      "line": 4263,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22176,7 +22366,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e6086e361966bf8c:1",
-      "line": 15950,
+      "line": 16069,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22186,7 +22376,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e618061ad9e7324c:1",
-      "line": 7214,
+      "line": 7325,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22196,7 +22386,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e79c29d5f886f26b:1",
-      "line": 14165,
+      "line": 14284,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22206,7 +22396,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e7b1fa8c318f839c:1",
-      "line": 13542,
+      "line": 13661,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22216,7 +22406,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e8051e15ac18b257:1",
-      "line": 522,
+      "line": 530,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22226,7 +22416,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:e9586af971403925:1",
-      "line": 14913,
+      "line": 15032,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22236,7 +22426,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ea1a3e5b3fb9db5f:1",
-      "line": 7181,
+      "line": 7292,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22246,7 +22436,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ea60f2b68893e20e:1",
-      "line": 9969,
+      "line": 10088,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22256,7 +22446,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ec0f30afa6690bd8:1",
-      "line": 14073,
+      "line": 14192,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22266,7 +22456,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ed39ad04ea8484c3:1",
-      "line": 3527,
+      "line": 3535,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22276,7 +22466,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:edea23f34acfcdf1:1",
-      "line": 17480,
+      "line": 17599,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22286,7 +22476,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ee92a46ff9489ea2:1",
-      "line": 14831,
+      "line": 14950,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22296,7 +22486,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:eefd472f2a539787:1",
-      "line": 5886,
+      "line": 5894,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22306,7 +22496,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:ef978769ef996443:1",
-      "line": 14017,
+      "line": 14136,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22316,7 +22506,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:efc0a356f6da9d04:1",
-      "line": 10569,
+      "line": 10688,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22326,7 +22516,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f1ca066fdda87bbd:1",
-      "line": 16287,
+      "line": 16406,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22336,7 +22526,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f267aa6ff5528deb:1",
-      "line": 10365,
+      "line": 10484,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22346,7 +22536,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f2855c6adf791da2:1",
-      "line": 3305,
+      "line": 3313,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22356,7 +22546,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f2bca63c9360ffaa:1",
-      "line": 6133,
+      "line": 6141,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22366,7 +22556,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f2e147cb5a78b613:1",
-      "line": 5555,
+      "line": 5563,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22376,7 +22566,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f31b795ecba0721c:1",
-      "line": 5889,
+      "line": 5897,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22386,7 +22576,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f367c45353e7fd12:1",
-      "line": 7101,
+      "line": 7212,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22396,7 +22586,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f4b9b9be85ffbe70:1",
-      "line": 16412,
+      "line": 16531,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22406,7 +22596,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f4c038d44a02d782:1",
-      "line": 16381,
+      "line": 16500,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22416,7 +22606,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f519d5c0ef5c1740:1",
-      "line": 4909,
+      "line": 4917,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22426,7 +22616,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f692ddb85683f21a:1",
-      "line": 16311,
+      "line": 16430,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22436,7 +22626,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f840a1eb2893f39c:1",
-      "line": 5876,
+      "line": 5884,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22446,7 +22636,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f8e039578a5e1093:1",
-      "line": 17878,
+      "line": 17997,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22456,7 +22646,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:f8e0d1d63112298f:1",
-      "line": 17520,
+      "line": 17639,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22466,7 +22656,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:fa3fbac7b79ee373:1",
-      "line": 1300,
+      "line": 1308,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22476,7 +22666,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:fc9de1accd1bd60f:1",
-      "line": 17864,
+      "line": 17983,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -22486,7 +22676,7 @@
     },
     {
       "key": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs:fee014912a65951e:1",
-      "line": 14711,
+      "line": 14830,
       "path": "implementations/rust/sugar-walk/src/bin/walk_rpc.rs",
       "reason": "lifter-side output/status/effect vocabulary still uses the verifier verb",
       "replacement": "rename to typed effect/incomplete vocabulary with dual-read compatibility for wire strings",
@@ -24239,11 +24429,11 @@
   "speaker_counts": {
     "emitter-provenance-guard": 3,
     "instrument-prose": 10,
-    "lift-output-backlog": 2269,
+    "lift-output-backlog": 2288,
     "provenance-oracle-guard": 57,
     "vendor-language-identifier": 2,
     "verifier-verdict-quote": 40,
     "verify-dialect-boundary": 42
   },
-  "total_occurrences": 2423
+  "total_occurrences": 2442
 }


### PR DESCRIPTION
## Denominator first

The pinned scanner population at a6f24803579ba166720c2ea7bac516358b57f506 and this head base f6fd5bb88cd8a909cabdae43b8773fd13ca57212 is the same 754 members by key in both directions: removed 0, added 0. This is not demand-table fallout and not a substituted roster.

## Vanished rows, individually cleared

Both vanished keys remain reached with identical semantics. Black #7242 joined their source lines and therefore rekeyed the normalized line text:

- board_function_facts.py pinned 404 -> current 388: the same refused-functionsClean branch and same concatenated runtime reason.
- floor_value.py pinned 1225 -> current 1196: the same _undecided_ordering_law call to _refuse_ordering_meaning with identical arguments.

Stopped being reached: 0. Deliberate taxonomy retirement: 0. Earned line-join rekeys: 2.

## Genuinely added rows

Nineteen additions have no vanished mate:

- #7227: manager_summary_derivation.py:1295.
- #7250: resolution_session.py:57 and :342.
- #7266: rust_test_assertions_rpc.rs:6741, :6742, :6858, :6884, :6890, :6891.
- #7268: walk_rpc.rs:6465.
- #7269: lift_rpc.py:2632.
- #7280: callsite.rs:63, :145, :152, :711.
- #7281: constraint.rs:1922, :1939, :1945.
- #7289: no_call_body_attribution.py:520.

Shared-key classification movement is zero. The conserved exact delta is 2423 - 2 + 21 = 2442 occurrences across 195 files; lift-output backlog is 2288.

## Instrument evidence

Using the unchanged collector with system Python because the local enforcement guard terminates Homebrew Python 3.14 processes:

- exact pinned-multiset comparison: PASS at 2442 / 195.
- planted new refusal-vocabulary twin: PASS, still trips the census.
- diff check: clean.

This refresh classifies measured movement only. It does not claim the underlying constructs are complete, and it does not touch the other three red jobs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh refusal vocabulary census after earned additions
> Updates [lift_refusal_vocabulary_census.json](https://github.com/TSavo/sugar/pull/7290/files#diff-679d9c70dea0d4d683f60434858a4764a923719253749aa1c59b8f5e596046ab) to reflect newly added refusal vocabulary entries across Python and Rust source files. The backlog count increases from 2269 to 2288 and total occurrences from 2423 to 2442, with new entries spanning RPC, session, callsite, and constraint modules. Line positions for many existing entries are also adjusted to reflect current file state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f42704b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->