### PR TITLE
Bind source seat into module materialization identity

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -2139,7 +2139,7 @@ def _module_materialize_key(
     Per-definition frame projection still keys on the definition coordinate.
     Materializing the whole module per definition is what multiplied
     in-population megamodules (``pandas/_config/config.py`` ×18). Key is
-    artifact + dependency seats + source CID + module name — never process
+    artifact + dependency seats + source CID + module name + source seat — never process
     state; the session is the authority boundary.
     """
     return (
@@ -2152,6 +2152,7 @@ def _module_materialize_key(
         ),
         module.source_cid,
         module.module_name,
+        module.source_seat,
     )
 
 

--- a/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_dependency_artifact_graph.py
@@ -1263,12 +1263,38 @@ def test_session_module_materialize_amortizes_across_definitions(
     impl_hits = sum(
         1 for p in materializations["paths"] if str(p).endswith("implementation.py")
     )
-    assert impl_hits == 1, (
-        f"implementation module SourceFile count={impl_hits} (total "
-        f"{materializations['count']}, paths={materializations['paths']}); "
-        f"expected 1 under one session for {len(resolved)} definitions"
-    )
+    implementation_keys = [
+        key
+        for key in session.module_materializations
+        if key[-2] == "example_pkg.implementation"
+    ]
+    assert len(implementation_keys) == 1, implementation_keys
+    assert implementation_keys[0][-1] == "example_pkg/implementation.py"
     assert len(session.module_materializations) >= 1
+
+    # Seat identity is part of the materialized object.  A truthful repeat
+    # hits, while the same module under a different seat must miss rather
+    # than reuse a typed SourceFile carrying the wrong filename.
+    from sugar_lift_python_source.manager_construction import _module_materialize_key
+
+    module = graph.modules["example_pkg.implementation"]
+    same_seat = replace(module, source_seat=module.source_seat)
+    other_seat = replace(module, source_seat="alternate/implementation.py")
+    same_key = _module_materialize_key(
+        graph=graph, module=same_seat, dependency_graphs={}
+    )
+    repeat_key = _module_materialize_key(
+        graph=graph, module=module, dependency_graphs={}
+    )
+    other_key = _module_materialize_key(
+        graph=graph, module=other_seat, dependency_graphs={}
+    )
+    assert same_key == repeat_key
+    assert other_key != same_key
+    marker = object()
+    session.remember_module_materialize(same_key, marker)
+    assert session.module_materialize_hit(repeat_key) is marker
+    assert session.module_materialize_hit(other_key) is None
 
     # Discrimination: a fresh session re-materializes (isolation, not process memo).
     other = _session_enrolling_graph(graph)
@@ -1279,6 +1305,41 @@ def test_session_module_materialize_amortizes_across_definitions(
         resolve_source_visible_frame(resolved[0], graph=graph, session=other)
     finally:
         mc.SourceFile = original_sf  # type: ignore[misc, assignment]
-    assert (
-        materializations["count"] >= 1
-    ), "fresh session paid zero materialize; process-global memo returned"
+    other_implementation_keys = [
+        key
+        for key in other.module_materializations
+        if key[-2] == "example_pkg.implementation"
+    ]
+    assert len(other_implementation_keys) == 1, other_implementation_keys
+    assert other_implementation_keys[0][-1] == "example_pkg/implementation.py"
+
+
+def test_module_materialize_identity_binds_source_seat(tmp_path: Path) -> None:
+    """A same-seat repeat hits; a different seat cannot reuse the object."""
+    from sugar_lift_python_source.manager_construction import _module_materialize_key
+
+    distribution = _install_distribution(
+        tmp_path,
+        package_source="from example_pkg.implementation import alpha\n",
+        implementation_source="def alpha(value):\n    return value\n",
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    module = graph.modules["example_pkg.implementation"]
+    session = _session_enrolling_graph(graph)
+
+    same_key = _module_materialize_key(graph=graph, module=module, dependency_graphs={})
+    repeat_key = _module_materialize_key(
+        graph=graph, module=replace(module, source_seat=module.source_seat), dependency_graphs={}
+    )
+    other_key = _module_materialize_key(
+        graph=graph,
+        module=replace(module, source_seat="alternate/implementation.py"),
+        dependency_graphs={},
+    )
+    assert same_key == repeat_key
+    assert same_key != other_key
+
+    marker = object()
+    session.remember_module_materialize(same_key, marker)
+    assert session.module_materialize_hit(repeat_key) is marker
+    assert session.module_materialize_hit(other_key) is None


### PR DESCRIPTION
The module materialization cache key now includes the authenticated source seat. A module materialized under a different seat is a different typed object and can no longer reuse a cached SourceFile with the wrong filename.

Evidence on main f2a0bde815:
- same-seat amortization and separate-session materialization: 2/2 focused bpytest tests passed
- alternate-seat cache twin: distinct key and cache miss
- truthful same-seat repeat: identical key and cache hit

The original construction-count assertion was stale instrumentation: it installed its monkeypatch after resolve_import_binding had already materialized the module. It has been replaced by direct session-key evidence.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind source seat into module materialization memoization key
> Previously, `_module_materialize_key` identified a module materialization session by artifact CID, dependency seats, source CID, and module name. This adds `source_seat` as a final element so that the same module encountered under different seats triggers re-materialization rather than a memo hit.
>
> - Updates [`manager_construction.py`](https://github.com/TSavo/sugar/pull/7297/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to append `module.source_seat` to the key tuple.
> - Adds a new test `test_module_materialize_identity_binds_source_seat` and expands `test_session_module_materialize_amortizes_across_definitions` to assert same-seat hits and cross-seat misses.
> - Behavioral Change: modules with identical artifact/source CIDs but different seats now bypass the memo and are re-materialized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56a11a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected module caching so materialized source files remain distinct when they originate from different source locations.
  * Ensured identical source locations reuse cached results while separate sessions create independent materializations.

* **Tests**
  * Added coverage validating cache behavior for matching and differing source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->