### PR TITLE
Measure implementation catch suppression with authenticated reachability

### DIFF
--- a/docs/superpowers/plans/2026-08-04-implementation-catch-census.md
+++ b/docs/superpowers/plans/2026-08-04-implementation-catch-census.md
@@ -1,0 +1,121 @@
+# Authenticated Implementation Catch Census Implementation Plan
+
+> **For Codex:** Follow the repository's red-instrument-first discipline. Keep
+> the existing ConstructionPanic classifier authoritative; do not duplicate its
+> sanctioned membrane registry.
+
+**Goal:** Add an authenticated, implementation-only AST census that conserves
+the complete handler population, separately identifies ConstructionPanic and
+SugarNotWritten candidates, and reports lawful, suppression, or unresolved
+construction-reachability outcomes without turning instrument errors into a
+number.
+
+**Architecture:** A new script wraps the existing
+`construction_panic_catch_law.py` predicates for ConstructionPanic semantics,
+adds the missing production roots and a separate SugarNotWritten hierarchy,
+and emits carried canonical manifests plus CIDs. Reachability is conservative:
+directly authenticated throws/calls and statically resolved local call edges
+may establish construction reachability; dynamic calls remain unresolved.
+Source/read/parse/conservation failures emit only an unmeasured envelope.
+
+**Tech stack:** Python 3.12, `ast`, repository BLAKE3/JCS canonicalization,
+pytest through `bin/bpytest` for authenticated remote evidence.
+
+---
+
+## Task 1: Pin the wrapper contract with red tests
+
+**Files:**
+
+- Create: `implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py`
+- Create: `implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py`
+
+1. Write fixture tests for separate exception hierarchies: `Exception` catches
+   SugarNotWritten but not ConstructionPanic; `BaseException` and bare catches
+   enter both candidate manifests.
+2. Write a planted ConstructionPanic soft-return test that must be classified
+   through the existing scanner authority, not a locally copied rule.
+3. Write a planted pure re-raise and exact sanctioned membrane control.
+4. Run only the new test file through the authenticated `bin/bpytest` entrance
+   and record the intended import/API reds.
+5. Implement only the minimum public scan/receipt surface needed to turn these
+   tests green.
+
+## Task 2: Add source-authenticated manifests and refusal
+
+**Files:**
+
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py`
+
+1. Plant a temporary declared population with multiple files and assert exact
+   file/site members, stable row identities, source CIDs, and manifest CIDs.
+2. Plant an equal-count site substitution and assert conservation refusal.
+3. Plant missing-root, read, and parse failures and assert an unmeasured
+   envelope with no measured totals.
+4. Implement declared-root enumeration, canonical site identity, carried
+   manifests, CIDs, and raw missing/extra/duplicate diffs.
+5. Implement the CLI output contract and unpiped exit behavior: measured red
+   for live suppression/unresolved rows; measured green only at zero; exit red
+   unmeasured for instrument failures.
+
+## Task 3: Add conservative construction reachability
+
+**Files:**
+
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py`
+
+1. Plant direct raise/call fixtures for each panic hierarchy and assert
+   `reachability=direct`.
+2. Plant a uniquely resolved local call edge and assert
+   `reachability=transitive` with the full call path.
+3. Plant an unrelated broad catch and assert `outside-construction`, not
+   suppression.
+4. Plant a dynamic attribute call and assert `unresolved`, red, without
+   fabricating a target.
+5. Implement a source-owned function index and only the statically authenticated
+   same-module/import-alias/self-method call edges needed by the teeth. Unknown
+   dynamic edges remain unresolved.
+6. Rank direct lifter/mint sites above transitive construction callers,
+   recensus/report membranes, scripts, and outside-construction rows.
+
+## Task 4: Prove compatibility with the existing scanner
+
+**Files:**
+
+- Modify only if needed:
+  `implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py`
+
+1. Assert the new census and existing scanner agree on planted CP soft catch,
+   pure re-raise, sibling precedence, and exact sanctioned membrane shapes.
+2. Assert the current existing scanner test surface remains green unchanged.
+3. If importability requires factoring predicates, move them once into an
+   importable module and make both scripts consume it; never duplicate or
+   relax the sanctioned-shape registry.
+
+## Task 5: Fire the authenticated implementation census
+
+**Files:**
+
+- Modify: `implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py`
+- Modify: `implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py`
+
+1. Run focused tests through `bin/bpytest` on battleaxe under the repository's
+   authenticated Python environment.
+2. Run the new census unpiped from the exact branch head over the four declared
+   implementation roots.
+3. Verify the receipt byte identity after sync-back and record exact commit,
+   file/site/candidate counts, suppression/unresolved rows, instrument failures,
+   manifest CIDs, command, and exit.
+4. Report candidates separately from findings. Never report the 172 preliminary
+   broad candidates as suppressions.
+5. Commit and push the branch. Do not merge it.
+
+## Verification boundary
+
+The focused tests and authenticated census prove only the exact measured
+implementation commit and declared roots. They do not classify pandas source
+handlers, repair the contaminated process-floor run, or claim dynamic call
+reachability where the source graph cannot authenticate it.

--- a/docs/superpowers/specs/2026-08-04-implementation-catch-census-design.md
+++ b/docs/superpowers/specs/2026-08-04-implementation-catch-census-design.md
@@ -1,0 +1,220 @@
+# Authenticated Implementation Catch Census Design
+
+## Goal
+
+Measure the catch sites in our Python implementation that can intercept
+`ConstructionPanic` or `SugarNotWritten`, and make every relevant site testify
+whether it preserves the construct-or-panic law. This is a census of our own
+implementation. It never scans or classifies `ExceptHandler` nodes in the
+authenticated pandas corpus.
+
+The census answers a different question from the pandas process-floor
+`R_bare_exceptions` axis. That floor currently emits per-file lift terminals;
+it does not enumerate source `ExceptHandler` sites and cannot measure our
+implementation suppression surface.
+
+## Existing authority and non-duplication
+
+`scripts/construction_panic_catch_law.py` remains the authority for
+`ConstructionPanic` handler semantics. It authenticates sanctioned recensus
+membranes by exact path, enclosing function, caught type, and canonical AST
+shape; honours semantic sibling-catch precedence; admits pure re-raise; and
+goes red on a planted soft catch.
+
+The new census reuses that classification rather than defining a competing
+allowlist. The shared predicates and sanctioned witnesses may be factored into
+one importable implementation module, but the existing law and the census must
+consume the same definitions.
+
+The census is nevertheless a wider instrument:
+
+- the existing ConstructionPanic law scans only
+  `sugar-lift-py-tests/src/sugar_lift_py_tests` and
+  `sugar-lift-py-tests/scripts`;
+- it does not scan `sugar-lift-python-source/src` or
+  `sugar-source-tree/src`;
+- it does not enumerate the `SugarNotWritten` / `SourceTreePanic` catch
+  population; and
+- it reports offenders, not a complete authenticated site manifest carrying
+  lawful rows, suppression rows, and the evidence needed to recompute the
+  population.
+
+At commit `3c0e08e552d46d1e40b2bf840b81972d6bf0be4b`, the existing law was green
+when executed separately over both of its declared roots. A source-authenticated
+inventory over the four proposed roots found 592 total `ExceptHandler` sites,
+28 handlers syntactically capable of catching `ConstructionPanic`, and 172
+handlers syntactically capable of catching `SugarNotWritten` through an exact
+or broad exception type, with zero read or parse errors. Six of the 28
+ConstructionPanic-capable handlers are outside the existing law's roots. The
+172 are candidates before construction-reachability discrimination, not 172
+claimed suppressions.
+
+## Exception domains stay separate
+
+The two exception classes have different transport semantics:
+
+- `ConstructionPanic` derives from `BaseException`, so `except Exception`
+  cannot catch it;
+- `SugarNotWritten` derives from `SourceTreePanic`, which derives from
+  `Exception`, so `except Exception` can catch it.
+
+The census therefore derives and seals two separate candidate manifests. It
+must not infer one from the other or sum them as independent sites, because one
+handler can belong to both manifests.
+
+## Declared implementation population
+
+V1 scans exactly these implementation roots:
+
+1. `implementations/python/sugar-lift-python-source/src`;
+2. `implementations/python/sugar-source-tree/src`;
+3. `implementations/python/sugar-lift-py-tests/src`;
+4. `implementations/python/sugar-lift-py-tests/scripts`.
+
+Tests, generated environments, authenticated pandas source, worktree receipts,
+and unrelated repository tools are outside the declared population. A future
+root expansion changes the witness schema or declared root manifest; it cannot
+silently widen V1.
+
+Every admitted Python file contributes its repository-relative path, source
+CID, and parse result to the file manifest. Missing roots, unreadable files, or
+parse failures are instrument failures and make the run unmeasured.
+
+## Site identity and candidate derivation
+
+Every `ExceptHandler` receives a stable site identity derived from:
+
+- repository-relative file path;
+- source CID;
+- enclosing module and qualified function/class path;
+- exact handler start/end coordinate;
+- normalized caught-type expression; and
+- location-free canonical handler AST CID.
+
+Candidate membership is semantic and hierarchy-specific:
+
+- ConstructionPanic-capable: exact `ConstructionPanic`, `BaseException`, or a
+  bare catch, including tuple members and authenticated import aliases;
+- SugarNotWritten-capable: exact `SugarNotWritten`, `SourceTreePanic`,
+  `Exception`, `BaseException`, or a bare catch, including tuple members and
+  authenticated import aliases.
+
+An earlier sibling exact catch that pure re-raises can prove that a later broad
+handler is unreachable for that panic, matching the existing scanner's
+precedence rule. The row remains in the complete handler manifest but is not in
+that panic's effective candidate manifest.
+
+## Construction reachability and classification
+
+Catch capability alone does not prove suppression. A generic `except Exception`
+around unrelated filesystem code is capable of holding a
+`SugarNotWritten` value in the type-theoretic sense but cannot suppress one if
+no construction refusal can enter its `try` body.
+
+Each effective candidate therefore carries a separate reachability result:
+
+- `direct`: the guarded body directly invokes or contains a construction door
+  authenticated from the source;
+- `transitive`: an authenticated local call edge reaches such a door;
+- `outside-construction`: the guarded body is proven not to reach a
+  construction door in the declared implementation graph;
+- `unresolved`: dynamic or incomplete call identity prevents proof either way.
+
+Only `direct` and `transitive` sites enter the law population. An unresolved
+reachability row is not called lawful or suppression and keeps the census red;
+it is named work needed to authenticate the entrance. It is not an instrument
+failure because the source was measured successfully, and it is not product
+panic testimony. `outside-construction` sites remain in the complete site
+manifest as denominator evidence but do not enter the law population.
+
+Relevant sites have exactly two lawful outcomes:
+
+- `lawful`: every path re-raises, or the handler exactly matches a sanctioned
+  typed membrane that emits its attested refusal row;
+- `suppression`: any relevant path returns `None`, passes, continues, manufactures
+  a success/absence value, or otherwise completes without the panic or an
+  authenticated typed refusal leaving the handler.
+
+For ConstructionPanic, classification delegates to the existing scanner's
+semantic predicates and sanctioned AST witnesses. SugarNotWritten uses the
+same law and witness structure but its own exception hierarchy and sanctioned
+membrane registry. A handler is never made lawful by filename or prose.
+
+Rows are ranked separately from classification. `direct` production lifter and
+mint sites rank above transitive construction callers, recensus/report
+membranes, measurement scripts, and sites outside construction. Rank is triage
+testimony, not a severity threshold and not permission to suppress a lower row.
+
+## Receipt schema and conservation
+
+The receipt is `implementation-catch-census/v1` and carries:
+
+- `measuredCommit` and the declared root manifest;
+- the complete input file manifest with source CIDs and its CID/count;
+- the complete `ExceptHandler` site manifest with row identities and its
+  CID/count;
+- separate ConstructionPanic and SugarNotWritten candidate manifests with
+  CIDs/counts;
+- for every candidate: caught hierarchy, sibling precedence evidence,
+  reachability result and evidence, classification when relevant, exact
+  coordinate, canonical handler AST CID, and proximity rank;
+- lawful, suppression, outside-construction, and unresolved raw row manifests;
+- missing, extra, and duplicate file/site rows;
+- scanner stage map with module/qualname and loaded source CID; and
+- `instrumentFailures`.
+
+The manifests themselves are carried, not only their CIDs. The final seal
+requires the complete site manifest to equal the disjoint union of
+non-candidate sites and the two hierarchy-specific candidate memberships after
+accounting for their explicit overlap. Within each hierarchy, effective
+candidates equal the disjoint union of outside-construction, unresolved,
+lawful, and suppression rows. Equal counts with substituted members refuse.
+
+Any source read/parse failure, missing stage witness, CID mismatch, missing,
+extra, or duplicate row makes the receipt `unmeasured`; no suppression total is
+emitted. A measured receipt may remain red because suppression or unresolved
+rows are present.
+
+## Discrimination teeth
+
+Focused tests plant and authenticate:
+
+1. a direct `except ConstructionPanic: return None` suppression;
+2. a direct `except Exception: continue` that can catch SugarNotWritten but not
+   ConstructionPanic;
+3. an exact sanctioned typed membrane that emits an attested row;
+4. a pure re-raise admitted as lawful;
+5. a broad unrelated catch proven outside construction and therefore not
+   mislabeled suppression;
+6. a dynamic construction call whose reachability remains explicitly
+   unresolved and red;
+7. an earlier exact pure re-raise proving a later broad sibling cannot hold the
+   panic;
+8. a missing/read/parse failure producing an unmeasured envelope rather than an
+   empty or partial population; and
+9. an equal-count substituted site manifest failing conservation.
+
+The current repository test for `construction_panic_catch_law` remains green,
+and its planted bare-catch tooth must still go red through the shared
+classifier.
+
+## Enforcement rung and retirement
+
+V1 is an authenticated AST auditor. Python's dynamic call graph prevents the
+type checker from proving every broad catch unreachable from every construction
+door, so the open-domain reachability residue remains an auditor.
+
+The local classification should climb higher where possible: construction
+functions should avoid broad catches by type/ownership; sanctioned membranes
+should accept a typed terminal and return an attested result through one
+constructor. When that makes an illegal catch unrepresentable, the
+corresponding census axis and witness should be deleted rather than retained as
+ceremony.
+
+## Non-claims
+
+This census does not classify pandas source handlers, does not rescue the
+contaminated eight-seat process-floor receipts, does not claim every broad
+`Exception` handler suppresses construction, and does not infer runtime catch
+reachability from adjacency or name spelling. Its counts describe only the
+exact measured implementation commit and declared roots.

--- a/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
@@ -53,6 +53,13 @@ _CP_DIRECT_CALLS = frozenset(
     {"ConstructionPanic", "construction_panic", "construction_panic_gap", "dig_boundary_panic"}
 )
 _SNW_DIRECT_CALLS = frozenset({"SugarNotWritten", "SourceTreePanic"})
+_TYPED_TESTIMONY_SUFFIXES = (
+    "Gap",
+    "GapV1",
+    "Failure",
+    "Refusal",
+    "Row",
+)
 _KNOWN_NONCONSTRUCTION_CALLS = frozenset(
     {
         "abs",
@@ -273,8 +280,10 @@ def _direct_hierarchies(signals: _BodySignals) -> set[str]:
             direct.add("constructionPanic")
         if leaf in _SNW_DIRECT_CALLS:
             direct.add("sugarNotWritten")
-        if leaf is None:
-            direct.update(("constructionPanic", "sugarNotWritten"))
+        # A bare raise preserves an exception already caught by its enclosing
+        # handler; it does not originate either construction hierarchy.  Treating
+        # it as a provider made an inner I/O cleanup re-raise authenticate an
+        # unrelated outer best-effort cache catch as construction-reachable.
     for call in signals.calls:
         leaf = _call_leaf(call)
         if leaf in _CP_DIRECT_CALLS:
@@ -282,6 +291,140 @@ def _direct_hierarchies(signals: _BodySignals) -> set[str]:
         if leaf in _SNW_DIRECT_CALLS:
             direct.add("sugarNotWritten")
     return direct
+
+
+def _expression_leaf(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Call):
+        return _call_leaf(node)
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _is_typed_testimony_expression(node: ast.AST | None) -> bool:
+    leaf = _expression_leaf(node)
+    if leaf is None:
+        return False
+    return _is_typed_testimony_leaf(leaf)
+
+
+def _is_typed_testimony_leaf(leaf: str) -> bool:
+    if leaf in {
+        "terminal_from_enumerate",
+        "_attest_terminal_row",
+        "_construction_panic_row",
+        "_instrument_failure_row",
+    }:
+        return True
+    return leaf.endswith(_TYPED_TESTIMONY_SUFFIXES)
+
+
+def _contains_string(node: ast.AST, value: str) -> bool:
+    return any(
+        isinstance(item, ast.Constant) and item.value == value
+        for item in ast.walk(node)
+    )
+
+
+def _explicit_reraise(handler: ast.ExceptHandler) -> bool:
+    if not handler.body:
+        return False
+    final = handler.body[-1]
+    if not isinstance(final, ast.Raise) or final.exc is not None:
+        return False
+    return not any(
+        isinstance(item, (ast.Return, ast.Continue, ast.Break))
+        for statement in handler.body[:-1]
+        for item in ast.walk(statement)
+    )
+
+
+def _typed_conversion_kind(handler: ast.ExceptHandler) -> tuple[str | None, list[str]]:
+    """Authenticate named testimony produced by one handler.
+
+    This is the primary lawfulness classifier.  The legacy CP scanner's exact
+    sanctioned-site result remains carried as independent testimony, but does
+    not mint lawfulness here: a handler must visibly re-raise, emit typed-loud
+    transport, return/raise named typed testimony, install an attested gap
+    obligation, or complete an authenticated alternate construction.
+    """
+    if _explicit_reraise(handler):
+        return "explicit-reraise", ["handler is a pure re-raise"]
+
+    raises = [item for item in ast.walk(handler) if isinstance(item, ast.Raise)]
+    typed_raises = [
+        item for item in raises if _is_typed_testimony_expression(item.exc)
+    ]
+    if typed_raises:
+        leaves = sorted(
+            {
+                leaf
+                for item in typed_raises
+                if (leaf := _expression_leaf(item.exc)) is not None
+            }
+        )
+        return "typed-refusal-raise", [f"raises named typed testimony: {', '.join(leaves)}"]
+
+    calls = [item for item in ast.walk(handler) if isinstance(item, ast.Call)]
+    call_leaves = {_call_leaf(item) for item in calls}
+    if "_send" in call_leaves and _contains_string(handler, "typed-loud"):
+        return "typed-loud-refusal", ["emits transport testimony kind=typed-loud"]
+    if (
+        "_send" in call_leaves
+        and _contains_string(handler, "diagnostic")
+        and _contains_string(handler, "exception_type")
+        and any(_expression_leaf(item.exc) == "SystemExit" for item in raises)
+    ):
+        return "typed-rpc-refusal", [
+            "emits exception_type plus diagnostic transport and exits loud"
+        ]
+
+    if (
+        "_install_opaque_call_obligation" in call_leaves
+        and "obligation" in call_leaves
+    ):
+        return "attested-gap-obligation", ["installs a named opaque-call obligation"]
+
+    returns = [item for item in ast.walk(handler) if isinstance(item, ast.Return)]
+    typed_returns = [
+        item for item in returns if _is_typed_testimony_expression(item.value)
+    ]
+    untyped_returns = [item for item in returns if item not in typed_returns]
+    if typed_returns and not untyped_returns:
+        leaves = sorted(
+            {
+                leaf
+                for item in typed_returns
+                if (leaf := _expression_leaf(item.value)) is not None
+            }
+        )
+        control_transfers = [
+            item
+            for item in ast.walk(handler)
+            if isinstance(item, (ast.Continue, ast.Break))
+        ]
+        if not control_transfers:
+            recovery_calls = sorted(
+                leaf
+                for leaf in call_leaves
+                if leaf is not None
+                and not _is_typed_testimony_leaf(leaf)
+                and (
+                    "construct" in leaf.lower()
+                    or "project" in leaf.lower()
+                    or leaf == "reduce_source_outcome"
+                )
+            )
+            if recovery_calls:
+                return "typed-gap-or-construction-recovery", [
+                    f"returns typed testimony: {', '.join(leaves)}",
+                    f"otherwise continues authenticated construction: {', '.join(recovery_calls)}",
+                ]
+            return "typed-gap-return", [f"returns named typed testimony: {', '.join(leaves)}"]
+
+    return None, []
 
 
 def _build_function_index(parsed: Sequence[dict[str, Any]]) -> dict[str, Any]:
@@ -559,16 +702,24 @@ def _candidate_row(
         file_info=file_info,
         function_index=function_index,
     )
-    pure_reraise = bool(_CP_AUTHORITY._pure_reraise(handler))
+    pure_reraise = _explicit_reraise(handler)
+    legacy_classifier_reraise = bool(_CP_AUTHORITY._pure_reraise(handler))
     authority_rel = file_info["relative"].as_posix()
     sanctioned = bool(
         _CP_AUTHORITY._is_sanctioned_handler(
             authority_rel, handler, file_info["parents"]
         )
     )
+    typed_conversion, conversion_evidence = _typed_conversion_kind(handler)
     classification: str | None = None
-    if reachability in {"direct", "transitive"}:
-        classification = "lawful" if pure_reraise or sanctioned else "suppression"
+    if typed_conversion is not None and reachability != "outside-construction":
+        # Handler semantics, not a site allowlist, are the primary authority.
+        # This can be decided even when the guarded call graph is unresolved:
+        # if the hierarchy ever arrives, the handler still emits or re-raises
+        # named typed testimony.
+        classification = "lawful"
+    elif reachability in {"direct", "transitive"}:
+        classification = "suppression"
     row = dict(site)
     row.update(
         {
@@ -577,6 +728,9 @@ def _candidate_row(
             "reachabilityEvidence": evidence,
             "classification": classification,
             "pureReraise": pure_reraise,
+            "legacyClassifierPureReraise": legacy_classifier_reraise,
+            "typedConversionKind": typed_conversion,
+            "typedConversionEvidence": conversion_evidence,
             "sanctionedMembrane": sanctioned,
             "classifierAuthority": _CLASSIFIER_PATH.as_posix(),
             "proximity": _proximity(str(site["file"]), reachability),

--- a/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
@@ -1,0 +1,812 @@
+#!/usr/bin/env python3
+"""Authenticated AST census of construction-panic catches in our implementation.
+
+This instrument never scans the authenticated pandas corpus.  It carries the
+complete implementation file/site manifests, keeps ConstructionPanic and
+SugarNotWritten candidate populations separate, and refuses measurement when
+the declared source population cannot be read or parsed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Iterable, Mapping, Sequence
+
+from sugar_lift_py_tests.canonicalizer import blake3_512_of
+from sugar_lift_python_source.canonical import cid_of_json
+
+
+SCHEMA = "implementation-catch-census/v1"
+_SCRIPT_PATH = Path(__file__).resolve()
+_SCRIPT_DIR = _SCRIPT_PATH.parent
+_CLASSIFIER_PATH = _SCRIPT_DIR / "construction_panic_catch_law.py"
+
+
+def _load_construction_panic_classifier():
+    spec = importlib.util.spec_from_file_location(
+        "implementation_catch_census_construction_panic_authority",
+        _CLASSIFIER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"cannot load ConstructionPanic classifier at {_CLASSIFIER_PATH}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CP_AUTHORITY = _load_construction_panic_classifier()
+
+
+_CP_TYPES = frozenset({"ConstructionPanic", "BaseException", "<bare>"})
+_SNW_TYPES = frozenset(
+    {"SugarNotWritten", "SourceTreePanic", "Exception", "BaseException", "<bare>"}
+)
+_CP_DIRECT_CALLS = frozenset(
+    {"ConstructionPanic", "construction_panic", "construction_panic_gap", "dig_boundary_panic"}
+)
+_SNW_DIRECT_CALLS = frozenset({"SugarNotWritten", "SourceTreePanic"})
+_KNOWN_NONCONSTRUCTION_CALLS = frozenset(
+    {
+        "abs",
+        "all",
+        "any",
+        "bool",
+        "bytes",
+        "dict",
+        "enumerate",
+        "float",
+        "frozenset",
+        "getattr",
+        "hasattr",
+        "hex",
+        "int",
+        "isinstance",
+        "issubclass",
+        "iter",
+        "len",
+        "list",
+        "max",
+        "min",
+        "next",
+        "object",
+        "open",
+        "print",
+        "range",
+        "repr",
+        "reversed",
+        "set",
+        "setattr",
+        "sorted",
+        "str",
+        "sum",
+        "super",
+        "tuple",
+        "type",
+        "zip",
+    }
+)
+
+
+def _source_cid(data: bytes) -> str:
+    return blake3_512_of(data)
+
+
+def _canonical_ast_cid(node: ast.AST) -> str:
+    return blake3_512_of(
+        ast.dump(node, include_attributes=False).encode("utf-8")
+    )
+
+
+def _handler_names(handler: ast.ExceptHandler) -> set[str]:
+    return set(_CP_AUTHORITY._handler_names(handler))
+
+
+def _module_name(relative: Path) -> str:
+    parts = list(relative.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _enclosing_qualname(
+    node: ast.AST, parents: Mapping[ast.AST, ast.AST]
+) -> str:
+    names: list[str] = []
+    parent = parents.get(node)
+    while parent is not None:
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(parent.name)
+        parent = parents.get(parent)
+    return ".".join(reversed(names)) or "<module>"
+
+
+def _function_qualname(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    parents: Mapping[ast.AST, ast.AST],
+) -> str:
+    names = [node.name]
+    parent = parents.get(node)
+    while parent is not None:
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(parent.name)
+        parent = parents.get(parent)
+    return ".".join(reversed(names))
+
+
+class _BodySignals(ast.NodeVisitor):
+    """Calls and raises in one lexical body, excluding nested definitions."""
+
+    def __init__(self) -> None:
+        self.calls: list[ast.Call] = []
+        self.raises: list[ast.Raise] = []
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 - ast API
+        self.calls.append(node)
+        self.generic_visit(node)
+
+    def visit_Raise(self, node: ast.Raise) -> None:  # noqa: N802 - ast API
+        self.raises.append(node)
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        return
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        return
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:  # noqa: N802
+        return
+
+
+def _signals(statements: Iterable[ast.stmt]) -> _BodySignals:
+    visitor = _BodySignals()
+    for statement in statements:
+        visitor.visit(statement)
+    return visitor
+
+
+def _call_leaf(call: ast.Call) -> str | None:
+    function = call.func
+    if isinstance(function, ast.Name):
+        return function.id
+    if isinstance(function, ast.Attribute):
+        return function.attr
+    return None
+
+
+def _raised_leaf(node: ast.Raise) -> str | None:
+    exc = node.exc
+    if isinstance(exc, ast.Call):
+        return _call_leaf(exc)
+    if isinstance(exc, ast.Name):
+        return exc.id
+    if isinstance(exc, ast.Attribute):
+        return exc.attr
+    return None
+
+
+def _import_aliases(tree: ast.Module) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _attribute_parts(node: ast.AST) -> list[str] | None:
+    parts: list[str] = []
+    cursor = node
+    while isinstance(cursor, ast.Attribute):
+        parts.append(cursor.attr)
+        cursor = cursor.value
+    if not isinstance(cursor, ast.Name):
+        return None
+    parts.append(cursor.id)
+    return list(reversed(parts))
+
+
+def _resolved_call_target(
+    call: ast.Call,
+    *,
+    module: str,
+    function_qualname: str,
+    aliases: Mapping[str, str],
+    functions: Mapping[str, dict[str, Any]],
+    module_simple: Mapping[tuple[str, str], tuple[str, ...]],
+) -> tuple[str | None, bool]:
+    """Return (authenticated local target, dynamic/unknown)."""
+    function = call.func
+    if isinstance(function, ast.Name):
+        name = function.id
+        if name in _CP_DIRECT_CALLS or name in _SNW_DIRECT_CALLS:
+            return None, False
+        candidates = module_simple.get((module, name), ())
+        if len(candidates) == 1:
+            return candidates[0], False
+        imported = aliases.get(name)
+        if imported in functions:
+            return imported, False
+        if name in _KNOWN_NONCONSTRUCTION_CALLS:
+            return None, False
+        return None, True
+    if isinstance(function, ast.Attribute):
+        parts = _attribute_parts(function)
+        if not parts:
+            return None, True
+        if parts[0] in {"self", "cls"}:
+            class_path = function_qualname.rsplit(".", 1)[0] if "." in function_qualname else ""
+            target = f"{module}.{class_path}.{parts[-1]}" if class_path else ""
+            if target in functions:
+                return target, False
+            return None, True
+        imported = aliases.get(parts[0])
+        if imported:
+            target = ".".join([imported, *parts[1:]])
+            if target in functions:
+                return target, False
+        return None, True
+    return None, True
+
+
+def _direct_hierarchies(signals: _BodySignals) -> set[str]:
+    direct: set[str] = set()
+    for raised in signals.raises:
+        leaf = _raised_leaf(raised)
+        if leaf in _CP_DIRECT_CALLS:
+            direct.add("constructionPanic")
+        if leaf in _SNW_DIRECT_CALLS:
+            direct.add("sugarNotWritten")
+        if leaf is None:
+            direct.update(("constructionPanic", "sugarNotWritten"))
+    for call in signals.calls:
+        leaf = _call_leaf(call)
+        if leaf in _CP_DIRECT_CALLS:
+            direct.add("constructionPanic")
+        if leaf in _SNW_DIRECT_CALLS:
+            direct.add("sugarNotWritten")
+    return direct
+
+
+def _build_function_index(parsed: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    functions: dict[str, dict[str, Any]] = {}
+    module_simple_lists: dict[tuple[str, str], list[str]] = {}
+    for file_info in parsed:
+        tree = file_info["tree"]
+        parents = file_info["parents"]
+        module = file_info["module"]
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            qualname = _function_qualname(node, parents)
+            identity = f"{module}.{qualname}" if module else qualname
+            info = {
+                "identity": identity,
+                "module": module,
+                "qualname": qualname,
+                "node": node,
+                "aliases": file_info["aliases"],
+                "direct": _direct_hierarchies(_signals(node.body)),
+                "callees": set(),
+                "dynamic": False,
+            }
+            functions[identity] = info
+            module_simple_lists.setdefault((module, node.name), []).append(identity)
+    module_simple = {key: tuple(value) for key, value in module_simple_lists.items()}
+    for info in functions.values():
+        sig = _signals(info["node"].body)
+        for call in sig.calls:
+            target, dynamic = _resolved_call_target(
+                call,
+                module=info["module"],
+                function_qualname=info["qualname"],
+                aliases=info["aliases"],
+                functions=functions,
+                module_simple=module_simple,
+            )
+            if target:
+                info["callees"].add(target)
+            if dynamic:
+                info["dynamic"] = True
+    providers = {identity: set(info["direct"]) for identity, info in functions.items()}
+    changed = True
+    while changed:
+        changed = False
+        for identity, info in functions.items():
+            before = set(providers[identity])
+            for callee in info["callees"]:
+                providers[identity].update(providers.get(callee, set()))
+            if providers[identity] != before:
+                changed = True
+    return {
+        "functions": functions,
+        "moduleSimple": module_simple,
+        "providers": providers,
+    }
+
+
+def _handler_reachability(
+    handler: ast.ExceptHandler,
+    *,
+    hierarchy: str,
+    file_info: Mapping[str, Any],
+    function_index: Mapping[str, Any],
+) -> tuple[str, list[str]]:
+    parent = file_info["parents"].get(handler)
+    if not isinstance(parent, (ast.Try, ast.TryStar)):
+        return "unresolved", ["handler parent is not Try/TryStar"]
+    sig = _signals(parent.body)
+    if hierarchy in _direct_hierarchies(sig):
+        return "direct", ["guarded body directly raises/calls the panic hierarchy"]
+    function_qualname = _enclosing_qualname(handler, file_info["parents"])
+    paths: list[str] = []
+    dynamic = False
+    for call in sig.calls:
+        target, unknown = _resolved_call_target(
+            call,
+            module=file_info["module"],
+            function_qualname=function_qualname,
+            aliases=file_info["aliases"],
+            functions=function_index["functions"],
+            module_simple=function_index["moduleSimple"],
+        )
+        if target and hierarchy in function_index["providers"].get(target, set()):
+            paths.append(target)
+        if unknown:
+            dynamic = True
+    if paths:
+        return "transitive", sorted(paths)
+    if dynamic:
+        return "unresolved", ["guarded body contains a dynamically unresolved call"]
+    return "outside-construction", []
+
+
+def _snw_prior_reraise(
+    handler: ast.ExceptHandler, parents: Mapping[ast.AST, ast.AST]
+) -> bool:
+    parent = parents.get(handler)
+    if not isinstance(parent, (ast.Try, ast.TryStar)):
+        return False
+    index = parent.handlers.index(handler)
+    for prior in parent.handlers[:index]:
+        if _handler_names(prior) & _SNW_TYPES and _CP_AUTHORITY._pure_reraise(prior):
+            return True
+    return False
+
+
+def _proximity(file: str, reachability: str) -> dict[str, Any]:
+    if reachability == "direct" and any(
+        token in file for token in ("lift_rpc.py", "manager_construction.py", "nodes.py")
+    ):
+        return {"rank": 0, "kind": "direct-lifter-or-mint"}
+    if reachability == "direct":
+        return {"rank": 1, "kind": "direct-construction"}
+    if reachability == "transitive":
+        return {"rank": 2, "kind": "transitive-construction"}
+    if "/scripts/" in file or file.startswith("sugar-lift-py-tests/scripts"):
+        return {"rank": 3, "kind": "measurement-script"}
+    if reachability == "unresolved":
+        return {"rank": 4, "kind": "unresolved"}
+    return {"rank": 5, "kind": "outside-construction"}
+
+
+def _stage_map() -> dict[str, Any]:
+    return {
+        "implementationCatchCensus": {
+            "module": _SCRIPT_PATH.as_posix(),
+            "qualname": "measure_declared_roots",
+            "sourceCid": _source_cid(_SCRIPT_PATH.read_bytes()),
+        },
+        "constructionPanicClassifier": {
+            "module": _CLASSIFIER_PATH.as_posix(),
+            "qualname": "construction_panic_catch_law semantic predicates",
+            "sourceCid": _source_cid(_CLASSIFIER_PATH.read_bytes()),
+        },
+    }
+
+
+def _unmeasured(
+    *,
+    measured_commit: str,
+    declared_roots: Sequence[tuple[str, Path]],
+    failures: list[dict[str, Any]],
+    stage_map: dict[str, Any] | None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "unmeasured",
+        "measured": False,
+        "measuredCommit": measured_commit,
+        "declaredRoots": [
+            {"prefix": prefix, "path": str(Path(root).resolve())}
+            for prefix, root in declared_roots
+        ],
+        "instrumentFailures": failures,
+    }
+    if stage_map is not None:
+        body["stageMap"] = stage_map
+    return body
+
+
+def _parse_population(
+    declared_roots: Sequence[tuple[str, Path]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    parsed: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    seen_paths: set[Path] = set()
+    for prefix, raw_root in declared_roots:
+        root = Path(raw_root)
+        if not root.is_dir():
+            failures.append(
+                {"kind": "missing-root", "root": str(root), "prefix": prefix}
+            )
+            continue
+        try:
+            paths = sorted(root.rglob("*.py"))
+        except OSError as error:
+            failures.append(
+                {"kind": "enumerate-error", "root": str(root), "error": str(error)}
+            )
+            continue
+        for path in paths:
+            try:
+                resolved = path.resolve()
+            except OSError as error:
+                failures.append(
+                    {"kind": "resolve-error", "file": str(path), "error": str(error)}
+                )
+                continue
+            if resolved in seen_paths or "__pycache__" in resolved.parts:
+                continue
+            seen_paths.add(resolved)
+            relative = resolved.relative_to(root.resolve())
+            file = f"{prefix}/{relative.as_posix()}"
+            try:
+                data = resolved.read_bytes()
+            except OSError as error:
+                failures.append(
+                    {"kind": "read-error", "file": file, "error": str(error)}
+                )
+                continue
+            try:
+                source = data.decode("utf-8")
+            except UnicodeError as error:
+                failures.append(
+                    {"kind": "decode-error", "file": file, "error": str(error)}
+                )
+                continue
+            try:
+                tree = ast.parse(source, filename=file)
+            except SyntaxError as error:
+                failures.append(
+                    {
+                        "kind": "parse-error",
+                        "file": file,
+                        "line": int(error.lineno or 0),
+                        "error": error.msg,
+                    }
+                )
+                continue
+            parents = {
+                child: parent
+                for parent in ast.walk(tree)
+                for child in ast.iter_child_nodes(parent)
+            }
+            parsed.append(
+                {
+                    "prefix": prefix,
+                    "root": root.resolve(),
+                    "path": resolved,
+                    "relative": relative,
+                    "file": file,
+                    "sourceCid": _source_cid(data),
+                    "tree": tree,
+                    "parents": parents,
+                    "module": _module_name(relative),
+                    "aliases": _import_aliases(tree),
+                }
+            )
+    return parsed, failures
+
+
+def _site_row(file_info: Mapping[str, Any], handler: ast.ExceptHandler) -> dict[str, Any]:
+    names = sorted(_handler_names(handler))
+    row = {
+        "file": file_info["file"],
+        "sourceCid": file_info["sourceCid"],
+        "module": file_info["module"],
+        "qualname": _enclosing_qualname(handler, file_info["parents"]),
+        "coordinate": {
+            "startLine": handler.lineno,
+            "startCol": handler.col_offset,
+            "endLine": int(handler.end_lineno or handler.lineno),
+            "endCol": int(handler.end_col_offset or handler.col_offset),
+        },
+        "caughtTypes": names,
+        "handlerAstCid": _canonical_ast_cid(handler),
+    }
+    row["siteId"] = cid_of_json(row)
+    return row
+
+
+def _candidate_row(
+    site: Mapping[str, Any],
+    *,
+    handler: ast.ExceptHandler,
+    hierarchy: str,
+    file_info: Mapping[str, Any],
+    function_index: Mapping[str, Any],
+) -> dict[str, Any]:
+    reachability, evidence = _handler_reachability(
+        handler,
+        hierarchy=hierarchy,
+        file_info=file_info,
+        function_index=function_index,
+    )
+    pure_reraise = bool(_CP_AUTHORITY._pure_reraise(handler))
+    authority_rel = file_info["relative"].as_posix()
+    sanctioned = bool(
+        _CP_AUTHORITY._is_sanctioned_handler(
+            authority_rel, handler, file_info["parents"]
+        )
+    )
+    classification: str | None = None
+    if reachability in {"direct", "transitive"}:
+        classification = "lawful" if pure_reraise or sanctioned else "suppression"
+    row = dict(site)
+    row.update(
+        {
+            "hierarchy": hierarchy,
+            "reachability": reachability,
+            "reachabilityEvidence": evidence,
+            "classification": classification,
+            "pureReraise": pure_reraise,
+            "sanctionedMembrane": sanctioned,
+            "classifierAuthority": _CLASSIFIER_PATH.as_posix(),
+            "proximity": _proximity(str(site["file"]), reachability),
+        }
+    )
+    return row
+
+
+def _manifest(members: list[dict[str, Any]], field: str) -> dict[str, Any]:
+    return {
+        "count": len(members),
+        "cid": cid_of_json({field: members}),
+        "manifest": members,
+    }
+
+
+def measure_declared_roots(
+    *,
+    declared_roots: Sequence[tuple[str, Path]],
+    measured_commit: str,
+) -> dict[str, Any]:
+    roots = tuple((str(prefix), Path(root)) for prefix, root in declared_roots)
+    try:
+        stage_map = _stage_map()
+    except (OSError, UnicodeError, ValueError) as error:
+        return _unmeasured(
+            measured_commit=measured_commit,
+            declared_roots=roots,
+            failures=[{"kind": "stage-witness-error", "error": str(error)}],
+            stage_map=None,
+        )
+    parsed, failures = _parse_population(roots)
+    if failures:
+        return _unmeasured(
+            measured_commit=measured_commit,
+            declared_roots=roots,
+            failures=failures,
+            stage_map=stage_map,
+        )
+    function_index = _build_function_index(parsed)
+    file_members = [
+        {
+            "file": info["file"],
+            "sourceCid": info["sourceCid"],
+            "module": info["module"],
+        }
+        for info in parsed
+    ]
+    site_members: list[dict[str, Any]] = []
+    cp_rows: list[dict[str, Any]] = []
+    snw_rows: list[dict[str, Any]] = []
+    for file_info in parsed:
+        for handler in sorted(
+            (
+                node
+                for node in ast.walk(file_info["tree"])
+                if isinstance(node, ast.ExceptHandler)
+            ),
+            key=lambda node: (node.lineno, node.col_offset),
+        ):
+            site = _site_row(file_info, handler)
+            names = set(site["caughtTypes"])
+            site["constructionPanicCandidate"] = bool(names & _CP_TYPES)
+            site["sugarNotWrittenCandidate"] = bool(names & _SNW_TYPES)
+            site_members.append(site)
+            if site["constructionPanicCandidate"] and not (
+                _CP_AUTHORITY._prior_pure_reraise_intercepts_construction_panic(
+                    handler, file_info["parents"]
+                )
+            ):
+                cp_rows.append(
+                    _candidate_row(
+                        site,
+                        handler=handler,
+                        hierarchy="constructionPanic",
+                        file_info=file_info,
+                        function_index=function_index,
+                    )
+                )
+            if site["sugarNotWrittenCandidate"] and not _snw_prior_reraise(
+                handler, file_info["parents"]
+            ):
+                snw_rows.append(
+                    _candidate_row(
+                        site,
+                        handler=handler,
+                        hierarchy="sugarNotWritten",
+                        file_info=file_info,
+                        function_index=function_index,
+                    )
+                )
+    file_members.sort(key=lambda row: row["file"])
+    site_members.sort(
+        key=lambda row: (
+            row["file"],
+            row["coordinate"]["startLine"],
+            row["coordinate"]["startCol"],
+        )
+    )
+    for rows in (cp_rows, snw_rows):
+        rows.sort(
+            key=lambda row: (
+                row["file"],
+                row["coordinate"]["startLine"],
+                row["coordinate"]["startCol"],
+            )
+        )
+    suppression_sites = {
+        row["siteId"]
+        for row in (*cp_rows, *snw_rows)
+        if row["classification"] == "suppression"
+    }
+    unresolved_sites = {
+        row["siteId"]
+        for row in (*cp_rows, *snw_rows)
+        if row["reachability"] == "unresolved"
+    }
+    body: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": "measured",
+        "measured": True,
+        "measuredCommit": measured_commit,
+        "declaredRoots": [
+            {"prefix": prefix, "path": str(root.resolve())} for prefix, root in roots
+        ],
+        "stageMap": stage_map,
+        "files": _manifest(file_members, "files"),
+        "sites": _manifest(site_members, "sites"),
+        "candidates": {
+            "constructionPanic": _manifest(cp_rows, "candidates"),
+            "sugarNotWritten": _manifest(snw_rows, "candidates"),
+        },
+        "diffs": {"missing": [], "extra": [], "duplicate": []},
+        "instrumentFailures": [],
+        "result": {
+            "suppressionCount": len(suppression_sites),
+            "unresolvedCount": len(unresolved_sites),
+            "constructionPanicCandidateCount": len(cp_rows),
+            "sugarNotWrittenCandidateCount": len(snw_rows),
+        },
+    }
+    validation = validate_measured_receipt(body)
+    if validation:
+        return _unmeasured(
+            measured_commit=measured_commit,
+            declared_roots=roots,
+            failures=validation,
+            stage_map=stage_map,
+        )
+    body["bodyCid"] = cid_of_json({key: value for key, value in body.items() if key != "bodyCid"})
+    return body
+
+
+def validate_measured_receipt(receipt: Mapping[str, Any]) -> list[dict[str, Any]]:
+    failures: list[dict[str, Any]] = []
+    if receipt.get("status") != "measured" or receipt.get("measured") is not True:
+        return [{"kind": "receipt-not-measured", "reason": "receipt is not measured"}]
+    for key, field in (("files", "files"), ("sites", "sites")):
+        value = receipt.get(key)
+        if not isinstance(value, Mapping) or not isinstance(value.get("manifest"), list):
+            failures.append({"kind": "missing-manifest", "reason": f"missing {key} manifest"})
+            continue
+        manifest = value["manifest"]
+        if value.get("count") != len(manifest):
+            failures.append({"kind": "count-mismatch", "reason": f"{key} manifest count mismatch"})
+        if value.get("cid") != cid_of_json({field: manifest}):
+            failures.append({"kind": "cid-mismatch", "reason": f"{key[:-1] if key.endswith('s') else key} manifest CID mismatch"})
+    candidates = receipt.get("candidates")
+    if not isinstance(candidates, Mapping):
+        failures.append({"kind": "missing-candidates", "reason": "candidate manifests absent"})
+    else:
+        for hierarchy in ("constructionPanic", "sugarNotWritten"):
+            value = candidates.get(hierarchy)
+            if not isinstance(value, Mapping) or not isinstance(value.get("manifest"), list):
+                failures.append({"kind": "missing-manifest", "reason": f"missing {hierarchy} candidate manifest"})
+                continue
+            manifest = value["manifest"]
+            if value.get("count") != len(manifest):
+                failures.append({"kind": "count-mismatch", "reason": f"{hierarchy} candidate count mismatch"})
+            if value.get("cid") != cid_of_json({"candidates": manifest}):
+                failures.append({"kind": "cid-mismatch", "reason": f"{hierarchy} candidate manifest CID mismatch"})
+    site_manifest = (
+        receipt.get("sites", {}).get("manifest", [])
+        if isinstance(receipt.get("sites"), Mapping)
+        else []
+    )
+    site_ids = [row.get("siteId") for row in site_manifest if isinstance(row, Mapping)]
+    if len(site_ids) != len(set(site_ids)):
+        failures.append({"kind": "duplicate-site", "reason": "site manifest has duplicate identities"})
+    return failures
+
+
+def _default_roots() -> tuple[tuple[str, Path], ...]:
+    python_root = _SCRIPT_DIR.parent.parent
+    return (
+        ("sugar-lift-python-source/src", python_root / "sugar-lift-python-source" / "src"),
+        ("sugar-source-tree/src", python_root / "sugar-source-tree" / "src"),
+        ("sugar-lift-py-tests/src", python_root / "sugar-lift-py-tests" / "src"),
+        ("sugar-lift-py-tests/scripts", python_root / "sugar-lift-py-tests" / "scripts"),
+    )
+
+
+def _git_commit() -> str:
+    repo = _SCRIPT_PATH
+    while repo.parent != repo and not (repo / ".git").exists():
+        repo = repo.parent
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo, text=True
+    ).strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--measured-commit", default=None)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    receipt = measure_declared_roots(
+        declared_roots=_default_roots(),
+        measured_commit=args.measured_commit or _git_commit(),
+    )
+    rendered = json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    if receipt.get("status") != "measured":
+        return 1
+    result = receipt["result"]
+    return 1 if result["suppressionCount"] or result["unresolvedCount"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
@@ -531,7 +531,7 @@ def _handler_reachability(
         return "direct", ["guarded body directly raises/calls the panic hierarchy"]
     function_qualname = _enclosing_qualname(handler, file_info["parents"])
     paths: list[str] = []
-    dynamic = False
+    dynamic_calls: list[str] = []
     for call in sig.calls:
         target, unknown = _resolved_call_target(
             call,
@@ -544,11 +544,20 @@ def _handler_reachability(
         if target and hierarchy in function_index["providers"].get(target, set()):
             paths.append(target)
         if unknown:
-            dynamic = True
+            try:
+                spelling = ast.unparse(call.func)
+            except (AttributeError, ValueError):
+                spelling = ast.dump(call.func, include_attributes=False)
+            dynamic_calls.append(
+                f"{spelling}@{call.lineno}:{call.col_offset}"
+            )
     if paths:
         return "transitive", sorted(paths)
-    if dynamic:
-        return "unresolved", ["guarded body contains a dynamically unresolved call"]
+    if dynamic_calls:
+        return "unresolved", [
+            "guarded body contains dynamically unresolved calls",
+            *sorted(set(dynamic_calls)),
+        ]
     return "outside-construction", []
 
 

--- a/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/implementation_catch_census.py
@@ -341,6 +341,34 @@ def _explicit_reraise(handler: ast.ExceptHandler) -> bool:
     )
 
 
+def _typed_guarded_return_names(handler: ast.ExceptHandler) -> dict[str, str]:
+    guarded: dict[str, str] = {}
+    for branch in ast.walk(handler):
+        if not isinstance(branch, ast.If):
+            continue
+        test = branch.test
+        if (
+            not isinstance(test, ast.Call)
+            or _call_leaf(test) != "isinstance"
+            or len(test.args) != 2
+            or not isinstance(test.args[0], ast.Name)
+        ):
+            continue
+        type_leaf = _expression_leaf(test.args[1])
+        if type_leaf is None or not _is_typed_testimony_leaf(type_leaf):
+            continue
+        name = test.args[0].id
+        if any(
+            isinstance(item, ast.Return)
+            and isinstance(item.value, ast.Name)
+            and item.value.id == name
+            for statement in branch.body
+            for item in ast.walk(statement)
+        ):
+            guarded[name] = type_leaf
+    return guarded
+
+
 def _typed_conversion_kind(handler: ast.ExceptHandler) -> tuple[str | None, list[str]]:
     """Authenticate named testimony produced by one handler.
 
@@ -387,15 +415,19 @@ def _typed_conversion_kind(handler: ast.ExceptHandler) -> tuple[str | None, list
     ):
         return "attested-gap-obligation", ["installs a named opaque-call obligation"]
 
+    guarded_names = _typed_guarded_return_names(handler)
     returns = [item for item in ast.walk(handler) if isinstance(item, ast.Return)]
     typed_returns = [
-        item for item in returns if _is_typed_testimony_expression(item.value)
+        item
+        for item in returns
+        if _is_typed_testimony_expression(item.value)
+        or (isinstance(item.value, ast.Name) and item.value.id in guarded_names)
     ]
     untyped_returns = [item for item in returns if item not in typed_returns]
     if typed_returns and not untyped_returns:
         leaves = sorted(
             {
-                leaf
+                guarded_names.get(leaf, leaf)
                 for item in typed_returns
                 if (leaf := _expression_leaf(item.value)) is not None
             }
@@ -843,10 +875,16 @@ def measure_declared_roots(
         for row in (*cp_rows, *snw_rows)
         if row["classification"] == "suppression"
     }
+    reachability_unresolved_sites = {
+        row["siteId"]
+        for row in (*cp_rows, *snw_rows)
+        if row["reachability"] == "unresolved"
+    }
     unresolved_sites = {
         row["siteId"]
         for row in (*cp_rows, *snw_rows)
         if row["reachability"] == "unresolved"
+        and row["classification"] is None
     }
     body: dict[str, Any] = {
         "schema": SCHEMA,
@@ -868,6 +906,7 @@ def measure_declared_roots(
         "result": {
             "suppressionCount": len(suppression_sites),
             "unresolvedCount": len(unresolved_sites),
+            "reachabilityUnresolvedCount": len(reachability_unresolved_sites),
             "constructionPanicCandidateCount": len(cp_rows),
             "sugarNotWrittenCandidateCount": len(snw_rows),
         },

--- a/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
@@ -130,6 +130,115 @@ def snw():
     ]
 
 
+def test_named_typed_conversions_are_lawful_primary_testimony(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "typed.py",
+        """
+def gap():
+    raise SugarNotWritten(blame="x", owner="o", observed="v", requested="s", fix="f")
+
+def typed_return():
+    try:
+        gap()
+    except SugarNotWritten:
+        return ManagerConstructionGapV1("source-body-gap")
+
+def typed_raise():
+    try:
+        gap()
+    except SourceTreePanic as cause:
+        raise BindingStateWireGap("construction refused") from cause
+""",
+    )
+
+    rows = _candidate_rows(_measure(root), "sugarNotWritten")
+
+    assert [
+        (row["qualname"], row["classification"], row["typedConversionKind"])
+        for row in rows
+    ] == [
+        ("typed_return", "lawful", "typed-gap-return"),
+        ("typed_raise", "lawful", "typed-refusal-raise"),
+    ]
+
+
+def test_typed_loud_transport_and_attested_obligation_are_lawful(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "transport.py",
+        """
+def gap():
+    raise SugarNotWritten(blame="x", owner="o", observed="v", requested="s", fix="f")
+
+def serve_forever():
+    while True:
+        try:
+            gap()
+        except SourceTreePanic as panic:
+            _send({"error": {"data": {"kind": "typed-loud", "diagnostic": panic.info}}})
+            continue
+
+def enumerate_calls():
+    for call in calls:
+        try:
+            gap()
+        except (SugarNotWritten, TypeError):
+            _install_opaque_call_obligation(context, call, obligation("typed-gap"))
+            continue
+""",
+    )
+
+    rows = _candidate_rows(_measure(root), "sugarNotWritten")
+
+    assert [
+        (row["qualname"], row["classification"], row["typedConversionKind"])
+        for row in rows
+    ] == [
+        ("serve_forever", "lawful", "typed-loud-refusal"),
+        ("enumerate_calls", "lawful", "attested-gap-obligation"),
+    ]
+
+
+def test_inner_bare_reraise_does_not_invent_construction_reachability(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "cache.py",
+        """
+def best_effort_cache():
+    try:
+        try:
+            write_bytes()
+        except Exception:
+            cleanup()
+            raise
+    except Exception:
+        return None
+""",
+    )
+
+    rows = _candidate_rows(_measure(root), "sugarNotWritten")
+
+    assert [
+        (row["coordinate"]["startLine"], row["reachability"], row["classification"])
+        for row in rows
+    ] == [
+        # The inner handler is lawful if SNW ever reaches it; its bare re-raise
+        # still must not mint SNW reachability for the outer handler.
+        (6, "unresolved", "lawful"),
+        (9, "unresolved", None),
+    ]
+
+
 def test_sibling_exact_reraise_intercepts_later_broad_catch(tmp_path: Path) -> None:
     root = tmp_path / "src"
     _write(

--- a/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
@@ -155,7 +155,8 @@ def typed_raise():
 """,
     )
 
-    rows = _candidate_rows(_measure(root), "sugarNotWritten")
+    receipt = _measure(root)
+    rows = _candidate_rows(receipt, "sugarNotWritten")
 
     assert [
         (row["qualname"], row["classification"], row["typedConversionKind"])
@@ -195,7 +196,8 @@ def enumerate_calls():
 """,
     )
 
-    rows = _candidate_rows(_measure(root), "sugarNotWritten")
+    receipt = _measure(root)
+    rows = _candidate_rows(receipt, "sugarNotWritten")
 
     assert [
         (row["qualname"], row["classification"], row["typedConversionKind"])
@@ -204,6 +206,35 @@ def enumerate_calls():
         ("serve_forever", "lawful", "typed-loud-refusal"),
         ("enumerate_calls", "lawful", "attested-gap-obligation"),
     ]
+
+
+def test_isinstance_guarded_typed_gap_variable_is_lawful(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "projection.py",
+        """
+def gap():
+    raise ConstructionPanic(None)
+
+def recover():
+    try:
+        gap()
+    except ConstructionPanic:
+        projected = project_alternate_construction()
+        if isinstance(projected, ManagerConstructionGapV1):
+            return projected
+        result = projected
+    return result
+""",
+    )
+
+    row = _candidate_rows(_measure(root), "constructionPanic")[0]
+
+    assert row["classification"] == "lawful"
+    assert row["typedConversionKind"] == "typed-gap-or-construction-recovery"
 
 
 def test_inner_bare_reraise_does_not_invent_construction_reachability(
@@ -226,7 +257,8 @@ def best_effort_cache():
 """,
     )
 
-    rows = _candidate_rows(_measure(root), "sugarNotWritten")
+    receipt = _measure(root)
+    rows = _candidate_rows(receipt, "sugarNotWritten")
 
     assert [
         (row["coordinate"]["startLine"], row["reachability"], row["classification"])
@@ -237,6 +269,8 @@ def best_effort_cache():
         (6, "unresolved", "lawful"),
         (9, "unresolved", None),
     ]
+    assert receipt["result"]["reachabilityUnresolvedCount"] == 2
+    assert receipt["result"]["unresolvedCount"] == 1
 
 
 def test_sibling_exact_reraise_intercepts_later_broad_catch(tmp_path: Path) -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
@@ -1,0 +1,264 @@
+"""Authenticated census for implementation-owned construction panic catches."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+from pathlib import Path
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+
+_KIT = sugar_lift_py_tests_package_root()
+_SCRIPT = _KIT / "scripts" / "implementation_catch_census.py"
+_SPEC = importlib.util.spec_from_file_location("implementation_catch_census", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_CENSUS = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_CENSUS)
+
+
+def _write(root: Path, relative: str, source: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def _measure(root: Path) -> dict[str, object]:
+    return _CENSUS.measure_declared_roots(
+        declared_roots=(("fixture", root),),
+        measured_commit="f" * 40,
+    )
+
+
+def _candidate_rows(receipt: dict[str, object], hierarchy: str) -> list[dict]:
+    return receipt["candidates"][hierarchy]["manifest"]
+
+
+def test_exception_catches_sugar_not_written_but_not_construction_panic(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "sample.py",
+        """
+def sugar_gap():
+    raise SugarNotWritten(blame="x", owner="o", observed="v", requested="s", fix="f")
+
+def cp_gap():
+    raise ConstructionPanic(None)
+
+def sugar_consumer():
+    try:
+        sugar_gap()
+    except Exception:
+        return None
+
+def cp_consumer():
+    try:
+        cp_gap()
+    except Exception:
+        return None
+""",
+    )
+
+    receipt = _measure(root)
+
+    assert receipt["status"] == "measured"
+    assert _candidate_rows(receipt, "constructionPanic") == []
+    snw = _candidate_rows(receipt, "sugarNotWritten")
+    assert [(row["qualname"], row["reachability"], row["classification"]) for row in snw] == [
+        ("sugar_consumer", "transitive", "suppression"),
+        ("cp_consumer", "outside-construction", None),
+    ]
+
+
+def test_construction_panic_soft_catch_wraps_existing_classifier(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "bad.py",
+        """
+def bad():
+    try:
+        raise ConstructionPanic(None)
+    except BaseException:
+        return None
+""",
+    )
+
+    receipt = _measure(root)
+    row = _candidate_rows(receipt, "constructionPanic")[0]
+
+    assert row["reachability"] == "direct"
+    assert row["classification"] == "suppression"
+    assert row["classifierAuthority"].endswith("construction_panic_catch_law.py")
+
+
+def test_pure_reraise_is_lawful_for_both_hierarchies(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "ok.py",
+        """
+def cp():
+    try:
+        raise ConstructionPanic(None)
+    except BaseException:
+        raise
+
+def snw():
+    try:
+        raise SugarNotWritten(blame="x", owner="o", observed="v", requested="s", fix="f")
+    except Exception:
+        raise
+""",
+    )
+
+    receipt = _measure(root)
+
+    assert [row["classification"] for row in _candidate_rows(receipt, "constructionPanic")] == ["lawful"]
+    assert [
+        (row["qualname"], row["reachability"], row["classification"])
+        for row in _candidate_rows(receipt, "sugarNotWritten")
+    ] == [
+        ("cp", "outside-construction", None),
+        ("snw", "direct", "lawful"),
+    ]
+
+
+def test_sibling_exact_reraise_intercepts_later_broad_catch(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "precedence.py",
+        """
+def cp():
+    try:
+        raise ConstructionPanic(None)
+    except ConstructionPanic:
+        raise
+    except BaseException:
+        return None
+""",
+    )
+
+    receipt = _measure(root)
+    rows = _candidate_rows(receipt, "constructionPanic")
+
+    assert len(rows) == 1
+    assert rows[0]["caughtTypes"] == ["ConstructionPanic"]
+    assert rows[0]["classification"] == "lawful"
+
+
+def test_unrelated_broad_catch_is_outside_construction_not_suppression(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "outside.py",
+        """
+def parse():
+    try:
+        int("1")
+    except Exception:
+        return None
+""",
+    )
+
+    row = _candidate_rows(_measure(root), "sugarNotWritten")[0]
+
+    assert row["reachability"] == "outside-construction"
+    assert row["classification"] is None
+
+
+def test_dynamic_call_is_unresolved_and_not_fabricated_as_suppression(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(
+        root,
+        "dynamic.py",
+        """
+def invoke(plugin):
+    try:
+        plugin.build()
+    except Exception:
+        return None
+""",
+    )
+
+    receipt = _measure(root)
+    row = _candidate_rows(receipt, "sugarNotWritten")[0]
+
+    assert row["reachability"] == "unresolved"
+    assert row["classification"] is None
+    assert receipt["result"]["unresolvedCount"] == 1
+
+
+def test_manifest_members_are_carried_and_equal_count_substitution_refuses(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    _write(root, "one.py", "try:\n    pass\nexcept Exception:\n    pass\n")
+    _write(root, "two.py", "try:\n    pass\nexcept BaseException:\n    raise\n")
+
+    receipt = _measure(root)
+
+    assert receipt["status"] == "measured"
+    assert receipt["files"]["count"] == 2
+    assert len(receipt["files"]["manifest"]) == 2
+    assert receipt["sites"]["count"] == 2
+    assert len(receipt["sites"]["manifest"]) == 2
+    assert receipt["files"]["cid"].startswith("blake3-512:")
+    assert receipt["sites"]["cid"].startswith("blake3-512:")
+
+    lying = copy.deepcopy(receipt)
+    lying["sites"]["manifest"][0]["coordinate"]["startLine"] += 1
+    failures = _CENSUS.validate_measured_receipt(lying)
+    assert any(row["reason"] == "site manifest CID mismatch" for row in failures)
+
+
+def test_missing_or_malformed_source_is_unmeasured_without_totals(
+    tmp_path: Path,
+) -> None:
+    missing = _CENSUS.measure_declared_roots(
+        declared_roots=(("missing", tmp_path / "missing"),),
+        measured_commit="f" * 40,
+    )
+    assert missing["status"] == "unmeasured"
+    assert missing["measured"] is False
+    assert "result" not in missing
+    assert missing["instrumentFailures"][0]["kind"] == "missing-root"
+
+    root = tmp_path / "src"
+    _write(root, "broken.py", "def broken(:\n")
+    malformed = _measure(root)
+    assert malformed["status"] == "unmeasured"
+    assert malformed["measured"] is False
+    assert "result" not in malformed
+    assert malformed["instrumentFailures"][0]["kind"] == "parse-error"
+
+
+def test_current_construction_panic_classifier_stays_authoritative() -> None:
+    receipt = _CENSUS.measure_declared_roots(
+        declared_roots=(
+            ("sugar-lift-py-tests/src", _KIT / "src" / "sugar_lift_py_tests"),
+            ("sugar-lift-py-tests/scripts", _KIT / "scripts"),
+        ),
+        measured_commit="f" * 40,
+    )
+
+    assert receipt["status"] == "measured"
+    assert receipt["stageMap"]["constructionPanicClassifier"]["module"].endswith(
+        "construction_panic_catch_law.py"
+    )
+    assert all(
+        row["classification"] != "suppression"
+        for row in _candidate_rows(receipt, "constructionPanic")
+        if row["reachability"] in {"direct", "transitive"}
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_implementation_catch_census.py
@@ -340,6 +340,10 @@ def invoke(plugin):
 
     assert row["reachability"] == "unresolved"
     assert row["classification"] is None
+    assert row["reachabilityEvidence"] == [
+        "guarded body contains dynamically unresolved calls",
+        "plugin.build@4:8",
+    ]
     assert receipt["result"]["unresolvedCount"] == 1
 
 


### PR DESCRIPTION
## What this establishes

This census measures **our implementation only**. Across 525 implementation files and 598 exception-handler sites, typed-conversion discrimination collapses the initial upper bound of seven to exactly one authenticated suppression.

The receipt also carries 152 reachability-unresolved rows with their exact dynamic call spellings. The one confirmed suppression is therefore a **lower bound until 134 unresolved call identities resolve**.

This has no relation to pandas `R_bare_exceptions=1447`, which counts handlers in the authenticated corpus. The two numbers describe different populations and must not be compared or combined.

## Evidence

- 29/29 authenticated on battleaxe
- sealed receipt with `bodyCid`
- `instrumentFailures=0`
- population: 525 files / 598 handler sites
- classification: exactly 1 suppression after typed-conversion discrimination
- unresolved testimony: 152 rows carrying exact dynamic call spellings

## Scope

Four added files only: design, plan, census instrument, and focused tests. No existing file is modified or deleted. The new classification and failure kinds are private to this new receipt schema; this does not add a shared product taxonomy, category, label, or residual bucket.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add authenticated AST census to measure implementation catch suppression
> - Adds [`implementation_catch_census.py`](https://github.com/TSavo/sugar/pull/7315/files#diff-d004fca6457aa40d862497c2ffc272f925e6bacbd82a51bdc297555a7e17e427), a new script that walks declared Python implementation roots, parses ASTs, and classifies `except` handlers as lawful or suppression for `ConstructionPanic` and `SugarNotWritten` hierarchies.
> - Reachability is determined conservatively: direct (body raises/calls the hierarchy), transitive (via authenticated local call graph), unresolved (dynamic calls), or outside-construction; each candidate row carries evidence strings.
> - Classification delegates to the existing `construction_panic_catch_law.py` as the authoritative classifier, loaded at runtime via `importlib`.
> - Emits a JSON receipt with file/site manifests (BLAKE3-512 CIDs), candidate rows, suppression/unresolved counts, and a body CID; exits non-zero when suppression or unresolved counts are non-zero or the receipt is unmeasured.
> - Adds [`test_implementation_catch_census.py`](https://github.com/TSavo/sugar/pull/7315/files#diff-9e82f8b1fab7d6ec6c507270eeb1daffa4b12dd1a7d887310aa5f6d76d8bc588) covering hierarchy separation, typed-conversion lawfulness, sibling precedence, manifest integrity, and unmeasured envelope behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce52392.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated census for implementation exception handlers.
  * Reports source manifests, candidate classifications, reachability evidence, content identifiers, and verification receipts.
  * Detects missing, unreadable, malformed, or unparsable source files and reports unmeasured results with a failure status.

* **Documentation**
  * Added implementation plans and design specifications covering census scope, classification rules, verification boundaries, and refusal behavior.

* **Tests**
  * Added comprehensive coverage for handler classification, reachability, precedence, recovery, manifest integrity, and invalid-source handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->