### PR TITLE
Render instrument failure testimony in recensus

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -104,7 +104,7 @@ import tempfile
 import time
 from collections import Counter
 from pathlib import Path
-from typing import Any, Callable, TextIO
+from typing import Any, Callable, Mapping, TextIO
 
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
 
@@ -629,6 +629,22 @@ def _measure_file(
 def _is_process_control(error: BaseException) -> bool:
     """Never swallow process death as a per-file terminal."""
     return isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit))
+
+
+def _render_terminal_category(row: Mapping[str, Any]) -> str:
+    """Render a terminal without discarding instrument-failure testimony."""
+    category = row.get("category")
+    if category:
+        return str(category)
+    failure = row.get("instrumentFailure")
+    if isinstance(failure, Mapping):
+        return (
+            "instrument-failure "
+            f"stageId={failure.get('stageId', '?')} "
+            f"phase={failure.get('phase', '?')} "
+            f"message={failure.get('message', '?')}"
+        )
+    return "?"
 
 
 def terminal_after_measure_escape(
@@ -1619,7 +1635,7 @@ def main() -> int:
                 checkpoint.append(file, row)
                 measured_now.append((file, row))
 
-                cat = str(row.get("category") or "?")
+                cat = _render_terminal_category(row)
                 fn = int(row.get("functionsTotal") or 0)
                 # functionsClean may be null when clean ratio is refused.
                 # Law: never treat null clean as 0-of-N and mint clean%=100.

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_construction_panic_escape.py
@@ -56,6 +56,24 @@ def _raise(error: BaseException):
     return boom
 
 
+def test_instrument_failure_renderer_names_its_testimony() -> None:
+    row = {
+        "instrumentFailure": {
+            "stageId": "recensus-enumerate-file-terminal/v1",
+            "phase": "roster",
+            "message": "typed module seat mismatch",
+        }
+    }
+    rendered = RECENSUS._render_terminal_category(row)
+    assert "stageId=recensus-enumerate-file-terminal/v1" in rendered
+    assert "phase=roster" in rendered
+    assert "message=typed module seat mismatch" in rendered
+
+
+def test_missing_category_without_instrument_failure_stays_explicit() -> None:
+    assert RECENSUS._render_terminal_category({}) == "?"
+
+
 def _fixture_file(tmp_path: Path) -> Path:
     path = tmp_path / "fixture.py"
     path.write_text("def fixture():\n    return 1\n", encoding="utf-8")


### PR DESCRIPTION
Instrument-failure rows deliberately omit `category` and carry named `stageId`, `phase`, and `message`. The recensus progress renderer previously collapsed those rows to `?`, discarding the diagnosis and making compose refusal opaque.

This renders instrument failures as `instrument-failure stageId=... phase=... message=...`. A genuinely missing category without an instrument-failure payload remains `?`.

Focused authenticated bpytest evidence: 2 passed in 0.50s.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render instrument failure testimony as category text in recensus
> Adds a `_render_terminal_category` helper to [`control_effect_recensus.py`](https://github.com/TSavo/sugar/pull/7299/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) that produces a descriptive `instrument-failure` string (including `stageId`, `phase`, and `message`) when a row has no `category` but contains an `instrumentFailure` mapping, falling back to `?` when neither is present. The `main` entrypoint now calls this helper instead of inline category extraction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6047f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->