### PR TITLE
Run measurement composers in declared Python environments

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -435,7 +435,7 @@ jobs:
 
   floor-enrollment:
     name: floor-enrollment
-    needs: [process-floor, static-floors]
+    needs: [python-test-env-prepare, process-floor, static-floors]
     if: always()
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
@@ -443,6 +443,16 @@ jobs:
       PYTHONUNBUFFERED: "1"
     steps:
       - uses: actions/checkout@v4
+      - name: Download shared third-party wheelhouse
+        uses: actions/download-artifact@v4
+        with:
+          name: python-test-wheelhouse
+          path: ${{ runner.temp }}/python-test-wheelhouse
+      - name: Install declared environment from shared wheelhouse
+        id: floor-enrollment-env
+        uses: ./.github/actions/python-test-environment-from-wheelhouse
+        with:
+          wheelhouse-path: ${{ runner.temp }}/python-test-wheelhouse
       - name: "Phase: download axis reports"
         uses: actions/download-artifact@v4
         with:
@@ -456,7 +466,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "floor_enrollment phase=job status=start commit=$GITHUB_SHA"
-          python3 -u tools/sole_construction_floor_enrollment.py \
+          "${{ steps.floor-enrollment-env.outputs.python }}" -u tools/sole_construction_floor_enrollment.py \
             --check-attendance floor-axis-artifacts \
             --require-commit "${GITHUB_SHA}" \
             --write-campaign-body floor-measurement.json \
@@ -464,7 +474,7 @@ jobs:
             | tee -a "$GITHUB_STEP_SUMMARY"
           # Fail attendance if incomplete (tool exit already).
           # Also fail if any residual-red axis attended: residual red is campaign red.
-          python3 -u - <<'PY'
+          "${{ steps.floor-enrollment-env.outputs.python }}" -u - <<'PY'
           import json, sys
           from pathlib import Path
           body = json.loads(Path("floor-measurement.json").read_text())

--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Prepare declared Python environment
+        id: roll-call-env
+        uses: ./.github/actions/python-test-environment
+
       - name: "Phase: resolve roll-call subject commit"
         id: subject
         env:
@@ -112,7 +116,7 @@ jobs:
           # PER-COMMIT cadence only. Nightlies are a different obligation.
           # CRITICAL: attendance exit 1 must NOT skip compose/gate.
           set +e
-          python3 -u tools/heavy_measurement_attendance.py \
+          "${{ steps.roll-call-env.outputs.python }}" -u tools/heavy_measurement_attendance.py \
             --commit "$SHA" \
             --cadence per-commit \
             --receipts-dir receipts \
@@ -136,7 +140,7 @@ jobs:
           att_exit="${{ steps.attendance.outputs.attendance_exit }}"
           # Compose even when receipts/ are empty: that is PartialVector, not silence.
           echo "attendance phase=compose status=start"
-          python3 -u - <<'PY'
+          "${{ steps.roll-call-env.outputs.python }}" -u - <<'PY'
           from pathlib import Path
           import json
           import importlib.util
@@ -159,7 +163,7 @@ jobs:
 
           set +e
           echo "attendance phase=gate status=start"
-          python3 -u tools/commit_measurement_gate.py \
+          "${{ steps.roll-call-env.outputs.python }}" -u tools/commit_measurement_gate.py \
             --composition commit-measurement.json \
             --require-complete \
             | tee -a "$GITHUB_STEP_SUMMARY"

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -197,6 +197,19 @@ def test_floor_workflow_is_parallel_matrix_with_enrollment():
     assert LEASE_WRAPPER not in text
 
 
+def test_roll_call_composes_under_the_declared_python_environment():
+    """CommitMeasurement imports package code and must not use ambient python3."""
+    text = _text("heavy-measurement-attendance.yml")
+    assert "uses: ./.github/actions/python-test-environment" in text
+    assert "id: roll-call-env" in text
+    managed_python = '"${{ steps.roll-call-env.outputs.python }}"'
+    assert f"{managed_python} -u tools/heavy_measurement_attendance.py" in text
+    assert f"{managed_python} -u - <<'PY'" in text
+    assert f"{managed_python} -u tools/commit_measurement_gate.py" in text
+    assert "python3 -u tools/heavy_measurement_attendance.py" not in text
+    assert "python3 -u tools/commit_measurement_gate.py" not in text
+
+
 def test_process_floor_matrix_restores_and_saves_ca_terminal_shelf():
     """Parallel jobs must not each cold-lift: fleet-wide actions/cache over the CA shelf.
 

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -91,6 +91,26 @@ def test_workflow_is_parallel_matrix_not_serial_monolith() -> None:
     assert "uses: ./.github/actions/python-test-environment\n" not in process_job
 
 
+def test_floor_enrollment_uses_the_declared_shared_python_environment() -> None:
+    """The roll call must not inherit packages from an unrelated job's system Python."""
+    workflow = WORKFLOW.read_text()
+    enrollment_job = workflow.split("floor-enrollment:", 1)[1]
+
+    assert "python-test-env-prepare" in enrollment_job.split("steps:", 1)[0]
+    assert "name: python-test-wheelhouse" in enrollment_job
+    assert "uses: ./.github/actions/python-test-environment-from-wheelhouse" in (
+        enrollment_job
+    )
+    assert "id: floor-enrollment-env" in enrollment_job
+    assert (
+        '"${{ steps.floor-enrollment-env.outputs.python }}" -u '
+        "tools/sole_construction_floor_enrollment.py"
+    ) in enrollment_job
+    assert "python3 -u tools/sole_construction_floor_enrollment.py" not in (
+        enrollment_job
+    )
+
+
 def test_static_job_binds_every_static_axis() -> None:
     static = STATIC.read_text()
     for axis, command in STATIC_SCRIPTS.items():


### PR DESCRIPTION
## Summary

Bind the sole-construction floor enrollment and heavy-measurement roll-call composer to the repository's declared Python environment instead of ambient system `python3`.

`blake3` was not absent from the project: it is a declared package dependency. The two jobs failed because they invoked package-importing tools through bare system Python. Floor enrollment now consumes the already-built shared wheelhouse through `python-test-environment-from-wheelhouse`; the roll call uses the single authoritative `python-test-environment` action. Each Python command names the action's interpreter output explicitly. No dependency name is hand-listed and nothing is installed into system Python.

## Root cause and bounded audit

The floor job had been relying on state an earlier job happened to leave in a self-hosted system interpreter. When the environment-preparation path went red, `sole_construction_floor_enrollment.py` reached its package import under bare `python3` and died with `ModuleNotFoundError: blake3`. The roll-call composer had the same hidden interpreter assumption when it loaded `commit_measurement.py`.

An AST import-closure audit covered every other bare `python3 tools/*.py` workflow call. The only other call whose local closure imports a Sugar package is the static-floor mint, and that call already runs after `python-test-environment-from-wheelhouse`. Every other bare tools call has zero Sugar package imports across its local tool closure. This bounds the class; there is no third unbound package-importing workflow tool.

## Instrument and evidence

- Red twins before the change: floor enrollment lacked the shared declared environment; roll-call composition lacked the authoritative environment, 0/2.
- Same interpreter-provenance teeth after the change: 2/2.
- Owning test files under authenticated battleaxe CPython 3.12.13 / pandas 3.0.3: 34/34 passed, unpiped exit 0.
- `actionlint v1.7.12` accepts all 15 workflow documents.
- All 15 workflow YAML documents parse.
- `python -m py_compile` on both owning test files passes.
- `git diff --check` passes.
- Four modified files, zero deletions; closing-account digest remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Non-claims

This PR does not hand-list or newly provision `blake3`. It does not claim a factory workflow result yet. The `factory-zero-tolerance` workflow dispatch is intentionally held until the demand-table mint/validate/load path is coherent on the selected ref; dispatching against the earlier split-CID tree would measure the wrong defect.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run measurement composer scripts under declared Python environments instead of system python3
> - The `floor-enrollment` job in [factory-zero-tolerance.yml](.github/workflows/factory-zero-tolerance.yml) now downloads a shared wheelhouse artifact and installs a declared Python env via `./.github/actions/python-test-environment-from-wheelhouse` before running enrollment scripts.
> - The `roll-call` job in [heavy-measurement-attendance.yml](.github/workflows/heavy-measurement-attendance.yml) installs a declared Python env via `./.github/actions/python-test-environment` and uses it for all three script invocations (attendance, compose, and gate).
> - Tests are added to assert that both jobs use the managed interpreter and do not fall back to `python3`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe85ae3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->