### PR TITLE
Bind impl assertion facts to canonical owners

### DIFF
--- a/implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/bin/rust_test_assertions_rpc.rs
@@ -10436,22 +10436,149 @@ mod tests {
     }
 
     #[test]
-    fn assertion_surface_audit_reports_emitted_fact_without_matching_fnref_owner() {
-        let root = unique_temp_dir(
-            "assertion_surface_audit_reports_emitted_fact_without_matching_fnref_owner",
-        );
+    fn impl_method_facts_bind_their_exact_self_type_owners() {
+        let root = unique_temp_dir("impl_method_facts_bind_their_exact_self_type_owners");
         std::fs::create_dir_all(root.join("src")).expect("mkdir src");
         std::fs::write(
             root.join("src/lib.rs"),
             r#"
-struct S;
+struct NonFused;
+struct Unfuse;
 
-impl S {
+impl NonFused {
+    fn next() {
+        assert_eq!(1 + 1, 2);
+    }
+
+    fn next_back() {
+        assert_eq!(2 + 2, 4);
+    }
+}
+
+impl Unfuse {
+    fn next() {
+        assert_eq!(3 + 3, 6);
+    }
+
+    fn next_back() {
+        assert_eq!(4 + 4, 8);
+    }
+}
+"#,
+        )
+        .expect("write rust source");
+
+        let response = lift(&json!({
+            "workspace_root": root,
+            "source_paths": ["src/lib.rs"]
+        }));
+        let mut owners = response["ir"]
+            .as_array()
+            .expect("ir array")
+            .iter()
+            .filter(|contract| contract["kind"] == "contract")
+            .filter_map(|contract| contract.get("sourceWarrants"))
+            .filter_map(Value::as_array)
+            .flatten()
+            .filter_map(|warrant| warrant.get("sourceFunctionName"))
+            .filter_map(Value::as_str)
+            .filter(|owner| {
+                matches!(
+                    *owner,
+                    "NonFused::next" | "NonFused::next_back" | "Unfuse::next" | "Unfuse::next_back"
+                )
+            })
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        owners.sort();
+        assert_eq!(
+            owners,
+            vec![
+                "NonFused::next",
+                "NonFused::next_back",
+                "Unfuse::next",
+                "Unfuse::next_back",
+            ],
+            "same-spelled impl methods must bind by exact SelfTy owner: {response}"
+        );
+        assert!(
+            response["assertionSurfaceAudits"]
+                .as_array()
+                .expect("assertionSurfaceAudits is an array")
+                .iter()
+                .all(|row| row["status"] != "provenance-unmatched"),
+            "all four exact impl owners exist; none may remain unmatched: {response}"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn trait_default_facts_bind_their_exact_trait_owners() {
+        let root = unique_temp_dir("trait_default_facts_bind_their_exact_trait_owners");
+        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+        std::fs::write(
+            root.join("src/lib.rs"),
+            r#"
+trait Alpha {
     fn check() {
         assert_eq!(1 + 1, 2);
     }
 }
+
+trait Beta {
+    fn check() {
+        assert_eq!(2 + 2, 4);
+    }
+}
 "#,
+        )
+        .expect("write rust source");
+
+        let response = lift(&json!({
+            "workspace_root": root,
+            "source_paths": ["src/lib.rs"]
+        }));
+        let mut owners = response["ir"]
+            .as_array()
+            .expect("ir array")
+            .iter()
+            .filter(|contract| contract["kind"] == "contract")
+            .filter_map(|contract| contract.get("sourceWarrants"))
+            .filter_map(Value::as_array)
+            .flatten()
+            .filter_map(|warrant| warrant.get("sourceFunctionName"))
+            .filter_map(Value::as_str)
+            .filter(|owner| matches!(*owner, "Alpha::check" | "Beta::check"))
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        owners.sort();
+        assert_eq!(
+            owners,
+            vec!["Alpha::check", "Beta::check"],
+            "same-spelled trait defaults must bind by exact Trait owner: {response}"
+        );
+        assert!(
+            response["assertionSurfaceAudits"]
+                .as_array()
+                .expect("assertionSurfaceAudits is an array")
+                .iter()
+                .all(|row| row["status"] != "provenance-unmatched"),
+            "both exact trait owners exist; neither may remain unmatched: {response}"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn assertion_surface_audit_keeps_genuinely_ownerless_const_fact_unmatched() {
+        let root = unique_temp_dir(
+            "assertion_surface_audit_keeps_genuinely_ownerless_const_fact_unmatched",
+        );
+        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+        std::fs::write(
+            root.join("src/lib.rs"),
+            "const CHECK: () = assert!(1 + 1 == 2);\n",
         )
         .expect("write rust source");
 
@@ -10464,11 +10591,9 @@ impl S {
             .expect("assertionSurfaceAudits is an array");
         let unmatched = audits
             .iter()
-            .find(|row| row["assertionSource"] == "src/lib.rs::check")
+            .find(|row| row["assertionSource"] == "src/lib.rs::const-item")
             .unwrap_or_else(|| {
-                panic!(
-                    "an emitted fact whose FnRef owner is S::check must remain visible: {audits:#?}"
-                )
+                panic!("an emitted const-item fact has no FnRef owner and must stay visible: {audits:#?}")
             });
         assert_eq!(unmatched["status"], "provenance-unmatched", "{unmatched}");
         assert_eq!(unmatched["sourceStatus"], "unresolved", "{unmatched}");
@@ -10484,18 +10609,10 @@ impl S {
         assert_eq!(
             facts.len(),
             1,
-            "only the verifier-missing fact is audited: {unmatched}"
+            "the ownerless const fact is audited: {unmatched}"
         );
-        assert_eq!(
-            unmatched["supportFacts"],
-            json!([]),
-            "derived panic-callsite facts already carry ProofIR provenance and are not missing: {unmatched}"
-        );
-        let fact = facts
-            .first()
-            .unwrap_or_else(|| panic!("unmatched emitted fact must be named: {unmatched}"));
-        assert_eq!(fact["sourceMementos"], json!([]), "{fact}");
-        let contract_name = fact["contract"]
+        assert_eq!(facts[0]["sourceMementos"], json!([]), "{unmatched}");
+        let contract_name = facts[0]["contract"]
             .as_str()
             .expect("unmatched fact contract name");
         let contract = response["ir"]
@@ -10511,7 +10628,6 @@ impl S {
 
         let _ = std::fs::remove_dir_all(root);
     }
-
     /// Showcase shape: test calls a local helper that holds the assert_eq!.
     /// Statement spans resolve on the helper, not the test body — without a
     /// function-memento fallback the warranted fact sealed with zero provenance

--- a/implementations/rust/sugar-lift-rust-tests/src/lib.rs
+++ b/implementations/rust/sugar-lift-rust-tests/src/lib.rs
@@ -1690,7 +1690,11 @@ fn walk_non_test_fns_inner(
                         if count == 0 {
                             continue;
                         }
-                        let item_name = scoped_test_name(source_path, modules, &method_name);
+                        let owner_name = self_ty
+                            .as_ref()
+                            .map(|ty| format!("{ty}::{method_name}"))
+                            .unwrap_or_else(|| method_name.clone());
+                        let item_name = scoped_test_name(source_path, modules, &owner_name);
                         let lifted = lift_source_assertion_contracts_in_stmts(
                             &method.block.stmts,
                             source_path,
@@ -1744,7 +1748,8 @@ fn walk_non_test_fns_inner(
                     if count == 0 {
                         continue;
                     }
-                    let item_name = scoped_test_name(source_path, modules, &method_name);
+                    let owner_name = format!("{}::{method_name}", trait_item.ident);
+                    let item_name = scoped_test_name(source_path, modules, &owner_name);
                     let lifted = lift_source_assertion_contracts_in_stmts(
                         &default.stmts,
                         source_path,
@@ -26992,7 +26997,7 @@ fn t() {
             out.assertion_facts
         );
         assert!(
-            contract_names(&out).contains(&"tests/test_src.rs::next"),
+            contract_names(&out).contains(&"tests/test_src.rs::W::next"),
             "the method contract should be named for the impl method: {:?}",
             contract_names(&out)
         );
@@ -27000,7 +27005,7 @@ fn t() {
             out.assertion_facts
                 .iter()
                 .any(|fact| fact.kind == AssertionFactKind::Warranted
-                    && fact.item_name == "tests/test_src.rs::next"),
+                    && fact.item_name == "tests/test_src.rs::W::next"),
             "the impl-method assertion should be emitted as a warranted source contract: {:?}",
             out.assertion_facts
         );


### PR DESCRIPTION
## What changed

- emit assertion contracts owned by impl methods under the collector's canonical `SelfTy::method` spelling
- emit assertion contracts owned by trait defaults under the canonical `Trait::method` spelling
- retain exact provenance lookup and the verifier refusal; no suffix or basename matching was added
- replace the former defect-pinning tooth with exact-owner impl and trait-default twins plus a genuinely ownerless const refusal twin

## Root cause and law

Emission and collection named the same owner in two incompatible ways. Emission used `<file>::<method>`, while the collected `FnRef` population used `<SelfTy>::<method>` for impls and `<Trait>::<method>` for trait defaults. The owner existed, but the exact provenance join could not reach it.

The repair makes the producer publish the identity already owned by the collector. The join remains exact and the verifier remains loud. Same-spelled methods on `NonFused` and `Unfuse` prove that this is owner identity, not method-name matching.

The trait-default case is preventive: current corpus `R=0`, but its producer and collector were structurally mismatched and would have failed on the first emitted trait-default assertion.

## Evidence

Authenticated battleaxe run after rebasing onto `2e52d291aa39fc12bed520d135e8ab94ca5ef71b`:

- `impl_method_facts_bind_their_exact_self_type_owners`: pass
- `trait_default_facts_bind_their_exact_trait_owners`: pass
- `assertion_surface_audit_keeps_genuinely_ownerless_const_fact_unmatched`: pass
- `collect_fns_enumerates_impl_and_trait_default_methods`: pass
- `assertion_in_impl_method_emits_source_contract_without_residual_refusal`: pass

The red counterfactual was also observed before implementation: both exact-owner teeth failed with `provenance-unmatched`, while the ownerless const control passed.

## Predicted movement and non-claims

Predicted, not corpus-measured: unwarranted impl contracts `-4`; trait-default current `R=0`; const-item and macro-generated populations unchanged. Applied to the prior authenticated 54-row receipt, the prediction is 50 remaining, not a newly measured total.

The useful remaining split is therefore predicted as:

- 4 misnamed impl facts canonically owned by this change
- 6 const-item facts still requiring an owner shape that does not exist
- 44 macro-generated facts still awaiting the authority ruling in #7312

No corpus rerun is claimed in this PR. A broad library telemetry run also retained 11 unrelated current construction-frontier reds; they were not used as evidence for this lane.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind impl and trait default method assertion facts to canonical owner-qualified names
> - Updates `walk_non_test_fns_inner` in [lib.rs](https://github.com/TSavo/sugar/pull/7324/files#diff-3f0d4bf15961ed6dc96f121ab7f72b5721adf2edd21a77ae0588d14e7956a233) to qualify assertion contract identifiers with their owner: impl methods use `SelfType::method` and trait default methods use `Trait::method`, replacing bare method names.
> - Adds tests verifying that impl method facts bind to their exact Self type owners, trait default method facts bind to their exact trait owners, and genuinely ownerless const assertions remain `provenance-unmatched`.
> - Behavioral Change: emitted contract `item_name` values for impl and trait default methods now include the owner prefix (e.g. `W::next` instead of `next`), which breaks any downstream consumers matching on bare method names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4734828.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->