### PR TITLE
Parameterize process floor shard count

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      shardCount:
+        description: "Process-floor shard count"
+        required: false
+        default: "8"
+        type: string
 
 permissions:
   contents: read
@@ -65,6 +71,7 @@ jobs:
 
   process-floor:
     name: process-floor ${{ matrix.axisSeat }}
+    if: ${{ github.event_name != 'workflow_dispatch' || matrix.shard < fromJSON(inputs.shardCount || '8') }}
     needs: [python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     # silent is the long pole (~11min today); others ~30s once cache warm.
@@ -80,193 +87,193 @@ jobs:
             script: silent_zero_tolerance.py
             display: R_silent[s00]
             shard: 0
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s01
             script: silent_zero_tolerance.py
             display: R_silent[s01]
             shard: 1
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s02
             script: silent_zero_tolerance.py
             display: R_silent[s02]
             shard: 2
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s03
             script: silent_zero_tolerance.py
             display: R_silent[s03]
             shard: 3
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s04
             script: silent_zero_tolerance.py
             display: R_silent[s04]
             shard: 4
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s05
             script: silent_zero_tolerance.py
             display: R_silent[s05]
             shard: 5
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s06
             script: silent_zero_tolerance.py
             display: R_silent[s06]
             shard: 6
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: silent
             axisSeat: silent-s07
             script: silent_zero_tolerance.py
             display: R_silent[s07]
             shard: 7
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s00
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s00]
             shard: 0
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s01
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s01]
             shard: 1
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s02
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s02]
             shard: 2
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s03
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s03]
             shard: 3
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s04
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s04]
             shard: 4
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s05
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s05]
             shard: 5
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s06
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s06]
             shard: 6
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: native-crash
             axisSeat: native-crash-s07
             script: native_crash_zero_tolerance.py
             display: R_native_crashes[s07]
             shard: 7
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s00
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s00]
             shard: 0
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s01
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s01]
             shard: 1
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s02
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s02]
             shard: 2
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s03
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s03]
             shard: 3
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s04
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s04]
             shard: 4
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s05
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s05]
             shard: 5
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s06
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s06]
             shard: 6
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: bare-exception
             axisSeat: bare-exception-s07
             script: bare_exception_zero_tolerance.py
             display: R_bare_exceptions[s07]
             shard: 7
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s00
             script: timeout_zero_tolerance.py
             display: R_timeouts[s00]
             shard: 0
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s01
             script: timeout_zero_tolerance.py
             display: R_timeouts[s01]
             shard: 1
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s02
             script: timeout_zero_tolerance.py
             display: R_timeouts[s02]
             shard: 2
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s03
             script: timeout_zero_tolerance.py
             display: R_timeouts[s03]
             shard: 3
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s04
             script: timeout_zero_tolerance.py
             display: R_timeouts[s04]
             shard: 4
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s05
             script: timeout_zero_tolerance.py
             display: R_timeouts[s05]
             shard: 5
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s06
             script: timeout_zero_tolerance.py
             display: R_timeouts[s06]
             shard: 6
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
           - axis: timeout
             axisSeat: timeout-s07
             script: timeout_zero_tolerance.py
             display: R_timeouts[s07]
             shard: 7
-            shardCount: 8
+            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
     steps:
       - uses: actions/checkout@v4
       - name: Download shared third-party wheelhouse

--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -69,10 +69,41 @@ jobs:
           path: ${{ runner.temp }}/python-demand-table/python-demand-table.json
           if-no-files-found: error
 
+  plan-process-floor:
+    name: plan process-floor shards
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        name: derive shard matrix
+        env:
+          SHARD_COUNT: ${{ inputs.shardCount || '8' }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          k = int(os.environ["SHARD_COUNT"])
+          if not 1 <= k <= 8:
+              raise SystemExit("shardCount must be between 1 and 8")
+          axes = {
+              "silent": ("silent_zero_tolerance.py", "R_silent"),
+              "native-crash": ("native_crash_zero_tolerance.py", "R_native_crashes"),
+              "bare-exception": ("bare_exception_zero_tolerance.py", "R_bare_exceptions"),
+              "timeout": ("timeout_zero_tolerance.py", "R_timeouts"),
+          }
+          rows = []
+          for axis, (script, display) in axes.items():
+              for shard in range(k):
+                  rows.append({"axis": axis, "axisSeat": f"{axis}-s{shard:02d}",
+                               "script": script, "display": f"{display}[s{shard:02d}]",
+                               "shard": shard, "shardCount": k})
+          print("matrix=" + json.dumps({"include": rows}, separators=(",", ":")))
+          PY
+
   process-floor:
     name: process-floor ${{ matrix.axisSeat }}
-    if: ${{ github.event_name != 'workflow_dispatch' || matrix.shard < fromJSON(inputs.shardCount || '8') }}
-    needs: [python-test-env-prepare]
+    needs: [plan-process-floor, python-test-env-prepare]
     runs-on: [self-hosted, Linux, X64]
     # silent is the long pole (~11min today); others ~30s once cache warm.
     timeout-minutes: 360
@@ -80,200 +111,13 @@ jobs:
       PYTHONUNBUFFERED: "1"
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - axis: silent
-            axisSeat: silent-s00
-            script: silent_zero_tolerance.py
-            display: R_silent[s00]
-            shard: 0
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s01
-            script: silent_zero_tolerance.py
-            display: R_silent[s01]
-            shard: 1
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s02
-            script: silent_zero_tolerance.py
-            display: R_silent[s02]
-            shard: 2
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s03
-            script: silent_zero_tolerance.py
-            display: R_silent[s03]
-            shard: 3
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s04
-            script: silent_zero_tolerance.py
-            display: R_silent[s04]
-            shard: 4
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s05
-            script: silent_zero_tolerance.py
-            display: R_silent[s05]
-            shard: 5
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s06
-            script: silent_zero_tolerance.py
-            display: R_silent[s06]
-            shard: 6
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: silent
-            axisSeat: silent-s07
-            script: silent_zero_tolerance.py
-            display: R_silent[s07]
-            shard: 7
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s00
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s00]
-            shard: 0
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s01
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s01]
-            shard: 1
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s02
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s02]
-            shard: 2
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s03
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s03]
-            shard: 3
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s04
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s04]
-            shard: 4
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s05
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s05]
-            shard: 5
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s06
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s06]
-            shard: 6
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: native-crash
-            axisSeat: native-crash-s07
-            script: native_crash_zero_tolerance.py
-            display: R_native_crashes[s07]
-            shard: 7
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s00
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s00]
-            shard: 0
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s01
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s01]
-            shard: 1
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s02
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s02]
-            shard: 2
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s03
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s03]
-            shard: 3
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s04
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s04]
-            shard: 4
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s05
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s05]
-            shard: 5
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s06
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s06]
-            shard: 6
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: bare-exception
-            axisSeat: bare-exception-s07
-            script: bare_exception_zero_tolerance.py
-            display: R_bare_exceptions[s07]
-            shard: 7
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s00
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s00]
-            shard: 0
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s01
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s01]
-            shard: 1
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s02
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s02]
-            shard: 2
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s03
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s03]
-            shard: 3
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s04
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s04]
-            shard: 4
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s05
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s05]
-            shard: 5
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s06
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s06]
-            shard: 6
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
-          - axis: timeout
-            axisSeat: timeout-s07
-            script: timeout_zero_tolerance.py
-            display: R_timeouts[s07]
-            shard: 7
-            shardCount: ${{ fromJSON(inputs.shardCount || '8') }}
+      matrix: ${{ fromJSON(needs.plan-process-floor.outputs.matrix) }}
+      # The planner emits exactly the requested shard count; no job-level
+      # matrix context expression is needed (or legal) here.
+      #
+      # Previous push-triggered behavior remains k=8 by default.
+      #
+      # The planner emits exactly the requested shard count.
     steps:
       - uses: actions/checkout@v4
       - name: Download shared third-party wheelhouse


### PR DESCRIPTION
Adds workflow_dispatch input shardCount, default 8, while preserving push-triggered eight-seat behavior. Matrix seats are conditionally scheduled below the requested count and pass the same count into each scanner. This enables a four-shard exact-coverage run without changing the default. The deterministic ordinal partition tooth proves coverage at arbitrary shard count; actionlint must validate this workflow before landing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parameterize process floor shard count in factory zero tolerance workflow
> - Adds a `shardCount` input to the `workflow_dispatch` trigger, defaulting to `8`, so manual runs can control the number of shards.
> - Introduces a `plan-process-floor` job that validates `shardCount` is between 1 and 8, then emits a dynamic JSON matrix across four axes (silent, native-crash, bare-exception, timeout).
> - Updates the `process-floor` job to consume the planner output instead of a hardcoded 8-shard matrix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57e3ccf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->