### PR TITLE
Use the measured path for resident cache observation

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -893,7 +893,7 @@ def measure_file_via_enumerate(
     from sugar_source_tree.process_resident_file import get_resident
 
     _clear_d3_audit_open_observation(source_cid)
-    d3_present_before_demand = get_resident(source_cid, str(full_path)) is not None
+    d3_present_before_demand = get_resident(source_cid, str(path)) is not None
     try:
         audit, construction_gaps = demand_construction_residual(
             workspace_root=workspace_root,


### PR DESCRIPTION
Fixes the post-#7300 NameError in the process-resident observation arm: the function already derives the authoritative resolved `path`, so the observation now passes that path to `get_resident` instead of an undefined `full_path`. The strict seat-key behavior is unchanged; this only makes the branch executable. Focused fresh-root bpytest on main-based branch: 16 passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `measure_file_via_enumerate` to use the resolved path for resident cache observation
> In `measure_file_via_enumerate`, `d3_present_before_demand` was being computed using `full_path` instead of the resolved `path` variable. This fix ensures the correct path is passed to `get_resident`, so the `d3Residency` value recorded in the returned row reflects the actual measured file path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 587e982.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a D3 residency check to correctly identify the resolved path during consumer enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->