### PR TITLE
Preserve typed prefix-fallthrough refusal testimony

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -188,10 +188,17 @@ def _resolve_export_uncached(
     )
     # Normal-completion authority for the prefix (statements strictly before
     # the unique export-binding locus): producer-owned Completed faces only.
-    if locus is not None and not _prefix_has_completed_fallthrough(
-        module, locus, graph=graph, session=session
-    ):
-        return _gap("dynamic-export", binding_cid, graph, module_name, exported_name)
+    if locus is not None:
+        fallthrough = _prefix_has_completed_fallthrough(
+            module, locus, graph=graph, session=session
+        )
+        # Ordinary non-fallthrough and named construction refusal both cite
+        # through the existing typed dynamic-export membrane.  Their distinct
+        # producer testimony remains recoverable from the session memo.
+        if fallthrough.kind != "completed":
+            return _gap(
+                "dynamic-export", binding_cid, graph, module_name, exported_name
+            )
     return _resolve_export_binding(
         graph,
         binding_cid,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -1091,9 +1091,53 @@ def _static_prefix_always_fallthrough(module, locus) -> bool:
     return True
 
 
+@dataclass(frozen=True)
+class PrefixFallthroughOutcomeV1:
+    """Closed testimony for one authenticated module-prefix fallthrough ask.
+
+    The key already identifies the source locus completely.  The former bool
+    value did not identify which fact it cached: ordinary non-fallthrough or a
+    construction refusal.  One closed outcome keeps those facts distinct.
+    """
+
+    kind: Literal[
+        "completed", "ordinary-non-fallthrough", "construction-refusal"
+    ]
+    refusal_kind: Literal["sugar-not-written", "construction-type-error"] | None = (
+        None
+    )
+    observed_event_type: str | None = None
+    detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in {
+            "completed",
+            "ordinary-non-fallthrough",
+            "construction-refusal",
+        }:
+            raise ValueError(f"unknown prefix fallthrough outcome {self.kind!r}")
+        refusal_fields = (
+            self.refusal_kind,
+            self.observed_event_type,
+            self.detail,
+        )
+        if self.kind == "construction-refusal":
+            if any(value is None for value in refusal_fields):
+                raise ValueError("construction refusal requires named testimony")
+            if self.refusal_kind not in {
+                "sugar-not-written",
+                "construction-type-error",
+            }:
+                raise ValueError(
+                    f"unknown prefix construction refusal {self.refusal_kind!r}"
+                )
+        elif any(value is not None for value in refusal_fields):
+            raise ValueError("control-flow outcome cannot carry refusal testimony")
+
+
 def prefix_has_completed_fallthrough(
     module, locus, *, graph=None, session=None
-) -> bool:
+) -> PrefixFallthroughOutcomeV1:
     """Admit an export when the module prefix normally completes.
 
     POPULATION MEMBRANE: when ``graph`` is stdlib (off enrolled population),
@@ -1113,7 +1157,7 @@ def prefix_has_completed_fallthrough(
     session = session_or_new(session)
     if graph is not None and _graph_is_off_population(graph, session=session):
         # Cite path: admit static export without off-population construction.
-        return True
+        return PrefixFallthroughOutcomeV1("completed")
 
     from sugar_source_tree.panic import SugarNotWritten
 
@@ -1128,29 +1172,48 @@ def prefix_has_completed_fallthrough(
 
     # Cheap door: pure-binding AST prefix always falls through — no sugar.
     if _static_prefix_always_fallthrough(module, locus):
-        session.remember_fallthrough(fallthrough_key, True)
-        return True
+        outcome = PrefixFallthroughOutcomeV1("completed")
+        session.remember_fallthrough(fallthrough_key, outcome)
+        return outcome
 
     # Prefix sugar can SNW (e.g. decorated FunctionDef without publication) or
     # TypeError on construction (IfExp/spread require_* costume). Neither is
-    # "fallthrough completed"; both cite as dynamic-export at the export door
-    # and must never abort the open's population. Named classes only.
+    # ordinary non-fallthrough: retain named testimony in the session memo so a
+    # later caller cannot replay construction refusal as a clean ``False``.
     try:
         exits = _module_prefix_outcome(module, locus, graph=graph, session=session)
-    except (SugarNotWritten, TypeError):
-        session.remember_fallthrough(fallthrough_key, False)
-        return False
+    except (SugarNotWritten, TypeError) as exc:
+        if isinstance(exc, SugarNotWritten):
+            refusal = PrefixFallthroughOutcomeV1(
+                kind="construction-refusal",
+                refusal_kind="sugar-not-written",
+                observed_event_type=f"{type(exc).__module__}.{type(exc).__qualname__}",
+                detail=f"{exc.owner}: {exc.observed}",
+            )
+        else:
+            refusal = PrefixFallthroughOutcomeV1(
+                kind="construction-refusal",
+                refusal_kind="construction-type-error",
+                observed_event_type=f"{type(exc).__module__}.{type(exc).__qualname__}",
+                detail=str(exc),
+            )
+        session.remember_fallthrough(fallthrough_key, refusal)
+        return refusal
     if len(exits.exits) != 1:
-        session.remember_fallthrough(fallthrough_key, False)
-        return False
+        outcome = PrefixFallthroughOutcomeV1("ordinary-non-fallthrough")
+        session.remember_fallthrough(fallthrough_key, outcome)
+        return outcome
     face = exits.exits[0]
     ok = (
         isinstance(face, Completed)
         and face.guard == true_guard()
         and bool(getattr(face.value, "can_fall_through", False))
     )
-    session.remember_fallthrough(fallthrough_key, ok)
-    return ok
+    outcome = PrefixFallthroughOutcomeV1(
+        "completed" if ok else "ordinary-non-fallthrough"
+    )
+    session.remember_fallthrough(fallthrough_key, outcome)
+    return outcome
 
 
 @dataclass(frozen=True)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -95,7 +95,10 @@ from __future__ import annotations
 import collections
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .manager_construction import PrefixFallthroughOutcomeV1
 
 # (resolved workspace root, authenticated population) -> walk-owned session.
 # Not content-keyed; not a substitute for §4 residency. Cleared only by tests.
@@ -204,8 +207,10 @@ class SourceResolutionSession:
         # _module_prefix_outcome once per export locus and rebuilt config N times.
         # Separate from module_materializations: different context settings.
         self.prefix_files: dict[str, Any] = {}
-        # (source_cid, lineno, col_offset) -> bool fallthrough answer
-        self.prefix_fallthrough: dict[tuple, bool] = {}
+        # (source_cid, lineno, col_offset) -> PrefixFallthroughOutcomeV1.  The
+        # locus key is complete authority; the closed value prevents refusal
+        # from becoming a memoized ordinary non-fallthrough.
+        self.prefix_fallthrough: dict[tuple, Any] = {}
         # source_cid -> import-use / value-use receipt tuples (lexical pass once)
         self.import_use_rosters: dict[str, Any] = {}
         self.import_value_rosters: dict[str, Any] = {}
@@ -303,12 +308,18 @@ class SourceResolutionSession:
         if self.enabled:
             self.prefix_files[(source_cid, source_seat)] = source_file
 
-    def fallthrough_hit(self, key: tuple) -> bool | None:
+    def fallthrough_hit(self, key: tuple) -> PrefixFallthroughOutcomeV1 | None:
         if not self.enabled:
             return None
         return self.prefix_fallthrough.get(key)
 
-    def remember_fallthrough(self, key: tuple, value: bool) -> None:
+    def remember_fallthrough(
+        self, key: tuple, value: PrefixFallthroughOutcomeV1
+    ) -> None:
+        from .manager_construction import PrefixFallthroughOutcomeV1
+
+        if type(value) is not PrefixFallthroughOutcomeV1:
+            raise TypeError("prefix fallthrough memo requires its closed outcome")
         if self.enabled:
             self.prefix_fallthrough[key] = value
 

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_alias_star_warrants.py
@@ -1136,8 +1136,11 @@ def test_prefix_adapter_routes_exact_graph_and_session_to_module_execution(
         manager_construction, "_module_prefix_outcome", completed_prefix
     )
 
-    assert dependency_export_adapter._prefix_has_completed_fallthrough(
-        module, locus, graph=graph, session=session
+    assert (
+        dependency_export_adapter._prefix_has_completed_fallthrough(
+            module, locus, graph=graph, session=session
+        ).kind
+        == "completed"
     )
     assert observed == [(module, locus, graph, session)]
 

--- a/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
@@ -19,6 +19,7 @@ import pytest
 
 from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_python_source.manager_construction import (
+    PrefixFallthroughOutcomeV1,
     _module_prefix_outcome,
     _static_prefix_always_fallthrough,
     prefix_has_completed_fallthrough,
@@ -77,7 +78,9 @@ def test_static_pure_binding_prefix_admits_without_outcome(monkeypatch) -> None:
     )
     # This tooth has no dependency graph: its authoritative population is empty.
     session = SourceResolutionSession(enrolled_distributions=frozenset())
-    assert prefix_has_completed_fallthrough(module, locus, session=session) is True
+    assert prefix_has_completed_fallthrough(module, locus, session=session) == (
+        PrefixFallthroughOutcomeV1("completed")
+    )
     assert (
         calls["n"] == 0
     ), f"pure-binding prefix must not run _module_prefix_outcome; n={calls['n']}"
@@ -124,6 +127,117 @@ def test_stdlib_graph_still_short_circuits(monkeypatch) -> None:
             graph=graph,
             session=SourceResolutionSession(enrolled_distributions=frozenset()),
         )
-        is True
+        == PrefixFallthroughOutcomeV1("completed")
     )
     assert calls["n"] == 0
+
+
+def test_prefix_construction_refusal_is_typed_and_memoized(monkeypatch) -> None:
+    """Construction refusal is testimony, never cached ordinary False."""
+    from sugar_source_tree.panic import SugarNotWritten
+
+    source = (
+        "try:\n"
+        "    setup()\n"
+        "except Exception:\n"
+        "    pass\n"
+        "def export():\n"
+        "    return 1\n"
+    )
+    module = _module(source)
+    locus = _locus_of(source, "export")
+    calls = {"n": 0}
+
+    def refuses(*_args, **_kwargs):
+        calls["n"] += 1
+        raise SugarNotWritten(
+            owner="prefix-refusal-tooth",
+            blame="mod.py:2:4",
+            observed="opaque setup call",
+            requested="one completed module-prefix outcome",
+            fix="construct the setup call before export admission",
+        )
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction._module_prefix_outcome",
+        refuses,
+    )
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
+
+    first = prefix_has_completed_fallthrough(module, locus, session=session)
+    second = prefix_has_completed_fallthrough(module, locus, session=session)
+
+    assert first == PrefixFallthroughOutcomeV1(
+        kind="construction-refusal",
+        refusal_kind="sugar-not-written",
+        observed_event_type="sugar_source_tree.panic.SugarNotWritten",
+        detail="prefix-refusal-tooth: opaque setup call",
+    )
+    assert second == first
+    assert calls["n"] == 1, "typed refusal must survive the session memo"
+
+
+def test_prefix_ordinary_non_fallthrough_remains_clean_outcome(monkeypatch) -> None:
+    """An ordinary completed face that cannot fall through is not a refusal."""
+    from sugar_lift_py_tests.outcome import ExitSet
+
+    source = (
+        "try:\n"
+        "    setup()\n"
+        "except Exception:\n"
+        "    pass\n"
+        "def export():\n"
+        "    return 1\n"
+    )
+    module = _module(source)
+    locus = _locus_of(source, "export")
+    calls = {"n": 0}
+
+    def declines(*_args, **_kwargs):
+        calls["n"] += 1
+        return ExitSet.completed(SimpleNamespace(can_fall_through=False))
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction._module_prefix_outcome",
+        declines,
+    )
+    session = SourceResolutionSession(enrolled_distributions=frozenset())
+
+    expected = PrefixFallthroughOutcomeV1("ordinary-non-fallthrough")
+    assert prefix_has_completed_fallthrough(module, locus, session=session) == expected
+    assert prefix_has_completed_fallthrough(module, locus, session=session) == expected
+    assert calls["n"] == 1, "ordinary non-fallthrough remains a clean memo hit"
+
+
+def test_prefix_construction_typeerror_is_named(monkeypatch) -> None:
+    """The handler's TypeError arm is refusal testimony, not control flow."""
+    source = (
+        "try:\n"
+        "    setup()\n"
+        "except Exception:\n"
+        "    pass\n"
+        "def export():\n"
+        "    return 1\n"
+    )
+    module = _module(source)
+    locus = _locus_of(source, "export")
+
+    def refuses(*_args, **_kwargs):
+        raise TypeError("prefix construction shape mismatch")
+
+    monkeypatch.setattr(
+        "sugar_lift_python_source.manager_construction._module_prefix_outcome",
+        refuses,
+    )
+    outcome = prefix_has_completed_fallthrough(
+        module,
+        locus,
+        session=SourceResolutionSession(enrolled_distributions=frozenset()),
+    )
+
+    assert outcome == PrefixFallthroughOutcomeV1(
+        kind="construction-refusal",
+        refusal_kind="construction-type-error",
+        observed_event_type="builtins.TypeError",
+        detail="prefix construction shape mismatch",
+    )


### PR DESCRIPTION
## What this closes

This closes the single authenticated suppression measured by the implementation catch census over 525 implementation files and 598 handler sites.

`manager_construction.py::prefix_has_completed_fallthrough` caught `SugarNotWritten` or `TypeError`, memoized `False`, and returned `False`. One boolean therefore represented both ordinary non-fallthrough and construction refusal.

## Fix by construction

A closed `PrefixFallthroughOutcomeV1` now distinguishes:

- `completed`
- `ordinary-non-fallthrough`
- `construction-refusal`

Construction refusal retains its refusal kind, raw observed event type, and detail. The session memo rejects every value whose exact type is not `PrefixFallthroughOutcomeV1`, so the lossy boolean cannot return through that door.

This is a new closed internal outcome kind, not a shared product category, label, taxonomy, or residual bucket.

## Root cause

Two individually defensible commits composed into the defect:

- `a4186f5ad4` collapsed `SugarNotWritten` into `False`
- `a50753c68a` later memoized that collapsed boolean under the correct locus key

The key was authoritative; the value erased the distinction.

## Evidence

- authenticated focused evidence: 12/12
- full export module: 42/44 on unchanged main and 42/44 on this branch
- both sides have the exact same two pre-existing stale node IDs and mechanisms
- no skip or xfail added
- no file deleted
- the 134 unresolved implementation-census rows are untouched

## Scope

Exact remote head `1dbf63e55bf2e6ba1741ce8f7bdb4d26ad08bd1c`; parent and merge-base current main `adb54dd1af6a04deb126eb3daa49e1a52b19d91d`; one commit; five modified files; +224/-26; closing-account SHA-256 remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace boolean return with typed `PrefixFallthroughOutcomeV1` in prefix fallthrough resolution
> - Introduces `PrefixFallthroughOutcomeV1`, a frozen dataclass in [`manager_construction.py`](https://github.com/TSavo/sugar/pull/7318/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) with a `kind` field (`'completed'`, `'ordinary-non-fallthrough'`, or `'construction-refusal'`) plus typed testimony fields for refusal cases.
> - `prefix_has_completed_fallthrough` now returns `PrefixFallthroughOutcomeV1` instead of `bool`; memoization in [`resolution_session.py`](https://github.com/TSavo/sugar/pull/7318/files#diff-54257d48026540505071d0613a7c672ce198dc916935415abb69c38a81451ce5) is updated to store and enforce the new type.
> - [`dependency_export_adapter.py`](https://github.com/TSavo/sugar/pull/7318/files#diff-9ae971bf7816ef0dc9d57fc56a4b8eef1daa1b6955b6c0bd851f772712bbc01f) inspects `fallthrough.kind` and treats any outcome other than `'completed'` as a dynamic-export gap, preserving construction-refusal testimony through the membrane.
> - Behavioral Change: callers that previously received `True`/`False` now receive a structured object; existing tests are updated to compare against `PrefixFallthroughOutcomeV1('completed')` or check `.kind`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dbf63e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->