### PR TITLE
Exercise authenticated demand table miss fallback

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/no_call_body_attribution.py
@@ -10,6 +10,7 @@ producer-owned and propagates loud.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_exceptional_exit_producer.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -48,6 +50,44 @@ SITE_SHA256 = "0308786b24b61a2b98be5d649e57ee847d7993ae1d0e1823d7f760408523131f"
 # sha256:a223… is historical negative testimony only — never identity.
 MANIFEST_CID = CANONICAL_CORPUS_MANIFEST_CID
 MANIFEST_SHA256 = CANONICAL_CORPUS_MANIFEST_SHA256
+
+
+def test_pull_shared_demand_table_executes_authenticated_miss_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CAS-miss arm must execute, not merely compile."""
+    import subprocess
+    import sugar_lift_py_tests.authenticated_pytest as auth
+    import sugar_lift_py_tests.no_call_body_attribution as module
+    import sugar_lift_py_tests.prebuilt_demand_table as prebuilt
+
+    class FakeCorpus:
+        pass
+
+    table = SimpleNamespace(
+        semantic_identity=SimpleNamespace(content_key=module.SHARED_DEMAND_TABLE_CONTENT_KEY),
+        rows=({"kind": "test-row"},),
+        corpus_pin=SimpleNamespace(
+            version=module.AUTHENTICATED_PANDAS,
+            aggregate_hash=module.CANONICAL_CORPUS_MANIFEST_CID,
+            file_count=module.AUTHENTICATED_FILE_COUNT,
+        ),
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1, "", "miss"),
+    )
+    monkeypatch.setattr(auth, "authenticated_pandas_corpus", lambda: FakeCorpus())
+    monkeypatch.setattr(prebuilt, "mint_prebuilt_demand_table", lambda _: table)
+
+    output = tmp_path / "demand.json"
+    result = module.pull_shared_demand_table(Path("/repo"), output)
+
+    assert result["contentKey"] == module.SHARED_DEMAND_TABLE_CONTENT_KEY
+    assert json.loads(output.read_text(encoding="utf-8"))["rows"] == [
+        {"kind": "test-row"}
+    ]
 
 REJECTED_VENDOR_FILTER_SEEDS = (
     (


### PR DESCRIPTION
## Summary

- Import `sys` so the CAS-miss fallback can report and continue instead of raising NameError at the first real miss.
- Add a regression tooth that forces the CAS pull to return exit 1, executes authenticated fallback derivation, and validates/writes the returned table.

The dispatch failure was a real first-execution defect: py_compile and prior tests never entered the miss branch.

## Evidence

Authenticated battleaxe focused run: 1 passed, 23 deselected, exit 0, CPython 3.12.13 / pandas 3.0.3.

## Non-claims

This fixes the fallback branch only. The semantic-key-to-payload-CID lookup design remains unresolved; no publish/resolve cache arm is claimed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test for authenticated miss fallback in `pull_shared_demand_table`
> Adds a pytest test in [test_subscript_exceptional_exit_producer.py](https://github.com/TSavo/sugar/pull/7294/files#diff-5c5671a659b6b692c1993866e9055906803fa264e008b726b85172b480049df6) that exercises the CAS miss fallback path in `pull_shared_demand_table`. The test monkeypatches `subprocess.run` to simulate a non-zero exit with `stderr='miss'`, then verifies that the authenticated fallback runs, writes the expected demand table JSON, and returns a mapping with the correct `contentKey`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5aa1bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->