### PR TITLE
Project authenticated Range structs into sequence floor

### DIFF
--- a/implementations/rust/sugar-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/lib.rs
@@ -178,6 +178,7 @@ pub mod sugar {
     pub mod range_bounds_contains;
     pub mod range_construct;
     pub mod range_contains;
+    pub mod range_sequence;
     pub mod range_term;
     pub mod raw_addr_term;
     pub mod raw_pointer_arithmetic;

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/literal.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/literal.rs
@@ -7,7 +7,9 @@
 // `strip_refs_groups`, `SUGAR_SEQ_CAP`) stays in `crate::` and is imported below.
 
 use std::collections::BTreeMap;
+use std::rc::Rc;
 
+use sugar_ir_symbolic::Term;
 use syn::{Expr, Lit, UnOp};
 
 use crate::sugar::factory::SugarBuildCtx;
@@ -159,55 +161,7 @@ impl LiteralSugar {
                     start,
                     end,
                     inclusive,
-                } => {
-                    if let (Some(s), Some(e)) =
-                        (const_fold_u128_term(&start), const_fold_u128_term(&end))
-                    {
-                        if e < s {
-                            return None;
-                        }
-                        let len = e
-                            .checked_sub(s)?
-                            .checked_add(if inclusive { 1 } else { 0 })?;
-                        if len == 0 || len > SUGAR_SEQ_CAP as u128 {
-                            return None;
-                        }
-                        return Some(Desugared::Seq(
-                            (0..len)
-                                .map(|offset| {
-                                    let n = s.checked_add(offset)?;
-                                    Some(DesugaredElem {
-                                        expr: u128_expr(n)?,
-                                        value: Some(ConstVal::UInt128(n)),
-                                    })
-                                })
-                                .collect::<Option<Vec<_>>>()?,
-                        ));
-                    }
-                    let (Some(s), Some(e)) = (
-                        term_as_int(&start).or_else(|| const_fold_int_term(&start)),
-                        term_as_int(&end).or_else(|| const_fold_int_term(&end)),
-                    ) else {
-                        return None;
-                    };
-                    if e < s {
-                        return None;
-                    }
-                    let span = e.checked_sub(s)?;
-                    let len = span.checked_add(if inclusive { 1 } else { 0 })?;
-                    if len == 0 || len > i128::from(SUGAR_SEQ_CAP) {
-                        return None;
-                    }
-                    (0..len)
-                        .map(|offset| {
-                            let n = s.checked_add(offset)?;
-                            Some(DesugaredElem {
-                                expr: syn::parse_str::<Expr>(&n.to_string()).ok()?,
-                                value: Some(ConstVal::Int(n)),
-                            })
-                        })
-                        .collect::<Option<Vec<_>>>()?
-                }
+                } => finite_integer_range_sequence(&start, &end, inclusive).ok()?,
             };
             if seq.is_empty() {
                 return None;
@@ -215,6 +169,72 @@ impl LiteralSugar {
             Some(Desugared::Seq(seq))
         })()
     }
+}
+
+/// Materialize the one authenticated finite-integer-range sequence shared by
+/// written range syntax and the `Range { start, end }` sequence projection.
+///
+/// This is the sequence owner: callers must first authenticate the two bound
+/// terms. A failure stays a named source boundary; no caller may reinterpret a
+/// construction-constraint codomain as this sequence.
+pub(crate) fn finite_integer_range_sequence(
+    start: &Rc<Term>,
+    end: &Rc<Term>,
+    inclusive: bool,
+) -> Result<Vec<DesugaredElem>, &'static str> {
+    if let (Some(s), Some(e)) = (const_fold_u128_term(start), const_fold_u128_term(end)) {
+        if e < s {
+            return Err(EMPTY_DOMAIN_REASON);
+        }
+        let len = e
+            .checked_sub(s)
+            .and_then(|span| span.checked_add(if inclusive { 1 } else { 0 }))
+            .ok_or(OVERSIZE_DOMAIN_REASON)?;
+        if len == 0 {
+            return Err(EMPTY_DOMAIN_REASON);
+        }
+        if len > SUGAR_SEQ_CAP as u128 {
+            return Err(OVERSIZE_DOMAIN_REASON);
+        }
+        return (0..len)
+            .map(|offset| {
+                let n = s.checked_add(offset).ok_or(OVERSIZE_DOMAIN_REASON)?;
+                Ok(DesugaredElem {
+                    expr: u128_expr(n).ok_or(RUNTIME_BOUND_REASON)?,
+                    value: Some(ConstVal::UInt128(n)),
+                })
+            })
+            .collect();
+    }
+
+    let (Some(s), Some(e)) = (
+        term_as_int(start).or_else(|| const_fold_int_term(start)),
+        term_as_int(end).or_else(|| const_fold_int_term(end)),
+    ) else {
+        return Err(RUNTIME_BOUND_REASON);
+    };
+    if e < s {
+        return Err(EMPTY_DOMAIN_REASON);
+    }
+    let len = e
+        .checked_sub(s)
+        .and_then(|span| span.checked_add(if inclusive { 1 } else { 0 }))
+        .ok_or(OVERSIZE_DOMAIN_REASON)?;
+    if len == 0 {
+        return Err(EMPTY_DOMAIN_REASON);
+    }
+    if len > i128::from(SUGAR_SEQ_CAP) {
+        return Err(OVERSIZE_DOMAIN_REASON);
+    }
+    (0..len)
+        .map(|offset| {
+            let n = s.checked_add(offset).ok_or(OVERSIZE_DOMAIN_REASON)?;
+            Ok(DesugaredElem {
+                expr: syn::parse_str::<Expr>(&n.to_string()).map_err(|_| RUNTIME_BOUND_REASON)?,
+                value: Some(ConstVal::Int(n)),
+            })
+        })
+        .collect()
 }
 
 fn array_primitive_element_kind(arr: &syn::ExprArray) -> Option<PrimitiveIntKind> {

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/method_family.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/method_family.rs
@@ -82,16 +82,20 @@ pub(crate) fn build_literal_sequence_composite(
         return build_literal_sequence_composite(&inlined, fcx);
     }
     let (base, adaptors) = peel_fold_adaptors_in_scope(expr, fcx.let_inits(), fcx.scope(), 0)?;
+    let range_sequence = crate::sugar::range_sequence::build(&base, fcx);
     // Scope-aware base gate: a const-length repeat (`[7; SIZE]`) resolves to a finite literal
     // sequence here so the constructive floor (and its element-wise teeth) is reached.
     if !is_literal_sequence_base_in_scope(&base, fcx.scope())
         && !literal_slice::is_literal_slice_base_in_scope(&base, fcx.let_inits(), fcx.scope())
         && !literal_iter_call_base(&base)
+        && range_sequence.is_none()
         && !has_composite(&base, fcx)
     {
         return None;
     }
-    let mut node = if literal_iter_call_base(&base) {
+    let mut node = if let Some(range) = range_sequence {
+        range
+    } else if literal_iter_call_base(&base) {
         Box::new(LiteralIterCallSugar {
             seq: literal_iter_call_sequence(&base)?,
         }) as Box<dyn Sugar>

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/range_construct.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/range_construct.rs
@@ -26,54 +26,93 @@ pub(crate) const EXPR_SUGAR: crate::sugar::claim::ExprSugarClaim =
     );
 
 pub(crate) fn recognize(frag: &SourceFragment, fcx: &SugarBuildCtx) -> Option<Box<dyn Sugar>> {
-    match frag.observed().as_str() {
-        "Struct" => {
-            // Gate: no `..rest` spread.
-            if frag.struct_has_rest() {
-                return None;
+    AuthenticatedRangeFields::recognize(frag, fcx).map(RangeConstructSugar::new)
+}
+
+/// The source-authenticated field bodies shared by the construction-fact owner
+/// and the sequence projection. Each consumer chooses its own codomain only
+/// after these same TERM owners have reduced the written `start`/`end` fields.
+pub(crate) struct AuthenticatedRangeFields {
+    kind: RangeConstructKind,
+    fields: Vec<(String, SugarBody<TermFloor>)>,
+}
+
+impl AuthenticatedRangeFields {
+    pub(crate) fn recognize(frag: &SourceFragment, fcx: &SugarBuildCtx) -> Option<Self> {
+        match frag.observed().as_str() {
+            "Struct" => {
+                // Gate: no `..rest` spread.
+                if frag.struct_has_rest() {
+                    return None;
+                }
+                // Determine which range kind from the struct path's last segment.
+                let path_str = frag.struct_path_variant_string()?;
+                let last_seg = path_str.split("::").last()?;
+                let kind = RangeConstructKind::from_struct_name(last_seg)?;
+                // Collect accepted fields from the struct literal.
+                let all_fields = frag.struct_named_fields_frags();
+                let raw_fields: Vec<(String, SourceFragment<'_>)> = all_fields
+                    .into_iter()
+                    .filter(|(name, _)| kind.accepts_field(name))
+                    .collect();
+                let field_names: Vec<String> = raw_fields.iter().map(|(n, _)| n.clone()).collect();
+                if !kind.has_required_field_names(&field_names) {
+                    return None;
+                }
+                let fields = raw_fields
+                    .into_iter()
+                    .map(|(name, child_frag)| (name, SugarBody::term_frag(&child_frag, fcx)))
+                    .collect();
+                Some(Self { kind, fields })
             }
-            // Determine which range kind from the struct path's last segment.
-            let path_str = frag.struct_path_variant_string()?;
-            let last_seg = path_str.split("::").last()?;
-            let kind = RangeConstructKind::from_struct_name(last_seg)?;
-            // Collect accepted fields from the struct literal.
-            let all_fields = frag.struct_named_fields_frags();
-            let raw_fields: Vec<(String, SourceFragment<'_>)> = all_fields
-                .into_iter()
-                .filter(|(name, _)| kind.accepts_field(name))
-                .collect();
-            let field_names: Vec<String> = raw_fields.iter().map(|(n, _)| n.clone()).collect();
-            if !kind.has_required_field_names(&field_names) {
-                return None;
+            "Call" => {
+                // Gate: func path must end in `RangeInclusive::new`.
+                let func = frag.call_func()?;
+                if func.path_last_segment_ident().as_deref() != Some("new") {
+                    return None;
+                }
+                if func.path_penultimate_ident().as_deref() != Some("RangeInclusive") {
+                    return None;
+                }
+                if frag.call_arg_count() != 2 {
+                    return None;
+                }
+                let args = frag.call_args();
+                Some(Self {
+                    kind: RangeConstructKind::RangeInclusive,
+                    fields: vec![
+                        ("start".to_string(), SugarBody::term_frag(&args[0], fcx)),
+                        ("end".to_string(), SugarBody::term_frag(&args[1], fcx)),
+                    ],
+                })
             }
-            let fields = raw_fields
-                .into_iter()
-                .map(|(name, child_frag)| (name, SugarBody::term_frag(&child_frag, fcx)))
-                .collect();
-            Some(RangeConstructSugar::new(kind, fields))
+            _ => None,
         }
-        "Call" => {
-            // Gate: func path must end in `RangeInclusive::new`.
-            let func = frag.call_func()?;
-            if func.path_last_segment_ident().as_deref() != Some("new") {
-                return None;
-            }
-            if func.path_penultimate_ident().as_deref() != Some("RangeInclusive") {
-                return None;
-            }
-            if frag.call_arg_count() != 2 {
-                return None;
-            }
-            let args = frag.call_args();
-            Some(RangeConstructSugar::new(
-                RangeConstructKind::RangeInclusive,
-                vec![
-                    ("start".to_string(), SugarBody::term_frag(&args[0], fcx)),
-                    ("end".to_string(), SugarBody::term_frag(&args[1], fcx)),
-                ],
-            ))
+    }
+
+    pub(crate) fn inclusive(&self) -> Option<bool> {
+        match self.kind {
+            RangeConstructKind::Range => Some(false),
+            RangeConstructKind::RangeInclusive => Some(true),
+            RangeConstructKind::RangeFrom
+            | RangeConstructKind::RangeTo
+            | RangeConstructKind::RangeToInclusive => None,
         }
-        _ => None,
+    }
+
+    pub(crate) fn reduce(&self, ctx: &SugarCtx) -> Result<Vec<(String, Rc<Term>)>, crate::Effect> {
+        let mut fields = Vec::new();
+        for (name, body) in &self.fields {
+            let term = match body.reduce(ctx) {
+                Outcome::Complete(d) => d.accept_desugared_floor(RequiredTermVisitor {
+                    owner: "range construct field",
+                }),
+                Outcome::Incomplete(effect) => return Err(effect),
+            };
+            fields.push((name.clone(), term));
+        }
+        fields.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(fields)
     }
 }
 
@@ -143,23 +182,15 @@ fn has_field_name(fields: &[String], want: &str) -> bool {
 }
 
 struct RangeConstructSugar {
-    kind: RangeConstructKind,
-    fields: Vec<(String, SugarBody<TermFloor>)>,
+    range: AuthenticatedRangeFields,
 }
 
 impl Sugar for RangeConstructSugar {
     fn desugar(&self, ctx: &SugarCtx) -> Outcome {
-        let mut fields = Vec::new();
-        for (name, body) in &self.fields {
-            let term = match body.reduce(ctx) {
-                Outcome::Complete(d) => d.accept_desugared_floor(RequiredTermVisitor {
-                    owner: "range construct field",
-                }),
-                Outcome::Incomplete(effect) => return Outcome::Incomplete(effect),
-            };
-            fields.push((name.clone(), term));
-        }
-        fields.sort_by(|a, b| a.0.cmp(&b.0));
+        let fields = match self.range.reduce(ctx) {
+            Ok(fields) => fields,
+            Err(effect) => return Outcome::Incomplete(effect),
+        };
         let subject = self.subject_term(&fields);
         let atoms = fields
             .iter()
@@ -182,7 +213,7 @@ impl Sugar for RangeConstructSugar {
             n,
             kind: AssertionFactKind::Warranted,
             warrant: Warrant {
-                name: Some(self.kind.warrant_name().to_string()),
+                name: Some(self.range.kind.warrant_name().to_string()),
             },
         })
     }
@@ -190,7 +221,7 @@ impl Sugar for RangeConstructSugar {
 
 impl RangeConstructSugar {
     fn subject_term(&self, fields: &[(String, Rc<Term>)]) -> Rc<Term> {
-        match self.kind {
+        match self.range.kind {
             RangeConstructKind::RangeInclusive => {
                 let args = ["start", "end"]
                     .iter()
@@ -217,7 +248,7 @@ impl RangeConstructSugar {
                     })
                     .collect();
                 Rc::new(Term::Ctor {
-                    name: self.kind.ctor_name().to_string(),
+                    name: self.range.kind.ctor_name().to_string(),
                     args,
                 })
             }
@@ -226,11 +257,8 @@ impl RangeConstructSugar {
 }
 
 impl RangeConstructSugar {
-    fn new(
-        kind: RangeConstructKind,
-        fields: Vec<(String, SugarBody<TermFloor>)>,
-    ) -> Box<dyn Sugar> {
-        Box::new(Self { kind, fields })
+    fn new(range: AuthenticatedRangeFields) -> Box<dyn Sugar> {
+        Box::new(Self { range })
     }
 }
 

--- a/implementations/rust/sugar-lift-rust-tests/src/sugar/range_sequence.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/sugar/range_sequence.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//
+// Sequence projection for authenticated `Range { start, end }` construction.
+// The generic range-construction owner emits field constraints; this consumer
+// door instead asks those same authenticated TERM children for their bounds and
+// delegates finite integer enumeration to the literal-range sequence owner.
+
+use syn::Expr;
+
+use crate::sugar::claim::SugarRole;
+use crate::sugar::factory::{AccountedSugar, FactoryAuditSeed, SugarBuildCtx};
+use crate::sugar::literal::finite_integer_range_sequence;
+use crate::sugar::range_construct::AuthenticatedRangeFields;
+use crate::sugar::source_fragment::SourceFragment;
+use crate::{Desugared, Effect, Outcome, Sugar, SugarCtx};
+
+pub(crate) const OWNER: &str = "range_sequence_projection";
+
+/// Build the consumer-specific sequence projection without adding a second
+/// generic Composite claim for the same Range syntax. The accounted wrapper
+/// keeps the exact owner visible in factory testimony.
+pub(crate) fn build(expr: &Expr, fcx: &SugarBuildCtx) -> Option<Box<dyn Sugar>> {
+    let frag = SourceFragment::expr(expr, "<range-sequence-projection>");
+    let range = AuthenticatedRangeFields::recognize(&frag, fcx)?;
+    if range.inclusive() != Some(false) {
+        return None;
+    }
+    let seed = FactoryAuditSeed::expr(expr, SugarRole::Composite, Some(OWNER), Vec::new());
+    Some(AccountedSugar::new(
+        seed,
+        Box::new(RangeSequenceProjection { range }),
+    ))
+}
+
+struct RangeSequenceProjection {
+    range: AuthenticatedRangeFields,
+}
+
+impl Sugar for RangeSequenceProjection {
+    fn desugar(&self, ctx: &SugarCtx) -> Outcome {
+        let inclusive = self
+            .range
+            .inclusive()
+            .expect("range sequence projection admitted a non-finite range kind");
+        let fields = match self.range.reduce(ctx) {
+            Ok(fields) => fields,
+            Err(effect) => return Outcome::Incomplete(effect),
+        };
+        let start = fields
+            .iter()
+            .find(|(name, _)| name == "start")
+            .map(|(_, term)| term)
+            .unwrap_or_else(|| panic!("range sequence projection lost authenticated start field"));
+        let end = fields
+            .iter()
+            .find(|(name, _)| name == "end")
+            .map(|(_, term)| term)
+            .unwrap_or_else(|| panic!("range sequence projection lost authenticated end field"));
+        match finite_integer_range_sequence(start, end, inclusive) {
+            Ok(sequence) => Outcome::Complete(Desugared::Seq(sequence)),
+            Err(reason) => Outcome::Incomplete(Effect::LiteralDomain {
+                reason: reason.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use syn::{Expr, Item};
+
+    use super::*;
+    use crate::sugar::factory::SugarBuildCtx;
+    use crate::{
+        sugar_ctx_with_factory_audits, FactoryAuditLog, FactoryDisposition, FloatWidthScope,
+        LiftOptions, ReductionCtx, TemporalPlan, TemporalScope,
+    };
+
+    // Refusal twin: the Range shape alone is not authority. Exercise the real
+    // production projection door directly so this tooth stops at the boundary
+    // it owns instead of being preempted by a later callsite gap.
+    #[test]
+    fn runtime_bound_refuses_at_range_sequence_projection() {
+        let range: Expr = syn::parse_str("Range { start, end: 10 }").expect("parse range");
+        let runtime_start: Expr =
+            syn::parse_str("std::env::args().count()").expect("parse runtime bound");
+        let scope = TemporalScope::new("range-sequence-test", TemporalPlan::default());
+        let options = LiftOptions::default();
+        let mut let_inits = BTreeMap::new();
+        let_inits.insert("start".to_string(), &runtime_start);
+        let fcx = SugarBuildCtx::new(&scope, &options, &let_inits);
+        let node = build(&range, &fcx).expect("Range struct must reach projection owner");
+
+        let items = Vec::<Item>::new();
+        let reducer = ReductionCtx::from_items(&items);
+        let mut float_widths = FloatWidthScope::new();
+        let audits = FactoryAuditLog::default();
+        let ctx = sugar_ctx_with_factory_audits(
+            &scope,
+            &options,
+            &reducer,
+            &mut float_widths,
+            0,
+            Some(&audits),
+        );
+
+        assert!(
+            matches!(node.desugar(&ctx), Outcome::Incomplete(_)),
+            "a runtime-selected Range bound must not become a sequence"
+        );
+        let audits = audits.into_inner();
+        assert!(
+            audits.iter().any(|audit| {
+                audit.requested_role == "Composite"
+                    && audit.selected == Some(OWNER)
+                    && audit.disposition == FactoryDisposition::Effect
+                    && audit
+                        .reason
+                        .as_deref()
+                        .is_some_and(|reason| reason.contains("unknown iterator consumption"))
+            }),
+            "the exact projection owner must loudly refuse the unauthenticated bound: {audits:?}"
+        );
+    }
+}

--- a/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
+++ b/implementations/rust/sugar-lift-rust-tests/tests/assertion_lift.rs
@@ -4281,6 +4281,76 @@ fn for_enumerate_tuple_wrong_expected_is_unsat() {
     }
 }
 
+// A written `Range { start, end }` is a finite sequence only through the
+// range-sequence projection. The generic range construction owner emits field
+// constraints, which are not a sequence codomain and must never be reinterpreted
+// as one. This tooth pins both the exact projection owner and the authenticated
+// eight-element output consumed by `EnumerateSugar`.
+#[test]
+fn for_enumerate_range_struct_reaches_authenticated_sequence_projection() {
+    let src = r#"
+        use core::ops::Range;
+
+        #[test]
+        fn test_range() {
+            let r = Range { start: 2, end: 10 };
+            let mut count = 0;
+            for (i, ri) in r.enumerate() {
+                assert_eq!(ri, i + 2);
+                assert!(ri >= 2 && ri < 10);
+                count += 1;
+            }
+            assert_eq!(count, 8);
+        }
+    "#;
+    let out = lift_file(&parse(src), "tests/ops.rs");
+    assert!(
+        out.factory_audits.iter().any(|audit| {
+            audit.requested_role == "Composite"
+                && audit.selected == Some("range_sequence_projection")
+                && audit.site.contains("Range { start : 2 , end : 10 }")
+                && audit.disposition == sugar_lift_rust_tests::FactoryDisposition::Warranted
+                && audit.output == "sequence"
+        }),
+        "the Range struct must reach the exact sequence projection owner: {:?}",
+        out.factory_audits
+    );
+    assert!(
+        out.factory_audits.iter().any(|audit| {
+            audit.selected == Some("enumerate")
+                && audit.site == "enumerate adapter floor over 8 output tick(s)"
+        }),
+        "enumerate must consume the authenticated finite 2..10 projection: {:?}",
+        out.factory_audits
+    );
+    let sat = fast_smt_smoke_check(&inv_json(&out.decls[0]), "test_range");
+    assert!(sat, "ri == i + 2 over Range {{ 2, 10 }} must be SAT");
+}
+
+// Lying twin: a projection that emits an arbitrary eight-element sequence would
+// satisfy the count tooth above. The exact authenticated values are 2..10, so
+// claiming `ri == i + 3` must refute.
+#[test]
+fn for_enumerate_range_struct_wrong_values_are_unsat() {
+    let src = r#"
+        use core::ops::Range;
+
+        #[test]
+        fn t_range_struct_enumerate_bad() {
+            let r = Range { start: 2, end: 10 };
+            for (i, ri) in r.enumerate() {
+                assert_eq!(ri, i + 3);
+            }
+        }
+    "#;
+    let out = lift_file(&parse(src), "coretests/ops/range_struct_enumerate_bad.rs");
+    let sat = fast_smt_smoke_check(&inv_json(&out.decls[0]), "t_range_struct_enumerate_bad");
+    assert!(
+        !sat,
+        "Range {{ 2, 10 }} starts at 2, not 3 -- must be UNSAT"
+    );
+}
+
 // MECHANISM-2 gap (b): `.zip(rhs)` over two inline literal iterators. `ZipSugar` pairs the
 // two finite domains element-wise (`(a_i, b_i)`) and the TUPLE loop pattern `for (&a, &b)`
 // decomposes each pair per step -- exactly like `enumerate`'s `(i, e)`. The body asserts


### PR DESCRIPTION
## What changed

Adds a consumer-specific sequence projection for authenticated exclusive `Range { start, end }` values. The projection reuses the existing authenticated field `SugarBody` values and the finite literal-range sequence owner, so `EnumerateSugar` receives `Desugared::Seq` without reinterpreting the generic `range_construct` constraint codomain.

## Boundary

- Admits only exclusive `Range { start, end }`.
- Claims nothing about `RangeInclusive` or unbounded ranges.
- Runtime-selected bounds refuse at the exact projection owner.
- No `Constraints` value is reinterpreted as `Seq`.
- Raw-AST ratchet remains `R=21`.

## Evidence

- Exact `test_range` body plus lying-value twin: 2/2.
- Runtime-selected-bound refusal at the projection owner: 1/1.
- Factory body contract: 29/29.
- Branch is one commit on current main; six files, no deletions.
- Closing-account digest remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

## Unrelated baseline signal

`char_range_filter_map_eq_lifts_as_stdlib_axiom` remains red because miri target-CFG facts are absent; reproduced 0/1 on untouched `f457ab167f`. This PR does not claim or change that terminal.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Project authenticated Range structs into finite integer sequence floor
> - Introduces a `range_sequence_projection` path in [range_sequence.rs](https://github.com/TSavo/sugar/pull/7320/files#diff-585f7bd5815241cd5f329f6824766ea1aab3ed554fbdd4e7a5cd7bfe38b77def) that recognizes `Range { start, end }` struct literals and produces a concrete `Desugared::Seq` of elements rather than only emitting field-constraint facts.
> - Extracts range enumeration logic into a shared `finite_integer_range_sequence` helper in [literal.rs](https://github.com/TSavo/sugar/pull/7320/files#diff-7ebd8cbb285cb1d4f7b958227476710a7b80717af1adc79a18b79db187c46f06), replacing the previous inline code in `LiteralSugar` and reusing it in the new projection.
> - Refactors [range_construct.rs](https://github.com/TSavo/sugar/pull/7320/files#diff-8885c94c18027928137576511dc554669ab526f0d97b9f3386766f70797d806c) to delegate recognition to a new `AuthenticatedRangeFields` struct, which centralizes support for struct literals and `RangeInclusive::new` calls.
> - Integrates range sequence detection into `build_literal_sequence_composite` in [method_family.rs](https://github.com/TSavo/sugar/pull/7320/files#diff-7405849b981a4cb68404d44407922105f1fe984d35779aafd38756c35c5cf27a) so downstream adaptors like `enumerate` can consume finite range sequences.
> - Behavioral Change: `Range { start, end }` constructs now produce a concrete element sequence (or a `LiteralDomain` effect) instead of only range constraints; runtime-selected bounds are rejected with `RUNTIME_BOUND_REASON`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 013d6fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->