### PR TITLE
Route class initializer stores through constructed receiver

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -601,7 +601,7 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
         sf = _tree.source_file(source_path)
         for fn in sf.functions():
             try:
-                outcome = fn.sugar().desugar(None)
+                outcome = _tree.function_universe_outcome(fn)
             except SugarNotWritten:
                 # Typed tree frontier: no link unit to enroll. Gap remains
                 # visible on the universe/audit scan; never catch

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/function_universe_sugar.py
@@ -661,12 +661,14 @@ class FunctionUniverseSugar(Sugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        # No temporal name map and no ambient effect auth. The body was already
-        # SUBSTITUTED (FunctionDef.sugar): formals stay free Vars; as-bindings
-        # are EffectRef/ObservationRef coordinates. Routing deposits
-        # EffectBinding facts into the same record as other testimony.
-        del ctx
-        return reduce_body(self.statements).and_then(
+        # The body was already SUBSTITUTED (FunctionDef.sugar): ordinary
+        # formals stay free Vars; as-bindings are EffectRef/ObservationRef
+        # coordinates.  A class-owned initializer additionally carries one
+        # ConstructedReceiverRef coordinate, and its enumeration entrance seats
+        # that exact receiver in ``ctx``.  Threading the producer-owned context
+        # here lets the existing block reducer resolve it; callers without such
+        # authority continue to pass ``None`` and retain the ordinary behavior.
+        return reduce_body(self.statements, ctx).and_then(
             lambda record: Complete(
                 UniverseValue(
                     name=self.name,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -294,6 +294,60 @@ def function_def_memento(fn, file_rel: str):
     )
 
 
+def function_universe_outcome(fn):
+    """Construct one function universe through its authenticated entrance.
+
+    Ordinary functions reduce with symbolic formals.  The active ``__init__``
+    of a source class is different: its first parameter is the receiver that
+    the class constructor itself creates.  The backend's exact lexical-owner
+    relation selects that existing class door, and this seam seats the same
+    receiver coordinate before reducing the universe.  No spelling or inferred
+    parent walk is used.
+    """
+    sugar = fn.sugar()
+    owner = fn._active_initializer_owner()
+    if owner is None:
+        return sugar.desugar(None)
+
+    from sugar_lift_py_tests.context import ReduceContext
+    from sugar_lift_py_tests.floor import ClassDefinitionValue
+    from sugar_lift_py_tests.outcome import Complete
+    from sugar_source_tree.panic import SugarNotWritten
+
+    if not fn.params:
+        raise SugarNotWritten(
+            owner="function_universe_outcome",
+            blame=fn.fragment,
+            observed="class initializer has no receiver parameter",
+            requested="the active initializer receiver coordinate",
+            fix="preserve the parsed receiver parameter on __init__",
+        )
+    receiver_coordinate = fn._constructed_receiver_coordinate(owner, fn.params[0])
+    definition_outcome = owner.sugar().desugar(None)
+    if not isinstance(definition_outcome, Complete) or not isinstance(
+        definition_outcome.value, ClassDefinitionValue
+    ):
+        raise SugarNotWritten(
+            owner="function_universe_outcome",
+            blame=owner.fragment,
+            observed=type(definition_outcome).__name__,
+            requested="the authenticated source class definition",
+            fix="construct the initializer through its lexical class owner",
+        )
+    receiver = definition_outcome.value.construct_receiver_state_from_block(
+        None, receiver_coordinate.cid
+    )
+    root = ReduceContext.root(owner="function_universe_outcome")
+    context = root.with_temporal(
+        root.temporal.bind_value(
+            receiver_coordinate.cid,
+            receiver,
+            blame=fn.fragment,
+        )
+    )
+    return sugar.desugar(context)
+
+
 def function_contract_rows(fn, file_rel: str):
     """A function's contract DTO rows, produced from its TREE universe.
 
@@ -308,7 +362,7 @@ def function_contract_rows(fn, file_rel: str):
     from sugar_lift_py_tests.outcome import Complete
 
     def_memento = function_def_memento(fn, file_rel)
-    outcome = fn.sugar().desugar(None)
+    outcome = function_universe_outcome(fn)
     if not isinstance(outcome, Complete):
         return def_memento, None  # an effect; not a contract
     return def_memento, outcome.value.payload_rows(def_memento)

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -22,6 +22,7 @@ from sugar_lift_py_tests.sugar.constructed_receiver_ref_sugar import (
 )
 from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
 from sugar_lift_py_tests.sugar.formal_ref_sugar import FormalRefSugar
+from sugar_lift_py_tests.tree_enumerate import function_universe_outcome
 from sugar_source_tree.nodes import (
     ClassDef,
     FunctionDef,
@@ -82,44 +83,24 @@ class _FixedSugar(ConstructedTermSugar):
         return self.value.to_term(owner=owner)
 
 
-def test_free_method_receiver_uses_the_formal_store_entrance() -> None:
-    """A standalone formal carries no constructed receiver authority."""
-    source = (
-        "def mutate(target):\n"
-        "    target.value = 1\n"
-    )
-    tree = SourceFile((source, "formal_receiver.py", blake3_512_of(source.encode())))
-    function = next(
-        node
-        for node in tree.nodes()
-        if isinstance(node, FunctionDef) and node.name == "mutate"
-    )
-
-    universe = function.sugar()
-
-    assert isinstance(universe.statements[0], AttributeStoreEffectSugar)
-    assert isinstance(universe.statements[0].receiver, FormalRefSugar)
-
-
-def test_class_constructor_receiver_reaches_the_authenticated_state_owner() -> None:
-    """The class-owned entrance retains its exact constructed receiver."""
-    source = (
-        "class Box:\n"
-        "    def __init__(self):\n"
-        "        self.value = 1\n"
-    )
-    tree = SourceFile(
-        (source, "constructed_receiver.py", blake3_512_of(source.encode()))
-    )
+def test_class_initializer_reaches_the_authenticated_receiver_store_entrance() -> None:
+    """The active class initializer must not enter as an arbitrary formal."""
+    source = "class Box:\n" "    def __init__(self):\n" "        self.value = 1\n"
+    tree = SourceFile((source, "class_receiver.py", blake3_512_of(source.encode())))
     definition = next(
         node
         for node in tree.nodes()
         if isinstance(node, ClassDef) and node.name == "Box"
     )
+    initializer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "__init__"
+    )
 
+    universe = initializer.sugar()
+    statement = universe.statements[0]
     frame = definition.source_visible_constructor_frame()
-    initializer_body = frame.body.initializer_body
-    statement = initializer_body.statements[0]
 
     assert isinstance(statement, ExprStatementSugar)
     assert isinstance(statement.value, ReceiverFieldStoreStateSugar)
@@ -128,6 +109,38 @@ def test_class_constructor_receiver_reaches_the_authenticated_state_owner() -> N
         statement.value.receiver.binding_coordinate_cid
         == frame.body.receiver_coordinate_cid
     )
+
+
+def test_genuine_formal_receiver_keeps_the_formal_store_entrance() -> None:
+    """A module-level formal carries no constructed receiver authority."""
+    source = "def mutate(target):\n" "    target.value = 1\n"
+    tree = SourceFile((source, "formal_receiver.py", blake3_512_of(source.encode())))
+    function = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "mutate"
+    )
+
+    universe = function.sugar()
+    statement = universe.statements[0]
+
+    assert isinstance(statement, AttributeStoreEffectSugar)
+    assert isinstance(statement.receiver, FormalRefSugar)
+
+
+def test_class_initializer_universe_seats_its_constructed_receiver() -> None:
+    """Enumeration binds the exact class receiver before body reduction."""
+    source = "class Box:\n" "    def __init__(self):\n" "        self.value = 1\n"
+    tree = SourceFile((source, "class_receiver.py", blake3_512_of(source.encode())))
+    initializer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "__init__"
+    )
+
+    outcome = function_universe_outcome(initializer)
+
+    assert isinstance(outcome, Complete)
 
 
 def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -21,6 +21,7 @@ from sugar_lift_py_tests.sugar.constructed_receiver_ref_sugar import (
     ConstructedReceiverRefSugar,
 )
 from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+from sugar_lift_py_tests.sugar.formal_ref_sugar import FormalRefSugar
 from sugar_source_tree.nodes import (
     ClassDef,
     FunctionDef,
@@ -82,22 +83,22 @@ class _FixedSugar(ConstructedTermSugar):
 
 
 def test_free_method_receiver_uses_the_formal_store_entrance() -> None:
-    """A standalone method universe has no constructed receiver authority."""
+    """A standalone formal carries no constructed receiver authority."""
     source = (
-        "class Box:\n"
-        "    def __init__(self):\n"
-        "        self.value = 1\n"
+        "def mutate(target):\n"
+        "    target.value = 1\n"
     )
     tree = SourceFile((source, "formal_receiver.py", blake3_512_of(source.encode())))
-    initializer = next(
+    function = next(
         node
         for node in tree.nodes()
-        if isinstance(node, FunctionDef) and node.name == "__init__"
+        if isinstance(node, FunctionDef) and node.name == "mutate"
     )
 
-    universe = initializer.sugar()
+    universe = function.sugar()
 
     assert isinstance(universe.statements[0], AttributeStoreEffectSugar)
+    assert isinstance(universe.statements[0].receiver, FormalRefSugar)
 
 
 def test_class_constructor_receiver_reaches_the_authenticated_state_owner() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py
@@ -16,7 +16,17 @@ from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar, Sugar
 from sugar_lift_py_tests.sugar.receiver_field_store_state_sugar import (
     ReceiverFieldStoreStateSugar,
 )
-from sugar_source_tree.nodes import FunctionDef, ReceiverFieldStoreState, Return
+from sugar_lift_py_tests.sugar.store_effect_sugar import AttributeStoreEffectSugar
+from sugar_lift_py_tests.sugar.constructed_receiver_ref_sugar import (
+    ConstructedReceiverRefSugar,
+)
+from sugar_lift_py_tests.sugar.expr_statement_sugar import ExprStatementSugar
+from sugar_source_tree.nodes import (
+    ClassDef,
+    FunctionDef,
+    ReceiverFieldStoreState,
+    Return,
+)
 from sugar_source_tree.tree import SourceFile
 
 
@@ -69,6 +79,54 @@ class _FixedSugar(ConstructedTermSugar):
 
     def to_term(self, *, owner: str):
         return self.value.to_term(owner=owner)
+
+
+def test_free_method_receiver_uses_the_formal_store_entrance() -> None:
+    """A standalone method universe has no constructed receiver authority."""
+    source = (
+        "class Box:\n"
+        "    def __init__(self):\n"
+        "        self.value = 1\n"
+    )
+    tree = SourceFile((source, "formal_receiver.py", blake3_512_of(source.encode())))
+    initializer = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == "__init__"
+    )
+
+    universe = initializer.sugar()
+
+    assert isinstance(universe.statements[0], AttributeStoreEffectSugar)
+
+
+def test_class_constructor_receiver_reaches_the_authenticated_state_owner() -> None:
+    """The class-owned entrance retains its exact constructed receiver."""
+    source = (
+        "class Box:\n"
+        "    def __init__(self):\n"
+        "        self.value = 1\n"
+    )
+    tree = SourceFile(
+        (source, "constructed_receiver.py", blake3_512_of(source.encode()))
+    )
+    definition = next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, ClassDef) and node.name == "Box"
+    )
+
+    frame = definition.source_visible_constructor_frame()
+    initializer_body = frame.body.initializer_body
+    statement = initializer_body.statements[0]
+
+    assert isinstance(statement, ExprStatementSugar)
+    assert isinstance(statement.value, ReceiverFieldStoreStateSugar)
+    assert isinstance(statement.value.receiver, ConstructedReceiverRefSugar)
+    assert (
+        statement.value.receiver.binding_coordinate_cid
+        == frame.body.receiver_coordinate_cid
+    )
 
 
 def test_receiver_field_store_rebinds_the_same_receiver_for_the_tail():

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -507,6 +507,7 @@ class _ConstructedModuleV1(_SealedBackendRelation):
     root: object
     closed_roll_call: object
     function_nodes: tuple[object, ...]
+    function_class_owners: tuple[tuple[object, object | None], ...]
     lexical_call_rows: tuple[object, ...]
     provider_member_rows: tuple[object, ...]
     leaf_assertion_rows: tuple[object, ...]
@@ -693,6 +694,7 @@ class Backend:
             Assign,
             AsyncFunctionDef,
             Call,
+            ClassDef,
             Constant,
             Delete,
             FunctionDef,
@@ -739,6 +741,21 @@ class Backend:
         positions = {
             id(node): position for position, node in enumerate(constructed_nodes)
         }
+        function_class_owners_list: list[tuple[Node, ClassDef | None]] = []
+        for function in function_nodes:
+            position = positions[id(function)]
+            ancestor_position = parent_positions[position]
+            class_owner = None
+            while ancestor_position is not None:
+                ancestor = constructed_nodes[ancestor_position]
+                if isinstance(ancestor, (FunctionDef, AsyncFunctionDef)):
+                    break
+                if isinstance(ancestor, ClassDef):
+                    class_owner = ancestor
+                    break
+                ancestor_position = parent_positions[ancestor_position]
+            function_class_owners_list.append((function, class_owner))
+        function_class_owners = tuple(function_class_owners_list)
         unit.bind_typed_module(
             root,
             constructed_nodes=constructed_nodes,
@@ -996,6 +1013,7 @@ class Backend:
             root=root,
             closed_roll_call=closed_roll_call,
             function_nodes=function_nodes,
+            function_class_owners=function_class_owners,
             lexical_call_rows=lexical_call_rows,
             provider_member_rows=provider_member_rows,
             leaf_assertion_rows=leaf_assertion_rows,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -5130,6 +5130,16 @@ class Assign(Statement):
         receiver = target.value.substitute(scope)
         if not isinstance(receiver, Node):
             return None
+        # A formal is authority for an arbitrary caller-supplied value, not
+        # testimony that the value is this source class's constructed receiver.
+        # Sending it through ReceiverFieldStoreStateSugar makes reduction ask
+        # a SymbolicValue to behave as an ObjectValue.  The ordinary valued
+        # store ladder below already owns that formal-only case.  Class-owned
+        # ``self`` reaches this door as ConstructedReceiverRef, and subsequent
+        # stores carry ReceiverFieldStoreState, so both authenticated state
+        # paths remain here.
+        if isinstance(receiver, (FormalRef, BindingCoordinateRef)):
+            return None
         from .backend import Child, Leaf, materialize
         from .shadow import ShadowNode, _handle_of
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -518,6 +518,29 @@ class SourceUnit:
             if row.call_occurrence_identity is call.ref
         )
 
+    def lexical_class_owner_for(self, function: "Node") -> "ClassDef | None":
+        """Project the exact class owner from the backend's one structural walk.
+
+        The backend already records parent positions while materializing the
+        typed module.  Re-walking class bodies here would create a second answer
+        to the same ownership question, so consumers use that producer-owned
+        relation directly.
+        """
+        matches = tuple(
+            owner
+            for candidate, owner in self.constructed_module.function_class_owners
+            if candidate is function
+        )
+        if len(matches) != 1:
+            raise BackendDefect(
+                blame=function.fragment,
+                owner="SourceUnit.lexical_class_owner_for",
+                observed=f"{len(matches)} backend owner rows",
+                requested="one owner row for this exact function occurrence",
+                fix="preserve the backend parent relation through module construction",
+            )
+        return matches[0]
+
     def retain_lexical_call_row(self, source: "Call", rewritten: "Call") -> None:
         rows = self.lexical_call_rows_for(source)
         if not rows or type(source) is not type(rewritten):
@@ -3820,7 +3843,12 @@ class FunctionDef(Statement):
         return rewrite(self, **changed)
 
     def _make_parameter_entry(self, parameter: Param, ordinal: int, scope):
-        ref = self._make_parameter_ref(parameter, ordinal)
+        owner = self._active_initializer_owner()
+        if owner is not None and ordinal == 0:
+            coordinate = self._constructed_receiver_coordinate(owner, parameter)
+            ref = owner._make_constructed_receiver_ref(coordinate.cid)
+        else:
+            ref = self._make_parameter_ref(parameter, ordinal)
         factory = scope.get(_BINDING_ENTRY_FACTORY)
         if not isinstance(factory, RuntimeBindingEntryFactoryV1):
             return ref
@@ -3828,6 +3856,39 @@ class FunctionDef(Statement):
             binding_site=parameter.fragment,
             projection_path=("formal", ordinal),
             state=ref,
+        )
+
+    def _active_initializer_owner(self) -> "ClassDef | None":
+        """The exact class whose active ``__init__`` this occurrence is.
+
+        Class ownership is projected from the backend's parent relation.  The
+        last same-name initializer is Python's live class binding; overwritten
+        definitions and genuinely free functions keep the ordinary formal
+        entrance.
+        """
+        if self.name != "__init__":
+            return None
+        owner = self.unit.lexical_class_owner_for(self)
+        if owner is None:
+            return None
+        active = next(
+            (
+                item
+                for item in reversed(owner.body)
+                if isinstance(item, FunctionDef) and item.name == "__init__"
+            ),
+            None,
+        )
+        return owner if active is self else None
+
+    def _constructed_receiver_coordinate(self, owner: "ClassDef", parameter: Param):
+        """Mint the same receiver coordinate as the class-construction door."""
+        from sugar_source_tree.binding_provenance import BindingCoordinateV1
+
+        return BindingCoordinateV1.mint(
+            owner.fragment.seal().cid,
+            parameter.fragment,
+            ("receiver", 0),
         )
 
     def _formal_coordinate(self, parameter: Param, ordinal: int):
@@ -4084,6 +4145,12 @@ class AsyncFunctionDef(Statement):
 
     def _make_parameter_entry(self, parameter: Param, ordinal: int, scope):
         return FunctionDef._make_parameter_entry(self, parameter, ordinal, scope)
+
+    def _active_initializer_owner(self) -> "ClassDef | None":
+        return FunctionDef._active_initializer_owner(self)
+
+    def _constructed_receiver_coordinate(self, owner: "ClassDef", parameter: Param):
+        return FunctionDef._constructed_receiver_coordinate(self, owner, parameter)
 
     def _formal_coordinate(self, parameter: Param, ordinal: int):
         return FunctionDef._formal_coordinate(self, parameter, ordinal)
@@ -5130,14 +5197,11 @@ class Assign(Statement):
         receiver = target.value.substitute(scope)
         if not isinstance(receiver, Node):
             return None
-        # A formal is authority for an arbitrary caller-supplied value, not
-        # testimony that the value is this source class's constructed receiver.
-        # Sending it through ReceiverFieldStoreStateSugar makes reduction ask
-        # a SymbolicValue to behave as an ObjectValue.  The ordinary valued
-        # store ladder below already owns that formal-only case.  Class-owned
-        # ``self`` reaches this door as ConstructedReceiverRef, and subsequent
-        # stores carry ReceiverFieldStoreState, so both authenticated state
-        # paths remain here.
+        # An ordinary formal is not a constructed receiver.  Active class
+        # initializers have already projected their first parameter through the
+        # backend-authenticated class-owner relation, so they reach this point
+        # as ConstructedReceiverRef instead.  Only the genuinely formal arm
+        # falls through to AttributeStoreEffectSugar below.
         if isinstance(receiver, (FormalRef, BindingCoordinateRef)):
             return None
         from .backend import Child, Leaf, materialize


### PR DESCRIPTION
## What changed

- project each function's exact lexical class owner from the backend's existing parent-position walk
- route the active class `__init__` receiver through the class-owned `ConstructedReceiverRefSugar` entrance and its exact constructor coordinate
- seat that producer-owned receiver coordinate at function-universe enumeration
- preserve the ordinary `FormalRefSugar` / `AttributeStoreEffectSugar` entrance for genuine formal-only receivers

## Why

The NumPy attribute-safety showcase reached `ReceiverFieldStoreStateSugar` with a `FormalRefSugar` receiver even though the source class constructor had already authenticated the receiver. The first `self.values` store was the wrong entrance; the second store only failed downstream because the first did not construct an `ObjectValue`.

This change reuses the existing class-construction door. It does not add spelling dispatch or a second parent walk.

## Red / green evidence

- Red on the pre-fix tree: `test_receiver_field_store_binding.py` reported `1 failed, 9 passed`; the active initializer store contained `AttributeStoreEffectSugar(receiver=FormalRefSugar)` while the class-owned twin reached the constructed receiver.
- Green on `ed0c9814e9a7108eb4b4058d256a6c673dfbc800`:

  ```text
  bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_receiver_field_store_binding.py implementations/python/sugar-source-tree/tests/test_canonical_constructed_module_event.py implementations/python/sugar-source-tree/tests/test_l1a_functiondef_body_construction.py -q
  21 passed in 1.04s
  ```

- Authenticated environment: CPython 3.12.13, pandas 3.0.3, NumPy 2.5.1.

## First-terminal chain

- input: `examples/numpy-attribute-safety-showcase/good/src/numpy_box.py`
- before: first `self.values` store entered `ReceiverFieldStoreStateSugar` with `FormalRefSugar`
- after: mint succeeds, so that panic and the secondary `perform_operation` terminal do not recur before mint
- next semantic gap: prove emits one discharged witness row but zero attribute-safety/classShapes rows

The showcase command exits 1 in its own JSON parser because current `sugar prove --json` appends an `EXIT_LINK_FAIL` line after the valid JSON object. This PR does **not** claim the showcase is cleared or that attribute-safety testimony now exists.

## Instrument retirement

The discrimination teeth remain because they protect the entrance boundary: active class initializers must use the constructor-authenticated receiver, while genuine formal-only stores must retain the formal effect route. They could retire only when that distinction becomes unrepresentable in the source-tree types.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route class initializer `__init__` stores through a constructed receiver reference
> - In `FunctionDef._make_parameter_entry`, the first parameter of an active class initializer (`__init__`) is now minted as a `ConstructedReceiverRef` using a `BindingCoordinateV1` derived from the class, rather than as an ordinary formal parameter.
> - `Assign._receiver_field_store_state` is updated so that attribute assignments to genuine formals (or `BindingCoordinateRef`) no longer emit `ReceiverFieldStoreState`; only the constructed receiver still does.
> - A new `function_universe_outcome` helper in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/7322/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) desugars initializers with a receiver-bound `ReduceContext`; non-initializers fall back to `desugar(None)`.
> - `Backend.materialize_module` now computes a `function_class_owners` map (lexical class owner per function), exposed via `SourceUnit.lexical_class_owner_for`.
> - Behavioral Change: attribute stores on `self` inside `__init__` now follow the `ReceiverFieldStoreState` path rather than `AttributeStoreEffectSugar`; stores on other formals take the `AttributeStoreEffectSugar` path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59026a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->