### PR TITLE
Default push process floors to four shards

### DIFF
--- a/.github/workflows/factory-zero-tolerance.yml
+++ b/.github/workflows/factory-zero-tolerance.yml
@@ -8,7 +8,7 @@ on:
       shardCount:
         description: "Process-floor shard count"
         required: false
-        default: "8"
+        default: "4"
         type: string
 
 permissions:
@@ -78,7 +78,7 @@ jobs:
       - id: plan
         name: derive shard matrix
         env:
-          SHARD_COUNT: ${{ inputs.shardCount || '8' }}
+          SHARD_COUNT: ${{ inputs.shardCount || '4' }}
         run: |
           set -euo pipefail
           python3 - <<'PY' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Push-triggered process-floor telemetry now defaults to shardCount=4; workflow_dispatch still accepts an explicit 1..8 override. This preserves push telemetry while making the workflow schedulable rather than structurally stuck on an eight-runner fleet. Four shards halves seat demand from 32 to 16, but those 16 seats still drain in waves: contention is reduced, not eliminated. Fleet demand versus eight runners remains a separate capacity question tracked by #7240. Actionlint/path-smoke must validate this workflow edit before merge. No floor values are claimed by this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `shardCount` to 4 in the factory-zero-tolerance push workflow
> Updates the `factory-zero-tolerance` workflow's `shardCount` input default and its `SHARD_COUNT` fallback from `8` to `4` in [factory-zero-tolerance.yml](https://github.com/TSavo/sugar/pull/7332/files#diff-b7935b47613e0d7520fac82144ed2fcf0a5f55d0d2e259af5d19296ad96f177f). Behavioral Change: push runs with no explicit `shardCount` input now use 4 shards instead of 8.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b00489.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->