### PR TITLE
Fix lexical class owner defect import

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -45,6 +45,7 @@ from .operators import (
     UnaryOperator,
 )
 from .panic import (
+    BackendDefect,
     backend_defect,
     RuntimeSelectedContextManager,
     SourceTreePanic,

--- a/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
@@ -617,6 +617,18 @@ def test_producer_never_ran_is_loud(constructed_module_door) -> None:
         unit.constructed_module
 
 
+def test_lexical_class_owner_refuses_foreign_function_occurrence(
+    constructed_module_door,
+) -> None:
+    source = "class Box:\n    def __init__(self):\n        self.value = 1\n"
+    authentic = _file(source, "authentic-owner.py")
+    foreign = _file(source, "foreign-owner.py")
+    (foreign_initializer,) = foreign.constructed_module.function_nodes
+
+    with pytest.raises(BackendDefect, match="0 backend owner rows"):
+        authentic.unit.lexical_class_owner_for(foreign_initializer)
+
+
 def test_nested_rows_are_in_producer_order_and_module_calls_are_absent(
     constructed_module_door,
 ) -> None:


### PR DESCRIPTION
## What changed

- import the existing `BackendDefect` panic class for the lexical class-owner refusal paths
- add a real foreign-function-occurrence test that enters the zero-owner-row branch

## Root cause

Commit `aa35b26e52` introduced `SourceUnit.lexical_class_owner_for` with a bare `BackendDefect` reference. Classification: `BackendDefect` existed as a panic class, but it never existed in the `nodes.py` namespace on that path because only the `backend_defect` helper was imported; this was not a removed import or a rename. The lawful one-owner route was covered, but the refusal branch was not, so the missing name survived compilation and review until the pandas census executed it.

## Impact

The three-file pandas control-effect census no longer crashes with a `NameError` before its authenticated-partition frontier. Foreign or missing lexical-owner testimony now remains a loud typed `BackendDefect`.

## Checks

- red: the new authenticated foreign-function-occurrence test enters `lexical_class_owner_for`'s zero-owner-row branch at `nodes.py:535` and failed with the reported `NameError`
- green: new refusal arm plus lawful initializer receiver, genuine formal, and initializer-universe arms: `4 passed in 1.32s` on battleaxe

Predicted epsilon: `NameError(lexical_class_owner_for) 1 -> 0`. Floors preserved: foreign function occurrences remain a typed refusal; no owner relation is inferred or reconstructed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BackendDefect` import in `nodes` module and add test for `lexical_class_owner_for` rejection
> - Adds `BackendDefect` to the imports from `.panic` in [nodes.py](https://github.com/TSavo/sugar/pull/7334/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) so downstream code can reference it.
> - Adds a test in [test_constructed_module_backend_door.py](https://github.com/TSavo/sugar/pull/7334/files#diff-6c67bdc9d893cb9e4a7c948145c21b807a0101e6d09399dffd51c697cb9602d0) that verifies `lexical_class_owner_for` raises `BackendDefect` with a '0 backend owner rows' message when passed a function occurrence from a different module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88da0de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->