### PR TITLE
Preserve request identity in Python RPC errors

### DIFF
--- a/implementations/python/sugar-emit-python-hypothesis/src/sugar_emit_python_hypothesis/rpc.py
+++ b/implementations/python/sugar-emit-python-hypothesis/src/sugar_emit_python_hypothesis/rpc.py
@@ -19,6 +19,7 @@ def run_rpc() -> None:
         if not line:
             continue
         method = ""
+        request: Any = None
         try:
             request = json.loads(line)
             method = str(request.get("method", ""))
@@ -26,7 +27,7 @@ def run_rpc() -> None:
         except json.JSONDecodeError as exc:
             response = _error(None, -32700, f"PARSE_ERROR: {exc}")
         except Exception as exc:  # noqa: BLE001 - plugin errors must surface to host
-            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+            response = _dispatch_error(request, exc)
         _send(response)
         if method in {"sugar.plugin.shutdown", "shutdown"}:
             break
@@ -141,3 +142,18 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "id": msg_id,
         "error": {"code": code, "message": message},
     }
+
+
+def _dispatch_error(request: object, exc: Exception) -> dict[str, Any]:
+    exception_type = type(exc).__name__
+    msg_id = request.get("id") if isinstance(request, dict) else None
+    response = _error(
+        msg_id,
+        -32603,
+        f"{exception_type}: {exc}\n{traceback.format_exc()}",
+    )
+    response["error"]["data"] = {
+        "exception_type": exception_type,
+        "stage": "dispatch",
+    }
+    return response

--- a/implementations/python/sugar-emit-python-hypothesis/tests/test_rpc.py
+++ b/implementations/python/sugar-emit-python-hypothesis/tests/test_rpc.py
@@ -3,12 +3,71 @@
 from __future__ import annotations
 
 import json
+import io
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from sugar_emit_python_hypothesis import rpc
 from sugar_emit_python_hypothesis.rpc import dispatch
+
+
+class _CapturedStdout:
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def write(self, value: str) -> int:
+        return self.buffer.write(value.encode("utf-8"))
+
+    def flush(self) -> None:
+        return None
+
+
+def _run_one(monkeypatch: pytest.MonkeyPatch, request: str) -> dict[str, object]:
+    stdout = _CapturedStdout()
+    monkeypatch.setattr(rpc.sys, "stdin", io.StringIO(request + "\n"))
+    monkeypatch.setattr(rpc.sys, "stdout", stdout)
+    rpc.run_rpc()
+    return json.loads(stdout.buffer.getvalue())
+
+
+def test_dispatch_exception_keeps_request_id_and_named_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def refuse(_request: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("planted emitter failure")
+
+    monkeypatch.setattr(rpc, "dispatch", refuse)
+    response = _run_one(
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":37,"method":"sugar.plugin.invoke","params":{}}',
+    )
+
+    assert response["id"] == 37
+    assert response["error"]["data"] == {  # type: ignore[index]
+        "exception_type": "RuntimeError",
+        "stage": "dispatch",
+    }
+    assert str(response["error"]["message"]).startswith(  # type: ignore[index]
+        "RuntimeError: planted emitter failure"
+    )
+
+
+def test_run_rpc_normal_and_parse_error_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    normal = _run_one(
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":41,"method":"sugar.plugin.shutdown","params":{}}',
+    )
+    assert normal == {"jsonrpc": "2.0", "id": 41, "result": None}
+
+    malformed = _run_one(monkeypatch, "{")
+    assert malformed["id"] is None
+    assert malformed["error"]["code"] == -32700  # type: ignore[index]
 
 
 def _op(name: str, *args: dict) -> dict:

--- a/implementations/python/sugar-emit-python-pytest/src/sugar_emit_python_pytest/rpc.py
+++ b/implementations/python/sugar-emit-python-pytest/src/sugar_emit_python_pytest/rpc.py
@@ -36,6 +36,7 @@ def run_rpc() -> None:
         if not line:
             continue
         method = ""
+        request: Any = None
         try:
             request = json.loads(line)
             method = str(request.get("method", ""))
@@ -43,7 +44,7 @@ def run_rpc() -> None:
         except json.JSONDecodeError as exc:
             response = _error(None, -32700, f"PARSE_ERROR: {exc}")
         except Exception as exc:  # noqa: BLE001 - surface any plugin error to the host
-            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+            response = _dispatch_error(request, exc)
         _send(response)
         if method == "sugar.plugin.shutdown":
             break
@@ -115,3 +116,18 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "id": msg_id,
         "error": {"code": code, "message": message},
     }
+
+
+def _dispatch_error(request: object, exc: Exception) -> dict[str, Any]:
+    exception_type = type(exc).__name__
+    msg_id = request.get("id") if isinstance(request, dict) else None
+    response = _error(
+        msg_id,
+        -32603,
+        f"{exception_type}: {exc}\n{traceback.format_exc()}",
+    )
+    response["error"]["data"] = {
+        "exception_type": exception_type,
+        "stage": "dispatch",
+    }
+    return response

--- a/implementations/python/sugar-emit-python-pytest/tests/test_rpc.py
+++ b/implementations/python/sugar-emit-python-pytest/tests/test_rpc.py
@@ -2,9 +2,68 @@
 
 from __future__ import annotations
 
+import io
 import json
 
+import pytest
+
+from sugar_emit_python_pytest import rpc
 from sugar_emit_python_pytest.rpc import dispatch
+
+
+class _CapturedStdout:
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def write(self, value: str) -> int:
+        return self.buffer.write(value.encode("utf-8"))
+
+    def flush(self) -> None:
+        return None
+
+
+def _run_one(monkeypatch: pytest.MonkeyPatch, request: str) -> dict[str, object]:
+    stdout = _CapturedStdout()
+    monkeypatch.setattr(rpc.sys, "stdin", io.StringIO(request + "\n"))
+    monkeypatch.setattr(rpc.sys, "stdout", stdout)
+    rpc.run_rpc()
+    return json.loads(stdout.buffer.getvalue())
+
+
+def test_dispatch_exception_keeps_request_id_and_named_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def refuse(_request: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("planted emitter failure")
+
+    monkeypatch.setattr(rpc, "dispatch", refuse)
+    response = _run_one(
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":37,"method":"sugar.plugin.invoke","params":{}}',
+    )
+
+    assert response["id"] == 37
+    assert response["error"]["data"] == {  # type: ignore[index]
+        "exception_type": "RuntimeError",
+        "stage": "dispatch",
+    }
+    assert str(response["error"]["message"]).startswith(  # type: ignore[index]
+        "RuntimeError: planted emitter failure"
+    )
+
+
+def test_run_rpc_normal_and_parse_error_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    normal = _run_one(
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":41,"method":"sugar.plugin.shutdown","params":{}}',
+    )
+    assert normal == {"jsonrpc": "2.0", "id": 41, "result": None}
+
+    malformed = _run_one(monkeypatch, "{")
+    assert malformed["id"] is None
+    assert malformed["error"]["code"] == -32700  # type: ignore[index]
 
 
 def _op(name: str, *args: dict) -> dict:

--- a/implementations/python/sugar-emit-python-unittest/src/sugar_emit_python_unittest/rpc.py
+++ b/implementations/python/sugar-emit-python-unittest/src/sugar_emit_python_unittest/rpc.py
@@ -19,6 +19,7 @@ def run_rpc() -> None:
         if not line:
             continue
         method = ""
+        request: Any = None
         try:
             request = json.loads(line)
             method = str(request.get("method", ""))
@@ -26,7 +27,7 @@ def run_rpc() -> None:
         except json.JSONDecodeError as exc:
             response = _error(None, -32700, f"PARSE_ERROR: {exc}")
         except Exception as exc:  # noqa: BLE001 - surface plugin errors to the host
-            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+            response = _dispatch_error(request, exc)
         _send(response)
         if method == "sugar.plugin.shutdown":
             break
@@ -89,3 +90,18 @@ def _send(obj: dict[str, Any]) -> None:
 
 def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+
+def _dispatch_error(request: object, exc: Exception) -> dict[str, Any]:
+    exception_type = type(exc).__name__
+    msg_id = request.get("id") if isinstance(request, dict) else None
+    response = _error(
+        msg_id,
+        -32603,
+        f"{exception_type}: {exc}\n{traceback.format_exc()}",
+    )
+    response["error"]["data"] = {
+        "exception_type": exception_type,
+        "stage": "dispatch",
+    }
+    return response

--- a/implementations/python/sugar-emit-python-unittest/tests/test_rpc.py
+++ b/implementations/python/sugar-emit-python-unittest/tests/test_rpc.py
@@ -2,9 +2,68 @@
 
 from __future__ import annotations
 
+import io
 import json
 
+import pytest
+
+from sugar_emit_python_unittest import rpc
 from sugar_emit_python_unittest.rpc import dispatch
+
+
+class _CapturedStdout:
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def write(self, value: str) -> int:
+        return self.buffer.write(value.encode("utf-8"))
+
+    def flush(self) -> None:
+        return None
+
+
+def _run_one(monkeypatch: pytest.MonkeyPatch, request: str) -> dict[str, object]:
+    stdout = _CapturedStdout()
+    monkeypatch.setattr(rpc.sys, "stdin", io.StringIO(request + "\n"))
+    monkeypatch.setattr(rpc.sys, "stdout", stdout)
+    rpc.run_rpc()
+    return json.loads(stdout.buffer.getvalue())
+
+
+def test_dispatch_exception_keeps_request_id_and_named_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def refuse(_request: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("planted emitter failure")
+
+    monkeypatch.setattr(rpc, "dispatch", refuse)
+    response = _run_one(
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":37,"method":"sugar.plugin.invoke","params":{}}',
+    )
+
+    assert response["id"] == 37
+    assert response["error"]["data"] == {  # type: ignore[index]
+        "exception_type": "RuntimeError",
+        "stage": "dispatch",
+    }
+    assert str(response["error"]["message"]).startswith(  # type: ignore[index]
+        "RuntimeError: planted emitter failure"
+    )
+
+
+def test_run_rpc_normal_and_parse_error_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    normal = _run_one(
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":41,"method":"sugar.plugin.shutdown","params":{}}',
+    )
+    assert normal == {"jsonrpc": "2.0", "id": 41, "result": None}
+
+    malformed = _run_one(monkeypatch, "{")
+    assert malformed["id"] is None
+    assert malformed["error"]["code"] == -32700  # type: ignore[index]
 
 
 def _atomic(name: str, *args: dict) -> dict:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_rpc.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/bind_rpc.py
@@ -65,13 +65,14 @@ def run_rpc() -> None:
         line = line.strip()
         if not line:
             continue
+        request: Any = None
         try:
             request = json.loads(line)
             response = dispatch(request)
         except json.JSONDecodeError as exc:
             response = _error(None, -32700, f"PARSE_ERROR: {exc}")
         except Exception as exc:
-            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+            response = _dispatch_error(request, exc)
         _send(response)
 
 
@@ -255,6 +256,21 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "id": msg_id,
         "error": {"code": code, "message": message},
     }
+
+
+def _dispatch_error(request: object, exc: Exception) -> dict[str, Any]:
+    exception_type = type(exc).__name__
+    msg_id = request.get("id") if isinstance(request, dict) else None
+    response = _error(
+        msg_id,
+        -32603,
+        f"{exception_type}: {exc}\n{traceback.format_exc()}",
+    )
+    response["error"]["data"] = {
+        "exception_type": exception_type,
+        "stage": "dispatch",
+    }
+    return response
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/rpc.py
@@ -104,13 +104,14 @@ def run_rpc() -> None:
         line = line.strip()
         if not line:
             continue
+        request: Any = None
         try:
             request = json.loads(line)
             response = dispatch(request)
         except json.JSONDecodeError as exc:
             response = _error(None, -32700, f"PARSE_ERROR: {exc}")
         except Exception as exc:
-            response = _error(None, -32603, f"{exc}\n{traceback.format_exc()}")
+            response = _dispatch_error(request, exc)
         _send(response)
 
 
@@ -363,6 +364,21 @@ def _error(msg_id: Any, code: int, message: str) -> dict[str, Any]:
         "id": msg_id,
         "error": {"code": code, "message": message},
     }
+
+
+def _dispatch_error(request: object, exc: Exception) -> dict[str, Any]:
+    exception_type = type(exc).__name__
+    msg_id = request.get("id") if isinstance(request, dict) else None
+    response = _error(
+        msg_id,
+        -32603,
+        f"{exception_type}: {exc}\n{traceback.format_exc()}",
+    )
+    response["error"]["data"] = {
+        "exception_type": exception_type,
+        "stage": "dispatch",
+    }
+    return response
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_rpc.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/verify_rpc.py
@@ -299,6 +299,7 @@ def run_rpc() -> None:
         line = line.strip()
         if not line:
             continue
+        request: Any = None
         try:
             request = json.loads(line)
             response = dispatch(request)
@@ -311,18 +312,28 @@ def run_rpc() -> None:
         except (
             Exception
         ) as exc:  # noqa: BLE001 -- surface as RPC error, never crash the loop
-            response = {
-                "jsonrpc": "2.0",
-                "id": None,
-                "error": {
-                    "code": -32603,
-                    "message": f"{exc}\n{traceback.format_exc()}",
-                },
-            }
+            response = _dispatch_error(request, exc)
         sys.stdout.write(
             json.dumps(response, separators=(",", ":"), ensure_ascii=False) + "\n"
         )
         sys.stdout.flush()
+
+
+def _dispatch_error(request: object, exc: Exception) -> dict[str, Any]:
+    exception_type = type(exc).__name__
+    msg_id = request.get("id") if isinstance(request, dict) else None
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {
+            "code": -32603,
+            "message": f"{exception_type}: {exc}\n{traceback.format_exc()}",
+            "data": {
+                "exception_type": exception_type,
+                "stage": "dispatch",
+            },
+        },
+    }
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/implementations/python/sugar-lift-python-source/tests/test_rpc_error_identity.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_rpc_error_identity.py
@@ -1,0 +1,93 @@
+"""JSON-RPC failures retain the identity of the decoded request."""
+
+from __future__ import annotations
+
+import io
+import json
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_python_source import bind_rpc, rpc, verify_rpc
+from sugar_source_tree.binding_state import ConstructedValueCategoryGap
+
+
+class _CapturedStdout:
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+
+    def write(self, value: str) -> int:
+        return self.buffer.write(value.encode("utf-8"))
+
+    def flush(self) -> None:
+        return None
+
+    def response(self) -> dict[str, object]:
+        return json.loads(self.buffer.getvalue())
+
+
+RPC_MODULES = (rpc, bind_rpc, verify_rpc)
+
+
+def _run_one(
+    module: ModuleType, monkeypatch: pytest.MonkeyPatch, request: str
+) -> dict[str, object]:
+    stdout = _CapturedStdout()
+    monkeypatch.setattr(module.sys, "stdin", io.StringIO(request + "\n"))
+    monkeypatch.setattr(module.sys, "stdout", stdout)
+    module.run_rpc()
+    return stdout.response()
+
+
+@pytest.mark.parametrize("module", RPC_MODULES)
+def test_decoded_request_exception_keeps_id_and_named_reason(
+    module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def refuse(_request: dict[str, object]) -> dict[str, object]:
+        raise ConstructedValueCategoryGap(
+            "unclassified constructed value category builtins.complex"
+        )
+
+    monkeypatch.setattr(module, "dispatch", refuse)
+
+    response = _run_one(
+        module,
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":37,"method":"sugar.enumerate","params":{}}',
+    )
+
+    assert response["id"] == 37
+    assert response["error"]["code"] == -32603  # type: ignore[index]
+    assert response["error"]["data"] == {  # type: ignore[index]
+        "exception_type": "ConstructedValueCategoryGap",
+        "stage": "dispatch",
+    }
+    assert str(response["error"]["message"]).startswith(  # type: ignore[index]
+        "ConstructedValueCategoryGap: unclassified constructed value category "
+        "builtins.complex"
+    )
+
+
+@pytest.mark.parametrize("module", RPC_MODULES)
+def test_normal_request_keeps_existing_result_shape(
+    module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    response = _run_one(
+        module,
+        monkeypatch,
+        '{"jsonrpc":"2.0","id":41,"method":"shutdown","params":{}}',
+    )
+
+    assert response["id"] == 41
+    assert "result" in response
+    assert "error" not in response
+
+
+@pytest.mark.parametrize("module", RPC_MODULES)
+def test_undecoded_parse_error_remains_unattributed(
+    module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    response = _run_one(module, monkeypatch, "{")
+
+    assert response["id"] is None
+    assert response["error"]["code"] == -32700  # type: ignore[index]


### PR DESCRIPTION
A decoded JSON-RPC request that raised during dispatch was answered with `id: null`. Rust consumers validate response identity before decoding the error, so the real terminal (measured as `ConstructedValueCategoryGap` for `builtins.complex`) collapsed into a response-id mismatch.

This preserves the decoded request id on internal errors and carries the named exception as both the message prefix and structured `error.data = {exception_type, stage: dispatch}`. True JSON parse errors remain `id: null`; normal responses are unchanged.

Blast-radius audit found the same transport defect in all six Python newline-RPC loops: python-source, python-bind, python-verify, and the Hypothesis, unittest, and pytest emitters. All six are repaired rather than leaving adjacent consumers to rediscover it. No new category, kind, label, taxonomy, or residual bucket is introduced.

Evidence:
- red: 6/6 decoded-request exception arms returned `id: null`
- green: authenticated CPython 3.12.13, 32/32 focused RPC tests on exact head
- controls: normal shutdown response unchanged; undecodable parse error remains unattributed
- exact named arm: `ConstructedValueCategoryGap` survives in message and structured data
- Black 26.5.1: 10/10 files clean
- py_compile: 6/6 production modules clean
- branch tree: one commit on current main, 10 files, no deletions
- closing-account SHA-256 preserved: `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`

Predicted epsilon: the two python-bind rows stop at the real named product gap instead of the transport mismatch. This does not claim that `ConstructedValueCategoryGap` is repaired or that either row passes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve request ID in Python RPC dispatch error responses
> - Adds a `_dispatch_error` helper to all Python RPC modules that builds a `-32603` error response using the parsed request's `id` (when available), prefixes the message with the exception type, and attaches `error.data` with `exception_type` and `stage='dispatch'`.
> - Previously, unhandled dispatch exceptions always returned `id=null`; now the request `id` is captured before parsing so it can be echoed back in the error.
> - Adds tests across all three Python implementations verifying that dispatch exceptions preserve `id`, that normal shutdown requests echo `id`, and that malformed JSON still returns `id=null` with code `-32700`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0aa747e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->