### PR TITLE
Avoid undeclared demand-table option on process floors

### DIFF
--- a/tests/test_process_floor_demand_table.py
+++ b/tests/test_process_floor_demand_table.py
@@ -78,6 +78,15 @@ def test_all_process_floor_doors_forward_the_supplied_table() -> None:
         assert "scan_paths" in source
 
 
+def test_floor_caller_withholds_table_only_from_silent() -> None:
+    wrapper = (ROOT / "tools" / "run_one_process_floor_axis.sh").read_text()
+    assert 'script_name != "silent_zero_tolerance.py"' in wrapper
+    for script in FLOOR_SCRIPTS:
+        assert "add_demand_table_arg" in (SCRIPTS / script).read_text()
+    silent = (SCRIPTS / "silent_zero_tolerance.py").read_text()
+    assert "add_demand_table_arg" not in silent
+
+
 def test_factory_workflow_enrolls_the_authenticated_table_artifact() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     assert "Pull authenticated shared Python demand table" in workflow

--- a/tools/run_one_process_floor_axis.sh
+++ b/tools/run_one_process_floor_axis.sh
@@ -94,8 +94,16 @@ FLOOR_SUMMARY="${FLOOR_SCRATCH}/floor-summary.json"
 mkdir -p "$FLOOR_SCRATCH"
 
 set +e
-python -u "$SCRIPT" "$PANDAS_CORPUS" \
-  --demand-table-path "$demand_table_path" \
+script_args=(
+  "$PANDAS_CORPUS"
+)
+# Silent is the one floor that audits disk-vs-roll-call membership and does
+# not attribute construction through the demand table.  The other three
+# matrix consumers declare and require this authority.
+if [ "$script_name" != "silent_zero_tolerance.py" ]; then
+  script_args+=(--demand-table-path "$demand_table_path")
+fi
+python -u "$SCRIPT" "${script_args[@]}" \
   --repo-root "$PANDAS_CORPUS" \
   --out-dir "$FLOOR_SCRATCH" \
   --json "$FLOOR_SUMMARY" \


### PR DESCRIPTION
## Summary

The process-floor matrix has four top-level scripts, not `_enum_floor_runtime.py`. `silent_zero_tolerance.py` is the sole script without `add_demand_table_arg`; native-crash, bare-exception, and timeout all declare and require the supplied table.

The caller now withholds `--demand-table-path` only for silent and preserves it for the other three. This corrects the prior backwards condition that would have removed required authority from 24 seats.

Added discrimination coverage for the four-way asymmetry.

## Non-claims

No post-fix R_silent or process-floor product number is claimed; the next factory run is discovery.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `--demand-table-path` when invoking `silent_zero_tolerance.py` in process floor wrapper
> [`run_one_process_floor_axis.sh`](https://github.com/TSavo/sugar/pull/7295/files#diff-e2f37947c64a438368c7b6c2e4b00a46231fdc6065bcaaec43954d2ada2be00e) previously passed `--demand-table-path` to all floor scripts, but `silent_zero_tolerance.py` does not declare that argument, causing an error. The wrapper now builds a `script_args` array and conditionally appends `--demand-table-path` only when the script is not `silent_zero_tolerance.py`. A new test in [`test_process_floor_demand_table.py`](https://github.com/TSavo/sugar/pull/7295/files#diff-1fcd96e327df7d7acc9306883a771ba47a0d639c21cecdad6e17463bb041e8a4) verifies this behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fe86a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->