### PR TITLE
Retry rebuild lock after peer release

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -1646,7 +1646,7 @@ _stamp_short() {
 # log()) within 30s and every 30s after. CI is not a TTY — never gate these.
 acquire_rebuild_single_flight() {
   local stamp="$1" name="$2" lock_parent lockdir waited=0 stale_s age
-  local wait_start holder stamp_short now elapsed announced=0
+  local wait_start holder stamp_short now elapsed announced=0 missing_dir_retries=0
   _rebuild_lock_dir=""
   _rebuild_heartbeat_pid=""
   lock_parent="$(cache_dir)/.rebuild-locks"
@@ -1688,11 +1688,25 @@ acquire_rebuild_single_flight() {
       fi
       return 0
     fi
-    # A failed mkdir is contention only when a holder record exists. Give a
-    # peer that just won mkdir one bounded chance to publish its PID; absence
-    # after that is not an unknown holder to wait on forever.
+    # A failed mkdir proves contention only at that instant. The winner may
+    # publish and release before this waiter observes the lock; retry that
+    # lawful disappearance instead of misclassifying it as missing testimony.
+    if [[ ! -d "$lockdir" ]]; then
+      missing_dir_retries=$((missing_dir_retries + 1))
+      if (( missing_dir_retries >= 40 )); then
+        log "crime=missing-rebuild-lock-pid owner=bin/sugarbin path=$lockdir/pid lock=$lockdir holder_pid=unknown reason=lock-absent-after-bounded-retry replacement=repair the declared lock root; an absent holder record is not peer contention"
+        return 70
+      fi
+      continue
+    fi
+    missing_dir_retries=0
+    # A lock directory that still exists gets one bounded chance to publish
+    # its PID. Absence after that is not an unknown holder to wait on forever.
     if [[ ! -f "$lockdir/pid" ]]; then
       sleep 0.5
+      if [[ ! -d "$lockdir" ]]; then
+        continue
+      fi
       if [[ ! -f "$lockdir/pid" ]]; then
         log "crime=missing-rebuild-lock-pid owner=bin/sugarbin path=$lockdir/pid lock=$lockdir holder_pid=unknown replacement=repair the declared lock root; an absent holder record is not peer contention"
         return 70

--- a/tests/sugarbin_rebuild_single_flight.sh
+++ b/tests/sugarbin_rebuild_single_flight.sh
@@ -338,6 +338,80 @@ for testimony in (lock + "/pid", "holder_pid=unknown"):
         raise SystemExit(f"missing terminal testimony: {testimony}")
 PY
 
-echo 'PASS: production rebuild lock completes and both failure terminals terminate'
+# A failed mkdir only proves contention at that instant. The peer can publish
+# and release the whole lock before this waiter reads pid. That lawful absence
+# is not malformed lock state: the waiter must retry, then acquire normally.
+rm -rf "$production_lock"
+mkdir -p "$tmp/released-peer-mkdir-bin"
+cat >"$tmp/released-peer-mkdir-bin/mkdir" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$#" == 1 && "$1" == "${LOCK_TO_RELEASE:?}" \
+      && ! -e "${RELEASED_PEER_STATE:?}" ]]; then
+  : >"$RELEASED_PEER_STATE"
+  /bin/mkdir "$LOCK_TO_RELEASE"
+  printf 'peer\n' >"$LOCK_TO_RELEASE/pid"
+  : >"$LOCK_TO_RELEASE/heartbeat"
+  /bin/rm -rf "$LOCK_TO_RELEASE"
+  exit 1
+fi
+exec /bin/mkdir "$@"
+EOF
+chmod +x "$tmp/released-peer-mkdir-bin/mkdir"
+
+python3 - "$sugarbin" "$production_cache" "$production_stamp" \
+  "$production_lock" "$tmp/released-peer-mkdir-bin" \
+  "$tmp/released-peer-state" <<'PY'
+import os
+import subprocess
+import sys
+
+sugarbin, cache, stamp, lock, fake_bin, state = sys.argv[1:]
+env = os.environ.copy()
+env.update(
+    {
+        "LOCK_TO_RELEASE": lock,
+        "PATH": fake_bin + os.pathsep + env["PATH"],
+        "RELEASED_PEER_STATE": state,
+        "SUGAR_BINARY_CACHE_DIR": cache,
+        "SUGAR_BINARY_SOURCE_STAMP": stamp,
+    }
+)
+try:
+    result = subprocess.run(
+        [
+            sugarbin,
+            "preflight-lock",
+            "--bin",
+            "sugar",
+            "--profile",
+            "debug",
+            "--platform",
+            "fixture",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=8,
+        check=False,
+    )
+except subprocess.TimeoutExpired as error:
+    stderr = error.stderr or ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    print("released-peer retry arm did not terminate within 8s", file=sys.stderr)
+    print(stderr, file=sys.stderr)
+    raise SystemExit(1)
+if result.returncode != 0:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit(
+        f"released peer was misclassified as malformed lock: {result.returncode}"
+    )
+if "crime=missing-rebuild-lock-pid" in result.stderr:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit("released peer emitted missing-pid crime")
+PY
+
+echo 'PASS: production rebuild lock completes, released peer retries, and both failure terminals terminate'
 
 echo 'PASS: R_shelf_rebuild_single_flight — one build, waiter cell, dead-winner reclaim'


### PR DESCRIPTION
## Outcome

A waiter that loses the rebuild-lock mkdir now distinguishes a peer that has already published and removed the whole lock from a malformed surviving lock. A vanished lock is retried; a surviving lock without PID still refuses after the existing 0.5s publication grace; a path that remains absent across bounded retries still terminates once with the existing `crime=missing-rebuild-lock-pid`.

## Root cause

Fenster saw six consumer refusals but only two distinct lock paths (release/debug for one stamp), and both paths were absent afterward. The files were not split across host/container namespaces: managed Docker bind-mounts the shared host cache into every container. The actual race was:

1. waiter `mkdir` loses to the winner
2. winner publishes and removes the entire lock
3. waiter reads `pid` after removal and misclassifies lawful release as malformed lock state

## Executable discrimination

- planted released-peer arm creates PID/heartbeat, removes the lock between failed mkdir and waiter observation, and previously exits 70 with `missing-rebuild-lock-pid`
- repaired arm retries and acquires normally without emitting that crime
- permanently failing exact lock creation still terminates within the bounded tooth and emits the existing named crime once
- existing 8-contender/one-build, ordinary release, dead-winner reclaim, and unreclaimable-lock arms remain green

No new category, kind, label, taxonomy, or residual bucket is introduced.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry rebuild lock acquisition in `acquire_rebuild_single_flight` after peer release
> - When `mkdir` fails but the lock directory is absent (indicating a peer created and released the lock before it was observed), the function now retries up to 40 times instead of misclassifying the state as a missing-pid crime.
> - If the lock directory disappears between observing it and checking for a pid file, the loop continues rather than logging a crime.
> - After bounded retries, logs `crime=missing-rebuild-lock-pid` with `reason=lock-absent-after-bounded-retry` and exits 70.
> - Adds an integration test in [sugarbin_rebuild_single_flight.sh](https://github.com/TSavo/sugar/pull/7329/files#diff-3493587c81a430046f683f9f74a37b9480b15ac3993804953846e40850dbe6ae) that simulates the released-peer scenario by shadowing `mkdir` and verifies no missing-pid crime is emitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e748706.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock handling during concurrent rebuilds to correctly recover when a peer lock disappears during observation.
  * Prevented misleading missing-process errors when a lock is released before it can be fully inspected.
  * Added bounded retries and diagnostics for locks that remain incomplete.

* **Tests**
  * Added coverage for released-lock race conditions, including timeout and successful retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->