### PR TITLE
Enforce repository root construction doors

### DIFF
--- a/.github/workflows/recensus-path-smoke.yml
+++ b/.github/workflows/recensus-path-smoke.yml
@@ -43,6 +43,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Both root-resolution axes are zero-only laws.  #6989 drained fixed
+      # parents[N] walks to zero, yet an unrelated landing restored one within
+      # hours; its removal census could not judge whether the replacement door
+      # was lawful.  Enforce both the old shape and its repo-test replacement
+      # boundary before any package environment exists.
+      - name: Enforce repository root construction doors
+        run: |
+          python3 tools/repo_root_parents_n_census.py
+          python3 tools/repo_test_package_root_import_census.py
+
       # This must run in a workflow independent of ci.yml: a workflow rejected
       # before dispatch cannot execute its own context-availability tooth.
       - name: Set up Go for version-pinned actionlint

--- a/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/_enum_floor_runtime.py
@@ -34,10 +34,12 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Iterator, Sequence, TextIO, TypeVar
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 T = TypeVar("T")
 
 # Repo tools/ is not always on path when floors run as scripts/.
-_TOOLS = Path(__file__).resolve().parents[4] / "tools"
+_TOOLS = resolve_repo_root() / "tools"
 if _TOOLS.is_dir() and str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 

--- a/tests/examples_gate_test.py
+++ b/tests/examples_gate_test.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import unittest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/repo_root_test_support.py
+++ b/tests/repo_root_test_support.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Package-free entrance to the tools-owned monorepo root resolver.
+
+Repo-level tests are collected before the Python test kit is necessarily
+installed.  Seat the package-independent ``tools/sugar_repo_root.py`` twin
+once for that population; never import ``sugar_lift_py_tests.repo_root`` here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(_TOOLS))
+
+from sugar_repo_root import RepoRootUnresolved, resolve_repo_root  # noqa: E402
+
+__all__ = ("RepoRootUnresolved", "resolve_repo_root")

--- a/tests/sugarbin_legacy_shelf_migration.py
+++ b/tests/sugarbin_legacy_shelf_migration.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 import unittest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 REPO = resolve_repo_root()
 TOOL = REPO / "tools" / "migrate_legacy_binary_shelf.py"

--- a/tests/test_authenticated_python_launcher.py
+++ b/tests/test_authenticated_python_launcher.py
@@ -8,7 +8,7 @@ from types import ModuleType
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 from sugar_lift_py_tests.authenticated_pytest import (
     ExecutionEnvironmentMismatch,
     activate_checkout_import_roots,

--- a/tests/test_board_function_facts_c4.py
+++ b/tests/test_board_function_facts_c4.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 PKG_SRC = (

--- a/tests/test_bx_corpus_pin_gate.py
+++ b/tests/test_bx_corpus_pin_gate.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 GATE = ROOT / "tools" / "bx_corpus_pin_gate.py"

--- a/tests/test_checkout_import_foreign_site_packages_unit_twin.py
+++ b/tests/test_checkout_import_foreign_site_packages_unit_twin.py
@@ -22,7 +22,7 @@ from types import ModuleType
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 from sugar_lift_py_tests.authenticated_pytest import (
     ExecutionEnvironmentMismatch,

--- a/tests/test_ci_python_env_checkout_lift_import.py
+++ b/tests/test_ci_python_env_checkout_lift_import.py
@@ -26,7 +26,7 @@ import textwrap
 import venv
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 ACTION = ROOT / ".github/actions/python-test-environment/action.yml"

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 

--- a/tests/test_conservation_mint_contract.py
+++ b/tests/test_conservation_mint_contract.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 PKG_SRC = ROOT / "implementations/python/sugar-lift-py-tests/src"

--- a/tests/test_control_effect_recensus_lpt_ci_matrix.py
+++ b/tests/test_control_effect_recensus_lpt_ci_matrix.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 WORKFLOW = ROOT / ".github/workflows/control-effect-recensus.yml"

--- a/tests/test_core_matrix_parallel_fanout.py
+++ b/tests/test_core_matrix_parallel_fanout.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 CI = ROOT / ".github/workflows/ci.yml"

--- a/tests/test_first_party_venv_contamination_guard.py
+++ b/tests/test_first_party_venv_contamination_guard.py
@@ -7,7 +7,7 @@ import subprocess
 import venv
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 GUARD = ROOT / "tools/refuse_first_party_venv_contamination.py"

--- a/tests/test_floor_summary_residual_emission.py
+++ b/tests/test_floor_summary_residual_emission.py
@@ -7,7 +7,7 @@ import json
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"

--- a/tests/test_gh_rate_budget.py
+++ b/tests/test_gh_rate_budget.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 TOOL = ROOT / "tools" / "gh_rate_budget.py"

--- a/tests/test_heavy_measurement_concurrency_topology.py
+++ b/tests/test_heavy_measurement_concurrency_topology.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 WORKFLOWS = ROOT / ".github" / "workflows"

--- a/tests/test_job_log_heartbeat.py
+++ b/tests/test_job_log_heartbeat.py
@@ -7,7 +7,7 @@ import sys
 import time
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_lpt_acceptance_real_prior.py
+++ b/tests/test_lpt_acceptance_real_prior.py
@@ -19,7 +19,7 @@ import json
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_lpt_file_shards.py
+++ b/tests/test_lpt_file_shards.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_managed_python_closure_is_import_closed.py
+++ b/tests/test_managed_python_closure_is_import_closed.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 DOCKERFILE = ROOT / "tools" / "sugar-build" / "Dockerfile"

--- a/tests/test_pandas_timeout_residual_disposition.py
+++ b/tests/test_pandas_timeout_residual_disposition.py
@@ -7,7 +7,7 @@ from collections import Counter
 from pathlib import Path
 
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 REPO_ROOT = resolve_repo_root()
 SOURCE_LEDGER = (

--- a/tests/test_process_floor_demand_table.py
+++ b/tests/test_process_floor_demand_table.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import subprocess
 import sys
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"

--- a/tests/test_python_package_suite_shards.py
+++ b/tests/test_python_package_suite_shards.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 SHARDS = ROOT / "tools" / "python_package_suite_shards.py"

--- a/tests/test_python_sole_construction_ci.py
+++ b/tests/test_python_sole_construction_ci.py
@@ -12,7 +12,7 @@ import json
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 WORKFLOW = ROOT / ".github" / "workflows" / "factory-zero-tolerance.yml"

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"

--- a/tests/test_recensus_lpt_prior_write_through.py
+++ b/tests/test_recensus_lpt_prior_write_through.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_repo_root_context_boundary.py
+++ b/tests/test_repo_root_context_boundary.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Repo tests must resolve the checkout without importing the test kit.
+
+The test kit is not installed at every repo-test entrance: pre-dispatch jobs,
+plain-root collection, and direct checkout scripts all run earlier.  Those
+callers use the package-free ``tools/sugar_repo_root.py`` twin (seated through
+``repo_root_test_support``), while package-owned tests keep their package door.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from repo_root_test_support import resolve_repo_root
+
+from repo_test_package_root_import_census import forbidden_import_lines, scan
+
+
+def test_wrong_door_detector_distinguishes_package_from_tools_twin(
+    tmp_path: Path,
+) -> None:
+    package_door = tmp_path / "package_door.py"
+    package_door.write_text(
+        "from sugar_lift_py_tests.repo_root import resolve_repo_root\n",
+        encoding="utf-8",
+    )
+    tools_twin = tmp_path / "tools_twin.py"
+    tools_twin.write_text(
+        "from sugar_repo_root import resolve_repo_root\n", encoding="utf-8"
+    )
+
+    assert forbidden_import_lines(package_door) == (1,)
+    assert forbidden_import_lines(tools_twin) == ()
+
+
+def test_repo_level_tests_never_import_the_package_root_door() -> None:
+    tests_root = resolve_repo_root() / "tests"
+    offenders = {
+        str(path.relative_to(tests_root)): lines for path, lines in scan(tests_root)
+    }
+
+    assert offenders == {}, (
+        "repo-level tests run before sugar_lift_py_tests is guaranteed installed; "
+        "route them through the package-free tools/sugar_repo_root.py twin: "
+        f"{offenders}"
+    )
+
+
+def test_path_integrity_workflow_enforces_both_root_axes() -> None:
+    workflow = (
+        resolve_repo_root() / ".github/workflows/recensus-path-smoke.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "python3 tools/repo_root_parents_n_census.py" in workflow
+    assert "python3 tools/repo_test_package_root_import_census.py" in workflow
+
+
+def test_lpt_shard_test_collects_when_test_kit_package_is_unavailable() -> None:
+    """The observed pre-install failure is impossible through the tools twin."""
+    tests_root = Path(__file__).resolve().parent
+    code = """
+import importlib.abc
+import sys
+
+class RejectTestKit(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "sugar_lift_py_tests" or fullname.startswith("sugar_lift_py_tests."):
+            raise ModuleNotFoundError("test kit deliberately unavailable")
+        return None
+
+sys.meta_path.insert(0, RejectTestKit())
+import test_lpt_file_shards
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tests_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_rerank_input.py
+++ b/tests/test_rerank_input.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 _SPEC = importlib.util.spec_from_file_location(

--- a/tests/test_showcase_retirement.py
+++ b/tests/test_showcase_retirement.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_showcase_shared_setup_enrollment.py
+++ b/tests/test_showcase_shared_setup_enrollment.py
@@ -8,7 +8,7 @@ import sys
 import zipfile
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 sys.path.insert(0, str(ROOT / "tools"))

--- a/tests/test_sole_construction_floor_enrollment_measured.py
+++ b/tests/test_sole_construction_floor_enrollment_measured.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 _SPEC = importlib.util.spec_from_file_location(

--- a/tests/test_source_stamp_provisioning.py
+++ b/tests/test_source_stamp_provisioning.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 STAMP = ROOT / "tools" / "sugar_source_stamp.py"

--- a/tests/test_static_floor_residual_report.py
+++ b/tests/test_static_floor_residual_report.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 

--- a/tests/test_sugar_build_contract.py
+++ b/tests/test_sugar_build_contract.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 SPEC = importlib.util.spec_from_file_location(

--- a/tests/test_suite_pytest_job_log_heartbeat.py
+++ b/tests/test_suite_pytest_job_log_heartbeat.py
@@ -9,7 +9,7 @@ import sys
 import textwrap
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 TOOLS = ROOT / "tools"

--- a/tests/test_suite_report_lpt_prior_import.py
+++ b/tests/test_suite_report_lpt_prior_import.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 PLUGIN = ROOT / "tools" / "python_package_suite_report.py"

--- a/tests/test_test_extras_are_the_dependency_authority.py
+++ b/tests/test_test_extras_are_the_dependency_authority.py
@@ -38,7 +38,7 @@ import sys
 import tomllib
 from pathlib import Path
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 PACKAGE = ROOT / "implementations/python/sugar-lift-py-tests"

--- a/tests/wall_workflow_prerequisites_test.py
+++ b/tests/wall_workflow_prerequisites_test.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 import re
 
-from sugar_lift_py_tests.repo_root import resolve_repo_root
+from repo_root_test_support import resolve_repo_root
 
 ROOT = resolve_repo_root()
 WALL_WORKFLOWS = {

--- a/tools/repo_test_package_root_import_census.py
+++ b/tools/repo_test_package_root_import_census.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Live instrument: package-owned repo-root imports in repo-level tests.
+
+Repo-level tests run at entrances where ``sugar_lift_py_tests`` is not yet
+installed.  They must ask the package-free ``tools/sugar_repo_root.py`` twin
+for the checkout root instead of importing ``sugar_lift_py_tests.repo_root``.
+
+R_repo_test_package_root_import — wrong-door imports under repo ``tests/``.
+Exit 1 while R > 0.  Rescans the live tree; no hand-authored offender list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+FORBIDDEN_MODULE = "sugar_lift_py_tests.repo_root"
+
+
+def forbidden_import_lines(path: Path) -> tuple[int, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    lines = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == FORBIDDEN_MODULE:
+            lines.append(node.lineno)
+        if isinstance(node, ast.Import) and any(
+            alias.name == FORBIDDEN_MODULE for alias in node.names
+        ):
+            lines.append(node.lineno)
+    return tuple(sorted(lines))
+
+
+def scan(tests_root: Path) -> list[tuple[Path, tuple[int, ...]]]:
+    return [
+        (path, lines)
+        for path in sorted(tests_root.rglob("*.py"))
+        if (lines := forbidden_import_lines(path))
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tests-root",
+        type=Path,
+        default=Path("tests"),
+        help="repo-level tests directory (default: tests)",
+    )
+    args = parser.parse_args(argv)
+    tests_root = args.tests_root.resolve()
+    hits = scan(tests_root)
+    count = sum(len(lines) for _path, lines in hits)
+    print(f"R_repo_test_package_root_import={count}")
+    for path, lines in hits:
+        for line in lines:
+            print(f"{path.relative_to(tests_root)}:{line}: {FORBIDDEN_MODULE}")
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

- Route all 36 repo-level tests changed by #6989 through the package-free `tools/sugar_repo_root.py` twin via one `repo_root_test_support` entrance.
- Restore the package-owned `_enum_floor_runtime.py` script to the installed package resolver after unrelated #7309 reintroduced a fixed `parents[N]` walk.
- Promote the repo-test wrong-door detector to a live census and enforce it beside the existing fixed-parent census on every PR and main push.

## Why

#6989 drained 221 fixed `Path(__file__).parents[N]` sites to zero, but that census only recognizes removal of the old pattern. It stayed green while 36 of 38 repo-test replacements used the package-owned resolver at entrances where `sugar_lift_py_tests` is not guaranteed installed. Two failures exposed the boundary: the pre-dispatch workflow-context tooth and plain-root collection of `test_lpt_file_shards.py`.

The drain was also not self-sustaining: within hours, unrelated shard-partition work reintroduced one fixed-parent site in `_enum_floor_runtime.py`. That measured zero-to-one drift is why both axes are now enforced rather than merely runnable.

The guard prevents repo-level tests from importing `sugar_lift_py_tests.repo_root`, and its discriminating arm imports the LPT shard test while deliberately making the package unavailable. A removal census alone cannot establish that the replacement door is correct.

## Evidence

Measured on base `df6a26d5f50c6b17734475d44655e9d1fcc71a1b`, head `31e5e9bd38f0cb1f211f2b4dd19361d2ad358dcc`:

- `python3 tools/repo_root_parents_n_census.py` — exit 0, `R_repo_root_by_parents_count_outside_package_src=0` across package tests, package scripts, repo tests, and tools.
- `python3 tools/repo_test_package_root_import_census.py` — exit 0, `R_repo_test_package_root_import=0` across repo `tests/**/*.py`.
- `bin/bpytest tests/test_repo_root_context_boundary.py tests/test_lpt_file_shards.py -q` — exit 0, 10 passed under authenticated CPython 3.12.13.
- Direct authenticated load of `_enum_floor_runtime.py` with the test-kit source on `PYTHONPATH` — exit 0; package-derived tools root present.
- Black check for the new support/test/census files — exit 0.
- `git diff --check origin/main...HEAD` — exit 0.
- `.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.json` remains SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Not claiming

- This does not claim 36 observed runtime failures. It establishes 36 wrong-door sites; two were observed failing in package-absent contexts.
- The battleaxe `actionlint` absence is an instrument gap and no workflow verdict was banked from it.
- The newly landed `test_enum_floor_runtime_surface.py` currently cannot collect because `sugar_lift_py_tests.scripts` does not exist; that separate #7311 defect was reproduced twice and is not attributed to this repair.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce repository root import boundaries in tests via a new `repo_root_test_support` shim
> - Adds [repo_root_test_support.py](https://github.com/TSavo/sugar/pull/7314/files#diff-51a7cc2ff1798fcafd7c20bba4c54a80e8925b98bfa9b2ff8c84bbc83e949470), a shim that exposes `resolve_repo_root` from the tools directory so tests can resolve the repo root without importing `sugar_lift_py_tests.repo_root`.
> - Adds [repo_test_package_root_import_census.py](https://github.com/TSavo/sugar/pull/7314/files#diff-d4508509a5b7fa6ddaba1c48fc5284cfd6ea1291d68225ab021ab198bd5e42e5), a script that scans the `tests/` directory and exits non-zero if any file imports `sugar_lift_py_tests.repo_root`.
> - Updates ~35 test files to import `resolve_repo_root` from `repo_root_test_support` instead of `sugar_lift_py_tests.repo_root`.
> - Adds a CI step in [recensus-path-smoke.yml](https://github.com/TSavo/sugar/pull/7314/files#diff-2a88259228967a6b7e859fad9905325fb0cbae94c94c10bfa0296a50978b5751) that runs both enforcement scripts before Go setup, failing the job on any violation.
> - Adds [test_repo_root_context_boundary.py](https://github.com/TSavo/sugar/pull/7314/files#diff-40a188b96a4d4a664cf5aa3b56eb560b3f4d6bf4bd75bf3fa76d332fe4b3c29e) to verify boundary rules are enforced correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31e5e9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->