### PR TITLE
Advertise rust-fn-contracts parameter link level

### DIFF
--- a/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
+++ b/implementations/rust/sugar-walk/src/bin/walk_rpc.rs
@@ -6420,6 +6420,12 @@ fn kit_declaration_result() -> Value {
 
 fn enumerate_result(params: &Value) -> Result<Value, String> {
     let level = params.get("level").and_then(Value::as_str).unwrap_or("");
+    if level == "parameter-contract-link-units" {
+        // rust-fn-contracts has no parameter-link obligations; advertise the
+        // level explicitly so consumers receive a measured empty population
+        // rather than a false "level not served" refusal.
+        return Ok(json!({"rows": []}));
+    }
     let root = PathBuf::from(
         params
             .get("workspace_root")


### PR DESCRIPTION
rust-fn-contracts consumers request parameter-contract-link-units. The producer now explicitly serves that level with an authenticated empty rows result, matching build-witness, python-bind, and rust-test-assertions. This is a level-coverage repair, separate from the existing source_files/universe whole-population equality control. No non-empty link units are claimed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise `parameter-contract-link-units` level in `enumerate_result`
> In [walk_rpc.rs](https://github.com/TSavo/sugar/pull/7321/files#diff-b698776f7fa81e5f28e92ae22e885a0c9fc3a1ad1f7c35bc02e0106fc4e2ffa1), `enumerate_result` now returns an empty `{"rows": []}` response immediately when the requested level is `"parameter-contract-link-units"`, advertising this level as supported without populating any rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dde4998.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->