### PR TITLE
Bind source seats into every typed source cache

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -893,7 +893,7 @@ def measure_file_via_enumerate(
     from sugar_source_tree.process_resident_file import get_resident
 
     _clear_d3_audit_open_observation(source_cid)
-    d3_present_before_demand = get_resident(source_cid) is not None
+    d3_present_before_demand = get_resident(source_cid, str(full_path)) is not None
     try:
         audit, construction_gaps = demand_construction_residual(
             workspace_root=workspace_root,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1853,7 +1853,7 @@ def _roll_call_audit_leaf(
 
     reporter = CollectingReporter()
     resident_before_open = (
-        get_resident(expected_source_cid) if expected_source_cid is not None else None
+        get_resident(expected_source_cid, str(full_path)) if expected_source_cid is not None else None
     )
     source_file = None
     try:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -676,9 +676,9 @@ def _session_lexical_import_runner(session: SourceResolutionSession, module):
     )
     from sugar_source_tree.tree import SourceFile
 
-    source_file = session.prefix_file_hit(module.source_cid)
+    source_file = session.prefix_file_hit(module.source_cid, module.source_seat)
     if source_file is None:
-        resident = get_resident(module.source_cid)
+        resident = get_resident(module.source_cid, module.source_seat)
         if resident is not None:
             source_file = resident.source_file
     if source_file is not None:
@@ -890,7 +890,7 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     # used to rebuild config.py once per export locus (measured 33× SourceFile
     # on one _json open after the frame-door memo). Value is context-bound to
     # this session — never process-global.
-    source_file = session.prefix_file_hit(module.source_cid)
+    source_file = session.prefix_file_hit(module.source_cid, module.source_seat)
     if source_file is None:
         construction_context = TreeConstructionContextV1.for_source_call_construction()
         producer_reporter = ConstructionTestimonyReporterV1(
@@ -901,7 +901,7 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
             reporter=producer_reporter,
             construction_context=construction_context,
         )
-        session.remember_prefix_file(module.source_cid, source_file)
+        session.remember_prefix_file(module.source_cid, module.source_seat, source_file)
     construction_context = source_file.unit.construction_context
     locus_key = (locus.lineno, locus.col_offset)
     prefix = tuple(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -294,12 +294,14 @@ class SourceResolutionSession:
 
     # -- prefix-door SourceFile + fallthrough (export path) --------------
 
-    def prefix_file_hit(self, source_cid: str) -> Any | None:
-        return self.prefix_files.get(source_cid) if self.enabled else None
+    def prefix_file_hit(self, source_cid: str, source_seat: str) -> Any | None:
+        return self.prefix_files.get((source_cid, source_seat)) if self.enabled else None
 
-    def remember_prefix_file(self, source_cid: str, source_file: Any) -> None:
+    def remember_prefix_file(
+        self, source_cid: str, source_seat: str, source_file: Any
+    ) -> None:
         if self.enabled:
-            self.prefix_files[source_cid] = source_file
+            self.prefix_files[(source_cid, source_seat)] = source_file
 
     def fallthrough_hit(self, key: tuple) -> bool | None:
         if not self.enabled:

--- a/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_resolution_session_authority.py
@@ -655,3 +655,15 @@ def test_file_open_door_threads_resolution_session(tmp_path: Path, monkeypatch) 
     seen.clear()
     open_source_file_for_construction(path, root=root, resolution_session=shared)
     assert seen == [shared], "explicit package session must reach populate unchanged"
+
+
+def test_prefix_file_memo_binds_source_seat() -> None:
+    session = SourceResolutionSession(
+        enrolled_distributions=frozenset({"session-authority-fixture"})
+    )
+    first = object()
+    session.remember_prefix_file("cid-1", "pkg/one.py", first)
+    assert session.prefix_file_hit("cid-1", "pkg/one.py") is first
+    assert session.prefix_file_hit("cid-1", "pkg/two.py") is None
+    session.remember_prefix_file("cid-1", "pkg/one.py", first)
+    assert session.prefix_file_hit("cid-1", "pkg/one.py") is first

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/process_resident_file.py
@@ -1,11 +1,11 @@
-"""Enumeration protocol §4 — process-resident file context under content CID.
+"""Enumeration protocol §4 — process-resident file context under content CID + seat.
 
 Law (``protocol/specs/2026-07-08-enumeration-protocol.md`` §4):
 
     Inside the Python kit, demanded file context is process-resident under the
-    whole-file content CID. A file request parses and prepares module temporal
-    context once for that CID; distinct demanded descendants reuse it. Changing
-    the file changes the CID and therefore misses without a staleness check.
+    whole-file content CID and source seat. A file request parses and prepares
+    module temporal context once for that identity; a different seat is a
+    different typed object and therefore misses.
 
 This is not a new invention and not an optional cache. The protocol makes
 re-deriving the same content for every consumer **unrepresentable**: same CID
@@ -42,7 +42,7 @@ def _resident_limit() -> int:
 class ProcessResidentFileContext:
     """One whole-file content CID's prepared body, process-resident.
 
-    ``prepare_count`` is the number of times this CID paid MaterializeModule
+    ``prepare_count`` is the number of times this CID/seat paid MaterializeModule
     in this process (protocol: must be 1 after first demand).
     """
 
@@ -53,12 +53,12 @@ class ProcessResidentFileContext:
     prepare_count: int
 
 
-# content CID -> resident context (LRU by access)
-_RESIDENT: collections.OrderedDict[str, ProcessResidentFileContext] = (
+# (content CID, source seat) -> resident context (LRU by access)
+_RESIDENT: collections.OrderedDict[tuple[str, str], ProcessResidentFileContext] = (
     collections.OrderedDict()
 )
 # Teeth: prepare counts even after eviction from the LRU window
-_PREPARE_COUNTS: dict[str, int] = {}
+_PREPARE_COUNTS: dict[tuple[str, str], int] = {}
 
 # §4 module temporal context: lexical import preparation (call + value rows).
 # Content-derived; not a consumer projection shell. Keyed by content CID plus
@@ -67,9 +67,11 @@ _LEXICAL: collections.OrderedDict[tuple, Any] = collections.OrderedDict()
 _LEXICAL_PREPARE_COUNTS: dict[str, int] = {}
 
 
-def prepare_count_for(source_cid: str) -> int:
-    """How many times this content CID has paid full SourceFile prepare."""
-    return int(_PREPARE_COUNTS.get(source_cid, 0))
+def prepare_count_for(source_cid: str, source_seat: str | None = None) -> int:
+    """How many times this CID (optionally seat) paid full SourceFile prepare."""
+    if source_seat is not None:
+        return int(_PREPARE_COUNTS.get((source_cid, source_seat), 0))
+    return sum(n for (cid, _seat), n in _PREPARE_COUNTS.items() if cid == source_cid)
 
 
 def lexical_prepare_count_for(source_cid: str) -> int:
@@ -89,17 +91,18 @@ def clear_process_resident_files() -> None:
     _LEXICAL_PREPARE_COUNTS.clear()
 
 
-def _remember(source_cid: str, ctx: ProcessResidentFileContext) -> None:
-    _RESIDENT[source_cid] = ctx
-    _RESIDENT.move_to_end(source_cid)
+def _remember(source_cid: str, source_seat: str, ctx: ProcessResidentFileContext) -> None:
+    key = (source_cid, source_seat)
+    _RESIDENT[key] = ctx
+    _RESIDENT.move_to_end(key)
     while len(_RESIDENT) > _resident_limit():
         _RESIDENT.popitem(last=False)
 
 
-def get_resident(source_cid: str) -> ProcessResidentFileContext | None:
-    hit = _RESIDENT.get(source_cid)
+def get_resident(source_cid: str, source_seat: str) -> ProcessResidentFileContext | None:
+    hit = _RESIDENT.get((source_cid, source_seat))
     if hit is not None:
-        _RESIDENT.move_to_end(source_cid)
+        _RESIDENT.move_to_end((source_cid, source_seat))
     return hit
 
 
@@ -110,7 +113,7 @@ def source_file_from_identity(
     reporter: Any = None,
     construction_context: object | None = None,
 ) -> Any:
-    """Return SourceFile for identity, preparing at most once per content CID.
+    """Return SourceFile for identity, preparing at most once per CID and seat.
 
     Implements §4 at the construction door every demand already walks.
     """
@@ -127,7 +130,7 @@ def source_file_from_identity(
             construction_context=construction_context,
         )
 
-    hit = get_resident(source_cid)
+    hit = get_resident(source_cid, filename)
     if hit is not None:
         # Protocol: distinct demanded descendants reuse preparation.
         # Rebind consumer construction_context when provided so seating writes
@@ -140,8 +143,9 @@ def source_file_from_identity(
             sf.reporter = reporter
         return sf
 
-    # Miss: content CID not prepared. Pay once; changing bytes → new CID → miss.
-    _PREPARE_COUNTS[source_cid] = _PREPARE_COUNTS.get(source_cid, 0) + 1
+    # Miss: this CID/seat not prepared. Pay once; changing bytes or seat misses.
+    count_key = (source_cid, filename)
+    _PREPARE_COUNTS[count_key] = _PREPARE_COUNTS.get(count_key, 0) + 1
     sf = SourceFile._prepare_uncached(
         identity,
         backend=backend if backend is not None else _default_backend(),
@@ -150,12 +154,13 @@ def source_file_from_identity(
     )
     _remember(
         source_cid,
+        filename,
         ProcessResidentFileContext(
             source_cid=source_cid,
             source=source,
             filename=filename,
             source_file=sf,
-            prepare_count=_PREPARE_COUNTS[source_cid],
+            prepare_count=_PREPARE_COUNTS[count_key],
         ),
     )
     return sf

--- a/implementations/python/sugar-source-tree/tests/test_l0c_dependency_seat_materialize_once.py
+++ b/implementations/python/sugar-source-tree/tests/test_l0c_dependency_seat_materialize_once.py
@@ -31,17 +31,21 @@ def _install_root() -> Path:
     return Path(metadata.distribution("pandas").locate_file("")).resolve()
 
 
-def test_same_content_many_seats_one_prepare() -> None:
+def test_same_content_same_seat_hits_alternate_seat_misses() -> None:
     from sugar_lift_python_source.canonical import blake3_512_of
     from sugar_source_tree.tree import SourceFile
 
     clear_process_resident_files()
     body = "def f():\n    return 1\n"
     cid = blake3_512_of(body.encode("utf-8"))
-    for i in range(35):
-        SourceFile((body, f"seat_{i}/enum.py", cid))
-    assert prepare_count_for(cid) == 1, prepare_count_for(cid)
-    assert resident_size() == 1
+    first = SourceFile((body, "seat_0/enum.py", cid))
+    repeat = SourceFile((body, "seat_0/enum.py", cid))
+    alternate = SourceFile((body, "seat_1/enum.py", cid))
+    assert repeat is first
+    assert alternate is not first
+    assert prepare_count_for(cid, "seat_0/enum.py") == 1
+    assert prepare_count_for(cid, "seat_1/enum.py") == 1
+    assert resident_size() == 2
 
 
 def test_sourcefile_constructor_returns_resident_identity() -> None:
@@ -53,8 +57,9 @@ def test_sourcefile_constructor_returns_resident_identity() -> None:
     cid = blake3_512_of(body.encode("utf-8"))
     a = SourceFile((body, "pkg/a.py", cid))
     b = SourceFile((body, "other/a.py", cid))
-    assert a is b
-    assert prepare_count_for(cid) == 1
+    assert a is not b
+    assert prepare_count_for(cid, "pkg/a.py") == 1
+    assert prepare_count_for(cid, "other/a.py") == 1
 
 
 def test_json_open_enum_and_config_at_most_once() -> None:
@@ -73,6 +78,7 @@ def test_json_open_enum_and_config_at_most_once() -> None:
         sf = open_source_file_for_construction(
             path,
             root=install_root,
+            distribution="pandas",
             construction_context=TreeConstructionContextV1.for_source_call_construction(),
             populate_derived=True,
         )

--- a/implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py
+++ b/implementations/python/sugar-source-tree/tests/test_process_resident_file_cid.py
@@ -1,8 +1,7 @@
 """Enumeration protocol §4 — process-resident file context under content CID.
 
-Law: prepare once per whole-file content CID; descendants reuse; changing
-bytes changes the CID and misses. The tooth that made the violation
-unrepresentable: two consumers of the same module content prepare ONCE.
+Law: prepare once per whole-file content CID and source seat; descendants
+reuse; changing bytes or seat changes the identity and misses.
 """
 
 from __future__ import annotations
@@ -24,17 +23,19 @@ def setup_function() -> None:
     clear_process_resident_files()
 
 
-def test_same_content_cid_prepares_once_from_two_consumer_seats() -> None:
-    """§4 tooth: two different seats, same content CID → MaterializeModule once."""
+def test_same_content_cid_binds_source_seat() -> None:
+    """Same seat hits; alternate seat misses; repeat remains a hit."""
     body = "def shared(value):\n    return value\n"
     cid = blake3_512_of(body.encode("utf-8"))
     a = SourceFile(_identity(body, "consumer_a/dep.py"))
     b = SourceFile(_identity(body, "consumer_b/dep.py"))
     assert a.unit.source_cid == b.unit.source_cid == cid
-    assert a.unit is b.unit  # same preparation
-    assert a.root is b.root
-    assert prepare_count_for(cid) == 1
-    assert resident_size() == 1
+    assert a.unit is not b.unit
+    repeat = SourceFile(_identity(body, "consumer_a/dep.py"))
+    assert repeat is a
+    assert prepare_count_for(cid, "consumer_a/dep.py") == 1
+    assert prepare_count_for(cid, "consumer_b/dep.py") == 1
+    assert resident_size() == 2
 
 
 def test_changed_bytes_change_cid_and_miss() -> None:


### PR DESCRIPTION
## Summary

Bind source seat into every cache that serves typed source objects:

- session prefix-file memo now keys `(source_cid, source_seat)`;
- process-resident `SourceFile` memo now keys `(source_cid, source_seat)`;
- all resident observations and callers pass the authoritative seat.

A typed module or source file is a different object under a different seat. The same identity omission appeared in the module materialization cache and independently in the prefix-file and process-resident caches; this change makes the seat part of each storage identity rather than detecting foreign hits downstream.

## Teeth

Fresh battleaxe `bpytest` on the rebased head: 10 passed, including same-seat hit, alternate-seat miss, and repeat same-seat hit for both the prefix memo and process-resident `SourceFile` memo. Existing process-resident tests were updated to assert distinct seats do not alias.

Renderer PR #7299 remains separate and is not included here.

## Non-claims

This does not claim Stata's three With demands are resolved. The post-seat-fix Stata census is the follow-up measurement after this branch lands.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind source seats into process residency and typed source caches
> - Process residency in [`process_resident_file.py`](https://github.com/TSavo/sugar/pull/7300/files#diff-a419340dc11cf32686609067b2bf24ffcd464e3969e9df67f4a68d4d53559041) is now keyed by `(source_cid, source_seat)` instead of `source_cid` alone; the same content at different seats produces separate resident entries and prepare counts.
> - Prefix-door `SourceFile` memoization in [`resolution_session.py`](https://github.com/TSavo/sugar/pull/7300/files#diff-54257d48026540505071d0613a7c672ce198dc916935415abb69c38a81451ce5) is updated to key by `(source_cid, source_seat)`, so a memoized file for one seat will not satisfy a lookup for another.
> - D3 residency probes in the enumeration consumer and audit leaf now pass the source seat to `get_resident`, so cross-seat residents no longer count as hits.
> - Behavioral Change: any previously shared resident or memoized `SourceFile` across seats will now be treated as a miss, potentially triggering separate preparation per seat.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e339a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->