### PR TITLE
Own detached battleaxe jobs in user systemd

### DIFF
--- a/bin/brun
+++ b/bin/brun
@@ -15,6 +15,12 @@ Options:
                        the remote command's environment (repeatable).
   --sync-back R:L      After success, rsync remote path R back to local path L
                        (both absolute; repeatable).
+  --detach JOB_ID      Submit the complete managed Docker run to battleaxe user
+                       systemd. Host-owned log/status live under
+                       BCARGO_REMOTE_ROOT/.sugar-bx-jobs/JOB_ID. Detached runs
+                       reject --sync-back; write receipts under SUGAR_BX_JOB_DIR
+                       and collect them after completion with:
+                         bin/sugarbin job collect --host bx --id JOB_ID --output DIR
 
 Environment (shared with bcargo so roots, caps and test harnesses apply):
   BCARGO_REMOTE_HOST   SSH host alias (default: battleaxe)

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -712,10 +712,8 @@ sugar_bx_start_detached_host_command() {
   exit_code="$job_dir/exit-code"
   launch="$job_dir/launch"
 
-  set +e
-  sugar_bx_ssh "umask 022; mkdir -p $(sugar_bx_quote "$(dirname "$job_dir")"); if ! mkdir $(sugar_bx_quote "$job_dir") 2>/dev/null; then printf 'sugarbin: crime=duplicate-detached-job-id jobId=%s path=%s replacement=choose a new job id or query/collect the existing job\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$job_dir") >&2; exit 70; fi; chmod 0755 $(sugar_bx_quote "$job_dir"); : > $(sugar_bx_quote "$output"); chmod 0644 $(sugar_bx_quote "$output"); printf 'schema=sugar-bx-detached-job/v1\\njobId=%s\\nunit=%s\\nroot=%s\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$unit") $(sugar_bx_quote "$SUGAR_BX_ROOT") > $(sugar_bx_quote "$launch"); chmod 0644 $(sugar_bx_quote "$launch")"
-  setup_status=$?
-  set -e
+  sugar_bx_ssh "umask 022; mkdir -p $(sugar_bx_quote "$(dirname "$job_dir")"); if ! mkdir $(sugar_bx_quote "$job_dir") 2>/dev/null; then printf 'sugarbin: crime=duplicate-detached-job-id jobId=%s path=%s replacement=choose a new job id or query/collect the existing job\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$job_dir") >&2; exit 70; fi; chmod 0755 $(sugar_bx_quote "$job_dir"); : > $(sugar_bx_quote "$output"); chmod 0644 $(sugar_bx_quote "$output"); printf 'schema=sugar-bx-detached-job/v1\\njobId=%s\\nunit=%s\\nroot=%s\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$unit") $(sugar_bx_quote "$SUGAR_BX_ROOT") > $(sugar_bx_quote "$launch"); chmod 0644 $(sugar_bx_quote "$launch")" \
+    || setup_status=$?
   [[ "$setup_status" == 0 ]] || return "$setup_status"
 
   local runner_body

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -650,6 +650,130 @@ SCRIPT
   printf '\n'
 }
 
+# Detached Docker jobs have a different lifetime owner from foreground brun:
+# the battleaxe user systemd manager owns the complete `docker run --rm`
+# process, while the invoking SSH session only submits it. Durable testimony
+# lives below the remote root, never in the container PID or /tmp namespaces.
+sugar_bx_validate_detached_job_id() {
+  local job_id="$1"
+  if [[ ! "$job_id" =~ ^[a-z0-9][a-z0-9_-]{0,63}$ ]]; then
+    printf 'sugarbin: crime=invalid-detached-job-id jobId=%s replacement=use 1-64 lowercase letters, digits, underscore, or hyphen, beginning with a letter or digit\n' \
+      "$job_id" >&2
+    return 70
+  fi
+}
+
+sugar_bx_detached_job_dir() {
+  printf '%s/.sugar-bx-jobs/%s\n' "$SUGAR_BX_ROOT" "$1"
+}
+
+sugar_bx_detached_unit_name() {
+  local job_id="$1" identity
+  identity="$(printf '%s' "$SUGAR_BX_ROOT:$job_id" | shasum -a 256 | cut -c1-20)"
+  printf 'sugar-bx-%s-%s.service\n' "$job_id" "$identity"
+}
+
+sugar_bx_require_detached_supervisor() {
+  if ! sugar_bx_ssh \
+    'command -v systemd-run >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1'; then
+    printf 'sugarbin: crime=detached-supervisor-unavailable host=%s owner=bin/lib/sugar-bx.sh replacement=enable the battleaxe user systemd manager; never fall back to container-local nohup\n' \
+      "$SUGAR_BX_HOST" >&2
+    return 70
+  fi
+  local linger
+  linger="$(sugar_bx_ssh 'loginctl show-user "$USER" -p Linger --value' 2>/dev/null || true)"
+  linger="$(printf '%s' "$linger" | tr -d '\r[:space:]')"
+  if [[ "$linger" != yes ]]; then
+    printf 'sugarbin: crime=detached-linger-disabled host=%s observed=%s owner=bin/lib/sugar-bx.sh replacement=enable Linger=yes for the battleaxe execution user before submitting detached jobs\n' \
+      "$SUGAR_BX_HOST" "${linger:-unknown}" >&2
+    return 70
+  fi
+}
+
+sugar_bx_validate_detached_request() {
+  local job_id="$1"
+  sugar_bx_validate_detached_job_id "$job_id" || return $?
+  if [[ "${SUGAR_BX_CLEAN:-never}" != never ]]; then
+    printf 'sugarbin: crime=detached-cleanup-policy-conflict jobId=%s policy=%s owner=bin/lib/sugar-bx.sh replacement=use BCARGO_CLEAN_REMOTE_ROOT=never; collect evidence before an explicit later cleanup\n' \
+      "$job_id" "$SUGAR_BX_CLEAN" >&2
+    return 70
+  fi
+  sugar_bx_require_detached_supervisor
+}
+
+sugar_bx_start_detached_host_command() {
+  local job_id="$1" host_command="$2"
+  sugar_bx_validate_detached_request "$job_id" || return $?
+  local job_dir unit runner output exit_code launch setup_status=0
+  job_dir="$(sugar_bx_detached_job_dir "$job_id")"
+  unit="$(sugar_bx_detached_unit_name "$job_id")"
+  runner="$job_dir/run.sh"
+  output="$job_dir/output.log"
+  exit_code="$job_dir/exit-code"
+  launch="$job_dir/launch"
+
+  set +e
+  sugar_bx_ssh "umask 022; mkdir -p $(sugar_bx_quote "$(dirname "$job_dir")"); if ! mkdir $(sugar_bx_quote "$job_dir") 2>/dev/null; then printf 'sugarbin: crime=duplicate-detached-job-id jobId=%s path=%s replacement=choose a new job id or query/collect the existing job\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$job_dir") >&2; exit 70; fi; chmod 0755 $(sugar_bx_quote "$job_dir"); : > $(sugar_bx_quote "$output"); chmod 0644 $(sugar_bx_quote "$output"); printf 'schema=sugar-bx-detached-job/v1\\njobId=%s\\nunit=%s\\nroot=%s\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$unit") $(sugar_bx_quote "$SUGAR_BX_ROOT") > $(sugar_bx_quote "$launch"); chmod 0644 $(sugar_bx_quote "$launch")"
+  setup_status=$?
+  set -e
+  [[ "$setup_status" == 0 ]] || return "$setup_status"
+
+  local runner_body
+  runner_body="#!/usr/bin/env bash
+set +e
+umask 022
+bash -lc $(sugar_bx_quote "$host_command") >>$(sugar_bx_quote "$output") 2>&1
+status=\$?
+tmp=$(sugar_bx_quote "$job_dir/.exit-code.")\$\$
+printf '%s\\n' \"\$status\" >\"\$tmp\"
+chmod 0644 \"\$tmp\"
+mv -f \"\$tmp\" $(sugar_bx_quote "$exit_code")
+exit \"\$status\""
+  if ! printf '%s\n' "$runner_body" | \
+    sugar_bx_ssh "cat > $(sugar_bx_quote "$runner") && chmod 0755 $(sugar_bx_quote "$runner")"; then
+    printf 'sugarbin: crime=detached-runner-publication-failed jobId=%s path=%s owner=bin/lib/sugar-bx.sh\n' \
+      "$job_id" "$runner" >&2
+    return 70
+  fi
+
+  if ! sugar_bx_ssh \
+    "systemd-run --user --collect --quiet --unit=$(sugar_bx_quote "$unit") --property=Type=exec -- bash $(sugar_bx_quote "$runner")"; then
+    printf 'sugarbin: crime=detached-supervisor-submit-failed jobId=%s unit=%s owner=bin/lib/sugar-bx.sh replacement=inspect the user-systemd journal and retain the host job directory\n' \
+      "$job_id" "$unit" >&2
+    return 70
+  fi
+  if ! sugar_bx_ssh \
+    "test -r $(sugar_bx_quote "$exit_code") || systemctl --user is-active $(sugar_bx_quote "$unit") >/dev/null 2>&1"; then
+    printf 'sugarbin: crime=detached-job-testimony-missing jobId=%s unit=%s path=%s owner=bin/lib/sugar-bx.sh replacement=inspect the retained runner and user-systemd journal; do not claim launch success\n' \
+      "$job_id" "$unit" "$job_dir" >&2
+    return 70
+  fi
+  printf 'jobId=%s state=accepted unit=%s root=%s log=%s\n' \
+    "$job_id" "$unit" "$job_dir" "$output"
+}
+
+sugar_bx_detached_job_status() {
+  local job_id="$1" job_dir unit output exit_code launch
+  sugar_bx_validate_detached_job_id "$job_id" || return $?
+  job_dir="$(sugar_bx_detached_job_dir "$job_id")"
+  unit="$(sugar_bx_detached_unit_name "$job_id")"
+  output="$job_dir/output.log"
+  exit_code="$job_dir/exit-code"
+  launch="$job_dir/launch"
+  sugar_bx_ssh "if ! test -r $(sugar_bx_quote "$launch") || ! test -r $(sugar_bx_quote "$output"); then printf 'sugarbin: crime=unknown-detached-job-id jobId=%s path=%s replacement=use the exact BCARGO_REMOTE_ROOT and job id returned by launch\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$job_dir") >&2; exit 70; fi; if test -r $(sugar_bx_quote "$exit_code"); then status=\$(tr -d '[:space:]' < $(sugar_bx_quote "$exit_code")); case \"\$status\" in ''|*[!0-9]*) printf 'sugarbin: crime=detached-exit-testimony-malformed jobId=%s path=%s observed=%s\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$exit_code") \"\$status\" >&2; exit 70;; esac; printf 'jobId=%s state=completed exitCode=%s unit=%s root=%s log=%s\\n' $(sugar_bx_quote "$job_id") \"\$status\" $(sugar_bx_quote "$unit") $(sugar_bx_quote "$job_dir") $(sugar_bx_quote "$output"); elif systemctl --user is-active $(sugar_bx_quote "$unit") >/dev/null 2>&1; then printf 'jobId=%s state=running unit=%s root=%s log=%s\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$unit") $(sugar_bx_quote "$job_dir") $(sugar_bx_quote "$output"); else printf 'sugarbin: crime=detached-job-testimony-missing jobId=%s unit=%s path=%s replacement=inspect the retained runner and user-systemd journal; no result is measured\\n' $(sugar_bx_quote "$job_id") $(sugar_bx_quote "$unit") $(sugar_bx_quote "$job_dir") >&2; exit 70; fi"
+}
+
+sugar_bx_collect_detached_job() {
+  local job_id="$1" local_path="$2" status
+  status="$(sugar_bx_detached_job_status "$job_id")" || return $?
+  if [[ "$status" != *"state=completed"* ]]; then
+    printf 'sugarbin: crime=detached-job-still-running jobId=%s owner=bin/lib/sugar-bx.sh replacement=wait for a completed status before collecting final testimony\n' \
+      "$job_id" >&2
+    return 70
+  fi
+  sugar_bx_sync_back "$(sugar_bx_detached_job_dir "$job_id")/" "$local_path/"
+}
+
 sugar_bx_build_artifacts_docker() {
   local image="$1" needs="$2" profile="$3" provision_artifacts="${4:-0}"
   local artifact_format="${5:-uniform}"
@@ -726,7 +850,7 @@ sugar_bx_run_docker() {
   shift 4
   local remote_cwd="/workspace/sugar"
   [[ -n "$SUGAR_BX_REL_CWD" ]] && remote_cwd="$remote_cwd/$SUGAR_BX_REL_CWD"
-  local workspace_source artifacts_source manifest_source shelf_source
+  local workspace_source artifacts_source manifest_source shelf_source job_source job_dir
   workspace_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_REPO")" || return $?
   sugar_bx_ssh "mkdir -p $(sugar_bx_quote "$SUGAR_BX_BINARY_SHELF")" || return $?
   shelf_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_BINARY_SHELF")" || return $?
@@ -736,6 +860,12 @@ sugar_bx_run_docker() {
     --env "SUGAR_BX_MOUNT_PROOF=$SUGAR_BX_MOUNT_PROOF"
     --mount "type=bind,src=$workspace_source,dst=/workspace/sugar"
     --mount "type=bind,src=$shelf_source,dst=/root/.cache/sugar/binary-shelf-v2,readonly")
+  if [[ -n "${SUGAR_BX_DETACH_JOB_ID:-}" ]]; then
+    job_dir="$(sugar_bx_detached_job_dir "$SUGAR_BX_DETACH_JOB_ID")"
+    job_source="$(sugar_bx_docker_bind_source "$job_dir")" || return $?
+    docker_args+=(--mount "type=bind,src=$job_source,dst=/run/sugar-bx-job")
+    docker_args+=(--env SUGAR_BX_JOB_DIR=/run/sugar-bx-job)
+  fi
   [[ "$network" != none ]] || docker_args+=(--network none)
   if [[ "$has_artifacts" == 1 ]]; then
     artifacts_source="$(sugar_bx_docker_bind_source "$SUGAR_BX_ROOT/artifacts")" || return $?
@@ -778,7 +908,11 @@ sugar_bx_run_docker() {
   fi
   docker_args+=("$@")
   for arg in "${docker_args[@]}"; do command+=" $(sugar_bx_quote "$arg")"; done
-  sugar_bx_ssh "exec${command}"
+  if [[ -n "${SUGAR_BX_DETACH_JOB_ID:-}" ]]; then
+    sugar_bx_start_detached_host_command "$SUGAR_BX_DETACH_JOB_ID" "exec${command}"
+  else
+    sugar_bx_ssh "exec${command}"
+  fi
 }
 
 sugar_bx_is_foreign() { [[ "$(uname -s 2>/dev/null)" != Linux ]] && [[ "$(file -b "$1" 2>/dev/null || true)" == *ELF* ]]; }

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -26,6 +26,7 @@ dispatch_execution_subcommand() {
   local profile="release"
   local needs=""
   local task=""
+  local detach_job_id=""
   local saw_boundary=0
   local -a command=()
   local -a path_prefixes=() env_names=() sync_backs=()
@@ -86,6 +87,12 @@ dispatch_execution_subcommand() {
         [[ "$subcommand" == run || "$subcommand" == explain ]] || { echo "sugarbin: --task is only valid for run and explain" >&2; return 2; }
         [[ $# -ge 2 ]] || { echo "sugarbin: --task requires a value" >&2; return 2; }
         task="$2"
+        shift 2
+        ;;
+      --detach)
+        [[ "$subcommand" == run ]] || { echo "sugarbin: --detach is only valid for run" >&2; return 2; }
+        [[ $# -ge 2 ]] || { echo "sugarbin: --detach requires a job id" >&2; return 2; }
+        detach_job_id="$2"
         shift 2
         ;;
       --)
@@ -280,6 +287,7 @@ dispatch_execution_subcommand() {
   SUGAR_BX_ENV_NAMES=()
   SUGAR_BX_SYNC_BACKS=()
   SUGAR_BX_MANAGED_PRECONDITION_PLAN="$task_preconditions_json"
+  SUGAR_BX_DETACH_JOB_ID="$detach_job_id"
   ((${#path_prefixes[@]} == 0)) || SUGAR_BX_PATH_PREFIXES=("${path_prefixes[@]}")
   ((${#env_names[@]} == 0)) || SUGAR_BX_ENV_NAMES=("${env_names[@]}")
   ((${#sync_backs[@]} == 0)) || SUGAR_BX_SYNC_BACKS=("${sync_backs[@]}")
@@ -289,6 +297,19 @@ dispatch_execution_subcommand() {
   [[ -n "$repo_root" ]] || { echo "sugarbin: must be run from inside a git checkout" >&2; return 2; }
   local_cwd="$(pwd -P)"
   sugar_bx_init "$repo_root" "$local_cwd" || return $?
+  if [[ -n "$detach_job_id" ]]; then
+    if [[ "$route_env" != docker ]]; then
+      printf 'sugarbin: crime=unsupported-detached-execution-route host=%s env=%s jobId=%s replacement=detached jobs currently require a managed Docker environment\n' \
+        "$host" "$execution_env" "$detach_job_id" >&2
+      return 70
+    fi
+    if ((${#SUGAR_BX_SYNC_BACKS[@]} != 0)); then
+      printf 'sugarbin: crime=detached-sync-back-requires-collect jobId=%s owner=bin/sugarbin replacement=write subject receipts under SUGAR_BX_JOB_DIR and use sugarbin job collect after completion\n' \
+        "$detach_job_id" >&2
+      return 70
+    fi
+    sugar_bx_validate_detached_request "$detach_job_id" || return $?
+  fi
   [[ "$route_env" != docker ]] || sugar_bx_require_docker_ready || return $?
   sugar_bx_sync_workspace || return $?
   # Quiet gate is opt-in (SUGAR_BX_REQUIRE_QUIET / SUGAR_BX_MAX_LOADAVG).
@@ -464,12 +485,64 @@ sugarbin_bx_cargo() {
   sugar_bx_finish "$status"
 }
 
+dispatch_job_subcommand() {
+  local action="${1:-}"
+  [[ "$action" == status || "$action" == collect ]] || {
+    echo "sugarbin: job requires status or collect" >&2
+    return 2
+  }
+  shift
+  local host="bx" job_id="" output=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --host)
+        [[ $# -ge 2 ]] || { echo "sugarbin: job --host requires a value" >&2; return 2; }
+        host="$2"; shift 2 ;;
+      --id)
+        [[ $# -ge 2 ]] || { echo "sugarbin: job --id requires a value" >&2; return 2; }
+        job_id="$2"; shift 2 ;;
+      --output)
+        [[ "$action" == collect && $# -ge 2 ]] || { echo "sugarbin: job collect --output requires a value" >&2; return 2; }
+        output="$2"; shift 2 ;;
+      *)
+        echo "sugarbin: unknown job $action argument: $1" >&2
+        return 2 ;;
+    esac
+  done
+  [[ "$host" == bx ]] || {
+    printf 'sugarbin: crime=unsupported-detached-execution-route host=%s replacement=detached jobs are owned by the battleaxe user systemd manager\n' "$host" >&2
+    return 70
+  }
+  [[ -n "$job_id" ]] || { echo "sugarbin: job $action requires --id" >&2; return 2; }
+  [[ "$action" != collect || -n "$output" ]] || { echo "sugarbin: job collect requires --output" >&2; return 2; }
+
+  local repo_root local_cwd
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -n "$repo_root" ]] || { echo "sugarbin: must be run from inside a git checkout" >&2; return 2; }
+  local_cwd="$(pwd -P)"
+  # shellcheck source=bin/lib/sugar-bx.sh
+  source "$script_dir/lib/sugar-bx.sh"
+  BCARGO_REAP_DAYS=0 sugar_bx_init "$repo_root" "$local_cwd" || return $?
+  if [[ "$action" == status ]]; then
+    sugar_bx_detached_job_status "$job_id"
+    return $?
+  fi
+  [[ "$output" == /* ]] || output="$local_cwd/$output"
+  sugar_bx_collect_detached_job "$job_id" "$output"
+}
+
 lock_preflight=0
 case "${1:-}" in
   run|cargo|build|explain)
     subcommand="$1"
     shift
     dispatch_execution_subcommand "$subcommand" "$@"
+    exit $?
+    ;;
+  job)
+    [[ $# -ge 2 ]] || { echo "sugarbin: job requires status or collect" >&2; exit 2; }
+    shift
+    dispatch_job_subcommand "$@"
     exit $?
     ;;
   artifact)
@@ -486,6 +559,9 @@ esac
 usage() {
   cat <<'EOF'
 usage: bin/sugarbin [--bin <name>] [--profile release|debug] [--platform <auto|key>] [--print-source-stamp]
+       bin/sugarbin run --host bx --env docker:<closure> --detach <job-id> -- <command> [args...]
+       bin/sugarbin job status --host bx --id <job-id>
+       bin/sugarbin job collect --host bx --id <job-id> --output <local-dir>
        bin/sugarbin preflight-lock --bin <name> --profile <profile> --platform <key>
        bin/sugarbin artifact publish --kind python-demand-table --content-key <key> --input <json> --runtime <name> [--platform <key>] [--profile <name>] [--shelf-root <dir>]
        bin/sugarbin artifact pull --kind python-demand-table --content-key <key> --output <json> --runtime <name> [--platform <key>] [--profile <name>] [--shelf-root <dir>]

--- a/docs/superpowers/specs/2026-08-04-battleaxe-detached-job-protocol-design.md
+++ b/docs/superpowers/specs/2026-08-04-battleaxe-detached-job-protocol-design.md
@@ -82,4 +82,3 @@ leave every long corpus measurement structurally tied to an agent turn.
 
 User systemd is already present, has `Linger=yes`, exposes structured cgroup
 ownership, and preserved both exit `0` and exit `23` in the measured prototype.
-

--- a/docs/superpowers/specs/2026-08-04-battleaxe-detached-job-protocol-design.md
+++ b/docs/superpowers/specs/2026-08-04-battleaxe-detached-job-protocol-design.md
@@ -1,0 +1,85 @@
+# Battleaxe Detached Job Protocol Design
+
+## Problem
+
+`bin/brun` currently owns a foreground execution contract. In Docker mode it
+starts `docker run --rm` through one SSH session and returns when that container
+exits. A caller can put `nohup ... &` inside the container, but that only
+detaches from the container's shell. The process, PID namespace, `/proc`, and
+`/tmp` receipts still belong to the disposable container and disappear when
+the foreground `docker run --rm` owner exits.
+
+Three pandas census launches used exactly that unsupported shape. Their printed
+PID and log paths were container-local, so later `brun` probes necessarily
+entered a different container and could not observe either. No remote-root
+cleanup was requested; the evidence loss was ownership and lifetime, not a
+proven signal, OOM, reaper, or SSH failure.
+
+## Decision
+
+Add an explicit host-owned detached-job protocol for managed Docker runs.
+
+- `sugarbin run --host bx --detach <job-id> ...` performs the ordinary sync,
+  artifact provisioning, and preflight setup, then gives ownership of the
+  complete `docker run --rm` command to `systemd-run --user` on battleaxe.
+- `systemd-run --user` is the only detached supervisor. If user systemd or
+  `Linger=yes` is unavailable, the command refuses by name. There is no `nohup`
+  or tmux fallback.
+- A durable job directory lives at
+  `$BCARGO_REMOTE_ROOT/.sugar-bx-jobs/<job-id>` on the host. It owns the runner,
+  stdout/stderr log, immutable launch testimony, and atomically published final
+  exit code.
+- The job directory is bind-mounted into the container at
+  `/run/sugar-bx-job`, exposed as `SUGAR_BX_JOB_DIR`, so subject receipts can be
+  written into the same host-owned lifetime.
+- `sugarbin job status` and `sugarbin job collect` are separate operations.
+  Status never starts a new container. Collect transfers the complete durable
+  job directory, not an inferred `/tmp` path.
+
+The protocol is initially Docker-only. Ambient detachment has a different
+artifact and environment lifetime and refuses rather than silently selecting a
+weaker owner.
+
+## Refusal Contract
+
+- Invalid job IDs refuse with `crime=invalid-detached-job-id`.
+- An existing job directory refuses with `crime=duplicate-detached-job-id`.
+- Missing user systemd refuses with
+  `crime=detached-supervisor-unavailable`.
+- Missing `Linger=yes` refuses with `crime=detached-linger-disabled`.
+- `BCARGO_CLEAN_REMOTE_ROOT=success|always` refuses with
+  `crime=detached-cleanup-policy-conflict` because the foreground launcher
+  cannot delete the root of a running detached job.
+- Detached ambient execution refuses with
+  `crime=unsupported-detached-execution-route`.
+- A launched unit that is neither active nor carrying a final status refuses
+  with `crime=detached-job-testimony-missing`.
+
+No refusal falls back to container-local `nohup`.
+
+## Executable Discrimination
+
+The focused contract must prove both arms before implementation is claimed:
+
+1. Original failure: a process detached inside `docker run --rm` does not own a
+   durable PID or container-local `/tmp` log after the container owner exits.
+2. Host-owned success: launch a delayed job, end the launching SSH session, and
+   prove from a second SSH session that the unit remains active and the host log
+   is readable.
+3. Final success: after completion, status reports exit `0` and collect returns
+   the host-owned log/status bytes.
+4. Final failure: a subject exiting `23` durably reports exactly `23`.
+5. Invalid ID, duplicate ID, unavailable systemd, unavailable linger, cleanup
+   conflict, and unsupported route each refuse before subject execution with
+   their own crime.
+
+## Alternatives Rejected
+
+`tmux` survives SSH disconnects on battleaxe, but durable status, collision
+handling, and log ownership would need a second handwritten supervisor
+protocol. Documenting foreground-only execution would stop the false claim but
+leave every long corpus measurement structurally tied to an agent turn.
+
+User systemd is already present, has `Linger=yes`, exposes structured cgroup
+ownership, and preserved both exit `0` and exit `23` in the measured prototype.
+

--- a/tests/battleaxe_detached_job_lifetime.sh
+++ b/tests/battleaxe_detached_job_lifetime.sh
@@ -7,10 +7,24 @@ repo_root="${1:-$(git rev-parse --show-toplevel)}"
 root="${BCARGO_REMOTE_ROOT:?set BCARGO_REMOTE_ROOT to an explicit disposable battleaxe root}"
 job_id="${SUGAR_BX_LIVE_JOB_ID:-axis8-live-$PPID-$$}"
 collected="${SUGAR_BX_LIVE_COLLECT_DIR:-$repo_root/.sugar/axis8-live-$job_id}"
+failed_job_id="$job_id-fail"
 
 fail() {
   echo "FAIL: $*" >&2
   exit 1
+}
+
+wait_for_completed_status() {
+  local wanted_job_id="$1" observation="" attempt
+  for attempt in $(seq 1 60); do
+    observation="$(BCARGO_REAP_DAYS=0 bin/sugarbin job status --host bx --id "$wanted_job_id")"
+    case "$observation" in
+      *'state=completed'*) printf '%s\n' "$observation"; return 0 ;;
+      *'state=running'*) sleep 1 ;;
+      *) fail "unexpected detached status for $wanted_job_id: $observation" ;;
+    esac
+  done
+  fail "detached job did not complete inside 60s: $observation"
 }
 
 cd "$repo_root"
@@ -22,8 +36,7 @@ running="$(BCARGO_REAP_DAYS=0 bin/sugarbin job status --host bx --id "$job_id")"
 [[ "$running" == *'state=running'* ]] \
   || fail "job did not survive launching SSH disconnect: $running"
 
-sleep 3
-completed="$(BCARGO_REAP_DAYS=0 bin/sugarbin job status --host bx --id "$job_id")"
+completed="$(wait_for_completed_status "$job_id")"
 [[ "$completed" == *'state=completed'* && "$completed" == *'exitCode=0'* ]] \
   || fail "job did not preserve successful exit: $completed"
 
@@ -35,5 +48,19 @@ grep -Fq 'subject-complete' "$collected/output.log" \
 [[ "$(tr -d '[:space:]' <"$collected/exit-code")" == 0 ]] \
   || fail "collected exit identity was not zero"
 
-echo "PASS: battleaxe detached job survived launching SSH disconnect"
+# The launcher succeeding is not the subject succeeding. A second live job
+# proves a nonzero subject verdict remains exactly nonzero after disconnect,
+# status, and collection.
+BCARGO_REAP_DAYS=0 bin/brun --env docker:core --detach "$failed_job_id" -- \
+  bash -lc 'printf "failed-subject\n"; exit 23'
+failed="$(wait_for_completed_status "$failed_job_id")"
+[[ "$failed" == *'exitCode=23'* ]] \
+  || fail "failed job did not preserve exit 23: $failed"
+BCARGO_REAP_DAYS=0 bin/sugarbin job collect --host bx --id "$failed_job_id" \
+  --output "$collected-fail"
+[[ "$(tr -d '[:space:]' <"$collected-fail/exit-code")" == 23 ]] \
+  || fail "collected failed exit identity was not 23"
+grep -Fq 'failed-subject' "$collected-fail/output.log" \
+  || fail "collected failed log omitted subject testimony"
 
+echo "PASS: battleaxe detached jobs survived disconnect and preserved exit 0/23"

--- a/tests/battleaxe_detached_job_lifetime.sh
+++ b/tests/battleaxe_detached_job_lifetime.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Live exact-topology tooth. The launching invocation and every observation are
+# separate brun/sugarbin processes and therefore separate SSH sessions.
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+root="${BCARGO_REMOTE_ROOT:?set BCARGO_REMOTE_ROOT to an explicit disposable battleaxe root}"
+job_id="${SUGAR_BX_LIVE_JOB_ID:-axis8-live-$PPID-$$}"
+collected="${SUGAR_BX_LIVE_COLLECT_DIR:-$repo_root/.sugar/axis8-live-$job_id}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cd "$repo_root"
+BCARGO_REAP_DAYS=0 bin/brun --env docker:core --detach "$job_id" -- \
+  bash -lc 'printf "subject-started\n"; sleep 3; printf "subject-complete\n"'
+
+sleep 1
+running="$(BCARGO_REAP_DAYS=0 bin/sugarbin job status --host bx --id "$job_id")"
+[[ "$running" == *'state=running'* ]] \
+  || fail "job did not survive launching SSH disconnect: $running"
+
+sleep 3
+completed="$(BCARGO_REAP_DAYS=0 bin/sugarbin job status --host bx --id "$job_id")"
+[[ "$completed" == *'state=completed'* && "$completed" == *'exitCode=0'* ]] \
+  || fail "job did not preserve successful exit: $completed"
+
+BCARGO_REAP_DAYS=0 bin/sugarbin job collect --host bx --id "$job_id" --output "$collected"
+grep -Fq 'subject-started' "$collected/output.log" \
+  || fail "collected host log omitted subject start"
+grep -Fq 'subject-complete' "$collected/output.log" \
+  || fail "collected host log omitted subject completion"
+[[ "$(tr -d '[:space:]' <"$collected/exit-code")" == 0 ]] \
+  || fail "collected exit identity was not zero"
+
+echo "PASS: battleaxe detached job survived launching SSH disconnect"
+

--- a/tests/sugarbin_bx_detached_jobs.sh
+++ b/tests/sugarbin_bx_detached_jobs.sh
@@ -26,8 +26,22 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 [[ -n "$unit" && $# -gt 0 ]]
-nohup "$@" </dev/null >/dev/null 2>&1 &
-printf '%s\n' "$!" >"$FAKE_SYSTEMD_STATE/$unit.pid"
+python3 - "$FAKE_SYSTEMD_STATE/$unit.pid" "$@" <<'PY'
+import subprocess
+import sys
+
+pid_path, *command = sys.argv[1:]
+with open("/dev/null", "rb") as stdin, open("/dev/null", "ab") as output:
+    child = subprocess.Popen(
+        command,
+        stdin=stdin,
+        stdout=output,
+        stderr=output,
+        start_new_session=True,
+    )
+with open(pid_path, "w", encoding="utf-8") as receipt:
+    receipt.write(f"{child.pid}\n")
+PY
 SH
 
 cat >"$tmp/bin/systemctl" <<'SH'
@@ -73,14 +87,17 @@ SUGAR_BX_HOST=fake-battleaxe
 SUGAR_BX_LOCAL=0
 SUGAR_BX_ROOT="$tmp/remote-root"
 SUGAR_BX_CLEAN=never
+SUGAR_BX_RSYNC="$(command -v rsync)"
 
 start_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
 sugar_bx_start_detached_host_command axis8-ok \
-  "sleep 0.5; printf 'subject-complete\\n'"
+  "sleep 3; printf 'subject-complete\\n'"
 end_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
 elapsed_ms="$(( (end_ns - start_ns) / 1000000 ))"
-[[ "$elapsed_ms" -lt 400 ]] \
+[[ "$elapsed_ms" -lt 2500 ]] \
   || fail "launch waited for the subject instead of returning ownership: ${elapsed_ms}ms"
+[[ ! -e "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/exit-code" ]] \
+  || fail "subject completed before the detached launch returned"
 
 # The launching session has returned. A distinct shell must see the job active
 # and its host-owned log readable while the subject is still running.
@@ -90,14 +107,14 @@ running="$(sugar_bx_detached_job_status axis8-ok)"
 [[ -r "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/output.log" ]] \
   || fail "host-owned log was not readable after launch session returned"
 
-sleep 0.6
+sleep 3.1
 completed="$(sugar_bx_detached_job_status axis8-ok)"
 [[ "$completed" == *'state=completed'* && "$completed" == *'exitCode=0'* ]] \
   || fail "successful final status was not durable: $completed"
 grep -Fq 'subject-complete' "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/output.log" \
   || fail "successful subject output was not durable"
 
-sugar_bx_collect_detached_job axis8-ok "$tmp/collected-ok"
+SUGAR_BX_LOCAL=1 sugar_bx_collect_detached_job axis8-ok "$tmp/collected-ok"
 cmp "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/output.log" "$tmp/collected-ok/output.log" \
   || fail "collect changed durable output bytes"
 cmp "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/exit-code" "$tmp/collected-ok/exit-code" \
@@ -148,4 +165,3 @@ grep -Fq 'crime=detached-cleanup-policy-conflict' "$tmp/clean.err" \
   || fail "cleanup conflict refusal was unnamed"
 
 echo "PASS: sugarbin battleaxe detached-job contract"
-

--- a/tests/sugarbin_bx_detached_jobs.sh
+++ b/tests/sugarbin_bx_detached_jobs.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/systemd" "$tmp/remote-root"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cat >"$tmp/bin/systemd-run" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${FAKE_SYSTEMD_AVAILABLE:-1}" == 1 ]] || exit 1
+unit=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --unit=*) unit="${1#*=}"; shift ;;
+    --unit) unit="$2"; shift 2 ;;
+    --property=*|--collect|--user|--quiet) shift ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+done
+[[ -n "$unit" && $# -gt 0 ]]
+nohup "$@" </dev/null >/dev/null 2>&1 &
+printf '%s\n' "$!" >"$FAKE_SYSTEMD_STATE/$unit.pid"
+SH
+
+cat >"$tmp/bin/systemctl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${FAKE_SYSTEMD_AVAILABLE:-1}" == 1 ]] || exit 1
+[[ "${1:-}" == --user ]] && shift
+case "${1:-}" in
+  show-environment) exit 0 ;;
+  is-active)
+    unit="${2:?unit}"
+    pid_file="$FAKE_SYSTEMD_STATE/$unit.pid"
+    [[ -r "$pid_file" ]] || exit 3
+    pid="$(cat "$pid_file")"
+    kill -0 "$pid" 2>/dev/null
+    ;;
+  *) exit 1 ;;
+esac
+SH
+
+cat >"$tmp/bin/loginctl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${FAKE_LINGER_ENABLED:-1}" == 1 ]] && printf 'yes\n' || printf 'no\n'
+SH
+chmod +x "$tmp/bin/systemd-run" "$tmp/bin/systemctl" "$tmp/bin/loginctl"
+
+# shellcheck source=bin/lib/sugar-bx.sh
+source "$repo_root/bin/lib/sugar-bx.sh"
+
+# A separate shell per call models separate SSH sessions while retaining only
+# host-owned files and the user-systemd unit between them.
+sugar_bx_ssh() {
+  bash -c "$*"
+}
+
+export PATH="$tmp/bin:$PATH"
+export FAKE_SYSTEMD_STATE="$tmp/systemd"
+export FAKE_SYSTEMD_AVAILABLE=1
+export FAKE_LINGER_ENABLED=1
+export USER="${USER:-tester}"
+SUGAR_BX_HOST=fake-battleaxe
+SUGAR_BX_LOCAL=0
+SUGAR_BX_ROOT="$tmp/remote-root"
+SUGAR_BX_CLEAN=never
+
+start_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+sugar_bx_start_detached_host_command axis8-ok \
+  "sleep 0.5; printf 'subject-complete\\n'"
+end_ns="$(python3 -c 'import time; print(time.monotonic_ns())')"
+elapsed_ms="$(( (end_ns - start_ns) / 1000000 ))"
+[[ "$elapsed_ms" -lt 400 ]] \
+  || fail "launch waited for the subject instead of returning ownership: ${elapsed_ms}ms"
+
+# The launching session has returned. A distinct shell must see the job active
+# and its host-owned log readable while the subject is still running.
+sleep 0.1
+running="$(sugar_bx_detached_job_status axis8-ok)"
+[[ "$running" == *'state=running'* ]] || fail "second session did not see running job: $running"
+[[ -r "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/output.log" ]] \
+  || fail "host-owned log was not readable after launch session returned"
+
+sleep 0.6
+completed="$(sugar_bx_detached_job_status axis8-ok)"
+[[ "$completed" == *'state=completed'* && "$completed" == *'exitCode=0'* ]] \
+  || fail "successful final status was not durable: $completed"
+grep -Fq 'subject-complete' "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/output.log" \
+  || fail "successful subject output was not durable"
+
+sugar_bx_collect_detached_job axis8-ok "$tmp/collected-ok"
+cmp "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/output.log" "$tmp/collected-ok/output.log" \
+  || fail "collect changed durable output bytes"
+cmp "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-ok/exit-code" "$tmp/collected-ok/exit-code" \
+  || fail "collect changed durable exit identity"
+
+# A failed detached subject must remain a failed measurement. The protocol
+# records 23 exactly rather than converting it into launch success or silence.
+sugar_bx_start_detached_host_command axis8-fail "printf 'failed-subject\\n'; exit 23"
+for _ in 1 2 3 4 5; do
+  [[ -r "$SUGAR_BX_ROOT/.sugar-bx-jobs/axis8-fail/exit-code" ]] && break
+  sleep 0.1
+done
+failed="$(sugar_bx_detached_job_status axis8-fail)"
+[[ "$failed" == *'state=completed'* && "$failed" == *'exitCode=23'* ]] \
+  || fail "nonzero subject exit was not preserved: $failed"
+
+status=0
+sugar_bx_start_detached_host_command '../bad' true >"$tmp/invalid.out" 2>"$tmp/invalid.err" || status=$?
+[[ "$status" == 70 ]] || fail "invalid job id returned $status, want 70"
+grep -Fq 'crime=invalid-detached-job-id' "$tmp/invalid.err" \
+  || fail "invalid job id refusal was unnamed"
+
+status=0
+sugar_bx_start_detached_host_command axis8-ok true >"$tmp/duplicate.out" 2>"$tmp/duplicate.err" || status=$?
+[[ "$status" == 70 ]] || fail "duplicate job id returned $status, want 70"
+grep -Fq 'crime=duplicate-detached-job-id' "$tmp/duplicate.err" \
+  || fail "duplicate job id refusal was unnamed"
+
+status=0
+FAKE_SYSTEMD_AVAILABLE=0 sugar_bx_start_detached_host_command axis8-no-systemd true \
+  >"$tmp/systemd.out" 2>"$tmp/systemd.err" || status=$?
+[[ "$status" == 70 ]] || fail "unavailable systemd returned $status, want 70"
+grep -Fq 'crime=detached-supervisor-unavailable' "$tmp/systemd.err" \
+  || fail "unavailable systemd refusal was unnamed"
+
+status=0
+FAKE_LINGER_ENABLED=0 sugar_bx_start_detached_host_command axis8-no-linger true \
+  >"$tmp/linger.out" 2>"$tmp/linger.err" || status=$?
+[[ "$status" == 70 ]] || fail "disabled linger returned $status, want 70"
+grep -Fq 'crime=detached-linger-disabled' "$tmp/linger.err" \
+  || fail "disabled linger refusal was unnamed"
+
+status=0
+SUGAR_BX_CLEAN=success sugar_bx_start_detached_host_command axis8-clean true \
+  >"$tmp/clean.out" 2>"$tmp/clean.err" || status=$?
+[[ "$status" == 70 ]] || fail "cleanup conflict returned $status, want 70"
+grep -Fq 'crime=detached-cleanup-policy-conflict' "$tmp/clean.err" \
+  || fail "cleanup conflict refusal was unnamed"
+
+echo "PASS: sugarbin battleaxe detached-job contract"
+


### PR DESCRIPTION
## Outcome

Battleaxe detached Docker jobs now have a host-owned lifetime. `systemd-run --user` owns the complete `docker run --rm`; durable launch, log, and atomic exit testimony live under `BCARGO_REMOTE_ROOT/.sugar-bx-jobs/<job-id>`, and `sugarbin job status|collect` reads that testimony without starting another container.

## Root cause

The three lost census launches put `nohup` inside the `brun` container. Their PID namespace, `/proc`, and `/tmp` logs belonged to that disposable container, so later probes necessarily entered a different container and could not observe them. No cleanup request, signal, OOM, reaper, or SSH failure was established.

## Contract

- invalid or duplicate job IDs refuse by name
- missing user systemd or `Linger=yes` refuses; there is no weaker nohup/tmux fallback
- detached cleanup policies refuse while evidence is live
- container subjects receive a bind-mounted `SUGAR_BX_JOB_DIR`
- status and collect are separate operations; detached `--sync-back` refuses
- failed subjects preserve their exact nonzero exit identity

This intentionally adds named detached-execution `crime=` categories. It adds no residual bucket, semantic kind, label, or product taxonomy.

## Evidence

- focused executable contract: launch returns before subject; a distinct session observes it running; host log remains readable; completed 0 and failed 23 both persist; invalid/duplicate/systemd/linger/cleanup arms refuse by name
- live battleaxe exact-topology arm on final tree: launching SSH disconnected; second invocation observed the job; collected host log contains `subject-started` and `subject-complete`; durable exits are exactly 0 and 23
- `tests/sugarbin_docker_exec.sh`: green, including the existing nine-axis falsifier
- `tests/sugarbin_bx_exec.sh`: green
- `tests/macos_bash3_build_wrappers.sh`: green
- shell syntax and diff-check: green

`tests/brun_remote_exec.sh` retains an unrelated `real-shaped quiet success collapsed to 255` red reproduced on untouched current main; this change does not claim or alter that baseline.

No remote root, shelf cell, or retained receipt was deleted.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add detached Docker job support owned by user systemd to `sugarbin`
> - Adds `sugarbin run --detach <job-id>` to launch managed Docker containers as detached systemd user units; the command returns immediately with an acceptance receipt while the job runs in the background.
> - Adds `sugarbin job status --id <job-id>` and `sugarbin job collect --id <job-id> --output <path>` to inspect running/completed state and rsync job artifacts (logs, exit code) back to a local directory.
> - Job directories are created under `BCARGO_REMOTE_ROOT/.sugar-bx-jobs/<job-id>` on the host with a bind-mount at `/run/sugar-bx-job` inside the container; the exit code is written atomically to `exit-code` on completion.
> - Validation rejects invalid job IDs, conflicting cleanup policies, `--sync-back` in detached mode, non-docker routes, and environments where user systemd linger is disabled.
> - Risk: requires `systemd-run`, `systemctl`, and `loginctl linger=yes` on the remote host; missing any of these causes exit 70 with a named crime on stderr.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b76349.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->