### PR TITLE
Restore process-floor demand table entrance

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -130,6 +130,35 @@ def add_lpt_shard_args(parser) -> None:
     )
 
 
+def add_demand_table_arg(parser) -> None:
+    """Expose the authenticated shared demand-table entrance on process floors."""
+    parser.add_argument(
+        "--demand-table-path",
+        type=Path,
+        default=None,
+        help=(
+            "authenticated python-demand-table JSON; omission is an immediate "
+            "UNMEASURED refusal, never local demand derivation"
+        ),
+    )
+
+
+def require_demand_table(path: Path | None) -> Path:
+    """Refuse before scanning when the authenticated table was not supplied."""
+    if path is None:
+        raise ValueError(
+            "authenticated python-demand-table is required; refusing local "
+            "demand derivation (pass --demand-table-path)"
+        )
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise ValueError(
+            "authenticated python-demand-table is not a file: "
+            f"{resolved}; refusing local demand derivation"
+        )
+    return resolved
+
+
 def apply_lpt_file_shard(
     paths: Sequence[Path],
     *,

--- a/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_runtime_surface.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enum_floor_runtime_surface.py
@@ -1,0 +1,11 @@
+"""Surface tooth for the shared process-floor scanner helpers."""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.scripts import _enum_floor_runtime
+
+
+def test_process_floor_runtime_exports_required_cli_helpers() -> None:
+    """Partition tests must not pass while the scanner module loses its API."""
+    for name in ("add_demand_table_arg", "require_demand_table", "apply_lpt_file_shard"):
+        assert callable(getattr(_enum_floor_runtime, name, None)), name


### PR DESCRIPTION
Restores the authenticated demand-table CLI helper accidentally omitted from the process-floor partition landing. Current-main discrimination jobs failed at collection with ImportError before scanning. No floor number was measured. This follow-up restores add_demand_table_arg and require_demand_table without changing the deterministic shard partition.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore demand table entrance by adding `add_demand_table_arg` and `require_demand_table` to floor runtime
> Adds two helpers to [_enum_floor_runtime.py](https://github.com/TSavo/sugar/pull/7311/files#diff-722768a8db41f7e5bee7a5b826a61b0ebdc49edb27a8ff262303b2d68fd8c709) to restore the demand table CLI entry point.
> - `add_demand_table_arg` registers a `--demand-table-path` argument on an `argparse.ArgumentParser`, defaulting to `None` when omitted.
> - `require_demand_table` validates the supplied path, raising `ValueError` if it is `None` or does not resolve to an existing file, and returns the resolved `Path` on success.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a71f8e. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->