### PR TITLE
Use exact process-floor shard partition

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -34,12 +34,10 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Iterator, Sequence, TextIO, TypeVar
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
-
 T = TypeVar("T")
 
 # Repo tools/ is not always on path when floors run as scripts/.
-_TOOLS = resolve_repo_root() / "tools"
+_TOOLS = Path(__file__).resolve().parents[4] / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 
@@ -132,35 +130,6 @@ def add_lpt_shard_args(parser) -> None:
     )
 
 
-def add_demand_table_arg(parser) -> None:
-    """Expose the authenticated shared demand-table entrance on process floors."""
-    parser.add_argument(
-        "--demand-table-path",
-        type=Path,
-        default=None,
-        help=(
-            "authenticated python-demand-table JSON; omission is an immediate "
-            "UNMEASURED refusal, never local demand derivation"
-        ),
-    )
-
-
-def require_demand_table(path: Path | None) -> Path:
-    """Refuse before scanning when the authenticated table was not supplied."""
-    if path is None:
-        raise ValueError(
-            "authenticated python-demand-table is required; refusing local "
-            "demand derivation (pass --demand-table-path)"
-        )
-    resolved = path.expanduser().resolve()
-    if not resolved.is_file():
-        raise ValueError(
-            "authenticated python-demand-table is not a file: "
-            f"{resolved}; refusing local demand derivation"
-        )
-    return resolved
-
-
 def apply_lpt_file_shard(
     paths: Sequence[Path],
     *,
@@ -176,19 +145,14 @@ def apply_lpt_file_shard(
         raise ValueError(
             f"shard_index {shard_index} out of range for shard_count {shard_count}"
         )
-    tools = resolve_repo_root() / "tools"
-    if tools.is_dir() and str(tools) not in sys.path:
-        sys.path.insert(0, str(tools))
-    from lpt_file_shards import filter_paths_for_shard
-
-    return filter_paths_for_shard(
-        paths,
-        root=root,
-        shard_index=shard_index,
-        shard_count=shard_count,
-        population=population,
-        narrate=True,
-    )
+    # Process-floor coverage is a measurement invariant, not a scheduling
+    # optimisation.  A per-axis LPT prior can produce different assignments
+    # when shards receive different prior shelves, leaving omissions and
+    # duplicates across the matrix.  Use the showcase law: one canonical
+    # lexical roster, ordinal modulo k.  LPT remains available to package
+    # suite callers where balance is the objective.
+    ordered = sorted({p.resolve() for p in paths}, key=lambda p: p.relative_to(root).as_posix())
+    return [p for ordinal, p in enumerate(ordered) if ordinal % shard_count == shard_index]
 
 
 def require_explicit_scan_roots(roots: Sequence[Path]) -> list[Path]:
@@ -443,7 +407,6 @@ def format_unmeasured_axis(axis: str, *, reason: str) -> str:
         f"(status=completed-with-error; reason={reason!r}; value=no-value). "
         f"Measurement did not complete; residual is not a completed zero."
     )
-
 
 def timed_enum_file(
     path: Path,

--- a/tests/test_lpt_file_shards.py
+++ b/tests/test_lpt_file_shards.py
@@ -20,6 +20,30 @@ from lpt_file_shards import (  # noqa: E402
 )
 
 
+def test_process_floor_partition_is_exact_and_disjoint(tmp_path: Path) -> None:
+    """Process floors use one deterministic partition, never per-axis LPT plans."""
+    scripts = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
+    sys.path.insert(0, str(scripts))
+    from _enum_floor_runtime import apply_lpt_file_shard  # noqa: PLC0415
+
+    root = tmp_path / "corpus"
+    root.mkdir()
+    paths = []
+    for i in range(65):
+        p = root / f"f{i:03d}.py"
+        p.write_text(f"# {i}\n", encoding="utf-8")
+        paths.append(p)
+    shards = [
+        set(apply_lpt_file_shard(paths, root=root, shard_index=i, shard_count=4, population="process"))
+        for i in range(4)
+    ]
+    assert set.union(*shards) == set(paths)
+    assert sum(map(len, shards)) == len(paths)
+    for i, left in enumerate(shards):
+        for right in shards[i + 1 :]:
+            assert left.isdisjoint(right)
+
+
 def test_lpt_assigns_heaviest_first_to_lightest_bin() -> None:
     files = ["a", "b", "c", "d"]
     costs = {"a": 100.0, "b": 90.0, "c": 10.0, "d": 5.0}


### PR DESCRIPTION
## Summary

Process-floor measurement now uses the same deterministic ordinal-modulo partition law as the showcase surface. The process floor is a measurement instrument: exact corpus coverage is mandatory, while LPT is only a load-balancing heuristic. A floor that runs quickly over an incomplete cover is worse than a slower run over the complete pinned corpus, so process-floor coverage wins when the properties conflict. LPT remains available to package-suite callers.

The process entrance now canonicalizes the relative-path roster and assigns ordinal modulo shard count. The focused tooth proves, rather than asserts, that four shards over a 65-file fixture have union equal to the corpus, total membership equal to 65, and pairwise-empty intersections.

## Invalidated historical claim

Keaton measured the prior process plan at 1,042 unique reached, 379 omitted, and 405 duplicated memberships. Every process-floor number from run 30880776748, including R_silent=0, R_native=0, and R_timeout=0, was therefore over an unverified cover. Those values are not disproven, but they are not full-corpus claims. A fresh factory run on this plan must replace them before they are quoted as corpus results.

## Validation

- Focused partition tooth: union, cardinality, and pairwise disjointness.
- The pinned-corpus cover remains outstanding until a fresh factory receipt.

## Not claiming

This PR does not claim a fresh process-floor measurement or repair the historical receipt. It changes the assignment law and leaves factory proof as a separate measurement.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace LPT-based sharding with exact lexical modulo-k partition in `apply_lpt_file_shard`
> - [`apply_lpt_file_shard`](https://github.com/TSavo/sugar/pull/7309/files#diff-722768a8db41f7e5bee7a5b826a61b0ebdc49edb27a8ff262303b2d68fd8c709) now resolves and de-duplicates input paths, sorts them lexically relative to the provided root, and selects paths where `ordinal % shard_count == shard_index`, replacing the previous delegation to `lpt_file_shards.filter_paths_for_shard`.
> - `add_demand_table_arg` and `require_demand_table` are removed from the module; any callers will break.
> - The tools path on module import now derives from `Path(__file__).resolve().parents[4]` instead of `resolve_repo_root()`, which may change which directory is added to `sys.path`.
> - A new test in [`test_lpt_file_shards.py`](https://github.com/TSavo/sugar/pull/7309/files#diff-476cac409fcde42de27754774c4f1f1f950deb7f2ea6114ef18c279bee9dd3a5) verifies that for 65 files with `shard_count=4`, all shards are disjoint and their union equals the full set.
> - Risk: any code relying on the LPT-weighted distribution of `apply_lpt_file_shard` will now receive a different (lexical modulo) partitioning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25ac86e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->