### PR TITLE
Activate the declared showcase capability image

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -722,7 +722,8 @@ sugar_bx_build_profiled_artifacts_docker() {
 }
 
 sugar_bx_run_docker() {
-  local image="$1" network="$2" has_artifacts="$3"; shift 3
+  local image="$1" network="$2" has_artifacts="$3" preflight_protocol="$4"
+  shift 4
   local remote_cwd="/workspace/sugar"
   [[ -n "$SUGAR_BX_REL_CWD" ]] && remote_cwd="$remote_cwd/$SUGAR_BX_REL_CWD"
   local workspace_source artifacts_source manifest_source shelf_source
@@ -754,8 +755,23 @@ sugar_bx_run_docker() {
   done
   docker_args+=(--env SUGAR_BINARY_SHELF_READ_ONLY=1)
   docker_args+=(--env SUGAR_BINARY_PUBLISH=0)
+  case "$preflight_protocol" in
+    managed-entrypoint/v1)
+      [[ -n "${SUGAR_BX_MANAGED_PRECONDITION_PLAN:-}" ]] || {
+        echo "sugarbin: crime=missing-managed-precondition-plan owner=bin/lib/sugar-bx.sh protocol=$preflight_protocol" >&2
+        return 70
+      }
+      docker_args+=(--env "SUGAR_BX_MANAGED_PRECONDITION_PLAN=$SUGAR_BX_MANAGED_PRECONDITION_PLAN")
+      ;;
+    workspace-wrapper/v1) ;;
+    *)
+      echo "sugarbin: crime=unknown-managed-preflight-protocol owner=bin/lib/sugar-bx.sh protocol=$preflight_protocol" >&2
+      return 70
+      ;;
+  esac
   docker_args+=("$image")
-  if [[ -n "${SUGAR_BX_MANAGED_PRECONDITION_PLAN:-}" ]]; then
+  if [[ "$preflight_protocol" == workspace-wrapper/v1 \
+    && -n "${SUGAR_BX_MANAGED_PRECONDITION_PLAN:-}" ]]; then
     docker_args+=(python /workspace/sugar/tools/sugar-build/preflight.py run
       --plan-json "$SUGAR_BX_MANAGED_PRECONDITION_PLAN"
       --artifact-root /opt/sugar --)

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -603,8 +603,56 @@ SCRIPT
   printf '\n'
 }
 
+sugar_bx_profiled_artifact_build_script() {
+  local spec="$1"
+  local workspace="${2:-/workspace/sugar}" out="${3:-/out}"
+  {
+    printf 'workspace=%q; out=%q; spec=%q; ' "$workspace" "$out" "$spec"
+    cat <<'SCRIPT'
+set -euo pipefail;
+cd "$workspace";
+manifest="$out/required-artifacts.json";
+manifest_tmp="$(mktemp "$out/.required-artifacts.json.XXXXXX")";
+cleanup_manifest_tmp() { [[ -z "${manifest_tmp:-}" ]] || rm -f -- "$manifest_tmp"; };
+trap cleanup_manifest_tmp EXIT;
+trap 'exit 129' HUP;
+trap 'exit 130' INT;
+trap 'exit 143' TERM;
+printf '{"artifacts":[' >"$manifest_tmp";
+first=1;
+names=,;
+IFS=,;
+for item in $spec; do
+  [[ "$item" == *:* ]] || { echo "sugarbin: crime=invalid-profiled-artifact item=$item" >&2; exit 70; };
+  profile="${item%%:*}";
+  b="${item#*:}";
+  [[ "$profile" == debug || "$profile" == release ]] || { echo "sugarbin: crime=invalid-profiled-artifact item=$item" >&2; exit 70; };
+  [[ -n "$b" ]] || { echo "sugarbin: crime=invalid-profiled-artifact item=$item" >&2; exit 70; };
+  case "$names" in
+    *",$b,"*) echo "sugarbin: crime=duplicate-profiled-artifact name=$b" >&2; exit 70 ;;
+  esac;
+  names="$names$b,";
+  r="$(env -u SUGAR_BIN -u SUGAR_BINARY_DIR bin/sugarbin --profile "$profile" --platform linux-x86_64 --bin "$b")";
+  cp "$r" "$out/$b";
+  cp "$r.sugarbin.json" "$out/$b.sugarbin.json";
+  sum="$(sha256sum "$out/$b" | cut -d' ' -f1)";
+  [[ "$first" == 1 ]] || printf ',' >>"$manifest_tmp";
+  first=0;
+  printf '{"name":"%s","sha256":"%s"}' "$b" "$sum" >>"$manifest_tmp";
+done;
+printf ']}' >>"$manifest_tmp";
+chmod 0644 "$manifest_tmp";
+mv -f -- "$manifest_tmp" "$manifest";
+manifest_tmp="";
+trap - EXIT HUP INT TERM;
+SCRIPT
+  } | tr '\n' ' '
+  printf '\n'
+}
+
 sugar_bx_build_artifacts_docker() {
   local image="$1" needs="$2" profile="$3" provision_artifacts="${4:-0}"
+  local artifact_format="${5:-uniform}"
   local image_digest="${image##*@sha256:}"
   local managed_target="${BCARGO_REMOTE_MANAGED_TARGET:-/home/tsavo/.cache/sugar/managed-targets/$image_digest}"
   local quarantine_def reset_command
@@ -622,7 +670,11 @@ mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_B
   shelf_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_BINARY_SHELF")" || return $?
   target_source="$(sugar_bx_docker_bind_source "$managed_target")" || return $?
   local build_script
-  build_script="$(sugar_bx_artifact_build_script "$needs" "$profile")"
+  if [[ "$artifact_format" == profiled ]]; then
+    build_script="$(sugar_bx_profiled_artifact_build_script "$needs")"
+  else
+    build_script="$(sugar_bx_artifact_build_script "$needs" "$profile")"
+  fi
   local shelf_mount="type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2,readonly"
   local shelf_read_only=1
   local name
@@ -662,6 +714,11 @@ mkdir -p $(sugar_bx_quote "$SUGAR_BX_ROOT/artifacts") $(sugar_bx_quote "$SUGAR_B
   local arg command=""
   for arg in "${docker_args[@]}"; do command+=" $(sugar_bx_quote "$arg")"; done
   sugar_bx_ssh "exec${command}"
+}
+
+sugar_bx_build_profiled_artifacts_docker() {
+  local image="$1" spec="$2"
+  sugar_bx_build_artifacts_docker "$image" "$spec" "" 0 profiled
 }
 
 sugar_bx_run_docker() {

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -1612,6 +1612,16 @@ acquire_rebuild_single_flight() {
       fi
       return 0
     fi
+    # A failed mkdir is contention only when a holder record exists. Give a
+    # peer that just won mkdir one bounded chance to publish its PID; absence
+    # after that is not an unknown holder to wait on forever.
+    if [[ ! -f "$lockdir/pid" ]]; then
+      sleep 0.5
+      if [[ ! -f "$lockdir/pid" ]]; then
+        log "crime=missing-rebuild-lock-pid owner=bin/sugarbin path=$lockdir/pid lock=$lockdir holder_pid=unknown replacement=repair the declared lock root; an absent holder record is not peer contention"
+        return 70
+      fi
+    fi
     # First contention: announce wait immediately (not after 30s of silence).
     if (( ! announced )); then
       holder="$(tr -d '[:space:]' <"$lockdir/pid" 2>/dev/null || true)"

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -107,6 +107,7 @@ dispatch_execution_subcommand() {
   # networking available unless a named task explicitly proves it can run
   # offline in sugar-build.toml.
   local task_json="" task_capabilities="" task_needs="" task_network="required"
+  local task_profiled_artifacts=""
   local task_preconditions_json=""
   local -a task_command=()
   if [[ -n "$task" ]]; then
@@ -116,6 +117,7 @@ dispatch_execution_subcommand() {
     task_capabilities="$("$contract_python" -c 'import json,sys; print(",".join(json.load(sys.stdin)["capabilities"]))' <<<"$task_json")"
     task_needs="$("$contract_python" -c 'import json,sys; print(",".join(json.load(sys.stdin)["binaries"]))' <<<"$task_json")"
     task_network="$("$contract_python" -c 'import json,sys; print(json.load(sys.stdin)["network"])' <<<"$task_json")"
+    task_profiled_artifacts="$("$contract_python" -c 'import json,sys; task=json.load(sys.stdin); print(",".join("{profile}:{name}".format(**row) for row in task.get("closure", {}).get("artifacts", [])))' <<<"$task_json")"
     while IFS= read -r -d '' arg; do task_command+=("$arg"); done < <("$contract_python" -c 'import json,sys; [sys.stdout.write(x+"\0") for x in json.load(sys.stdin)["command"]]' <<<"$task_json")
     if [[ -n "$needs" ]]; then
       local normalized_needs
@@ -288,7 +290,15 @@ dispatch_execution_subcommand() {
   if [[ "$route_env" == docker ]]; then
     sugar_bx_write_mount_proof || return $?
     local remote_needs="$needs" has_artifacts=0
-    if [[ -n "$remote_needs" ]]; then
+    if [[ -n "$task_profiled_artifacts" ]]; then
+      [[ -z "$remote_needs" ]] || {
+        echo "sugarbin: task mixes profiled closure artifacts with legacy binaries" >&2
+        return 2
+      }
+      sugar_bx_build_profiled_artifacts_docker \
+        "$core_image" "$task_profiled_artifacts" || return $?
+      has_artifacts=1
+    elif [[ -n "$remote_needs" ]]; then
       local provision_artifacts=0
       [[ "$subcommand" != build ]] || provision_artifacts=1
       sugar_bx_build_artifacts_docker "$core_image" "$remote_needs" "$profile" "$provision_artifacts" || return $?

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -168,11 +168,17 @@ dispatch_execution_subcommand() {
   fi
 
   local route_env="${execution_env%%:*}" docker_image="" core_image=""
+  local task_preflight_protocol="workspace-wrapper/v1"
   if [[ "$route_env" == docker ]]; then
     local contract_python
     contract_python="$(sugarbin_contract_python)" || return $?
     local environment_json
-    environment_json="$("$contract_python" "$script_dir/../tools/sugar-build/contract.py" resolve-environment "$execution_env")" || return $?
+    if [[ -n "$task" && "$host" == bx && "$execution_env_explicit" == 0 ]]; then
+      environment_json="$("$contract_python" "$script_dir/../tools/sugar-build/contract.py" resolve-task-environment "$task")" || return $?
+      task_preflight_protocol="$("$contract_python" -c 'import json,sys; print(json.load(sys.stdin)["preflight"])' <<<"$environment_json")"
+    else
+      environment_json="$("$contract_python" "$script_dir/../tools/sugar-build/contract.py" resolve-environment "$execution_env")" || return $?
+    fi
     docker_image="$("$contract_python" -c 'import json,sys; print(json.load(sys.stdin)["image"])' <<<"$environment_json")"
     if [[ -n "$task" ]]; then
       local missing_capabilities
@@ -218,6 +224,7 @@ dispatch_execution_subcommand() {
     printf 'needs=%s\n' "$needs"
     printf 'network=%s\n' "$task_network"
     printf 'docker_image=%s\n' "$docker_image"
+    printf 'preflight=%s\n' "$task_preflight_protocol"
     return 0
   fi
 
@@ -310,7 +317,8 @@ dispatch_execution_subcommand() {
       return $?
     fi
     set +e
-    sugar_bx_run_docker "$docker_image" "$task_network" "$has_artifacts" "${command[@]}"
+    sugar_bx_run_docker "$docker_image" "$task_network" "$has_artifacts" \
+      "$task_preflight_protocol" "${command[@]}"
     status=$?
     set -e
     sugar_bx_report_load_after

--- a/docs/superpowers/plans/2026-08-04-showcase-capability-image.md
+++ b/docs/superpowers/plans/2026-08-04-showcase-capability-image.md
@@ -1,0 +1,180 @@
+# Showcase Capability Image Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish and select an immutable managed showcase image whose extra commands and Rust components are derived from the stage-one task closure, provision every declared profile-qualified artifact, and enforce the artifact ABI from inside the image before the showcase subject executes.
+
+**Architecture:** `resolve_task_preconditions()` remains the sole derivation door. A new image-build projection filters that plan into command packages and exact Rust components, while a task-image record binds the resulting immutable digest and entrypoint protocol to `showcases` without adding undeclared extras to the shared capability image. The transport keeps its workspace preflight fallback for old images; only a task image declaring `managed-entrypoint/v1` receives the plan as entrypoint testimony and executes the baked verifier.
+
+**Tech Stack:** Python 3.12 standard library, Bash, TOML, Docker Buildx, existing sugarbin/battleaxe transport.
+
+## Global Constraints
+
+- Derive `git` from `tasks.showcases.closure.required_commands`; do not add a second package roster.
+- Derive `rust-src` and channel `1.96.0` from active showcase-adjacent `rust-toolchain.toml`; do not add a second component roster.
+- Keep the workspace preflight fallback executable until the immutable task image advertises `managed-entrypoint/v1`.
+- Resolve the nine profile-qualified closure artifacts exactly once into one manifest; ordinary task execution keeps `SUGAR_BINARY_ALLOW_BUILD=0` and never invents an implicit build fallback.
+- Preserve the stage-one account at `R_precondition_axes_discovered=9`, `R_precondition_axes_predicted=9`, and `R_unpredicted_precondition_axes=0`; its planted unpredicted twin must still exit 70.
+- Detached remote execution remains unsolved and receives no managed success claim.
+- Preserve the closing-account JSON SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.
+
+---
+
+### Task 1: Derive the task-image build closure
+
+**Files:**
+- Modify: `tools/sugar-build/contract.py`
+- Create: `tools/sugar-build/build_task_image.py`
+- Modify: `tools/sugar-build/Dockerfile`
+- Modify: `tests/sugarbin_managed_preconditions.sh`
+
+**Interfaces:**
+- Consumes: `resolve_task_preconditions("showcases", "bx", repo_root)`.
+- Produces: `resolve_task_image_build(name, repo_root) -> dict` with `aptPackages`, `rustComponents`, `rustToolchain`, and `target`.
+- Produces: CLI `contract.py resolve-task-image-build TASK --repo-root PATH`.
+- Produces: CLI `build_task_image.py TASK --tag IMAGE [--push|--load]`.
+
+- [ ] **Step 1: Write the RED build-projection teeth**
+
+Extend `tests/sugarbin_managed_preconditions.sh` to require this exact projection from the live plan:
+
+```json
+{
+  "aptPackages": ["git"],
+  "rustComponents": ["rust-src"],
+  "rustToolchain": "1.96.0",
+  "target": "showcases-closure",
+  "task": "showcases"
+}
+```
+
+Copy the repository to a private fixture, add a second command and component declaration, and prove both appear without changing production code. Plant two Rust channels and require a named `ContractError`, because one image stage cannot honestly claim two active toolchains.
+
+- [ ] **Step 2: Run RED**
+
+Run:
+
+```bash
+bash tests/sugarbin_managed_preconditions.sh "$PWD"
+```
+
+Expected: nonzero because `resolve-task-image-build` does not exist.
+
+- [ ] **Step 3: Implement the minimal projection**
+
+Filter only `command` and `toolchain-component` rows from the canonical precondition plan. Command names must satisfy the Debian package token grammar and become apt package names without a second mapping. All component rows must share one exact channel; otherwise refuse rather than choosing one.
+
+Add a generic Docker target:
+
+```dockerfile
+FROM examples-closure AS showcases-closure
+ARG MANAGED_APT_PACKAGES
+ARG MANAGED_RUST_TOOLCHAIN
+ARG MANAGED_RUST_COMPONENTS
+RUN test -n "${MANAGED_APT_PACKAGES}" \
+ && test -n "${MANAGED_RUST_COMPONENTS}" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends ${MANAGED_APT_PACKAGES} \
+ && rm -rf /var/lib/apt/lists/* \
+ && for component in ${MANAGED_RUST_COMPONENTS}; do \
+      rustup component add --toolchain "${MANAGED_RUST_TOOLCHAIN}" "${component}"; \
+    done
+```
+
+`build_task_image.py` obtains every build arg from `resolve_task_image_build`, invokes Docker Buildx with `--platform linux/amd64`, and never accepts caller-authored package or component overrides.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run the managed-precondition shell contract, `python3 -m py_compile` on both Python files, and `git diff --check`. Commit `Derive showcase capability image inputs`.
+
+### Task 2: Provision the profile-qualified artifact closure
+
+**Files:**
+- Modify: `bin/sugarbin`
+- Modify: `bin/lib/sugar-bx.sh`
+- Modify: `tests/sugarbin_docker_exec.sh`
+
+**Interfaces:**
+- Consumes: `resolve-task` field `closure.artifacts`, preserving each `{profile, name}` pair.
+- Produces: `sugar_bx_profiled_artifact_build_script(SPEC)` and `sugar_bx_build_profiled_artifacts_docker(IMAGE, SPEC)`.
+- Produces: one `required-artifacts.json` containing every unique declared artifact name.
+
+- [ ] **Step 1: Write RED mixed-profile transport teeth**
+
+The fake Docker harness must show one artifact resolver container before the task container. Its command must carry `release:sugar` and all eight `debug:*` rows from the resolved task closure, emit one manifest, and keep `SUGAR_BINARY_ALLOW_BUILD=0`, `SUGAR_BINARY_PUBLISH=0`, and the shelf mount read-only. The task container must receive both the artifact directory and manifest.
+
+- [ ] **Step 2: Run RED**
+
+Run `bash tests/sugarbin_docker_exec.sh "$PWD"`. Expected: the showcase task launches no artifact resolver because `tasks.showcases.binaries` is intentionally empty.
+
+- [ ] **Step 3: Implement profile-aware resolution once**
+
+Serialize the validated closure rows as `profile:name` tokens. The production writer invokes `bin/sugarbin --profile "$profile" --bin "$name"` for each row and appends each checksum to one atomic manifest. Refuse duplicate names; never collapse the rows to the caller-wide `--profile` value. Keep the existing unprofiled builder unchanged for other tasks.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+Run the Docker shell contract twice, `bash -n bin/sugarbin bin/lib/sugar-bx.sh`, and `git diff --check`. Commit `Provision declared showcase artifacts`.
+
+### Task 3: Move managed preflight into the published image without an enforcement gap
+
+**Files:**
+- Modify: `sugar-build.toml`
+- Modify: `tools/sugar-build/contract.py`
+- Modify: `tools/sugar-build/Dockerfile`
+- Modify: `tools/sugar-build/entrypoint.sh`
+- Modify: `bin/sugarbin`
+- Modify: `bin/lib/sugar-bx.sh`
+- Modify: `tests/sugarbin_docker_exec.sh`
+- Modify: `tests/test_sugar_build_contract.py`
+
+**Interfaces:**
+- Produces: optional `[task-images.showcases]` with immutable `reference` and `preflight = "managed-entrypoint/v1"`.
+- Produces: `resolve_task_environment(name) -> dict` with task capabilities, immutable image, and preflight protocol.
+- Consumes: `SUGAR_BX_MANAGED_PRECONDITION_PLAN` only when the selected task-image protocol is `managed-entrypoint/v1`.
+
+- [ ] **Step 1: Write RED protocol-selection and entrypoint twins**
+
+Require an immutable task-image reference and reject mutable tags or unknown protocols. In the fake Docker harness, an old image with no task-image record must still invoke `/workspace/sugar/tools/sugar-build/preflight.py`; a `managed-entrypoint/v1` image must pass the canonical plan as environment and invoke the raw subject. Exercise the real entrypoint with the installed verifier path: a compatible artifact reaches a marker, while a planted GLIBC mismatch exits 70 before the marker and preserves `crime=artifact-abi-incompatible` plus loader output.
+
+- [ ] **Step 2: Run RED**
+
+Run the Docker and managed-precondition shell contracts. Expected: the entrypoint never calls a baked verifier and the resolver has no task-image protocol.
+
+- [ ] **Step 3: Bake and select the verifier**
+
+Copy `preflight.py` into `/usr/local/lib/sugar/managed-preflight.py` in `showcases-closure`. At the end of the entrypoint, execute it with the canonical plan, `/opt/sugar`, and the subject argv when the plan environment is present. `sugar_bx_run_docker` selects this path only from authenticated task-image metadata; otherwise it preserves the workspace wrapper exactly.
+
+- [ ] **Step 4: Run GREEN and commit before publication**
+
+Run both shell contracts, the focused contract test through `bin/bpytest`, `bash -n`, `py_compile`, and `git diff --check`. Commit `Bake managed preflight into showcase image`.
+
+### Task 4: Publish, pin, and execute the satisfying image
+
+**Files:**
+- Modify: `sugar-build.toml`
+- Test: `tests/sugarbin_managed_preconditions.sh`
+- Test: `tests/sugarbin_docker_exec.sh`
+
+**Interfaces:**
+- Consumes: `build_task_image.py showcases --push --tag ghcr.io/tsavo/sugar-env:showcases-<commit>`.
+- Produces: immutable `ghcr.io/tsavo/sugar-env@sha256:<digest>` under `[task-images.showcases]`.
+
+- [ ] **Step 1: Publish on battleaxe**
+
+Run the tracked build wrapper through the ambient battleaxe route in the foreground, poll its log without detaching, and push the task image. Read the registry digest with `docker buildx imagetools inspect`; never derive a digest from a local image ID.
+
+- [ ] **Step 2: Pin the immutable task image**
+
+Record the exact registry digest and `preflight = "managed-entrypoint/v1"`. Re-run contract teeth proving the showcase task resolves that digest while `examples-gate` retains its prior shared capability image.
+
+- [ ] **Step 3: Prove the restored subject edge**
+
+Run the single active std-core shard using the named task with `SHOWCASE_SHARD_COUNT=46` and `SHOWCASE_SHARD_INDEX=9`, forwarded through sugarbin. Require the preflight to pass `git`, `rust-src`, and all artifact ABI rows before `examples/std-core-showcase/run.sh` prints its subject witness. A semantic red after that point is discovery; success of the entrance is established by reaching the subject.
+
+- [ ] **Step 4: Re-run the stage-one falsifier and final hygiene**
+
+Require the live nine-axis account to remain 9/9/0 and the planted unpredicted twin to exit 70. Verify the closing-account digest, tree diff, no deletions, `bash -n`, `py_compile`, focused shell contracts, and `git diff --check`.
+
+- [ ] **Step 5: Commit, push, and open the PR**
+
+Commit `Publish managed showcase capability image`, push without force, and open a main-targeted PR. The body must distinguish early-refusal restoration from showcase semantics, name the published digest, state that detached lifetime remains unsolved, and report the exact stage-one account plus the single-shard subject-edge result.

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -64,6 +64,10 @@ reference = "ghcr.io/tsavo/sugar-env@sha256:f96731de7b4eb9a5660a6f8a14fc37f23ead
 [images."core,java,node,python-scientific,python-test,solver-coq,solver-z3,vampire"]
 reference = "ghcr.io/tsavo/sugar-env@sha256:f3474a1e1badba67f3daaf5c589f2844da28a7be6beda929ca5f7f2e5d95785e"
 
+[task-images.showcases]
+reference = "ghcr.io/tsavo/sugar-env@sha256:c8f9964d2a9d57fd36433d2e3bfe5d6a9c5a4367ff76e8aa5e3f53c0c28a2e2f"
+preflight = "managed-entrypoint/v1"
+
 [tasks.python-unit]
 capabilities = ["python-test"]
 binaries = ["sugar"]

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -205,9 +205,27 @@ examples="$(run explain --host bx --task examples-gate)"
 
 : >"$tmp/docker.log"
 run run --host bx --task showcases >/dev/null
+[[ "$(wc -l <"$tmp/docker.log" | tr -d ' ')" == 2 ]] \
+  || fail "showcase task did not resolve its declared artifact closure exactly once"
+showcase_build_line="$(head -1 "$tmp/docker.log")"
+[[ "$showcase_build_line" == *"release:sugar"* ]] \
+  || fail "showcase artifact resolver lost release:sugar"
+for artifact in sugar-ir-smt-lib sugar-ir-lean sugar-ir-coq sugar-ir-maude \
+  sugar-walk-rpc rust_test_assertions_rpc witness_rpc discharge_cli; do
+  [[ "$showcase_build_line" == *"debug:$artifact"* ]] \
+    || fail "showcase artifact resolver lost debug:$artifact"
+done
+[[ "$showcase_build_line" == *"'--env' 'SUGAR_BINARY_ALLOW_BUILD=0'"* ]] \
+  || fail "showcase artifact resolver gained implicit build authority"
+[[ "$showcase_build_line" == *"'--env' 'SUGAR_BINARY_PUBLISH=0'"* ]] \
+  || fail "showcase artifact resolver gained implicit publish authority"
+[[ "$showcase_build_line" == *"binary-shelf-v2,readonly"* ]] \
+  || fail "showcase artifact resolver gained writable shelf authority"
 showcase_line="$(tail -1 "$tmp/docker.log")"
 [[ "$showcase_line" == *"tools/sugar-build/preflight.py"* ]] \
   || fail "managed showcase task omitted pre-subject preflight"
+[[ "$showcase_line" == *"required-artifacts.json,readonly"* ]] \
+  || fail "managed showcase task omitted its declared artifact manifest"
 [[ "$showcase_line" == *"make"*"test-showcases"* ]] \
   || fail "managed showcase task lost its declared command"
 
@@ -367,10 +385,17 @@ cat >"$writer_workspace/bin/sugarbin" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 binary=""
+profile=""
 while (($#)); do
-  if [[ "$1" == --bin ]]; then binary="$2"; shift 2; else shift; fi
+  case "$1" in
+    --bin) binary="$2"; shift 2 ;;
+    --profile) profile="$2"; shift 2 ;;
+    *) shift ;;
+  esac
 done
 [[ -n "$binary" ]]
+[[ -z "${WRITER_INVOCATION_LOG:-}" ]] \
+  || printf '%s:%s\n' "$profile" "$binary" >>"$WRITER_INVOCATION_LOG"
 if [[ "$binary" == second && -n "${WRITER_BLOCK_MARKER:-}" ]]; then
   : >"$WRITER_BLOCK_MARKER"
   kill -TERM "$PPID"
@@ -424,6 +449,42 @@ assert item["name"] == "first", item
 assert item["sha256"] == hashlib.sha256((root / "first").read_bytes()).hexdigest(), item
 assert not list(root.glob(".required-artifacts.json.*"))
 PY
+
+profiled_out="$tmp/profiled-writer-out"
+mkdir -p "$profiled_out"
+profiled_script="$(sugar_bx_profiled_artifact_build_script \
+  release:first,debug:second "$writer_workspace" "$profiled_out")"
+WRITER_PAYLOAD_ROOT="$tmp/writer-payloads" \
+WRITER_INVOCATION_LOG="$tmp/profiled-writer-invocations" \
+  bash -c "$profiled_script"
+python3 - "$profiled_out" "$tmp/profiled-writer-invocations" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+invocations = pathlib.Path(sys.argv[2]).read_text().splitlines()
+assert invocations == ["release:first", "debug:second"], invocations
+manifest = json.loads(root.joinpath("required-artifacts.json").read_text())
+assert [row["name"] for row in manifest["artifacts"]] == ["first", "second"]
+for row in manifest["artifacts"]:
+    assert row["sha256"] == hashlib.sha256(
+        root.joinpath(row["name"]).read_bytes()
+    ).hexdigest(), row
+PY
+
+status=0
+duplicate_script="$(sugar_bx_profiled_artifact_build_script \
+  release:first,debug:first "$writer_workspace" "$tmp/profiled-duplicate")"
+mkdir -p "$tmp/profiled-duplicate"
+WRITER_PAYLOAD_ROOT="$tmp/writer-payloads" \
+  bash -c "$duplicate_script" >"$tmp/profiled-duplicate.out" \
+  2>"$tmp/profiled-duplicate.err" || status=$?
+[[ "$status" == 70 ]] || fail "duplicate profiled artifact status=$status, want 70"
+grep -Fq 'crime=duplicate-profiled-artifact name=first' \
+  "$tmp/profiled-duplicate.err" \
+  || fail "duplicate profiled artifact did not refuse by name"
 
 # Malformed prior manifests are evidence. Quarantine them by content before the
 # full artifact reset, collapse repeats, and make bounded eviction loud.

--- a/tests/sugarbin_docker_exec.sh
+++ b/tests/sugarbin_docker_exec.sh
@@ -222,8 +222,15 @@ done
 [[ "$showcase_build_line" == *"binary-shelf-v2,readonly"* ]] \
   || fail "showcase artifact resolver gained writable shelf authority"
 showcase_line="$(tail -1 "$tmp/docker.log")"
-[[ "$showcase_line" == *"tools/sugar-build/preflight.py"* ]] \
-  || fail "managed showcase task omitted pre-subject preflight"
+showcase_ref="$(python3 "$repo/tools/sugar-build/contract.py" \
+  resolve-task-environment showcases | \
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["image"])')"
+[[ "$showcase_line" == *"'$showcase_ref'"* ]] \
+  || fail "managed showcase task did not select its task image"
+[[ "$showcase_line" == *"SUGAR_BX_MANAGED_PRECONDITION_PLAN="* ]] \
+  || fail "managed showcase task did not pass its plan to the image entrypoint"
+[[ "$showcase_line" != *"/workspace/sugar/tools/sugar-build/preflight.py"* ]] \
+  || fail "managed showcase task retained the transport-owned preflight"
 [[ "$showcase_line" == *"required-artifacts.json,readonly"* ]] \
   || fail "managed showcase task omitted its declared artifact manifest"
 [[ "$showcase_line" == *"make"*"test-showcases"* ]] \
@@ -290,12 +297,17 @@ entrypoint_bin="$tmp/entrypoint-bin"
 mkdir -p "$entrypoint_root/opt/sugar/bin" \
   "$entrypoint_root/opt/pyright/nodeenv/bin" "$entrypoint_bin"
 python3 - "$repo/tools/sugar-build/entrypoint.sh" \
-  "$entrypoint_under_test" "$entrypoint_root" <<'PY'
+  "$entrypoint_under_test" "$entrypoint_root" \
+  "$repo/tools/sugar-build/preflight.py" <<'PY'
 from pathlib import Path
 import sys
 
-source, target, root = map(Path, sys.argv[1:])
-target.write_text(source.read_text().replace("/opt/", f"{root}/opt/"))
+source, target, root, preflight = map(Path, sys.argv[1:])
+text = source.read_text().replace("/opt/", f"{root}/opt/")
+text = text.replace(
+    "/usr/local/lib/sugar/managed-preflight.py", str(preflight)
+)
+target.write_text(text)
 PY
 cat >"$entrypoint_bin/rustc" <<'SH'
 #!/usr/bin/env bash
@@ -312,6 +324,14 @@ SH
 cat >"$entrypoint_bin/b3sum" <<'SH'
 #!/usr/bin/env bash
 printf 'b3sum 1.8.1\n'
+SH
+cat >"$entrypoint_bin/ldd" <<'SH'
+#!/usr/bin/env bash
+if [[ "${FAKE_LDD_MODE:-good}" == bad ]]; then
+  printf "%s: /lib/libc.so.6: version 'GLIBC_2.39' not found (required by %s)\n" "$1" "$1" >&2
+  exit 1
+fi
+printf 'libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0001)\n'
 SH
 cat >"$entrypoint_bin/python" <<'SH'
 #!/usr/bin/env bash
@@ -374,10 +394,71 @@ grep -Fq "observed=$observed" "$tmp/manifest-checksum.err" \
 ! grep -Fq 'crime=artifact-manifest-parse-failed' "$tmp/manifest-checksum.err" \
   || fail "checksum mismatch was misreported as a parse failure"
 
+# The republished task image must run the same plan inside its sealed
+# entrypoint. A compatible artifact reaches the subject; an ABI bad twin
+# refuses before it, retaining the loader testimony.
+printf '{"artifacts":[{"name":"sugar","sha256":"%s"}]}\n' \
+  "$observed" >"$manifest"
+entrypoint_plan='{"checks":[{"kind":"artifact-abi","name":"sugar","profile":"release","source":"task.closure.artifacts"}],"schemaVersion":1}'
+entrypoint_good_marker="$tmp/entrypoint-good-subject"
+PATH="$entrypoint_bin:$PATH" REAL_PYTHON="$(command -v python3)" \
+  SUGAR_BX_MANAGED_PRECONDITION_PLAN="$entrypoint_plan" \
+  "$entrypoint_under_test" sh -c ': >"$1"' sh "$entrypoint_good_marker" \
+  >"$tmp/entrypoint-good.out" 2>"$tmp/entrypoint-good.err" \
+  || fail "sealed entrypoint compatible ABI arm refused"
+[[ -e "$entrypoint_good_marker" ]] \
+  || fail "sealed entrypoint compatible ABI arm did not reach subject"
+
+entrypoint_bad_marker="$tmp/entrypoint-bad-subject"
+status=0
+FAKE_LDD_MODE=bad PATH="$entrypoint_bin:$PATH" \
+  REAL_PYTHON="$(command -v python3)" \
+  SUGAR_BX_MANAGED_PRECONDITION_PLAN="$entrypoint_plan" \
+  "$entrypoint_under_test" sh -c ': >"$1"' sh "$entrypoint_bad_marker" \
+  >"$tmp/entrypoint-bad.out" 2>"$tmp/entrypoint-bad.err" || status=$?
+[[ "$status" == 70 ]] \
+  || fail "sealed entrypoint incompatible ABI status=$status, want 70"
+[[ ! -e "$entrypoint_bad_marker" ]] \
+  || fail "sealed entrypoint incompatible ABI reached subject"
+grep -Fq 'crime=artifact-abi-incompatible' "$tmp/entrypoint-bad.err" \
+  || fail "sealed entrypoint incompatible ABI did not name its crime"
+grep -Fq 'GLIBC_2.39' "$tmp/entrypoint-bad.err" \
+  || fail "sealed entrypoint incompatible ABI discarded loader output"
+
 # Exercise the exact writer script used by the Docker artifact builder. A
 # signal after the first artifact has been appended must leave the prior final
 # manifest byte-identical; existence alone would admit a truncated replacement.
 source "$repo/bin/lib/sugar-bx.sh"
+
+# The workspace wrapper remains executable for every image that has not yet
+# published the managed entrypoint protocol. This is a real transport arm,
+# not a source-shape assertion.
+fallback_log="$tmp/fallback-preflight.log"
+sugar_bx_ssh() { printf '%s\n' "$1" >>"$fallback_log"; }
+sugar_bx_docker_bind_source() { printf '%s\n' "$1"; }
+SUGAR_BX_REL_CWD=""
+SUGAR_BX_REPO="$tmp/fallback-workspace"
+SUGAR_BX_BINARY_SHELF="$tmp/fallback-shelf"
+SUGAR_BX_ROOT="$tmp/fallback-root"
+SUGAR_BX_MOUNT_PROOF=proof
+SUGAR_BX_ENV_NAMES=()
+SUGAR_BX_MANAGED_PRECONDITION_PLAN="$entrypoint_plan"
+mkdir -p "$SUGAR_BX_REPO" "$SUGAR_BX_BINARY_SHELF" "$SUGAR_BX_ROOT"
+sugar_bx_run_docker fallback-image required 0 workspace-wrapper/v1 true
+fallback_line="$(tail -1 "$fallback_log")"
+[[ "$fallback_line" == *"/workspace/sugar/tools/sugar-build/preflight.py"* ]] \
+  || fail "workspace-wrapper fallback no longer executes its preflight"
+
+managed_log="$tmp/managed-entrypoint.log"
+: >"$managed_log"
+sugar_bx_ssh() { printf '%s\n' "$1" >>"$managed_log"; }
+sugar_bx_run_docker managed-image required 0 managed-entrypoint/v1 true
+managed_line="$(tail -1 "$managed_log")"
+[[ "$managed_line" == *"SUGAR_BX_MANAGED_PRECONDITION_PLAN="* ]] \
+  || fail "managed entrypoint did not receive its plan"
+[[ "$managed_line" != *"/workspace/sugar/tools/sugar-build/preflight.py"* ]] \
+  || fail "managed entrypoint duplicated the workspace preflight"
+
 writer_workspace="$tmp/writer-workspace"
 writer_out="$tmp/writer-out"
 mkdir -p "$writer_workspace/bin" "$writer_out" "$tmp/writer-payloads"

--- a/tests/sugarbin_managed_preconditions.sh
+++ b/tests/sugarbin_managed_preconditions.sh
@@ -14,6 +14,123 @@ trap 'rm -rf "$tmp"' EXIT
 plan="$(python3 "$contract" resolve-preconditions showcases \
   --host bx --repo-root "$repo")"
 
+status=0
+python3 "$contract" resolve-task-image-build showcases \
+  --repo-root "$repo" >"$tmp/image-build.json" \
+  2>"$tmp/image-build.err" || status=$?
+[[ "$status" == 0 ]] || fail "task image build projection refused: $(cat "$tmp/image-build.err")"
+python3 - "$tmp/image-build.json" <<'PY'
+import json
+import pathlib
+import sys
+
+projection = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert projection == {
+    "aptPackages": ["git"],
+    "rustComponents": ["rust-src"],
+    "rustToolchain": "1.96.0",
+    "schemaVersion": 1,
+    "target": "showcases-closure",
+    "task": "showcases",
+}, projection
+PY
+
+python3 - "$repo" "$tmp/derived-fixture" <<'PY'
+import importlib.util
+import pathlib
+import shutil
+import sys
+
+repo = pathlib.Path(sys.argv[1])
+fixture = pathlib.Path(sys.argv[2])
+fixture.mkdir()
+shutil.copy2(repo / "Makefile", fixture / "Makefile")
+shutil.copy2(repo / "sugar-build.toml", fixture / "sugar-build.toml")
+(fixture / ".github").mkdir()
+shutil.copy2(
+    repo / ".github/showcase-retirements.json",
+    fixture / ".github/showcase-retirements.json",
+)
+std_core = fixture / "examples/std-core-showcase"
+std_core.mkdir(parents=True)
+std_core.joinpath("rust-toolchain.toml").write_text(
+    '[toolchain]\nchannel = "1.96.0"\ncomponents = ["rust-src", "rustfmt"]\nprofile = "minimal"\n'
+)
+contract_text = (fixture / "sugar-build.toml").read_text()
+contract_text = contract_text.replace(
+    'required_commands = ["git"]',
+    'required_commands = ["git", "curl"]',
+)
+(fixture / "sugar-build.toml").write_text(contract_text)
+
+spec = importlib.util.spec_from_file_location(
+    "stage_two_contract", repo / "tools/sugar-build/contract.py"
+)
+contract = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(contract)
+projection = contract.resolve_task_image_build(
+    "showcases", fixture, fixture / "sugar-build.toml"
+)
+assert projection["aptPackages"] == ["curl", "git"], projection
+assert projection["rustComponents"] == ["rust-src", "rustfmt"], projection
+
+second = fixture / "examples/numpy-showcase"
+second.mkdir(parents=True)
+second.joinpath("rust-toolchain.toml").write_text(
+    '[toolchain]\nchannel = "1.95.0"\ncomponents = ["rust-src"]\nprofile = "minimal"\n'
+)
+try:
+    contract.resolve_task_image_build(
+        "showcases", fixture, fixture / "sugar-build.toml"
+    )
+except contract.ContractError as error:
+    assert "exactly one Rust toolchain" in str(error), error
+else:
+    raise AssertionError("mixed Rust toolchains did not refuse")
+PY
+
+mkdir -p "$tmp/image-build-bin"
+cat >"$tmp/image-build-bin/docker" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >"$DOCKER_BUILD_ARGS"
+SH
+chmod +x "$tmp/image-build-bin/docker"
+DOCKER_BUILD_ARGS="$tmp/docker-build.args" \
+  PATH="$tmp/image-build-bin:$PATH" \
+  python3 "$repo/tools/sugar-build/build_task_image.py" showcases \
+    --repo-root "$repo" --tag ghcr.io/tsavo/sugar-env:stage-two-tooth --load
+python3 - "$tmp/docker-build.args" <<'PY'
+import pathlib
+import sys
+
+args = pathlib.Path(sys.argv[1]).read_text().splitlines()
+assert args[:2] == ["buildx", "build"], args
+assert args[args.index("--platform") + 1] == "linux/amd64", args
+assert args[args.index("--target") + 1] == "showcases-closure", args
+build_args = [
+    args[index + 1]
+    for index, value in enumerate(args)
+    if value == "--build-arg"
+]
+assert "MANAGED_APT_PACKAGES=git" in build_args, build_args
+assert "MANAGED_RUST_TOOLCHAIN=1.96.0" in build_args, build_args
+assert "MANAGED_RUST_COMPONENTS=rust-src" in build_args, build_args
+assert "--load" in args and "--push" not in args, args
+PY
+
+python3 - "$repo/tools/sugar-build/Dockerfile" <<'PY'
+import pathlib
+import sys
+
+dockerfile = pathlib.Path(sys.argv[1]).read_text()
+stage = dockerfile.split("FROM examples-closure AS showcases-closure", 1)[1]
+assert "ARG MANAGED_APT_PACKAGES" in stage
+assert "ARG MANAGED_RUST_TOOLCHAIN" in stage
+assert "ARG MANAGED_RUST_COMPONENTS" in stage
+assert 'apt-get install -y --no-install-recommends ${MANAGED_APT_PACKAGES}' in stage
+assert 'rustup component add --toolchain "${MANAGED_RUST_TOOLCHAIN}" "${component}"' in stage
+PY
+
 python3 - "$plan" "$repo" <<'PY'
 import json
 import pathlib

--- a/tests/sugarbin_managed_preconditions.sh
+++ b/tests/sugarbin_managed_preconditions.sh
@@ -11,6 +11,68 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/managed-preconditions.XXXXXX")"
 trap 'rm -rf "$tmp"' EXIT
 
+task_environment="$(python3 "$contract" resolve-task-environment showcases)"
+python3 - "$task_environment" <<'PY'
+import json
+import sys
+
+environment = json.loads(sys.argv[1])
+assert environment["image"] == (
+    "ghcr.io/tsavo/sugar-env@sha256:"
+    "c8f9964d2a9d57fd36433d2e3bfe5d6a9c5a4367ff76e8aa5e3f53c0c28a2e2f"
+), environment
+assert environment["preflight"] == "managed-entrypoint/v1", environment
+PY
+
+python3 - "$repo" "$tmp/task-image-fixtures" <<'PY'
+import importlib.util
+import pathlib
+import shutil
+import sys
+
+repo = pathlib.Path(sys.argv[1])
+fixture_root = pathlib.Path(sys.argv[2])
+fixture_root.mkdir()
+contract_path = fixture_root / "sugar-build.toml"
+shutil.copy2(repo / "sugar-build.toml", contract_path)
+
+spec = importlib.util.spec_from_file_location(
+    "task_image_contract", repo / "tools/sugar-build/contract.py"
+)
+contract = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(contract)
+
+fallback = contract.resolve_task_environment("examples-gate", contract_path)
+assert fallback["preflight"] == "workspace-wrapper/v1", fallback
+assert fallback["image"] != contract.resolve_task_environment(
+    "showcases", contract_path
+)["image"], fallback
+
+original = contract_path.read_text()
+task_image_digest = (
+    "c8f9964d2a9d57fd36433d2e3bfe5d6a9c5a4367ff76e8aa5e3f53c0c28a2e2f"
+)
+contract_path.write_text(
+    original.replace("@sha256:" + task_image_digest, ":latest")
+)
+try:
+    contract.resolve_task_environment("showcases", contract_path)
+except contract.ContractError as error:
+    assert "immutable" in str(error), error
+else:
+    raise AssertionError("mutable task image reference did not refuse")
+
+contract_path.write_text(
+    original.replace("managed-entrypoint/v1", "unknown-entrypoint/v9")
+)
+try:
+    contract.resolve_task_environment("showcases", contract_path)
+except contract.ContractError as error:
+    assert "preflight protocol" in str(error), error
+else:
+    raise AssertionError("unknown task image preflight did not refuse")
+PY
+
 plan="$(python3 "$contract" resolve-preconditions showcases \
   --host bx --repo-root "$repo")"
 
@@ -129,6 +191,8 @@ assert "ARG MANAGED_RUST_TOOLCHAIN" in stage
 assert "ARG MANAGED_RUST_COMPONENTS" in stage
 assert 'apt-get install -y --no-install-recommends ${MANAGED_APT_PACKAGES}' in stage
 assert 'rustup component add --toolchain "${MANAGED_RUST_TOOLCHAIN}" "${component}"' in stage
+assert "COPY tools/sugar-build/preflight.py /usr/local/lib/sugar/managed-preflight.py" in stage
+assert "chmod 0555 /usr/local/lib/sugar/managed-preflight.py" in stage
 PY
 
 python3 - "$plan" "$repo" <<'PY'

--- a/tests/sugarbin_rebuild_single_flight.sh
+++ b/tests/sugarbin_rebuild_single_flight.sh
@@ -189,6 +189,7 @@ SUGAR_BINARY_SOURCE_STAMP="$production_stamp" \
 [[ ! -e "$production_lock" ]] || fail 'production acquire/release arm left lock residue'
 
 mkdir -p "$production_lock"
+printf 'dead\n' >"$production_lock/pid"
 mkdir -p "$tmp/refuse-rm-bin"
 cat >"$tmp/refuse-rm-bin/rm" <<'EOF'
 #!/usr/bin/env bash
@@ -258,12 +259,85 @@ terminal = "crime=unreclaimable-rebuild-lock"
 if result.stderr.count(terminal) != 1:
     print(result.stderr, file=sys.stderr)
     raise SystemExit("expected exactly one named unreclaimable-lock terminal")
-for testimony in (lock, "holder_pid=unknown", "heartbeat_age_s=999999"):
+for testimony in (lock, "holder_pid=dead", "heartbeat_age_s=999999"):
     if testimony not in result.stderr:
         print(result.stderr, file=sys.stderr)
         raise SystemExit(f"missing terminal testimony: {testimony}")
 PY
 
-echo 'PASS: production rebuild lock completes normally and unreclaimable lock terminates'
+rm -rf "$production_lock"
+mkdir -p "$tmp/refuse-lock-mkdir-bin"
+cat >"$tmp/refuse-lock-mkdir-bin/mkdir" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$#" == 1 && "$1" == "${LOCK_TO_REFUSE:?}" ]]; then
+  exit 77
+fi
+exec /bin/mkdir "$@"
+EOF
+chmod +x "$tmp/refuse-lock-mkdir-bin/mkdir"
+
+python3 - "$sugarbin" "$production_cache" "$production_stamp" \
+  "$production_lock" "$tmp/refuse-lock-mkdir-bin" \
+  "$tmp/production-missing-pid.json" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+sugarbin, cache, stamp, lock, refuse_bin, receipt = sys.argv[1:]
+env = os.environ.copy()
+env.update(
+    {
+        "LOCK_TO_REFUSE": lock,
+        "PATH": refuse_bin + os.pathsep + env["PATH"],
+        "SUGAR_BINARY_CACHE_DIR": cache,
+        "SUGAR_BINARY_SOURCE_STAMP": stamp,
+    }
+)
+try:
+    result = subprocess.run(
+        [
+            sugarbin,
+            "preflight-lock",
+            "--bin",
+            "sugar",
+            "--profile",
+            "debug",
+            "--platform",
+            "fixture",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+except subprocess.TimeoutExpired as error:
+    stderr = error.stderr or ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    print("production missing-pid arm did not terminate within 5s", file=sys.stderr)
+    print(stderr, file=sys.stderr)
+    raise SystemExit(1)
+json.dump(
+    {"returncode": result.returncode, "stdout": result.stdout, "stderr": result.stderr},
+    open(receipt, "w", encoding="utf-8"),
+    sort_keys=True,
+)
+if result.returncode != 70:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit(f"expected exit 70, observed {result.returncode}")
+terminal = "crime=missing-rebuild-lock-pid"
+if result.stderr.count(terminal) != 1:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit("expected exactly one named missing-pid terminal")
+for testimony in (lock + "/pid", "holder_pid=unknown"):
+    if testimony not in result.stderr:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(f"missing terminal testimony: {testimony}")
+PY
+
+echo 'PASS: production rebuild lock completes and both failure terminals terminate'
 
 echo 'PASS: R_shelf_rebuild_single_flight — one build, waiter cell, dead-winner reclaim'

--- a/tools/sugar-build/Dockerfile
+++ b/tools/sugar-build/Dockerfile
@@ -169,6 +169,8 @@ FROM examples-closure AS showcases-closure
 ARG MANAGED_APT_PACKAGES
 ARG MANAGED_RUST_TOOLCHAIN
 ARG MANAGED_RUST_COMPONENTS
+COPY tools/sugar-build/preflight.py /usr/local/lib/sugar/managed-preflight.py
+RUN chmod 0555 /usr/local/lib/sugar/managed-preflight.py
 RUN test -n "${MANAGED_APT_PACKAGES}" \
  && test -n "${MANAGED_RUST_TOOLCHAIN}" \
  && test -n "${MANAGED_RUST_COMPONENTS}" \

--- a/tools/sugar-build/Dockerfile
+++ b/tools/sugar-build/Dockerfile
@@ -161,3 +161,27 @@ RUN apt-get update \
  && pnpm --version \
  && vampire --version
 ENV JAVA_HOME=/opt/java PATH=/opt/java/bin:${PATH}
+
+# Task-specific requirements are projected by build_task_image.py from the
+# managed showcase closure. The Dockerfile owns only the generic installation
+# door; it does not carry a second git or rust-src roster.
+FROM examples-closure AS showcases-closure
+ARG MANAGED_APT_PACKAGES
+ARG MANAGED_RUST_TOOLCHAIN
+ARG MANAGED_RUST_COMPONENTS
+RUN test -n "${MANAGED_APT_PACKAGES}" \
+ && test -n "${MANAGED_RUST_TOOLCHAIN}" \
+ && test -n "${MANAGED_RUST_COMPONENTS}" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends ${MANAGED_APT_PACKAGES} \
+ && rm -rf /var/lib/apt/lists/* \
+ && for command_name in ${MANAGED_APT_PACKAGES}; do \
+      command -v "${command_name}" >/dev/null; \
+    done \
+ && for component in ${MANAGED_RUST_COMPONENTS}; do \
+      rustup component add --toolchain "${MANAGED_RUST_TOOLCHAIN}" "${component}"; \
+    done \
+ && installed_components="$(rustup component list --toolchain "${MANAGED_RUST_TOOLCHAIN}" --installed)" \
+ && for component in ${MANAGED_RUST_COMPONENTS}; do \
+      printf '%s\n' "${installed_components}" | grep -Eq "^${component}(-[^ ]+)?( \(installed\))?$"; \
+    done

--- a/tools/sugar-build/build_task_image.py
+++ b/tools/sugar-build/build_task_image.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3.12
+"""Build one task image from its derived managed-precondition closure."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import contract
+
+
+def build_command(
+    task: str,
+    *,
+    repo_root: Path,
+    tag: str,
+    push: bool,
+) -> list[str]:
+    projection = contract.resolve_task_image_build(
+        task,
+        repo_root,
+        repo_root / "sugar-build.toml",
+    )
+    return [
+        "docker",
+        "buildx",
+        "build",
+        "--platform",
+        "linux/amd64",
+        "--target",
+        projection["target"],
+        "--build-arg",
+        "MANAGED_APT_PACKAGES=" + " ".join(projection["aptPackages"]),
+        "--build-arg",
+        "MANAGED_RUST_TOOLCHAIN=" + projection["rustToolchain"],
+        "--build-arg",
+        "MANAGED_RUST_COMPONENTS=" + " ".join(projection["rustComponents"]),
+        "--tag",
+        tag,
+        "--push" if push else "--load",
+        "--file",
+        str(repo_root / "tools/sugar-build/Dockerfile"),
+        str(repo_root),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("task")
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--tag", required=True)
+    publication = parser.add_mutually_exclusive_group(required=True)
+    publication.add_argument("--push", action="store_true")
+    publication.add_argument("--load", action="store_true")
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    try:
+        command = build_command(
+            args.task,
+            repo_root=repo_root,
+            tag=args.tag,
+            push=args.push,
+        )
+    except contract.ContractError as exc:
+        print(f"sugar-build: {exc}", file=sys.stderr)
+        return 2
+    return subprocess.run(command, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -30,6 +30,7 @@ CLOSURE_KEYS = frozenset(
     }
 )
 PROFILED_ARTIFACT = re.compile(r"^(debug|release):([A-Za-z0-9._-]+)$")
+PACKAGE_TOKEN = re.compile(r"^[a-z0-9][a-z0-9+.-]*$")
 IMMUTABLE_IMAGE = re.compile(r"^[^@\s]+@sha256:[0-9a-f]{64}$")
 EXACT_TOOL_VERSION = {
     "rust": re.compile(r"\d+\.\d+\.\d+"),
@@ -327,6 +328,48 @@ def resolve_task_preconditions(name, host, repo_root, path=DEFAULT_CONTRACT):
     }
 
 
+def resolve_task_image_build(name, repo_root, path=DEFAULT_CONTRACT):
+    plan = resolve_task_preconditions(name, "bx", repo_root, path)
+    packages = sorted(
+        {
+            check["name"]
+            for check in plan["checks"]
+            if check["kind"] == "command"
+        }
+    )
+    invalid_package = next(
+        (package for package in packages if PACKAGE_TOKEN.fullmatch(package) is None),
+        None,
+    )
+    if invalid_package is not None:
+        raise ContractError(f"managed command has no Debian package identity: {invalid_package}")
+    component_checks = [
+        check
+        for check in plan["checks"]
+        if check["kind"] == "toolchain-component"
+    ]
+    channels = sorted({check["channel"] for check in component_checks})
+    if len(channels) != 1:
+        raise ContractError(
+            "task image requires exactly one Rust toolchain: " + ",".join(channels)
+        )
+    rust_version = load_contract(path)["tools"]["rust"]
+    if channels[0] != rust_version:
+        raise ContractError(
+            f"task image Rust toolchain {channels[0]} differs from core {rust_version}"
+        )
+    if PACKAGE_TOKEN.fullmatch(name) is None:
+        raise ContractError(f"task image has invalid target identity: {name}")
+    return {
+        "aptPackages": packages,
+        "rustComponents": sorted({check["name"] for check in component_checks}),
+        "rustToolchain": channels[0],
+        "schemaVersion": 1,
+        "target": f"{name}-closure",
+        "task": name,
+    }
+
+
 def match_task_command(argv, path=DEFAULT_CONTRACT):
     data = load_contract(path)
     matches = []
@@ -364,6 +407,9 @@ def main(argv=None):
     preconditions.add_argument("task")
     preconditions.add_argument("--host", required=True)
     preconditions.add_argument("--repo-root", required=True)
+    image_build = subparsers.add_parser("resolve-task-image-build")
+    image_build.add_argument("task")
+    image_build.add_argument("--repo-root", required=True)
     matcher = subparsers.add_parser("match-command")
     matcher.add_argument("argv", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
@@ -372,6 +418,7 @@ def main(argv=None):
         elif args.command == "resolve-environment": result = resolve_environment(args.environment)
         elif args.command == "resolve-task": result = resolve_task(args.task)
         elif args.command == "resolve-preconditions": result = resolve_task_preconditions(args.task, args.host, args.repo_root)
+        elif args.command == "resolve-task-image-build": result = resolve_task_image_build(args.task, args.repo_root)
         else:
             argv = args.argv[1:] if args.argv[:1] == ["--"] else args.argv
             result = {"task": match_task_command(argv)}

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -18,6 +18,7 @@ ROOT = resolve_repo_root()
 DEFAULT_CONTRACT = ROOT / "sugar-build.toml"
 PUBLISHED_BINARIES = frozenset({"sugar", "sugar-ir-smt-lib"})
 TASK_KEYS = frozenset({"capabilities", "binaries", "command", "network"})
+TASK_IMAGE_KEYS = frozenset({"preflight", "reference"})
 CLOSURE_KEYS = frozenset(
     {
         "adjacent_manifests",
@@ -32,6 +33,7 @@ CLOSURE_KEYS = frozenset(
 PROFILED_ARTIFACT = re.compile(r"^(debug|release):([A-Za-z0-9._-]+)$")
 PACKAGE_TOKEN = re.compile(r"^[a-z0-9][a-z0-9+.-]*$")
 IMMUTABLE_IMAGE = re.compile(r"^[^@\s]+@sha256:[0-9a-f]{64}$")
+TASK_IMAGE_PREFLIGHTS = frozenset({"managed-entrypoint/v1"})
 EXACT_TOOL_VERSION = {
     "rust": re.compile(r"\d+\.\d+\.\d+"),
     "cargo": re.compile(r"\d+\.\d+\.\d+"),
@@ -75,7 +77,15 @@ def load_contract(path=DEFAULT_CONTRACT):
         if "overwrite" in message.lower():
             message = f"duplicate definition: {message}"
         raise ContractError(message) from exc
-    if set(data) - {"schema", "tools", "packages", "capabilities", "tasks", "images"}:
+    if set(data) - {
+        "schema",
+        "tools",
+        "packages",
+        "capabilities",
+        "tasks",
+        "images",
+        "task-images",
+    }:
         raise ContractError("unknown top-level contract key")
     if data.get("schema") != 1:
         raise ContractError("unsupported contract schema")
@@ -91,6 +101,20 @@ def load_contract(path=DEFAULT_CONTRACT):
             raise ContractError(f"non-exact tool version: {name}")
     if "packages" in data and not isinstance(data["packages"], dict):
         raise ContractError("invalid packages table")
+    task_images = data.get("task-images", {})
+    if not isinstance(task_images, dict):
+        raise ContractError("invalid task-images table")
+    for name, task_image in task_images.items():
+        if name not in data["tasks"]:
+            raise ContractError(f"task image has no task owner: {name}")
+        if not isinstance(task_image, dict) or set(task_image) != TASK_IMAGE_KEYS:
+            raise ContractError(f"invalid task image definition: {name}")
+        reference = task_image.get("reference")
+        if not isinstance(reference, str) or IMMUTABLE_IMAGE.fullmatch(reference) is None:
+            raise ContractError(f"task image reference is not immutable: {name}")
+        preflight = task_image.get("preflight")
+        if preflight not in TASK_IMAGE_PREFLIGHTS:
+            raise ContractError(f"unknown task image preflight protocol: {name}")
     declared_capabilities = set(data["capabilities"])
     owner_capabilities = set(CAPABILITY_TOOL_OWNERS)
     if not declared_capabilities <= owner_capabilities:
@@ -175,6 +199,29 @@ def resolve_task(name, path=DEFAULT_CONTRACT):
     if "closure" in task:
         result["closure"] = _validate_task_closure(name, task["closure"])
     return result
+
+
+def resolve_task_environment(name, path=DEFAULT_CONTRACT):
+    data = load_contract(path)
+    task = resolve_task(name, path)
+    environment = resolve_environment(
+        "docker:" + ",".join(task["capabilities"]), path
+    )
+    task_image = data.get("task-images", {}).get(name)
+    if task_image is None:
+        return {
+            **environment,
+            "preflight": "workspace-wrapper/v1",
+            "task": name,
+        }
+    if "closure" not in task:
+        raise ContractError(f"task image has no declared command closure: {name}")
+    return {
+        **environment,
+        "image": task_image["reference"],
+        "preflight": task_image["preflight"],
+        "task": name,
+    }
 
 
 def _string_list(value, label):
@@ -403,6 +450,8 @@ def main(argv=None):
     environment.add_argument("environment")
     task = subparsers.add_parser("resolve-task")
     task.add_argument("task")
+    task_environment = subparsers.add_parser("resolve-task-environment")
+    task_environment.add_argument("task")
     preconditions = subparsers.add_parser("resolve-preconditions")
     preconditions.add_argument("task")
     preconditions.add_argument("--host", required=True)
@@ -417,6 +466,7 @@ def main(argv=None):
         if args.command == "tool-versions": result = tool_versions()
         elif args.command == "resolve-environment": result = resolve_environment(args.environment)
         elif args.command == "resolve-task": result = resolve_task(args.task)
+        elif args.command == "resolve-task-environment": result = resolve_task_environment(args.task)
         elif args.command == "resolve-preconditions": result = resolve_task_preconditions(args.task, args.host, args.repo_root)
         elif args.command == "resolve-task-image-build": result = resolve_task_image_build(args.task, args.repo_root)
         else:

--- a/tools/sugar-build/entrypoint.sh
+++ b/tools/sugar-build/entrypoint.sh
@@ -76,4 +76,15 @@ PY
   fi
 fi
 
+if [[ -n "${SUGAR_BX_MANAGED_PRECONDITION_PLAN:-}" ]]; then
+  managed_preflight=/usr/local/lib/sugar/managed-preflight.py
+  if [[ ! -x "$managed_preflight" ]]; then
+    echo "sugarbin: crime=missing-managed-preflight path=$managed_preflight replacement=publish the task capability image with its declared preflight protocol" >&2
+    exit 70
+  fi
+  exec python "$managed_preflight" run \
+    --plan-json "$SUGAR_BX_MANAGED_PRECONDITION_PLAN" \
+    --artifact-root /opt/sugar -- "$@"
+fi
+
 exec "$@"


### PR DESCRIPTION
## What changed

Stage two turns the stage-one showcase entrance account into an immutable capability-image route:

- derives task-image extras from the live declared command closure, including `git` and `rust-src` from `examples/std-core-showcase/rust-toolchain.toml`
- publishes and selects the immutable image `ghcr.io/tsavo/sugar-env@sha256:c8f9964d2a9d57fd36433d2e3bfe5d6a9c5a4367ff76e8aa5e3f53c0c28a2e2f`
- provisions the exact profile-qualified artifact closure once and keeps ordinary task execution build/publish disabled
- seals the managed preflight into the image while retaining the workspace-wrapper fallback for older declared images
- terminates the missing-PID rebuild-lock subcase after a bounded 0.5s winner grace instead of looping forever

The contract adds two explicit preflight protocol values (`managed-entrypoint/v1` and `workspace-wrapper/v1`) and named refusal terminals for missing plans, unknown protocols, missing sealed preflight, and missing lock-holder PID. These are boundary crimes, not new progress categories or residual buckets.

## Measured result

The previously blocked `std-core-showcase` entrance now passes the pinned `rust-src` 1.96.0 precondition in 249 ms. The terminal then moves before subject execution to the next declared axis:

`crime=artifact-abi-incompatible` for `/opt/sugar/bin/discharge_cli`, built for GLIBC 2.39, in the Debian 12 / GLIBC 2.36 image.

That is not a showcase semantic red. The subject did not execute. The ABI choice is filed separately in #7316 with both options and costs; this PR does not silently select one and does not weaken the ABI verifier.

## Verification on exact head

- `bash tests/sugarbin_managed_preconditions.sh "$PWD"` — PASS; 9 discovered / 9 predicted / 0 unpredicted and planted unpredicted twin red
- `bash tests/sugarbin_docker_exec.sh "$PWD"` — PASS; immutable selection, unknown-protocol refusal, workspace fallback, and baked ABI good/bad arms
- `bash tests/sugarbin_rebuild_single_flight.sh "$PWD"` — PASS in 3.8s; eight contenders, normal cycle, dead-winner reclaim, unreclaimable terminal, and missing-PID terminal
- shell syntax, Python `py_compile`, range `diff --check` — PASS
- closing-account SHA-256 remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`
- exact branch preflight: parent/merge-base current main `8588a17b766d67034ae4afc5602387cf92c52c53`; four commits; 11 files; +904/-15; no workflow, runner, autoscaler, or CI-capacity change

## Boundary and non-claims

The image now satisfies `git` and pinned `rust-src`; stage one still refuses cheaply and by name when a declared precondition is absent. Artifact ABI remains a real blocker pending #7316. Detached remote process lifetime remains unsolved; this PR makes no managed-detached-success claim. No showcase semantic verdict is claimed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Activate the showcase capability image with managed preflight and profiled artifact provisioning
> - Introduces a `managed-entrypoint/v1` preflight protocol: the container entrypoint in [entrypoint.sh](https://github.com/TSavo/sugar/pull/7317/files#diff-a9d742f38b5e10924edca17d0a5298b10a7fa3d5c704c534da28c5ef0a9a0dc9) checks for a baked `managed-preflight.py` and execs it with the precondition plan before the task subject.
> - Adds profiled artifact provisioning: [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7317/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) gains `sugar_bx_profiled_artifact_build_script` to resolve `profile:name` artifacts, copy binaries and metadata, compute sha256 checksums, and write a `required-artifacts.json` manifest.
> - Registers the `showcases` task in [sugar-build.toml](https://github.com/TSavo/sugar/pull/7317/files#diff-b714a26a105f372af4929844b95deb54b1e2701396f192e8761d975086b49835) with a pinned immutable image reference and `preflight = "managed-entrypoint/v1"`.
> - Adds a `showcases-closure` Docker stage in [Dockerfile](https://github.com/TSavo/sugar/pull/7317/files#diff-dc40c970f594e00cc156ccdf343d662e9f87bee887911a221d444ee15c55e9e9) that installs declared apt packages and Rust components, and bakes in `managed-preflight.py`.
> - Adds [build_task_image.py](https://github.com/TSavo/sugar/pull/7317/files#diff-bfe74d67a07128accb5141688a5ef65442677038b9a1ed15d0764cb5c31c9c76) CLI and extends [contract.py](https://github.com/TSavo/sugar/pull/7317/files#diff-542d62fc3e01ab11f18170519b78495374a6e499084ba08e14bd12dd00704460) to validate per-task image declarations and derive deterministic build inputs from the task closure.
> - Behavioral Change: `sugar_bx_run_docker` now requires an explicit `preflight_protocol` argument; the legacy workspace preflight wrapper is suppressed when `managed-entrypoint/v1` is selected and the plan is passed via `SUGAR_BX_MANAGED_PRECONDITION_PLAN` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13df12b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->