### PR TITLE
Preserve structured showcase JSON channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,11 @@ check-lift-manifest-pythonpath:
 	$(PYTHON) tools/check_lift_manifest_pythonpath.py --self-test
 	$(PYTHON) tools/check_lift_manifest_pythonpath.py
 
+.PHONY: check-showcase-json-channels
+check-showcase-json-channels:
+	$(PYTHON) tools/showcase_json_channel_law.py --self-test
+	$(PYTHON) tools/showcase_json_channel_law.py
+
 # Lane B instrument 3: partial wall progress receipt (not a product gate).
 # Score transport.jsonl + wall.txt → progress.json. Incomplete is measured.
 # Self-test always runs; scoring requires a wall artifact (set WALL_DIR/LOGS_DIR
@@ -495,7 +500,7 @@ examples-gate-extended:
 	  --nice $(EXAMPLES_GATE_NICE)
 
 .PHONY: test-showcases
-test-showcases: check-showcase-kit-preflight check-lift-manifest-pythonpath
+test-showcases: check-showcase-kit-preflight check-lift-manifest-pythonpath check-showcase-json-channels
 	@set -e; \
 	shard_count="$${SHOWCASE_SHARD_COUNT:-1}"; \
 	shard_index="$${SHOWCASE_SHARD_INDEX:-0}"; \

--- a/examples/numpy-attribute-safety-showcase/run.sh
+++ b/examples/numpy-attribute-safety-showcase/run.sh
@@ -279,7 +279,7 @@ run_suite() {
 
   echo "== prove $suite =="
   set +e
-  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json"
   local prove_rc=$?
   set -e
   : "$prove_rc"
@@ -289,7 +289,7 @@ run_suite() {
   if [ "$expect_witness" = "discharged" ]; then
     echo "== verify $suite witness =="
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
     local verify_rc=$?
     set -e
     : "$verify_rc"

--- a/examples/polars-showcase/run.sh
+++ b/examples/polars-showcase/run.sh
@@ -264,7 +264,7 @@ run_suite() {
 
   echo "== prove $suite =="
   set +e
-  (cd "$dir" && PATH="$BIN_DIR:$PATH" SUGAR_COMPONENT_PATH="$HERE/.sugar/components" "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && PATH="$BIN_DIR:$PATH" SUGAR_COMPONENT_PATH="$HERE/.sugar/components" "$SUGAR" prove . --json) > "$dir/.prove.json"
   local prove_rc=$?
   set -e
 
@@ -305,7 +305,7 @@ run_suite() {
 
     echo "== verify $suite witness =="
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" SUGAR_COMPONENT_PATH="$HERE/.sugar/components" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" SUGAR_COMPONENT_PATH="$HERE/.sugar/components" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
     local verify_rc=$?
     set -e
     : "$verify_rc"
@@ -319,7 +319,7 @@ run_suite() {
 
     rm -rf "$dir/.sugar/witnesses"
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" SUGAR_COMPONENT_PATH="$HERE/.sugar/components" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" SUGAR_COMPONENT_PATH="$HERE/.sugar/components" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json"
     local verify_recompute_rc=$?
     set -e
     : "$verify_recompute_rc"

--- a/examples/std-core-bodyguard-precondition/run.sh
+++ b/examples/std-core-bodyguard-precondition/run.sh
@@ -734,13 +734,13 @@ PY
 
   echo "== prove $case_name $suite =="
   set +e
-  (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" prove . --json) > "$dir/.prove.json"
   set -e
 
   echo "== verify $case_name $suite =="
   local verify_status
   set +e
-  (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+  (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
   verify_status=$?
   set -e
 
@@ -784,7 +784,7 @@ PY
 
   rm -rf "$dir/.sugar/witnesses"
   set +e
-  (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+  (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json"
   set -e
   local recompute verified
   recompute="$(recompute_strategy "$dir/.verify_recompute.json")"

--- a/examples/std-core-showcase/run.sh
+++ b/examples/std-core-showcase/run.sh
@@ -811,7 +811,7 @@ fi
 echo "proof: $(basename "$proof_path")"
 
 echo "== verify std/core selected source slice =="
-(cd "$PROJECT" && "$SUGAR" verify --project . --json) > "$PROJECT/.verify.json" 2>&1 || true
+(cd "$PROJECT" && "$SUGAR" verify --project . --json) > "$PROJECT/.verify.json" || true
 
 python3 - "$PROJECT/.verify.json" "$TARGET_POINTER_WIDTH" "$TARGET_POINTER_BYTES" <<'PY'
 import json

--- a/examples/std-core-string-predicates/run.sh
+++ b/examples/std-core-string-predicates/run.sh
@@ -193,7 +193,7 @@ PY
   fi
   echo "$label proof: $(basename "$proof_path")"
   echo "== verify $label =="
-  (cd "$project" && "$SUGAR" verify --project . --json) > "$project/.verify.json" 2>&1 || true
+  (cd "$project" && "$SUGAR" verify --project . --json) > "$project/.verify.json" || true
 }
 
 run_mint_verify "$GOOD" GOOD

--- a/examples/tokio-await-implication-edge/run.sh
+++ b/examples/tokio-await-implication-edge/run.sh
@@ -181,7 +181,7 @@ run_suite() {
 
   echo "== prove $suite =="
   set +e
-  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json"
   set -e
 
   local got_edge got_witness
@@ -211,7 +211,7 @@ run_suite() {
 
     echo "== verify $suite witness =="
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
     set -e
     local verify_verdict
     verify_verdict="$(witness_verdict "$dir/.verify.json")"
@@ -223,7 +223,7 @@ run_suite() {
 
     rm -rf "$dir/.sugar/witnesses"
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json"
     set -e
     local recompute_strategy
     recompute_strategy="$(witness_recompute_strategy "$dir/.verify_recompute.json")"

--- a/examples/tokio-channel-implication-edge/run.sh
+++ b/examples/tokio-channel-implication-edge/run.sh
@@ -181,7 +181,7 @@ run_suite() {
 
   echo "== prove $suite =="
   set +e
-  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json"
   set -e
 
   local got_edge got_witness
@@ -211,7 +211,7 @@ run_suite() {
 
     echo "== verify $suite witness =="
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
     set -e
     local verify_verdict
     verify_verdict="$(witness_verdict "$dir/.verify.json")"
@@ -223,7 +223,7 @@ run_suite() {
 
     rm -rf "$dir/.sugar/witnesses"
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json"
     set -e
     local recompute_strategy
     recompute_strategy="$(witness_recompute_strategy "$dir/.verify_recompute.json")"

--- a/examples/tokio-effect-consistency/run.sh
+++ b/examples/tokio-effect-consistency/run.sh
@@ -211,7 +211,7 @@ run_suite() {
 
   echo "== prove $suite =="
   set +e
-  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json"
   set -e
 
   local got_consistency got_witness
@@ -255,7 +255,7 @@ run_suite() {
     # We still capture the exit code for the diagnostic message so a genuine
     # crash (nonzero rc AND no parseable witness verdict) is named, not silent.
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
     local verify_rc=$?
     set -e
     local verify_verdict
@@ -268,7 +268,7 @@ run_suite() {
 
     rm -rf "$dir/.sugar/witnesses"
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify_recompute.json"
     local recompute_rc=$?
     set -e
     local recompute_strategy

--- a/examples/tokio-mutex-implication-edge/run.sh
+++ b/examples/tokio-mutex-implication-edge/run.sh
@@ -147,7 +147,7 @@ run_suite() {
 
   echo "== prove $suite =="
   set +e
-  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json" 2>&1
+  (cd "$dir" && "$SUGAR" prove . --json) > "$dir/.prove.json"
   set -e
 
   local got_edge got_witness
@@ -177,7 +177,7 @@ run_suite() {
 
     echo "== verify $suite witness =="
     set +e
-    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json" 2>&1
+    (cd "$dir" && PATH="$BIN_DIR:$PATH" "$SUGAR" verify --project . --json) > "$dir/.verify.json"
     set -e
     local verify_verdict
     verify_verdict="$(witness_verdict "$dir/.verify.json")"

--- a/tools/showcase_json_channel_law.py
+++ b/tools/showcase_json_channel_law.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Refuse showcase commands that merge diagnostics into JSON artifacts.
+
+The Sugar CLI owns two channels: ``--json`` writes one structured document to
+stdout, while diagnostics and named nonzero-exit explanations go to stderr.
+A showcase may retain a combined ``.raw`` transcript and recover a receipt
+from it deliberately.  A file named ``.json`` is different: it promises one
+JSON document, so redirecting ``2>&1`` into it makes a valid CLI failure path
+corrupt the consumer's structured input.
+
+This is an open shell-script boundary, so the law remains an auditor rather
+than pretending a Python type can constrain future shell redirections.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from sugar_repo_root import resolve_repo_root
+
+
+_JSON_ARTIFACT_REDIRECT = re.compile(
+    r"(?<![0-9])>\s*[\"']?[^\s\"']*\.json[\"']?"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    command: str
+
+
+def _logical_shell_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Yield backslash-continued shell commands with their first line."""
+    start = 1
+    parts: list[str] = []
+    for line_number, physical in enumerate(text.splitlines(), 1):
+        if not parts:
+            start = line_number
+        stripped = physical.rstrip()
+        if stripped.endswith("\\"):
+            parts.append(stripped[:-1])
+            continue
+        parts.append(physical)
+        yield start, " ".join(part.strip() for part in parts)
+        parts = []
+    if parts:
+        yield start, " ".join(part.strip() for part in parts)
+
+
+def findings_for_text(path: str, text: str) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    for line_number, command in _logical_shell_lines(text):
+        if (
+            "--json" in command
+            and "2>&1" in command
+            and _JSON_ARTIFACT_REDIRECT.search(command)
+        ):
+            findings.append(
+                Finding(path=path, line=line_number, command=command.strip())
+            )
+    return tuple(findings)
+
+
+def scan(paths: Iterable[Path], root: Path) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    for path in sorted(paths):
+        findings.extend(
+            findings_for_text(
+                path.relative_to(root).as_posix(),
+                path.read_text(encoding="utf-8"),
+            )
+        )
+    return tuple(findings)
+
+
+def _self_test() -> None:
+    sample = """
+tool prove . --json > .prove.json 2> .prove.stderr
+tool prove . --json > .prove.raw 2>&1
+tool prove . --json > .prove.json 2>&1
+tool verify --json \\
+  > \"$dir/.verify.json\" 2>&1
+"""
+    findings = findings_for_text("examples/planted/run.sh", sample)
+    assert len(findings) == 2, findings
+    assert findings[0].line == 4
+    assert findings[1].line == 5
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        _self_test()
+        print("showcase-json-channel-law self-test: pass")
+        return 0
+
+    root = resolve_repo_root(start=Path.cwd(), extra_starts=(Path(__file__),))
+    findings = scan((root / "examples").glob("*/run.sh"), root)
+    for finding in findings:
+        print(
+            "crime=structured-json-channel-corrupted "
+            "owner=showcase-consumer "
+            f"coordinate={finding.path}:{finding.line} "
+            "observed=stderr-merged-into-json-artifact "
+            "replacement=write-stdout-to-json-and-stderr-to-a-separate-diagnostic-file"
+        )
+    print(f"R_showcase_json_channel_corruption_count={len(findings)}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- keep `prove --json` and `verify --json` stdout in `.json` artifacts while leaving diagnostics on stderr at 21 sites across 9 showcase consumers
- add `R_showcase_json_channel_corruption` with safe/unsafe planted twins
- run that instrument before every `test-showcases` shard so the zero cannot drift

## Root cause

The CLI was already correct: on an unresolved link surface, `prove --json` exits 4, writes one valid JSON document to stdout, and writes the `EXIT_LINK_FAIL` explanation to stderr.

The NumPy attribute-safety showcase redirected both channels into `.prove.json` with `2>&1`, then passed the combined file to `json.loads`. A valid failure response therefore became `JSONDecodeError: Extra data`, masking the semantic result.

This is the same failure-path channel-corruption family as the separately observed RPC path that serialized an internal exception with `id=null`: the structured response was otherwise sound, but failure testimony broke its consumer channel. This PR changes only showcase process-stream routing.

## Population and discrimination

At the red pin, the broad search found 38 merged-channel sites in 19 consumers. The enforced predicate deliberately selects only `--json` stdout redirected to a file named `.json` while `2>&1` merges diagnostics:

- selected: 21 physical sites in 9 consumers
- excluded: 17 sites writing `.raw` transcripts or intentionally consuming human text

The live instrument moved:

```text
R_showcase_json_channel_corruption_count=21  # exit 1, before
R_showcase_json_channel_corruption_count=0   # exit 0, after
```

This is not a claim that all 38 broad search hits were broken.

## Runtime audit

Six of the selected consumers used strict `json.loads` parsing. On current merged main plus this patch:

- NumPy attribute-safety: the parse mask is gone; the script now names `good: missing attribute-safety rows`
- Polars: names a lift-plugin transport stall before prove
- Tokio await/channel/mutex: parse cleanly and name unsatisfied implication edges
- Tokio effect consistency: both semantic twins pass; direct standalone invocation then lacks the examples-gate `SHOWCASE_SUBJECT_ID`

The first six-consumer attempt was discarded as no-verdict: all six hit one `sugarbin` acquire/release race across two lock paths. That instrument race is being repaired separately.

For the NumPy receipt specifically:

```text
JSON valid
total_rows=1
attribute_rows=0
witness_rows=1
witness_statuses=[discharged]
```

The showcase still exits 1, now for its own semantic assertion rather than a parser exception. This PR does not explain or repair the missing classShapes/attribute-safety testimony.

## Verification

```text
make check-showcase-json-channels
showcase-json-channel-law self-test: pass
R_showcase_json_channel_corruption_count=0

bash -n <all 9 edited showcase scripts>
exit 0
```

The instrument remains necessary because future shell scripts are an open boundary; Python or Rust types cannot make a shell redirection unrepresentable.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve structured showcase JSON channels by removing stderr merges in example scripts
> - Removes `2>&1` from redirections in multiple `examples/*/run.sh` files so that `.prove.json` and `.verify*.json` artifacts capture stdout only, preventing stderr from corrupting JSON output.
> - Adds [showcase_json_channel_law.py](https://github.com/TSavo/sugar/pull/7328/files#diff-7eb5a4238ae7b1fc3944ded2981e67face03f918f3f5c72fdc0595a0c5e8d0f3), a linting tool that scans `examples/*/run.sh` for commands combining `--json` with `2>&1` and a `.json` redirect, reporting violations and exiting nonzero.
> - Wires the new tool into the `test-showcases` Makefile target via a new `check-showcase-json-channels` phony target that runs the tool's self-test and then scans the repo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ac5f0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->