### PR TITLE
Instrument the managed showcase entrance

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -697,7 +697,13 @@ sugar_bx_run_docker() {
   done
   docker_args+=(--env SUGAR_BINARY_SHELF_READ_ONLY=1)
   docker_args+=(--env SUGAR_BINARY_PUBLISH=0)
-  docker_args+=("$image" "$@")
+  docker_args+=("$image")
+  if [[ -n "${SUGAR_BX_MANAGED_PRECONDITION_PLAN:-}" ]]; then
+    docker_args+=(python /workspace/sugar/tools/sugar-build/preflight.py run
+      --plan-json "$SUGAR_BX_MANAGED_PRECONDITION_PLAN"
+      --artifact-root /opt/sugar --)
+  fi
+  docker_args+=("$@")
   for arg in "${docker_args[@]}"; do command+=" $(sugar_bx_quote "$arg")"; done
   sugar_bx_ssh "exec${command}"
 }

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -446,6 +446,7 @@ sugarbin_bx_cargo() {
   sugar_bx_finish "$status"
 }
 
+lock_preflight=0
 case "${1:-}" in
   run|cargo|build|explain)
     subcommand="$1"
@@ -458,11 +459,16 @@ case "${1:-}" in
     artifact_subcommand="$2"
     shift 2
     ;;
+  preflight-lock)
+    lock_preflight=1
+    shift
+    ;;
 esac
 
 usage() {
   cat <<'EOF'
 usage: bin/sugarbin [--bin <name>] [--profile release|debug] [--platform <auto|key>] [--print-source-stamp]
+       bin/sugarbin preflight-lock --bin <name> --profile <profile> --platform <key>
        bin/sugarbin artifact publish --kind python-demand-table --content-key <key> --input <json> --runtime <name> [--platform <key>] [--profile <name>] [--shelf-root <dir>]
        bin/sugarbin artifact pull --kind python-demand-table --content-key <key> --output <json> --runtime <name> [--platform <key>] [--profile <name>] [--shelf-root <dir>]
 
@@ -1551,8 +1557,8 @@ acquire_rebuild_single_flight() {
   _rebuild_heartbeat_pid=""
   lock_parent="$(cache_dir)/.rebuild-locks"
   if ! mkdir -p "$lock_parent" 2>/dev/null; then
-    log "phase=resolve-wait-degraded bin=$bin_name reason=lock-parent-uncreatable path=$lock_parent"
-    return 0
+    log "crime=uncreatable-rebuild-lock-path owner=bin/sugarbin path=$lock_parent replacement=provide a writable declared cache root before binary resolution"
+    return 70
   fi
   # Directory name IS the lock: mkdir succeeds for exactly one contender.
   lockdir="$lock_parent/$(platform_key)-${profile}-$(stamp_for_filename "$stamp")-${bin_name}.lock"
@@ -1561,8 +1567,12 @@ acquire_rebuild_single_flight() {
   wait_start="$(date +%s)"
   while true; do
     if mkdir "$lockdir" 2>/dev/null; then
-      printf '%s\n' "$$" >"$lockdir/pid"
-      : >"$lockdir/heartbeat"
+      if ! printf '%s\n' "$$" >"$lockdir/pid" 2>/dev/null \
+        || ! : >"$lockdir/heartbeat" 2>/dev/null; then
+        rm -rf "$lockdir" 2>/dev/null || true
+        log "crime=unwriteable-rebuild-lock-state owner=bin/sugarbin path=$lockdir replacement=provide a writable lock directory before binary resolution"
+        return 70
+      fi
       _rebuild_lock_dir="$lockdir"
       # Heartbeat while we hold: keeps waiters from reclaiming a live cargo.
       (
@@ -1595,7 +1605,11 @@ acquire_rebuild_single_flight() {
     age="$(_rebuild_heartbeat_age_seconds "$lockdir")"
     if [[ "$age" -ge "$stale_s" ]]; then
       log "phase=resolve-wait-reclaim bin=$bin_name stamp=${stamp_short}… heartbeat_age_s=$age stale_s=$stale_s"
-      rm -rf "$lockdir" 2>/dev/null || true
+      holder="$(tr -d '[:space:]' <"$lockdir/pid" 2>/dev/null || true)"
+      if ! rm -rf "$lockdir" 2>/dev/null || [[ -e "$lockdir" ]]; then
+        log "crime=unreclaimable-rebuild-lock owner=bin/sugarbin path=$lockdir holder_pid=${holder:-unknown} heartbeat_age_s=$age replacement=repair the declared lock root; do not wait on an owner that cannot be authenticated or reclaimed"
+        return 70
+      fi
       continue
     fi
     # Also reclaim empty/new locks that never wrote a heartbeat (crashed mid-mkdir).
@@ -1604,7 +1618,11 @@ acquire_rebuild_single_flight() {
       sleep 0.5
       if [[ ! -f "$lockdir/heartbeat" ]]; then
         log "phase=resolve-wait-reclaim bin=$bin_name stamp=${stamp_short}… reason=no-heartbeat"
-        rm -rf "$lockdir" 2>/dev/null || true
+        holder="$(tr -d '[:space:]' <"$lockdir/pid" 2>/dev/null || true)"
+        if ! rm -rf "$lockdir" 2>/dev/null || [[ -e "$lockdir" ]]; then
+          log "crime=unreclaimable-rebuild-lock owner=bin/sugarbin path=$lockdir holder_pid=${holder:-unknown} heartbeat_age_s=999999 replacement=repair the declared lock root; do not wait on an owner that cannot be authenticated or reclaimed"
+          return 70
+        fi
         continue
       fi
     fi
@@ -1953,7 +1971,7 @@ main() {
   # waste. Key is stamp+bin+platform+profile — not a machine-wide lease.
   # Double-check pull after the lock: the winner's publish is visible to waiters.
   # Wait narration: phase=resolve-wait every 30s (job log / stderr, not TTY-gated).
-  acquire_rebuild_single_flight "$stamp" "$name"
+  acquire_rebuild_single_flight "$stamp" "$name" || return $?
   if candidate="$(pull_from_filesystem_shelf "$stamp" "$identity" "$name")"; then
     log "phase=resolve-hit source=peer-publish-after-wait bin=$bin_name stamp=$(_stamp_short "$stamp")…"
     release_rebuild_single_flight
@@ -1978,6 +1996,16 @@ main() {
 if [[ -n "$artifact_subcommand" ]]; then
   dispatch_artifact_subcommand
   exit $?
+fi
+
+if [[ "$lock_preflight" == "1" ]]; then
+  [[ -n "${SUGAR_BINARY_SOURCE_STAMP:-}" ]] || {
+    log "crime=missing-rebuild-lock-preflight-stamp owner=bin/sugarbin replacement=set SUGAR_BINARY_SOURCE_STAMP to the authenticated source stamp"
+    exit 70
+  }
+  acquire_rebuild_single_flight "$SUGAR_BINARY_SOURCE_STAMP" "preflight" || exit $?
+  release_rebuild_single_flight
+  exit 0
 fi
 
 main "$@"

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -107,6 +107,7 @@ dispatch_execution_subcommand() {
   # networking available unless a named task explicitly proves it can run
   # offline in sugar-build.toml.
   local task_json="" task_capabilities="" task_needs="" task_network="required"
+  local task_preconditions_json=""
   local -a task_command=()
   if [[ -n "$task" ]]; then
     local contract_python
@@ -132,6 +133,21 @@ dispatch_execution_subcommand() {
     # do not recreate that environment policy.
     if [[ "$host" == bx && "$execution_env_explicit" == 0 ]]; then
       execution_env="docker:$task_capabilities"
+    fi
+    if [[ "$host" == bx ]] && "$contract_python" -c \
+      'import json,sys; raise SystemExit("closure" not in json.load(sys.stdin))' \
+      <<<"$task_json"; then
+      task_preconditions_json="$("$contract_python" "$script_dir/../tools/sugar-build/contract.py" resolve-preconditions "$task" --host bx --repo-root "$script_dir/..")" || return $?
+    fi
+  elif [[ "$host" == bx && ${#command[@]} -gt 0 ]]; then
+    local contract_python command_owner_json command_owner
+    contract_python="$(sugarbin_contract_python)" || return $?
+    command_owner_json="$("$contract_python" "$script_dir/../tools/sugar-build/contract.py" match-command -- "${command[@]}")" || return $?
+    command_owner="$("$contract_python" -c 'import json,sys; print(json.load(sys.stdin)["task"] or "")' <<<"$command_owner_json")"
+    if [[ -n "$command_owner" ]]; then
+      printf 'sugarbin: crime=unmanaged-command-closure command=%s task=%s replacement=select --task %s\n' \
+        "$(IFS=,; printf '%s' "${command[*]}")" "$command_owner" "$command_owner" >&2
+      return 70
     fi
   fi
 
@@ -254,6 +270,7 @@ dispatch_execution_subcommand() {
   SUGAR_BX_PATH_PREFIXES=()
   SUGAR_BX_ENV_NAMES=()
   SUGAR_BX_SYNC_BACKS=()
+  SUGAR_BX_MANAGED_PRECONDITION_PLAN="$task_preconditions_json"
   ((${#path_prefixes[@]} == 0)) || SUGAR_BX_PATH_PREFIXES=("${path_prefixes[@]}")
   ((${#env_names[@]} == 0)) || SUGAR_BX_ENV_NAMES=("${env_names[@]}")
   ((${#sync_backs[@]} == 0)) || SUGAR_BX_SYNC_BACKS=("${sync_backs[@]}")

--- a/docs/superpowers/plans/2026-08-03-managed-entrance-precondition-gate.md
+++ b/docs/superpowers/plans/2026-08-03-managed-entrance-precondition-gate.md
@@ -1,0 +1,230 @@
+# Managed Entrance Precondition Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land stage one of the managed showcase entrance: a declared command closure, executable nine-axis authority falsification, early named refusal, finite rebuild-lock failure, and artifact ABI authentication.
+
+**Architecture:** `sugar-build.toml` owns the named showcase task and the roots from which its active scripts, toolchain components, commands, and profile-qualified artifacts are derived. `contract.py` produces a canonical plan; `preflight.py` authenticates it before the task subject; existing sugarbin shell-tier contracts enroll the teeth. Stage one publishes no image, so the current image must honestly refuse missing `git` and `rust-src` until stage two supplies a satisfying digest.
+
+**Tech Stack:** Python 3.12 standard library, Bash, TOML, JSON, existing sugarbin/battleaxe transport.
+
+## Global Constraints
+
+- Derive obligations from task, roster, retirement, toolchain, artifact, and route authority; never encode the nine incidents as production policy.
+- An axis without a producing declaration or route fact is unmeasured and refuses `crime=unpredicted-precondition-axis`.
+- Rebuild-lock failures terminate; no `holder_pid=unknown heartbeat_age=999999` retry loop is allowed.
+- Detached remote execution remains unsolved and receives no managed success claim.
+- Stage one must not modify `tools/sugar-build/Dockerfile` or any image digest.
+- Preserve the closing-account JSON SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.
+
+---
+
+### Task 1: Declare and derive the managed showcase closure
+
+**Files:**
+- Modify: `sugar-build.toml`
+- Modify: `tools/sugar-build/contract.py`
+- Create: `tools/sugar-build/preflight.py`
+- Create: `tests/fixtures/managed_entrance_axes.json`
+- Create: `tests/sugarbin_managed_preconditions.sh`
+- Modify: `tests/sugarbin_docker_exec.sh`
+
+**Interfaces:**
+- Produces: `resolve_task_preconditions(name, host, repo_root, path=DEFAULT_CONTRACT) -> dict`.
+- Produces: CLI `contract.py resolve-preconditions TASK --host bx --repo-root PATH`.
+- Produces: CLI `contract.py match-command -- ARGV...`.
+- Produces: CLI `preflight.py falsify --plan-json JSON --axes PATH`.
+
+- [ ] **Step 1: Write the failing derivation contract**
+
+Create the nine-row JSON fixture. Each row contains `axis`, `expectedKind`, and `expectedSourcePrefix`. Add a shell contract that resolves the showcase plan and runs the falsifier:
+
+```bash
+plan="$(python3 "$repo/tools/sugar-build/contract.py" \
+  resolve-preconditions showcases --host bx --repo-root "$repo")"
+python3 "$repo/tools/sugar-build/preflight.py" falsify \
+  --plan-json "$plan" \
+  --axes "$repo/tests/fixtures/managed_entrance_axes.json"
+```
+
+Assert the live 64-row roster, the retirement-derived active count, `rust-src` sourced from `examples/std-core-showcase/rust-toolchain.toml`, `git` sourced from task closure, profile-qualified artifacts, route facts, and `R_unpredicted_precondition_axes=0`. Change one copied fixture row to `expectedKind=not-derived`; require exit 70 and `crime=unpredicted-precondition-axis`.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+bash tests/sugarbin_managed_preconditions.sh "$PWD"
+```
+
+Expected: nonzero because the task, resolver, and falsifier do not exist.
+
+- [ ] **Step 3: Implement the strict closure**
+
+Add the approved `[tasks.showcases]` and nested closure. Extend `resolve_task` to accept the optional closure and reject unknown keys, invalid profiles, duplicate artifacts, absent roster paths, retirements outside the roster, missing adjacent manifests, and malformed toolchain tables.
+
+Build checks only from declarations and route facts:
+
+```python
+checks = [
+    *command_checks(closure["required_commands"], "task.closure.required_commands"),
+    *toolchain_component_checks(active_scripts, closure["adjacent_manifests"]),
+    *artifact_checks(closure["artifacts"]),
+    *route_checks(host),
+]
+```
+
+`route_checks("bx")` emits the closed kinds `cache-access`, `shelf-access`, `rebuild-lock`, `process-lifetime`, and `declared-interpreter`; no incident label appears in production code.
+
+- [ ] **Step 4: Implement executable falsification**
+
+For every fixture row require one plan check with matching `kind` and source prefix. Print uncovered rows and exact discovered/predicted/unpredicted counts. Return 70 if any row is uncovered.
+
+- [ ] **Step 5: Enroll and verify GREEN**
+
+Invoke the new shell contract from `tests/sugarbin_docker_exec.sh`, preserving the nine-test shell-tier roster. Run both contracts plus `git diff --check`. Commit:
+
+```bash
+git add sugar-build.toml tools/sugar-build/contract.py tools/sugar-build/preflight.py \
+  tests/fixtures/managed_entrance_axes.json tests/sugarbin_managed_preconditions.sh \
+  tests/sugarbin_docker_exec.sh
+git commit -m "Instrument managed showcase entrance authority"
+```
+
+### Task 2: Refuse unmanaged command closure and check declared prerequisites
+
+**Files:**
+- Modify: `bin/sugarbin`
+- Modify: `bin/lib/sugar-bx.sh`
+- Modify: `tools/sugar-build/preflight.py`
+- Modify: `tests/sugarbin_managed_preconditions.sh`
+- Modify: `tests/sugarbin_docker_exec.sh`
+
+**Interfaces:**
+- Produces: `preflight.py run --plan-json JSON --artifact-root PATH -- COMMAND...`.
+- Produces: transport-owned `SUGAR_BX_MANAGED_PRECONDITION_PLAN`.
+
+- [ ] **Step 1: Add RED twins**
+
+Prove raw `bin/sugarbin run --host bx -- make test-showcases` refuses before SSH/Docker with exit 70, `crime=unmanaged-command-closure`, and `task=showcases`; unrelated raw `true` remains allowed. Add fake plans proving an absent command refuses `crime=missing-managed-command` and a fake rustup missing `rust-src` refuses `crime=missing-toolchain-component` with channel `1.96.0`.
+
+- [ ] **Step 2: Run RED**
+
+Run the managed-precondition and Docker contracts. Expected: matching raw argv reaches transport and missing prerequisites reach their subjects.
+
+- [ ] **Step 3: Implement command ownership refusal**
+
+Before `sugar_bx_init`, when `host=bx` and no task was selected, ask `match-command` for an exact registered command prefix. Refuse only a claimed command:
+
+```text
+sugarbin: crime=unmanaged-command-closure command=make,test-showcases task=showcases replacement=select --task showcases
+```
+
+- [ ] **Step 4: Implement the plan runner**
+
+Resolve named-task plans locally. In `sugar_bx_run_docker`, wrap the subject:
+
+```bash
+python /workspace/sugar/tools/sugar-build/preflight.py run \
+  --plan-json "$SUGAR_BX_MANAGED_PRECONDITION_PLAN" \
+  --artifact-root /opt/sugar -- "${command[@]}"
+```
+
+The runner checks commands with `shutil.which`, rustup components using the exact manifest channel, then artifacts. Each check prints its name, source, elapsed milliseconds, and result. On success it `os.execvp`s the subject; on missing authority it exits 70 first.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+Run both focused contracts and `bash -n` on changed shell files. Commit `Refuse unmanaged showcase execution at entry`.
+
+### Task 3: Make rebuild-lock failure finite
+
+**Files:**
+- Modify: `bin/sugarbin`
+- Modify: `tests/sugarbin_rebuild_single_flight.sh`
+
+**Interfaces:**
+- Produces: `bin/sugarbin preflight-lock --stamp VALUE --bin NAME`, using the production acquire/release path.
+- Produces: `crime=uncreatable-rebuild-lock-path`, `crime=unwriteable-rebuild-lock-state`, and `crime=unreclaimable-rebuild-lock`.
+
+- [ ] **Step 1: Add both lock arms**
+
+Use Python `subprocess.run(..., timeout=5)` from the shell contract. The writable private-cache fixture must acquire and release with no residue. The unreclaimable fixture plants a stale lock and shadows `rm` with a test executable that refuses that exact removal. Require exit 70, exactly one unreclaimable crime, exact path, `holder_pid=unknown`, and `heartbeat_age_s=999999`.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+bash tests/sugarbin_rebuild_single_flight.sh "$PWD"
+```
+
+Expected: the disposable command is absent or the planted state times out.
+
+- [ ] **Step 3: Implement finite refusal**
+
+Change lock-parent creation from degraded success to named refusal. Require PID and heartbeat writes after winning `mkdir`. After stale or no-heartbeat reclaim, require both successful removal and absence of the path before continuing; otherwise log once and return 70.
+
+- [ ] **Step 4: Expose the real disposable cycle**
+
+Dispatch `preflight-lock` after function definitions and before normal `main`. Bind globals, call the production acquire, call the production release, and return the actual status. Do not duplicate the lock algorithm.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+Run the lock contract twice and `bash -n bin/sugarbin`. Commit `Terminate unreclaimable rebuild locks`.
+
+### Task 4: Authenticate artifact ABI before subject execution
+
+**Files:**
+- Modify: `tools/sugar-build/preflight.py`
+- Modify: `tools/sugar-build/entrypoint.sh`
+- Modify: `tests/sugarbin_docker_exec.sh`
+
+**Interfaces:**
+- Consumes: required-artifact manifest and plan `artifact-abi` checks.
+- Produces: `crime=artifact-abi-incompatible` with artifact path and loader output.
+
+- [ ] **Step 1: Add ABI twins**
+
+Extend the relocated entrypoint fixture. A fake `ldd` returning a normal libc mapping must allow the subject. A second fake returns nonzero with `version 'GLIBC_2.39' not found`; require exit 70, named ABI crime, artifact path, retained loader text, and no subject marker.
+
+- [ ] **Step 2: Run RED**
+
+Run `tests/sugarbin_docker_exec.sh`; expected: the incompatible twin reaches the subject or lacks the named reason.
+
+- [ ] **Step 3: Implement ABI authentication once**
+
+Put the ABI routine in `preflight.py` and invoke it from both the plan runner and checked-in entrypoint. Accept a non-ELF/static `ldd` result only when output says `not a dynamic executable`; refuse missing libraries and versioned loader failures. Never execute the artifact as a probe.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run Docker, managed-precondition, and shell-tier wrapper contracts. Commit `Refuse incompatible managed artifacts before execution`.
+
+### Task 5: Verify, publish, and land stage one
+
+**Files:**
+- Modify: the design spec only if verification reveals an actual correction.
+
+**Interfaces:**
+- Produces: stage-one PR and merge receipt.
+
+- [ ] **Step 1: Run focused verification**
+
+```bash
+bash -n bin/sugarbin bin/lib/sugar-bx.sh tools/sugar-build/entrypoint.sh \
+  tests/sugarbin_managed_preconditions.sh tests/sugarbin_docker_exec.sh \
+  tests/sugarbin_rebuild_single_flight.sh
+bash tests/sugarbin_managed_preconditions.sh "$PWD"
+bash tests/sugarbin_rebuild_single_flight.sh "$PWD"
+bash tests/sugarbin_docker_exec.sh "$PWD"
+git diff --check
+```
+
+Require nine discovered/predicted and zero uncovered, both lock arms, ABI twins, intentional current-image refusal, and the detached-lifetime non-claim.
+
+- [ ] **Step 2: Verify scope and sealed receipt**
+
+Confirm no Dockerfile/image digest changed, no file was deleted, no category/kind/label/taxonomy/residual bucket escaped the closed design vocabulary, and the closing-account digest remains exact.
+
+- [ ] **Step 3: Rebase and publish**
+
+Tree-compare against current main, rebase if needed, push the exact head, and open a PR with predicted `Epsilon R`, receipts, and non-claims. Do not force-push without separate authority.
+
+- [ ] **Step 4: Merge under the standing rule**
+
+Merge only if API MERGEABLE and every actual check that ran is green or absent. Verify API state `MERGED`, record merge SHA, re-check the closing-account digest, and report through Keyser with two Enters.

--- a/docs/superpowers/plans/2026-08-03-managed-entrance-precondition-gate.md
+++ b/docs/superpowers/plans/2026-08-03-managed-entrance-precondition-gate.md
@@ -172,7 +172,7 @@ Run the lock contract twice and `bash -n bin/sugarbin`. Commit `Terminate unrecl
 
 **Files:**
 - Modify: `tools/sugar-build/preflight.py`
-- Modify: `tools/sugar-build/entrypoint.sh`
+- Modify: `bin/lib/sugar-bx.sh`
 - Modify: `tests/sugarbin_docker_exec.sh`
 
 **Interfaces:**
@@ -181,7 +181,7 @@ Run the lock contract twice and `bash -n bin/sugarbin`. Commit `Terminate unrecl
 
 - [ ] **Step 1: Add ABI twins**
 
-Extend the relocated entrypoint fixture. A fake `ldd` returning a normal libc mapping must allow the subject. A second fake returns nonzero with `version 'GLIBC_2.39' not found`; require exit 70, named ABI crime, artifact path, retained loader text, and no subject marker.
+Extend the managed pre-subject wrapper fixture. A fake `ldd` returning a normal libc mapping must allow the subject. A second fake returns nonzero with `version 'GLIBC_2.39' not found`; require exit 70, named ABI crime, artifact path, retained loader text, and no subject marker.
 
 - [ ] **Step 2: Run RED**
 
@@ -189,7 +189,7 @@ Run `tests/sugarbin_docker_exec.sh`; expected: the incompatible twin reaches the
 
 - [ ] **Step 3: Implement ABI authentication once**
 
-Put the ABI routine in `preflight.py` and invoke it from both the plan runner and checked-in entrypoint. Accept a non-ELF/static `ldd` result only when output says `not a dynamic executable`; refuse missing libraries and versioned loader failures. Never execute the artifact as a probe.
+Put the ABI routine in `preflight.py` and invoke it from the transport-owned plan runner before `os.execvp`. Accept a non-ELF/static `ldd` result only when output says `not a dynamic executable`; refuse missing libraries and versioned loader failures. Never execute the artifact as a probe. Do not edit the checked-in image entrypoint in stage one: that source cannot affect already-published immutable images.
 
 - [ ] **Step 4: Run GREEN and commit**
 
@@ -206,7 +206,7 @@ Run Docker, managed-precondition, and shell-tier wrapper contracts. Commit `Refu
 - [ ] **Step 1: Run focused verification**
 
 ```bash
-bash -n bin/sugarbin bin/lib/sugar-bx.sh tools/sugar-build/entrypoint.sh \
+bash -n bin/sugarbin bin/lib/sugar-bx.sh \
   tests/sugarbin_managed_preconditions.sh tests/sugarbin_docker_exec.sh \
   tests/sugarbin_rebuild_single_flight.sh
 bash tests/sugarbin_managed_preconditions.sh "$PWD"

--- a/docs/superpowers/plans/2026-08-03-managed-entrance-precondition-gate.md
+++ b/docs/superpowers/plans/2026-08-03-managed-entrance-precondition-gate.md
@@ -47,7 +47,7 @@ python3 "$repo/tools/sugar-build/preflight.py" falsify \
   --axes "$repo/tests/fixtures/managed_entrance_axes.json"
 ```
 
-Assert the live 64-row roster, the retirement-derived active count, `rust-src` sourced from `examples/std-core-showcase/rust-toolchain.toml`, `git` sourced from task closure, profile-qualified artifacts, route facts, and `R_unpredicted_precondition_axes=0`. Change one copied fixture row to `expectedKind=not-derived`; require exit 70 and `crime=unpredicted-precondition-axis`.
+Assert the plan counts equal the live roster and retirement authorities, `rust-src` is sourced from `examples/std-core-showcase/rust-toolchain.toml`, `git` is sourced from task closure, profile-qualified artifacts and route facts are present, and `R_unpredicted_precondition_axes=0`. Change one copied fixture row to `expectedKind=not-derived`; require exit 70 and `crime=unpredicted-precondition-axis`.
 
 - [ ] **Step 2: Run RED**
 

--- a/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
+++ b/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
@@ -116,10 +116,12 @@ The plan is checked in two stages:
   toolchain components, remote-root/path creation, and a disposable lock
   create/write/heartbeat/remove cycle. Each check emits its name, elapsed time,
   and pass/refusal outcome.
-- The existing managed entrypoint checks the mounted required-artifact manifest
-  before the subject starts. It additionally proves each ELF artifact is
-  loadable by the managed image, distinguishing ABI incompatibility from a
-  product exit.
+- The transport-owned pre-subject wrapper runs inside the selected managed
+  image after the existing entrypoint authenticates the mounted artifact
+  manifest. It proves each ELF artifact is loadable by that exact image,
+  distinguishing ABI incompatibility from a product exit. Stage two bakes the
+  same verifier into the newly published image entrypoint; stage one cannot
+  change an entrypoint already sealed into an immutable image.
 
 The preflight never repairs state. A failed write probe, missing component,
 missing manifest, or ABI mismatch exits before the subject with a named

--- a/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
+++ b/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
@@ -1,0 +1,212 @@
+# Managed Entrance Precondition Gate Design
+
+## Status
+
+Approved by the explicit 2026-08-03 direction to build the entrance gate from
+declared requirements and falsify it against the nine observed axes.
+
+## Problem
+
+Battleaxe execution currently discovers several environmental preconditions
+only after synchronization, artifact resolution, compilation, or proof-binary
+resolution. The observed failures are not nine independent requirements to
+copy into a checklist. They are evidence that the managed entrance has three
+authorities whose obligations are not checked at their boundary:
+
+- `sugar-build.toml` and adjacent toolchain manifests declare the tools and
+  components required by the selected command;
+- `bin/lib/sugar-bx.sh` chooses the remote root, cache, shelf, build, staging,
+  and lock paths plus the foreground SSH lifetime;
+- the required-artifact manifest declares the binaries a managed payload will
+  execute.
+
+The current authority is incomplete for `make test-showcases`: it is not a
+named managed task, and its 64 enrolled scripts own additional declarations.
+The gate must therefore derive from both the selected command closure and its
+checked-in manifests. It must not encode the nine incidents as policy.
+
+## Rejected Designs
+
+### Hand-maintained precondition list
+
+A new JSON/TOML file containing `git`, `rust-src`, shelf paths, and the other
+observed incidents would reproduce the defect in a tidier form. It would not
+change when a command, toolchain manifest, binary set, or path mode changes.
+
+### Per-showcase checks
+
+Adding `command -v` and write probes to individual `run.sh` files leaves the
+failure after synchronization and binary resolution, duplicates ownership,
+and cannot protect `bpytest`, `brun`, or `bcargo` callers of the same entrance.
+
+## Design
+
+### Managed command authority
+
+An entry is managed only when the caller selects a named task with `--task`
+and the broker obtains its command and closure from `sugar-build.toml`. The
+showcase task adds one declarative closure descriptor:
+
+```toml
+[tasks.showcases]
+capabilities = ["python-test", "python-scientific", "solver-z3", "solver-coq", "java", "node", "vampire"]
+binaries = []
+command = ["make", "test-showcases"]
+network = "required"
+
+[tasks.showcases.closure]
+kind = "make-roster"
+path = "Makefile"
+variable = "SHOWCASE_RUNS"
+retirements = ".github/showcase-retirements.json"
+adjacent_manifests = ["rust-toolchain.toml"]
+required_commands = ["git"]
+artifacts = [
+  "release:sugar",
+  "debug:sugar-ir-smt-lib",
+  "debug:sugar-ir-lean",
+  "debug:sugar-ir-coq",
+  "debug:sugar-ir-maude",
+  "debug:sugar-walk-rpc",
+  "debug:rust_test_assertions_rpc",
+  "debug:witness_rpc",
+  "debug:discharge_cli",
+]
+```
+
+The closure describes where authority lives; it does not copy the 64 paths or
+the `rust-src` component. The resolver reads `SHOWCASE_RUNS`, subtracts only
+the source-controlled retirements, and discovers `rust-toolchain.toml` beside
+each active script. A raw battleaxe command whose argv matches a registered
+task command is an authority bypass and refuses with
+`crime=unmanaged-command-closure`, naming the task that must be selected.
+Unrelated ad-hoc `brun` commands remain possible because no registered task
+claims their argv. The profile-qualified artifact list moves the existing
+Makefile literals into the task closure; the Makefile consumes the resolved
+list instead of retaining a second binary roster.
+
+The broker produces one deterministic precondition plan before remote work.
+The plan is a projection of existing declarations, never an authored result:
+
+1. Resolve the selected named task or explicit command.
+2. Expand `make test-showcases` through the authoritative `SHOWCASE_RUNS`
+   roster and retirement manifest.
+3. Read adjacent declarative manifests in the selected command closure.
+   In particular, `rust-toolchain.toml` supplies the exact channel and
+   components such as `rust-src`.
+4. Project core broker commands from the execution route itself. `git` is a
+   broker requirement because repository identity and source-stamp discovery
+   call it; it is not inferred from a prior missing-git log.
+5. Project artifact, ABI, cache, shelf, and lock checks from the requested
+   binary set and the transport-selected access mode.
+6. Project process lifetime from the route. Battleaxe execution is foreground:
+   the SSH session remains the owner until the child exits. Detached remote
+   work is outside this entrance and cannot be reported as a managed run.
+
+The canonical JSON plan names its source declarations and the derived checks.
+Each check has a stable kind (`command`, `toolchain-component`,
+`artifact-manifest`, `artifact-abi`, `cache-access`, `shelf-access`,
+`rebuild-lock`, `process-lifetime`, or `declared-interpreter`). The kinds are
+closed vocabulary; incident names never enter production policy.
+
+The plan is checked in two stages:
+
+- A lightweight host/image preflight runs before workspace synchronization or
+  artifact construction. It checks required commands, exact declared versions,
+  toolchain components, remote-root/path creation, and a disposable lock
+  create/write/heartbeat/remove cycle. Each check emits its name, elapsed time,
+  and pass/refusal outcome.
+- The existing managed entrypoint checks the mounted required-artifact manifest
+  before the subject starts. It additionally proves each ELF artifact is
+  loadable by the managed image, distinguishing ABI incompatibility from a
+  product exit.
+
+The preflight never repairs state. A failed write probe, missing component,
+missing manifest, or ABI mismatch exits before the subject with a named
+`crime=` terminal. Publication authority remains separate: a read-only shelf
+consumer is checked for readable complete cells and is never probed for a
+write it is not allowed to perform.
+
+## Delivery Stages
+
+### Stage one: authority and refusal instruments
+
+Stage one lands the named showcase task and command closure, canonical plan
+derivation, unmanaged-command refusal, finite rebuild-lock refusal, and
+artifact ABI authentication. It also lands a nine-axis falsification fixture
+which maps the empirical incidents to derived check kinds and requires every
+row to be predicted by the plan.
+
+Stage one does **not** publish an image. The current core image lacks `git` and
+the declared `rust-src` component, so a showcase task under stage one refuses
+before expensive work with those exact missing preconditions. That red is the
+instrument correctly observing the current capability gap.
+
+### Stage two: satisfying capability image
+
+Stage two changes the Dockerfile through the single image entrance, installs
+the declared command and toolchain component closure, publishes the immutable
+image, updates the checked-in digest, and activates the profile-qualified
+artifact provisioning already declared by stage one. It turns the stage-one
+precondition red green without weakening, relocating, or bypassing any check.
+Image publication and digest replacement are excluded from stage one because
+they are an independently reviewable supply-chain change.
+
+## Rebuild Lock Law
+
+The rebuild single-flight loop must have a finite refusal arm. Failure to
+create or write the lock parent, lock directory, PID, or heartbeat is a named
+terminal. When stale reclaim cannot remove the lock, the resolver refuses once
+with the exact lock path and observed holder/heartbeat state. It never loops on
+`holder_pid=unknown heartbeat_age=999999`.
+
+This strengthens the existing single-flight instrument without raising its
+staleness threshold or silently bypassing serialization.
+
+## Nine-Axis Falsification Account
+
+The derived plan must explain every empirical axis:
+
+- missing `git`: broker-command projection;
+- missing shelf manifest: requested-binary artifact projection;
+- GLIBC mismatch: mounted-ELF loadability projection;
+- foreign cargo locks: route-selected cache/build-root write projection;
+- read-only `.incoming`: shelf access-mode projection;
+- missing `rust-src`: adjacent `rust-toolchain.toml` component projection;
+- phantom rebuild lock: disposable lock-cycle projection plus terminal reclaim;
+- detached process loss: foreground lifetime projection, with no managed
+  detached success claim;
+- bare Python dependency loss: named-task interpreter projection, already
+  enforced by #7293.
+
+If any axis lacks a producing declaration or route fact, the preflight reports
+the authority gap and the run is unmeasured. It does not fill the gap with a
+guessed requirement.
+
+## Instrumentation and Tests
+
+Focused shell contracts plant both arms:
+
+- each manifest-derived tool/component is accepted when present and refuses by
+  name when absent;
+- a complete required-artifact set passes, a missing manifest refuses, and an
+  ELF with an unavailable loader/version refuses before subject execution;
+- readable read-only shelf consumption passes while a requested publisher must
+  prove writable staging;
+- a writable lock cycle passes, while an unwriteable PID/heartbeat or
+  unreclaimable stale lock terminates with a named refusal;
+- a foreground remote child preserves its exit code; no detached outcome is
+  minted by the broker;
+- the static derivation receipt accounts for all nine observed axes without an
+  incident-name list in production code.
+
+The existing enrolled sugarbin Docker and shelf contracts call these teeth, so
+the gate has a current workflow execution edge rather than existing only as a
+referenced test.
+
+## Non-Claims
+
+This change does not make detached remote processes durable, repair old remote
+roots or shelf cells, infer arbitrary shell dependencies, or claim showcase
+semantics. It moves declared preconditions to the entrance and makes missing
+authority refuse before expensive work.

--- a/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
+++ b/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
@@ -209,4 +209,7 @@ referenced test.
 This change does not make detached remote processes durable, repair old remote
 roots or shelf cells, infer arbitrary shell dependencies, or claim showcase
 semantics. It moves declared preconditions to the entrance and makes missing
-authority refuse before expensive work.
+authority refuse before expensive work. Detached remote execution remains
+unsolved: stage one authenticates foreground SSH ownership and deliberately
+declines to mint any managed success claim for a child detached from that
+session.

--- a/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
+++ b/docs/superpowers/specs/2026-08-03-managed-entrance-precondition-gate-design.md
@@ -74,7 +74,7 @@ artifacts = [
 ]
 ```
 
-The closure describes where authority lives; it does not copy the 64 paths or
+The closure describes where authority lives; it does not copy the enrolled paths or
 the `rust-src` component. The resolver reads `SHOWCASE_RUNS`, subtracts only
 the source-controlled retirements, and discovers `rust-toolchain.toml` beside
 each active script. A raw battleaxe command whose argv matches a registered

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -106,6 +106,31 @@ binaries = ["sugar", "sugar-ir-smt-lib"]
 command = ["make", "examples-gate"]
 network = "required"
 
+[tasks.showcases]
+capabilities = ["python-test", "python-scientific", "solver-z3", "solver-coq", "java", "node", "vampire"]
+binaries = []
+command = ["make", "test-showcases"]
+network = "required"
+
+[tasks.showcases.closure]
+kind = "make-roster"
+path = "Makefile"
+variable = "SHOWCASE_RUNS"
+retirements = ".github/showcase-retirements.json"
+adjacent_manifests = ["rust-toolchain.toml"]
+required_commands = ["git"]
+artifacts = [
+  "release:sugar",
+  "debug:sugar-ir-smt-lib",
+  "debug:sugar-ir-lean",
+  "debug:sugar-ir-coq",
+  "debug:sugar-ir-maude",
+  "debug:sugar-walk-rpc",
+  "debug:rust_test_assertions_rpc",
+  "debug:witness_rpc",
+  "debug:discharge_cli",
+]
+
 [tasks.pandas-wall]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/tests/fixtures/managed_entrance_axes.json
+++ b/tests/fixtures/managed_entrance_axes.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "measurementClass": "managed-entrance-precondition-falsification",
+  "axes": [
+    {
+      "axis": "git-absent-in-managed-image",
+      "expectedKind": "command",
+      "expectedSourcePrefix": "task.closure.required_commands"
+    },
+    {
+      "axis": "cas-cell-missing-shelf-manifest",
+      "expectedKind": "artifact-manifest",
+      "expectedSourcePrefix": "task.closure.artifacts"
+    },
+    {
+      "axis": "artifact-glibc-incompatible-with-image",
+      "expectedKind": "artifact-abi",
+      "expectedSourcePrefix": "task.closure.artifacts"
+    },
+    {
+      "axis": "foreign-cargo-resolution-lock",
+      "expectedKind": "cache-access",
+      "expectedSourcePrefix": "route:bx"
+    },
+    {
+      "axis": "read-only-shelf-staging",
+      "expectedKind": "shelf-access",
+      "expectedSourcePrefix": "route:bx"
+    },
+    {
+      "axis": "pinned-toolchain-missing-rust-src",
+      "expectedKind": "toolchain-component",
+      "expectedSourcePrefix": "examples/std-core-showcase/rust-toolchain.toml"
+    },
+    {
+      "axis": "uncreatable-rebuild-lock-phantom-holder",
+      "expectedKind": "rebuild-lock",
+      "expectedSourcePrefix": "route:bx"
+    },
+    {
+      "axis": "detached-remote-process-does-not-survive",
+      "expectedKind": "process-lifetime",
+      "expectedSourcePrefix": "route:bx"
+    },
+    {
+      "axis": "bare-python-misses-declared-package",
+      "expectedKind": "declared-interpreter",
+      "expectedSourcePrefix": "task.command"
+    }
+  ]
+}

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -203,6 +203,14 @@ line="$(tail -1 "$tmp/docker.log")"
 examples="$(run explain --host bx --task examples-gate)"
 [[ "$examples" == *"network=required"* ]] || fail "examples-gate network requirement not explicit"
 
+: >"$tmp/docker.log"
+run run --host bx --task showcases >/dev/null
+showcase_line="$(tail -1 "$tmp/docker.log")"
+[[ "$showcase_line" == *"tools/sugar-build/preflight.py"* ]] \
+  || fail "managed showcase task omitted pre-subject preflight"
+[[ "$showcase_line" == *"make"*"test-showcases"* ]] \
+  || fail "managed showcase task lost its declared command"
+
 # Artifact-manifest refusal belongs to the managed entrypoint, after the
 # toolchain has authenticated. Exercise that real shell boundary with /opt
 # relocated into this test's private root; only absolute fixture paths change.

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -211,6 +211,58 @@ showcase_line="$(tail -1 "$tmp/docker.log")"
 [[ "$showcase_line" == *"make"*"test-showcases"* ]] \
   || fail "managed showcase task lost its declared command"
 
+# The transport-owned wrapper executes from the workspace mounted into today's
+# immutable image.  Prove its artifact ABI arm with a compatible loader and a
+# versioned-loader bad twin; the latter must refuse before the subject marker.
+abi_root="$tmp/abi-root"
+abi_bin="$tmp/abi-bin"
+mkdir -p "$abi_root/bin" "$abi_bin"
+printf 'ELF fixture\n' >"$abi_root/bin/sugar"
+chmod +x "$abi_root/bin/sugar"
+abi_sha="$(python3 - "$abi_root/bin/sugar" <<'PY'
+import hashlib
+import pathlib
+import sys
+print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+printf '{"artifacts":[{"name":"sugar","sha256":"%s"}]}\n' \
+  "$abi_sha" >"$abi_root/required-artifacts.json"
+abi_plan='{"checks":[{"kind":"artifact-abi","name":"sugar","profile":"release","source":"task.closure.artifacts"}],"schemaVersion":1}'
+cat >"$abi_bin/ldd" <<'SH'
+#!/usr/bin/env bash
+if [[ "${FAKE_LDD_MODE:-good}" == bad ]]; then
+  printf "%s: /lib/libc.so.6: version 'GLIBC_2.39' not found (required by %s)\n" "$1" "$1" >&2
+  exit 1
+fi
+printf 'libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0001)\n'
+SH
+chmod +x "$abi_bin/ldd"
+
+abi_good_marker="$tmp/abi-good-subject"
+PATH="$abi_bin:$PATH" python3 "$repo/tools/sugar-build/preflight.py" run \
+  --plan-json "$abi_plan" --artifact-root "$abi_root" -- \
+  sh -c ': >"$1"' sh "$abi_good_marker" \
+  >"$tmp/abi-good.out" 2>"$tmp/abi-good.err" \
+  || fail 'compatible artifact ABI arm refused'
+[[ -e "$abi_good_marker" ]] || fail 'compatible artifact ABI arm did not reach subject'
+
+abi_bad_marker="$tmp/abi-bad-subject"
+status=0
+FAKE_LDD_MODE=bad PATH="$abi_bin:$PATH" \
+  python3 "$repo/tools/sugar-build/preflight.py" run \
+    --plan-json "$abi_plan" --artifact-root "$abi_root" -- \
+    sh -c ': >"$1"' sh "$abi_bad_marker" \
+    >"$tmp/abi-bad.out" 2>"$tmp/abi-bad.err" || status=$?
+[[ "$status" == 70 ]] || fail "incompatible artifact ABI status=$status, want 70"
+[[ ! -e "$abi_bad_marker" ]] || fail 'incompatible artifact ABI reached subject'
+grep -Fq 'crime=artifact-abi-incompatible' "$tmp/abi-bad.err" \
+  || fail 'incompatible artifact ABI did not name its crime'
+grep -Fq "$abi_root/bin/sugar" "$tmp/abi-bad.err" \
+  || fail 'incompatible artifact ABI did not name its artifact'
+grep -Fq 'GLIBC_2.39' "$tmp/abi-bad.err" \
+  || fail 'incompatible artifact ABI discarded loader output'
+
 # Artifact-manifest refusal belongs to the managed entrypoint, after the
 # toolchain has authenticated. Exercise that real shell boundary with /opt
 # relocated into this test's private root; only absolute fixture paths change.

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -433,3 +433,5 @@ assert quarantine < reset, "malformed-manifest evidence is destroyed before quar
 PY
 
 echo "PASS: sugarbin Docker execution contract"
+
+"$repo/tests/sugarbin_managed_preconditions.sh" "$repo"

--- a/tests/sugarbin_managed_preconditions.sh
+++ b/tests/sugarbin_managed_preconditions.sh
@@ -93,4 +93,100 @@ grep -Fq 'axis=git-absent-in-managed-image' "$tmp/unpredicted.err" \
 grep -Fq 'R_unpredicted_precondition_axes=1' "$tmp/unpredicted.out" \
   || fail "unpredicted receipt did not conserve the missing row"
 
+# A registered command closure must not enter battleaxe through raw brun argv.
+cat >"$tmp/ssh" <<'SH'
+#!/usr/bin/env bash
+: >"$TRANSPORT_MARKER"
+exit 0
+SH
+cat >"$tmp/rsync" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$tmp/ssh" "$tmp/rsync"
+export TRANSPORT_MARKER="$tmp/transport-called"
+status=0
+(cd "$repo" && BCARGO_REAP_DAYS=0 BCARGO_SSH="$tmp/ssh" \
+  BCARGO_RSYNC="$tmp/rsync" bin/sugarbin run --host bx -- \
+  make test-showcases) >"$tmp/unmanaged.out" 2>"$tmp/unmanaged.err" \
+  || status=$?
+[[ "$status" == 70 ]] || fail "unmanaged registered command status=$status, want 70"
+grep -Fq 'crime=unmanaged-command-closure' "$tmp/unmanaged.err" \
+  || fail "unmanaged registered command did not refuse by name"
+grep -Fq 'task=showcases' "$tmp/unmanaged.err" \
+  || fail "unmanaged registered command did not name its task"
+[[ ! -e "$TRANSPORT_MARKER" ]] \
+  || fail "unmanaged registered command reached transport before refusal"
+
+rm -f "$TRANSPORT_MARKER"
+(cd "$repo" && BCARGO_REAP_DAYS=0 BCARGO_SSH="$tmp/ssh" \
+  BCARGO_RSYNC="$tmp/rsync" bin/sugarbin run --host bx -- true) \
+  >"$tmp/adhoc.out" 2>"$tmp/adhoc.err"
+[[ -e "$TRANSPORT_MARKER" ]] \
+  || fail "unclaimed ad-hoc command was refused before transport"
+
+# Missing declarations refuse before the subject, with their producing source.
+python3 - "$plan" "$tmp/missing-command.json" <<'PY'
+import json
+import pathlib
+import sys
+
+plan = json.loads(sys.argv[1])
+for check in plan["checks"]:
+    if check["kind"] == "command":
+        check["name"] = "sugar-command-definitely-absent"
+pathlib.Path(sys.argv[2]).write_text(json.dumps(plan))
+PY
+status=0
+PATH="$tmp:$PATH" python3 "$preflight" run \
+  --plan-json "$(cat "$tmp/missing-command.json")" \
+  --artifact-root "$tmp/artifacts" -- sh -c \
+  ": >'$tmp/missing-command-subject'" >"$tmp/missing-command.out" \
+  2>"$tmp/missing-command.err" || status=$?
+[[ "$status" == 70 ]] || fail "missing command status=$status, want 70"
+grep -Fq 'crime=missing-managed-command' "$tmp/missing-command.err" \
+  || fail "missing command did not refuse by name"
+grep -Fq 'name=sugar-command-definitely-absent' "$tmp/missing-command.err" \
+  || fail "missing command refusal did not name command"
+[[ ! -e "$tmp/missing-command-subject" ]] \
+  || fail "missing command executed subject"
+
+mkdir -p "$tmp/toolchain-bin"
+cat >"$tmp/toolchain-bin/rustup" <<'SH'
+#!/usr/bin/env bash
+printf 'rustfmt-x86_64-unknown-linux-gnu (installed)\n'
+SH
+chmod +x "$tmp/toolchain-bin/rustup"
+python3 - "$plan" "$tmp/missing-component.json" <<'PY'
+import json
+import pathlib
+import sys
+
+plan = json.loads(sys.argv[1])
+plan["checks"] = [
+    check
+    for check in plan["checks"]
+    if check["kind"] in {"command", "toolchain-component"}
+]
+for check in plan["checks"]:
+    if check["kind"] == "command":
+        check["name"] = "sh"
+pathlib.Path(sys.argv[2]).write_text(json.dumps(plan))
+PY
+status=0
+PATH="$tmp/toolchain-bin:/usr/bin:/bin" python3 "$preflight" run \
+  --plan-json "$(cat "$tmp/missing-component.json")" \
+  --artifact-root "$tmp/artifacts" -- sh -c \
+  ": >'$tmp/missing-component-subject'" >"$tmp/missing-component.out" \
+  2>"$tmp/missing-component.err" || status=$?
+[[ "$status" == 70 ]] || fail "missing component status=$status, want 70"
+grep -Fq 'crime=missing-toolchain-component' "$tmp/missing-component.err" \
+  || fail "missing toolchain component did not refuse by name"
+grep -Fq 'name=rust-src' "$tmp/missing-component.err" \
+  || fail "missing toolchain refusal did not name rust-src"
+grep -Fq 'channel=1.96.0' "$tmp/missing-component.err" \
+  || fail "missing toolchain refusal did not name channel"
+[[ ! -e "$tmp/missing-component-subject" ]] \
+  || fail "missing toolchain component executed subject"
+
 echo 'PASS: managed entrance precondition derivation and nine-axis falsification'

--- a/tests/sugarbin_managed_preconditions.sh
+++ b/tests/sugarbin_managed_preconditions.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:?usage: sugarbin_managed_preconditions.sh REPO_ROOT}"
+contract="$repo/tools/sugar-build/contract.py"
+preflight="$repo/tools/sugar-build/preflight.py"
+axes="$repo/tests/fixtures/managed_entrance_axes.json"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/managed-preconditions.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+plan="$(python3 "$contract" resolve-preconditions showcases \
+  --host bx --repo-root "$repo")"
+
+python3 - "$plan" "$repo" <<'PY'
+import json
+import pathlib
+import sys
+
+plan = json.loads(sys.argv[1])
+repo = pathlib.Path(sys.argv[2])
+sys.path.insert(0, str(repo / "tools"))
+import showcase_scope
+
+roster = showcase_scope.makefile_showcase_roster(repo / "Makefile")
+retirements = showcase_scope.load_manifest(
+    repo / ".github/showcase-retirements.json", roster
+)
+assert plan["schemaVersion"] == 1, plan
+assert plan["task"] == "showcases", plan
+assert plan["host"] == "bx", plan
+assert plan["roster"]["enrolled"] == len(roster), plan["roster"]
+assert plan["roster"]["retired"] == len(retirements), plan["roster"]
+assert plan["roster"]["active"] == len(roster) - len(retirements), plan["roster"]
+assert plan["roster"]["active"] + plan["roster"]["retired"] == len(roster)
+components = [
+    check
+    for check in plan["checks"]
+    if check["kind"] == "toolchain-component"
+]
+assert any(
+    check["name"] == "rust-src"
+    and check["channel"] == "1.96.0"
+    and check["source"] == "examples/std-core-showcase/rust-toolchain.toml"
+    for check in components
+), components
+commands = [check for check in plan["checks"] if check["kind"] == "command"]
+assert any(
+    check["name"] == "git"
+    and check["source"] == "task.closure.required_commands"
+    for check in commands
+), commands
+artifacts = [
+    (check["profile"], check["name"])
+    for check in plan["checks"]
+    if check["kind"] == "artifact-manifest"
+]
+assert ("release", "sugar") in artifacts, artifacts
+assert ("debug", "sugar-ir-lean") in artifacts, artifacts
+PY
+
+python3 "$preflight" falsify --plan-json "$plan" --axes "$axes" \
+  >"$tmp/falsify.out" 2>"$tmp/falsify.err"
+grep -Fq 'R_precondition_axes_discovered=9' "$tmp/falsify.out" \
+  || fail "falsifier did not enumerate all nine axes"
+grep -Fq 'R_precondition_axes_predicted=9' "$tmp/falsify.out" \
+  || fail "falsifier did not predict all nine axes"
+grep -Fq 'R_unpredicted_precondition_axes=0' "$tmp/falsify.out" \
+  || fail "falsifier did not prove zero uncovered axes"
+
+python3 - "$axes" "$tmp/unpredicted.json" <<'PY'
+import json
+import pathlib
+import sys
+
+source, destination = map(pathlib.Path, sys.argv[1:])
+payload = json.loads(source.read_text())
+payload["axes"][0]["expectedKind"] = "not-derived"
+destination.write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
+status=0
+python3 "$preflight" falsify --plan-json "$plan" \
+  --axes "$tmp/unpredicted.json" >"$tmp/unpredicted.out" \
+  2>"$tmp/unpredicted.err" || status=$?
+[[ "$status" == 70 ]] || fail "unpredicted axis status=$status, want 70"
+grep -Fq 'crime=unpredicted-precondition-axis' "$tmp/unpredicted.err" \
+  || fail "unpredicted axis did not refuse by name"
+grep -Fq 'axis=git-absent-in-managed-image' "$tmp/unpredicted.err" \
+  || fail "unpredicted refusal did not name its row"
+grep -Fq 'R_unpredicted_precondition_axes=1' "$tmp/unpredicted.out" \
+  || fail "unpredicted receipt did not conserve the missing row"
+
+echo 'PASS: managed entrance precondition derivation and nine-axis falsification'

--- a/tests/sugarbin_rebuild_single_flight.sh
+++ b/tests/sugarbin_rebuild_single_flight.sh
@@ -172,4 +172,98 @@ builds2=$(wc -l <"$build_count" | tr -d ' ')
 [[ "$builds2" == "2" ]] || fail "expected second build after dead reclaim, got $builds2 total"
 echo "PASS: dead winner lock reclaimed; next resolver built"
 
+# --- Dynamic 3: the production lock path terminates on both arms ---
+# Exercise the actual bin/sugarbin acquire/release functions, not the model
+# above.  The bad twin makes exactly one planted stale lock impossible to
+# remove; the resolver must refuse once rather than loop forever on
+# holder_pid=unknown / heartbeat_age=999999.
+production_cache="$tmp/production-cache"
+production_stamp="blake3-512_axis7"
+production_lock="$production_cache/.rebuild-locks/fixture-debug-${production_stamp}-sugar.lock"
+
+SUGAR_BINARY_CACHE_DIR="$production_cache" \
+SUGAR_BINARY_SOURCE_STAMP="$production_stamp" \
+  "$sugarbin" preflight-lock --bin sugar --profile debug --platform fixture \
+  >"$tmp/production-good.out" 2>"$tmp/production-good.err" \
+  || fail 'production acquire/release arm refused'
+[[ ! -e "$production_lock" ]] || fail 'production acquire/release arm left lock residue'
+
+mkdir -p "$production_lock"
+mkdir -p "$tmp/refuse-rm-bin"
+cat >"$tmp/refuse-rm-bin/rm" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == -rf && "${2:-}" == "${LOCK_TO_REFUSE:?}" ]]; then
+  exit 77
+fi
+exec /bin/rm "$@"
+EOF
+chmod +x "$tmp/refuse-rm-bin/rm"
+
+python3 - "$sugarbin" "$production_cache" "$production_stamp" \
+  "$production_lock" "$tmp/refuse-rm-bin" "$tmp/production-bad.json" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+sugarbin, cache, stamp, lock, refuse_bin, receipt = sys.argv[1:]
+env = os.environ.copy()
+env.update(
+    {
+        "LOCK_TO_REFUSE": lock,
+        "PATH": refuse_bin + os.pathsep + env["PATH"],
+        "SUGAR_BINARY_CACHE_DIR": cache,
+        "SUGAR_BINARY_REBUILD_LOCK_STALE_S": "0",
+        "SUGAR_BINARY_SOURCE_STAMP": stamp,
+    }
+)
+try:
+    result = subprocess.run(
+        [
+            sugarbin,
+            "preflight-lock",
+            "--bin",
+            "sugar",
+            "--profile",
+            "debug",
+            "--platform",
+            "fixture",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+except subprocess.TimeoutExpired as error:
+    stderr = error.stderr or ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    print(
+        "production unreclaimable-lock arm did not terminate within 5s",
+        file=sys.stderr,
+    )
+    print(stderr, file=sys.stderr)
+    raise SystemExit(1)
+json.dump(
+    {"returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr},
+    open(receipt, "w", encoding="utf-8"),
+    sort_keys=True,
+)
+if result.returncode != 70:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit(f"expected exit 70, observed {result.returncode}")
+terminal = "crime=unreclaimable-rebuild-lock"
+if result.stderr.count(terminal) != 1:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit("expected exactly one named unreclaimable-lock terminal")
+for testimony in (lock, "holder_pid=unknown", "heartbeat_age_s=999999"):
+    if testimony not in result.stderr:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(f"missing terminal testimony: {testimony}")
+PY
+
+echo 'PASS: production rebuild lock completes normally and unreclaimable lock terminates'
+
 echo 'PASS: R_shelf_rebuild_single_flight — one build, waiter cell, dead-winner reclaim'

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -2,6 +2,7 @@
 """Strict resolver for the checked-in Sugar build contract."""
 
 import argparse
+import importlib
 import json
 import re
 import sys
@@ -11,6 +12,19 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONTRACT = ROOT / "sugar-build.toml"
 PUBLISHED_BINARIES = frozenset({"sugar", "sugar-ir-smt-lib"})
+TASK_KEYS = frozenset({"capabilities", "binaries", "command", "network"})
+CLOSURE_KEYS = frozenset(
+    {
+        "adjacent_manifests",
+        "artifacts",
+        "kind",
+        "path",
+        "required_commands",
+        "retirements",
+        "variable",
+    }
+)
+PROFILED_ARTIFACT = re.compile(r"^(debug|release):([A-Za-z0-9._-]+)$")
 IMMUTABLE_IMAGE = re.compile(r"^[^@\s]+@sha256:[0-9a-f]{64}$")
 EXACT_TOOL_VERSION = {
     "rust": re.compile(r"\d+\.\d+\.\d+"),
@@ -139,7 +153,7 @@ def resolve_task(name, path=DEFAULT_CONTRACT):
     task = data["tasks"].get(name)
     if task is None:
         raise ContractError(f"unknown task: {name}")
-    if set(task) != {"capabilities", "binaries", "command", "network"}:
+    if set(task) not in (TASK_KEYS, TASK_KEYS | {"closure"}):
         raise ContractError(f"invalid task definition: {name}")
     for key in ("capabilities", "binaries", "command"):
         if not isinstance(task[key], list) or any(not isinstance(item, str) for item in task[key]):
@@ -151,7 +165,161 @@ def resolve_task(name, path=DEFAULT_CONTRACT):
     unknown = sorted(set(task["binaries"]) - PUBLISHED_BINARIES)
     if unknown:
         raise ContractError(f"unknown task binary: {unknown[0]}")
-    return {"binaries": sorted(set(task["binaries"])), "capabilities": _closure(task["capabilities"], data), "command": task["command"], "network": task["network"], "task": name}
+    result = {"binaries": sorted(set(task["binaries"])), "capabilities": _closure(task["capabilities"], data), "command": task["command"], "network": task["network"], "task": name}
+    if "closure" in task:
+        result["closure"] = _validate_task_closure(name, task["closure"])
+    return result
+
+
+def _string_list(value, label):
+    if not isinstance(value, list) or not value or any(
+        not isinstance(item, str) or not item for item in value
+    ):
+        raise ContractError(f"invalid task closure {label}")
+    if len(value) != len(set(value)):
+        raise ContractError(f"duplicate task closure {label}")
+    return list(value)
+
+
+def _validate_task_closure(name, closure):
+    if not isinstance(closure, dict) or set(closure) != CLOSURE_KEYS:
+        raise ContractError(f"invalid task closure: {name}")
+    if closure.get("kind") != "make-roster":
+        raise ContractError(f"unsupported task closure kind: {name}")
+    for key in ("path", "variable", "retirements"):
+        if not isinstance(closure.get(key), str) or not closure[key]:
+            raise ContractError(f"invalid task closure {key}: {name}")
+    adjacent = _string_list(closure.get("adjacent_manifests"), "adjacent_manifests")
+    commands = _string_list(closure.get("required_commands"), "required_commands")
+    artifacts = _string_list(closure.get("artifacts"), "artifacts")
+    parsed_artifacts = []
+    for artifact in artifacts:
+        match = PROFILED_ARTIFACT.fullmatch(artifact)
+        if match is None:
+            raise ContractError(f"invalid profiled task artifact: {artifact}")
+        parsed_artifacts.append({"profile": match.group(1), "name": match.group(2)})
+    return {
+        "adjacent_manifests": adjacent,
+        "artifacts": parsed_artifacts,
+        "kind": "make-roster",
+        "path": closure["path"],
+        "required_commands": commands,
+        "retirements": closure["retirements"],
+        "variable": closure["variable"],
+    }
+
+
+def _showcase_authority_module():
+    tools = ROOT / "tools"
+    if str(tools) not in sys.path:
+        sys.path.insert(0, str(tools))
+    return importlib.import_module("showcase_scope")
+
+
+def _toolchain_checks(repo_root, active, manifest_names):
+    checks = []
+    discovered = {name: [] for name in manifest_names}
+    for enrolled_path in active:
+        parent = (repo_root / enrolled_path).parent
+        for manifest_name in manifest_names:
+            manifest_path = parent / manifest_name
+            if manifest_path.is_file():
+                discovered[manifest_name].append(manifest_path)
+    for manifest_name, paths in discovered.items():
+        if not paths:
+            raise ContractError(f"task closure adjacent manifest absent: {manifest_name}")
+        for manifest_path in sorted(set(paths)):
+            try:
+                data = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, tomllib.TOMLDecodeError) as exc:
+                raise ContractError(f"task closure manifest unreadable: {manifest_path}") from exc
+            toolchain = data.get("toolchain")
+            if not isinstance(toolchain, dict):
+                raise ContractError(f"task closure manifest lacks toolchain: {manifest_path}")
+            channel = toolchain.get("channel")
+            components = toolchain.get("components")
+            if not isinstance(channel, str) or not channel:
+                raise ContractError(f"task closure manifest lacks channel: {manifest_path}")
+            components = _string_list(components, "toolchain components")
+            source = manifest_path.relative_to(repo_root).as_posix()
+            for component in components:
+                checks.append(
+                    {
+                        "channel": channel,
+                        "kind": "toolchain-component",
+                        "name": component,
+                        "source": source,
+                    }
+                )
+    return checks
+
+
+def _route_checks(host, task):
+    if host != "bx":
+        raise ContractError(f"unsupported precondition host: {host}")
+    return [
+        {"kind": "cache-access", "mode": "read-write", "name": "binary-cache", "source": "route:bx-cache"},
+        {"kind": "shelf-access", "mode": "declared", "name": "binary-shelf", "source": "route:bx-shelf"},
+        {"kind": "rebuild-lock", "mode": "finite", "name": "binary-rebuild", "source": "route:bx-cache"},
+        {"kind": "process-lifetime", "mode": "foreground", "name": "ssh-child", "source": "route:bx-foreground"},
+        {"command": task["command"], "kind": "declared-interpreter", "name": task["command"][0], "source": "task.command"},
+    ]
+
+
+def resolve_task_preconditions(name, host, repo_root, path=DEFAULT_CONTRACT):
+    task = resolve_task(name, path)
+    closure = task.get("closure")
+    if closure is None:
+        raise ContractError(f"task has no declared command closure: {name}")
+    repo_root = Path(repo_root).resolve()
+    roster_path = repo_root / closure["path"]
+    retirement_path = repo_root / closure["retirements"]
+    authority = _showcase_authority_module()
+    try:
+        enrolled = authority.makefile_showcase_roster(roster_path)
+        retirements = authority.load_manifest(retirement_path, enrolled)
+    except authority.ScopeRefusal as exc:
+        raise ContractError(f"task closure authority refused: {exc}") from exc
+    active = [item for item in enrolled if item not in retirements]
+    checks = [
+        *(
+            {
+                "kind": "command",
+                "name": command,
+                "source": "task.closure.required_commands",
+            }
+            for command in closure["required_commands"]
+        ),
+        *_toolchain_checks(repo_root, active, closure["adjacent_manifests"]),
+    ]
+    for artifact in closure["artifacts"]:
+        for kind in ("artifact-manifest", "artifact-abi"):
+            checks.append(
+                {
+                    "kind": kind,
+                    "name": artifact["name"],
+                    "profile": artifact["profile"],
+                    "source": "task.closure.artifacts",
+                }
+            )
+    checks.extend(_route_checks(host, task))
+    checks.sort(
+        key=lambda row: (
+            row["kind"], row["source"], row.get("profile", ""), row["name"]
+        )
+    )
+    return {
+        "checks": checks,
+        "host": host,
+        "roster": {
+            "active": len(active),
+            "enrolled": len(enrolled),
+            "retired": len(retirements),
+            "source": closure["path"],
+        },
+        "schemaVersion": 1,
+        "task": name,
+    }
 
 
 def tool_versions(path=DEFAULT_CONTRACT):
@@ -174,11 +342,16 @@ def main(argv=None):
     environment.add_argument("environment")
     task = subparsers.add_parser("resolve-task")
     task.add_argument("task")
+    preconditions = subparsers.add_parser("resolve-preconditions")
+    preconditions.add_argument("task")
+    preconditions.add_argument("--host", required=True)
+    preconditions.add_argument("--repo-root", required=True)
     args = parser.parse_args(argv)
     try:
         if args.command == "tool-versions": result = tool_versions()
         elif args.command == "resolve-environment": result = resolve_environment(args.environment)
-        else: result = resolve_task(args.task)
+        elif args.command == "resolve-task": result = resolve_task(args.task)
+        else: result = resolve_task_preconditions(args.task, args.host, args.repo_root)
     except ContractError as exc:
         print(f"sugar-build: {exc}", file=sys.stderr)
         return 2

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -322,6 +322,19 @@ def resolve_task_preconditions(name, host, repo_root, path=DEFAULT_CONTRACT):
     }
 
 
+def match_task_command(argv, path=DEFAULT_CONTRACT):
+    data = load_contract(path)
+    matches = []
+    for name in sorted(data["tasks"]):
+        task = resolve_task(name, path)
+        command = task["command"]
+        if list(argv[: len(command)]) == command:
+            matches.append(name)
+    if len(matches) > 1:
+        raise ContractError(f"command closure has multiple owners: {','.join(matches)}")
+    return matches[0] if matches else None
+
+
 def tool_versions(path=DEFAULT_CONTRACT):
     return dict(sorted(load_contract(path)["tools"].items()))
 
@@ -346,12 +359,17 @@ def main(argv=None):
     preconditions.add_argument("task")
     preconditions.add_argument("--host", required=True)
     preconditions.add_argument("--repo-root", required=True)
+    matcher = subparsers.add_parser("match-command")
+    matcher.add_argument("argv", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
     try:
         if args.command == "tool-versions": result = tool_versions()
         elif args.command == "resolve-environment": result = resolve_environment(args.environment)
         elif args.command == "resolve-task": result = resolve_task(args.task)
-        else: result = resolve_task_preconditions(args.task, args.host, args.repo_root)
+        elif args.command == "resolve-preconditions": result = resolve_task_preconditions(args.task, args.host, args.repo_root)
+        else:
+            argv = args.argv[1:] if args.argv[:1] == ["--"] else args.argv
+            result = {"task": match_task_command(argv)}
     except ContractError as exc:
         print(f"sugar-build: {exc}", file=sys.stderr)
         return 2

--- a/tools/sugar-build/preflight.py
+++ b/tools/sugar-build/preflight.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Authenticate managed task preconditions before subject execution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REFUSAL = 70
+
+
+def _load_json_text(raw: str, label: str) -> object:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+
+
+def falsify(plan: object, axes: object) -> int:
+    if not isinstance(plan, dict) or not isinstance(plan.get("checks"), list):
+        raise ValueError("precondition plan lacks checks")
+    if not isinstance(axes, dict) or axes.get("schemaVersion") != 1:
+        raise ValueError("precondition axes schemaVersion must be 1")
+    rows = axes.get("axes")
+    if not isinstance(rows, list):
+        raise ValueError("precondition axes must be a list")
+    checks = plan["checks"]
+    uncovered = []
+    for ordinal, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"precondition axis {ordinal} is not an object")
+        axis = row.get("axis")
+        kind = row.get("expectedKind")
+        source = row.get("expectedSourcePrefix")
+        if not all(isinstance(value, str) and value for value in (axis, kind, source)):
+            raise ValueError(f"precondition axis {ordinal} is malformed")
+        if not any(
+            isinstance(check, dict)
+            and check.get("kind") == kind
+            and isinstance(check.get("source"), str)
+            and check["source"].startswith(source)
+            for check in checks
+        ):
+            uncovered.append(row)
+            print(
+                "sugarbin: crime=unpredicted-precondition-axis "
+                f"axis={axis} expectedKind={kind} expectedSourcePrefix={source}",
+                file=sys.stderr,
+            )
+    print(f"R_precondition_axes_discovered={len(rows)}")
+    print(f"R_precondition_axes_predicted={len(rows) - len(uncovered)}")
+    print(f"R_unpredicted_precondition_axes={len(uncovered)}")
+    return REFUSAL if uncovered else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    falsifier = subparsers.add_parser("falsify")
+    falsifier.add_argument("--plan-json", required=True)
+    falsifier.add_argument("--axes", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        plan = _load_json_text(args.plan_json, "precondition plan")
+        axes = json.loads(args.axes.read_text(encoding="utf-8"))
+        return falsify(plan, axes)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"sugarbin: crime=precondition-instrument-invalid error={exc}", file=sys.stderr)
+        return REFUSAL
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sugar-build/preflight.py
+++ b/tools/sugar-build/preflight.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -129,6 +130,94 @@ def check_declared_prerequisites(plan: object) -> int:
     return 0
 
 
+def check_artifact_abi(plan: object, artifact_root: Path) -> int:
+    if not isinstance(plan, dict) or not isinstance(plan.get("checks"), list):
+        raise ValueError("precondition plan lacks checks")
+    checks = [
+        check
+        for check in plan["checks"]
+        if isinstance(check, dict) and check.get("kind") == "artifact-abi"
+    ]
+    if not checks:
+        return 0
+    manifest_path = artifact_root / "required-artifacts.json"
+    if not manifest_path.is_file():
+        return _named_refusal(
+            "artifact-manifest-absent",
+            checks[0],
+            manifest=manifest_path,
+        )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows = manifest.get("artifacts") if isinstance(manifest, dict) else None
+    if not isinstance(rows, list):
+        return _named_refusal(
+            "artifact-manifest-invalid",
+            checks[0],
+            manifest=manifest_path,
+        )
+    names = []
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("name"), str):
+            return _named_refusal(
+                "artifact-manifest-invalid",
+                checks[0],
+                manifest=manifest_path,
+            )
+        names.append(row["name"])
+    if len(names) != len(set(names)):
+        return _named_refusal(
+            "artifact-manifest-invalid",
+            checks[0],
+            manifest=manifest_path,
+            reason="duplicate-artifact-name",
+        )
+    enrolled = set(names)
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        return _named_refusal(
+            "artifact-abi-instrument-absent", checks[0], name="ldd"
+        )
+    for check in checks:
+        name = check.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("artifact ABI precondition lacks name")
+        path = artifact_root / "bin" / name
+        if name not in enrolled or not path.is_file():
+            return _named_refusal(
+                "artifact-manifest-incomplete",
+                check,
+                artifact=path,
+                manifest=manifest_path,
+            )
+        started = time.monotonic_ns()
+        result = subprocess.run(
+            [ldd, str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        loader_output = "\n".join(
+            part.rstrip("\n") for part in (result.stdout, result.stderr) if part
+        )
+        normalized = loader_output.lower()
+        explicitly_not_dynamic = "not a dynamic executable" in normalized
+        missing_library = re.search(r"\bnot found\b", normalized) is not None
+        if not explicitly_not_dynamic and (result.returncode != 0 or missing_library):
+            return _named_refusal(
+                "artifact-abi-incompatible",
+                check,
+                artifact=path,
+                loaderExit=result.returncode,
+                loaderOutput=json.dumps(loader_output),
+            )
+        print(
+            f"sugarbin: precondition=artifact-abi name={name} "
+            f"source={check.get('source')} elapsed_ms={_elapsed_ms(started)} outcome=pass",
+            file=sys.stderr,
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -149,6 +238,9 @@ def main(argv: list[str] | None = None) -> int:
         if not subject:
             raise ValueError("precondition runner lacks subject command")
         status = check_declared_prerequisites(plan)
+        if status != 0:
+            return status
+        status = check_artifact_abi(plan, args.artifact_root)
         if status != 0:
             return status
         os.execvp(subject[0], subject)

--- a/tools/sugar-build/preflight.py
+++ b/tools/sugar-build/preflight.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 REFUSAL = 70
@@ -55,17 +59,100 @@ def falsify(plan: object, axes: object) -> int:
     return REFUSAL if uncovered else 0
 
 
+def _elapsed_ms(started: int) -> int:
+    return max(0, (time.monotonic_ns() - started) // 1_000_000)
+
+
+def _named_refusal(crime: str, check: dict[str, object], **fields: object) -> int:
+    details = " ".join(f"{name}={value}" for name, value in fields.items())
+    print(
+        f"sugarbin: crime={crime} kind={check['kind']} "
+        f"source={check['source']} {details}".rstrip(),
+        file=sys.stderr,
+    )
+    return REFUSAL
+
+
+def check_declared_prerequisites(plan: object) -> int:
+    if not isinstance(plan, dict) or plan.get("schemaVersion") != 1:
+        raise ValueError("precondition plan schemaVersion must be 1")
+    checks = plan.get("checks")
+    if not isinstance(checks, list):
+        raise ValueError("precondition plan lacks checks")
+    for check in checks:
+        if not isinstance(check, dict):
+            raise ValueError("precondition check is not an object")
+        kind = check.get("kind")
+        if kind not in ("command", "toolchain-component"):
+            continue
+        started = time.monotonic_ns()
+        if kind == "command":
+            name = check.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError("command precondition lacks name")
+            if shutil.which(name) is None:
+                return _named_refusal("missing-managed-command", check, name=name)
+        else:
+            name = check.get("name")
+            channel = check.get("channel")
+            if not isinstance(name, str) or not isinstance(channel, str):
+                raise ValueError("toolchain component precondition is malformed")
+            rustup = shutil.which("rustup")
+            if rustup is None:
+                return _named_refusal(
+                    "missing-toolchain-component", check, name=name, channel=channel,
+                    reason="rustup-absent",
+                )
+            result = subprocess.run(
+                [rustup, "component", "list", "--toolchain", channel, "--installed"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            installed = {
+                line.split()[0]
+                for line in result.stdout.splitlines()
+                if line.strip()
+            }
+            if result.returncode != 0 or not any(
+                item == name or item.startswith(f"{name}-") for item in installed
+            ):
+                return _named_refusal(
+                    "missing-toolchain-component", check, name=name, channel=channel,
+                    rustupExit=result.returncode,
+                )
+        print(
+            f"sugarbin: precondition={kind} name={check.get('name')} "
+            f"source={check.get('source')} elapsed_ms={_elapsed_ms(started)} outcome=pass",
+            file=sys.stderr,
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     falsifier = subparsers.add_parser("falsify")
     falsifier.add_argument("--plan-json", required=True)
     falsifier.add_argument("--axes", type=Path, required=True)
+    runner = subparsers.add_parser("run")
+    runner.add_argument("--plan-json", required=True)
+    runner.add_argument("--artifact-root", type=Path, required=True)
+    runner.add_argument("subject", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
     try:
         plan = _load_json_text(args.plan_json, "precondition plan")
-        axes = json.loads(args.axes.read_text(encoding="utf-8"))
-        return falsify(plan, axes)
+        if args.command == "falsify":
+            axes = json.loads(args.axes.read_text(encoding="utf-8"))
+            return falsify(plan, axes)
+        subject = args.subject[1:] if args.subject[:1] == ["--"] else args.subject
+        if not subject:
+            raise ValueError("precondition runner lacks subject command")
+        status = check_declared_prerequisites(plan)
+        if status != 0:
+            return status
+        os.execvp(subject[0], subject)
+        raise AssertionError("os.execvp returned")
     except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
         print(f"sugarbin: crime=precondition-instrument-invalid error={exc}", file=sys.stderr)
         return REFUSAL


### PR DESCRIPTION
## What changed

This lands stage one of the managed showcase entrance.

- `showcases` now owns a declarative command closure derived from the live Makefile roster, retirement manifest, adjacent Rust toolchain declarations, profile-qualified artifact set, and battleaxe route facts.
- Raw battleaxe `make test-showcases` refuses with `crime=unmanaged-command-closure`; the named task is the only managed entrance. Unrelated ad-hoc commands remain available.
- The transport prepends a workspace-mounted pre-subject verifier that runs in today's immutable image. It checks declared commands and toolchain components, then authenticates artifact ABI without executing the artifact.
- The production rebuild single-flight path now refuses uncreatable/unwriteable/unreclaimable lock state instead of degrading or looping forever. `preflight-lock` exposes that exact path for discrimination.
- The checked-in nine-axis fixture is executable. A row without a producing declaration or route fact exits 70 with `crime=unpredicted-precondition-axis` instead of being filled from an incident handlist.

The live authority currently derives 65 enrolled showcases: 46 active and 19 explicitly retired. Those counts are measured from the roster and retirement manifest, not authored in the instrument.

## Why

`test-showcases` sat outside named task/image authority, so missing commands, toolchain pieces, artifact manifests, ABI compatibility, cache/shelf access, lock state, and process lifetime were discovered one expensive failure at a time. The checks that existed ran early; the undeclared preconditions failed only after staging or builds.

Stage one makes authority gaps and entry failures early, named, and finite. It does not repair or guess absent declarations.

## Executable evidence

Fresh on exact head `d87c67425d42bd258432ba8a6fd6c992cb9318ec`, based directly on main `9bdeb936d1f3d9395c0a7bbff2a6a2c39277ee8e`:

- `tests/sugarbin_managed_preconditions.sh`: `R_precondition_axes_discovered=9`, predicted=9, unpredicted=0; planted `not-derived` twin exits 70.
- `tests/sugarbin_rebuild_single_flight.sh`: 8 contenders produce one build; dead winner is reclaimed; the real disposable acquire/release completes; planted unreclaimable `holder_pid=unknown` lock terminates within five seconds at exit 70 exactly once.
- `tests/sugarbin_docker_exec.sh`: compatible loader reaches subject; planted `GLIBC_2.39 not found` exits 70 with artifact path and loader output, and never reaches subject.
- Shell syntax, Python compilation, and `git diff --check` pass.

Predicted epsilon: `R_unpredicted_precondition_axes` stays 0; the managed-command bypass, nonterminal unreclaimable-lock arm, and unverified pre-subject ABI edge each move from one live mechanism to zero. No floor is lowered: zero files deleted, no Dockerfile or image reference changed, and the sealed closing-account digest remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Non-claims and next stage

The current capability image still lacks `git` and the pinned toolchain's `rust-src` component. Stage one therefore makes an affected run refuse early and by name; it does **not** satisfy those preconditions, publish an image, or make that run succeed. Stage two owns installing the declared capability closure, publishing it, and updating the immutable digest. Only then can an affected run proceed instead of refusing earlier.

Detached remote execution remains **unsolved**. The plan authenticates only the foreground SSH-child lifetime; it makes no managed detached-success claim.

The ABI verifier executes today through the transport-owned workspace wrapper. It is not claimed to be baked into the already-published image entrypoint.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Instrument the managed showcase entrance with a preflight precondition gate
> - Adds `preflight.py` to enforce preconditions before executing managed tasks: checks required commands, rustup toolchain components, artifact manifests, and ABI compatibility via `ldd`; refuses with exit 70 and named crimes on failure.
> - Extends `contract.py` with `resolve-preconditions` and `match-command` subcommands: the former produces a structured JSON plan for a task's preconditions; the latter detects if a raw argv is owned by a registered task.
> - Updates `sugar_bx_run_docker` in [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7301/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) to inject the preflight runner before the subject command when `SUGAR_BX_MANAGED_PRECONDITION_PLAN` is set.
> - Updates [sugarbin](https://github.com/TSavo/sugar/pull/7301/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) to export a precondition plan for managed bx tasks and refuse unmanaged command invocations that match a registered task with `crime=unmanaged-command-closure` (exit 70).
> - Adds a `preflight-lock` subcommand to `sugarbin` and hardens `acquire_rebuild_single_flight` to terminate with exit 70 (instead of silently degrading) on uncreatable, unwritable, or unreclaimable lock state.
> - Registers `[tasks.showcases]` in [sugar-build.toml](https://github.com/TSavo/sugar/pull/7301/files#diff-b714a26a105f372af4929844b95deb54b1e2701396f192e8761d975086b49835) as the first managed task with a `make-roster` closure.
> - Risk: raw `bx` invocations whose argv prefix matches a registered task command now hard-refuse before any transport work.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d87c674.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->