### PR TITLE
Use authenticated preimage when loading demand tables

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -264,13 +264,16 @@ def load_prebuilt_demand_table(
             f"replacement=rebuild the table against the authenticated pin "
             f"(blonde law: wrong corpus is not a measurement)"
         )
-    preimage = {
-        "schema": SCHEMA,
-        "corpusPin": pin.as_dict(),
-        "rows": list(raw["rows"]),
-    }
-    recomputed = content_cid_for_preimage(preimage)
     presented = raw.get("contentCid")
+    # Reconstruct the authenticated value first; its preimage() is the only
+    # serialization door shared with minting and validation.
+    table = PrebuiltDemandTableV1(
+        content_cid=str(presented),
+        corpus_pin=pin,
+        rows=tuple(raw["rows"]),
+        semantic_identity=semantic_identity,
+    )
+    recomputed = content_cid_for_preimage(table.preimage())
     if presented != recomputed:
         raise DemandTableArtifactRefusal(
             f"prebuilt demand table contentCid mismatch: "
@@ -281,12 +284,7 @@ def load_prebuilt_demand_table(
             f"prebuilt demand table contentCid != plan demandTableCid: "
             f"artifact={presented!r} plan={expected_content_cid!r}"
         )
-    return PrebuiltDemandTableV1(
-        content_cid=str(presented),
-        corpus_pin=pin,
-        rows=tuple(raw["rows"]),
-        semantic_identity=semantic_identity,
-    )
+    return table
 
 
 def refs_from_prebuilt_table(table: PrebuiltDemandTableV1):


### PR DESCRIPTION
## Summary

Follow-up to merged #7291. This is a fresh main-based commit containing only the load-door correction; it does not carry the previously merged mint commit.

`load_prebuilt_demand_table` now reconstructs `PrebuiltDemandTableV1` and hashes `table.preimage()`, the same preimage used by minting and validation. The prior loader authored `{schema, corpusPin, rows}` separately and omitted `semanticIdentity`, so serialize/load and publish/resolve remained broken.

## Evidence

- Parent and merge-base: `d88435c09fe4f603a6bcaaf5866de2d4f16fa730`.
- Tree diff: exactly one file, `prebuilt_demand_table.py` (`+10/-12`).
- `python -m py_compile` passed.
- The focused authenticated battleaxe run for this exact load-door change passed 3 tests, 8 deselected, exit 0 on CPython 3.12.13 / pandas 3.0.3.

## Non-claims

The #7273 publish-then-resolve zero-walk and changed-key-miss arms remain unmeasured.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use authenticated preimage when loading prebuilt demand tables
> Updates `load_prebuilt_demand_table` in [prebuilt_demand_table.py](https://github.com/TSavo/sugar/pull/7292/files#diff-c9a8d3af76f6724a4431dab259902f9ac9cf470781760a699c29a90e6418715c) to construct a `PrebuiltDemandTableV1` instance first, then compute the content CID via `table.preimage()` rather than building a raw dict manually. The function now returns the already-constructed table instance instead of creating a second one at the return site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f882dbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->