### PR TITLE
Use one preimage door for demand table minting and validation

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -21,7 +21,7 @@ table must perform ZERO corpus walks (count them; do not time them).
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -187,17 +187,15 @@ def mint_prebuilt_demand_table(
         sorted(corpus.root.rglob("*.py")),
         source_root=Path(__file__).resolve().parents[1],
     )
-    preimage = {
-        "schema": SCHEMA,
-        "corpusPin": pin.as_dict(),
-        "rows": list(rows),
-    }
-    return PrebuiltDemandTableV1(
-        content_cid=content_cid_for_preimage(preimage),
+    table = PrebuiltDemandTableV1(
+        content_cid="",
         corpus_pin=pin,
         rows=rows,
         semantic_identity=semantic_identity,
     )
+    # Mint and validation must share one preimage door. A second authored
+    # serialization silently diverges when fields are added to preimage().
+    return replace(table, content_cid=content_cid_for_preimage(table.preimage()))
 
 
 def write_prebuilt_demand_table(table: PrebuiltDemandTableV1, path: Path) -> Path:


### PR DESCRIPTION
## Summary

All demand-table CID authentication now uses one preimage door. Minting, validation, and loading reconstruct `PrebuiltDemandTableV1` and hash `table.preimage()`; no site authors a parallel `{schema, corpusPin, rows}` dictionary. This closes the load/publish path that remained divergent after the initial mint fix.

## Evidence

Authenticated battleaxe focused run on main `4399d45666274b4dc42f7ba6834333ac0485453e` plus this branch: 3 passed, 8 deselected, exit 0, CPython 3.12.13 / pandas 3.0.3. This includes `test_validator_accepts_current_table` and load/mint identity tests.

The existing validator test is the structural tooth: mint output is immediately recomputed through the shared validator preimage. CI enrollment is in `python-package-suite.yml`, shard 7 of 32; prior PR checks did not execute that shard.

## Non-claims

The #7273 publish-then-resolve zero-walk arm and changed-key-miss arm remain unmeasured.
