### PR TITLE
Preserve source testimony across full-tree transport

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/body_universe_dto.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/kit_rpc/body_universe_dto.py
@@ -36,6 +36,10 @@ class BodyUniverseDto:
     # it appears in harvested call ctors.
     kind: str = "contract"
     bridge_source_symbol: str | None = None
+    # Source-owned testimony carried opaquely to mint/verifier. These are
+    # sidecars on a contract row, not evidence that the function body reduced.
+    panic_loci: list[dict[str, Any]] = field(default_factory=list)
+    class_shapes: list[dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         for slot in ("pre", "post", "inv"):
@@ -90,6 +94,10 @@ class BodyUniverseDto:
         return out
 
     def _attach_sidecars(self, out: dict[str, Any]) -> None:
+        if self.panic_loci:
+            out["panicLoci"] = [to_rpc_value(locus) for locus in self.panic_loci]
+        if self.class_shapes:
+            out["classShapes"] = [to_rpc_value(shape) for shape in self.class_shapes]
         if self.source_warrants:
             out["sourceWarrants"] = [
                 to_rpc_value(warrant) for warrant in self.source_warrants

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -14,6 +14,7 @@ assertion carries no call site — call_sites and assertions are the same locus,
 
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 from typing import Any, Optional
 
@@ -348,6 +349,92 @@ def function_universe_outcome(fn):
     return sugar.desugar(context)
 
 
+@functools.lru_cache(maxsize=128)
+def _source_sidecars_by_line(source_cid: str, source: str, file_rel: str) -> tuple[
+    tuple[dict[str, Any], ...],
+    tuple[tuple[int, tuple[dict[str, Any], ...]], ...],
+]:
+    """Construct source testimony once through its authoritative door."""
+    del source_cid  # cache identity; source remains the construction input
+    from sugar_lift_python_source import lift_source
+
+    rows = lift_source(source, file_rel).ir
+    class_shapes = tuple(
+        shape
+        for row in rows
+        for shape in row.get("classShapes", [])
+        if isinstance(shape, dict)
+    )
+    by_line = []
+    for row in rows:
+        locus = row.get("locus")
+        line = locus.get("line") if isinstance(locus, dict) else None
+        if not isinstance(line, int):
+            continue
+        panic_loci = tuple(
+            item for item in row.get("panicLoci", []) if isinstance(item, dict)
+        )
+        if panic_loci:
+            by_line.append((line, panic_loci))
+    return class_shapes, tuple(by_line)
+
+
+def _source_sidecars_for_function(fn, file_rel: str):
+    class_shapes, by_line = _source_sidecars_by_line(
+        fn.unit.source_cid, fn.unit.source, file_rel
+    )
+    line = fn.line_col_span().start_line
+    panic_loci = tuple(
+        locus
+        for row_line, row_loci in by_line
+        if row_line == line
+        for locus in row_loci
+    )
+    receiver_classes = {
+        safety.get("receiverClass")
+        for locus in panic_loci
+        if isinstance((safety := locus.get("attributeSafety")), dict)
+        and isinstance(safety.get("receiverClass"), str)
+    }
+    relevant_shapes = tuple(
+        shape for shape in class_shapes if shape.get("className") in receiver_classes
+    )
+    return panic_loci, relevant_shapes
+
+
+def _source_sidecar_carrier(fn, def_memento, panic_loci, class_shapes):
+    """Carry source testimony without claiming an incomplete body reduced."""
+    from sugar_lift_py_tests.floor.universe_mint_projection import claim_formula
+    from sugar_lift_py_tests.ir import atomic
+    from sugar_lift_py_tests.kit_rpc import BodyUniverseDto
+    from sugar_lift_py_tests.proofir.nodes import ConstructionSite, Derived, Provenance
+
+    span = def_memento.span
+    provenance = Provenance(
+        node_class="SourceSidecarCarrier",
+        construction_site=ConstructionSite(
+            path=def_memento.file,
+            line=span.start_line,
+            column=span.start_col,
+        ),
+        warrant=Derived(floor_chain=("sugar_lift_python_source.lift_source",)),
+    )
+    return BodyUniverseDto(
+        name=fn.name,
+        pre=claim_formula(
+            atomic("true", []),
+            formals=(),
+            provenance=provenance,
+            role="pre",
+        ),
+        source_warrants=[def_memento],
+        proofir_provenance=provenance.to_rpc(),
+        kind="contract",
+        panic_loci=list(panic_loci),
+        class_shapes=list(class_shapes),
+    )
+
+
 def function_contract_rows(fn, file_rel: str):
     """A function's contract DTO rows, produced from its TREE universe.
 
@@ -359,13 +446,26 @@ def function_contract_rows(fn, file_rel: str):
     a contract. A SugarNotWritten from an unported body statement propagates
     (the whole function is a frontier gap).
     """
+    import dataclasses
+
     from sugar_lift_py_tests.outcome import Complete
 
     def_memento = function_def_memento(fn, file_rel)
+    panic_loci, class_shapes = _source_sidecars_for_function(fn, file_rel)
     outcome = function_universe_outcome(fn)
     if not isinstance(outcome, Complete):
-        return def_memento, None  # an effect; not a contract
-    return def_memento, outcome.value.payload_rows(def_memento)
+        if not panic_loci and not class_shapes:
+            return def_memento, None  # an effect with no source testimony
+        return def_memento, [
+            _source_sidecar_carrier(fn, def_memento, panic_loci, class_shapes)
+        ]
+    rows = outcome.value.payload_rows(def_memento)
+    rows[0] = dataclasses.replace(
+        rows[0],
+        panic_loci=list(panic_loci),
+        class_shapes=list(class_shapes),
+    )
+    return def_memento, rows
 
 
 def call_nodes_in_assert(sf: SourceFile, span: Optional[dict]) -> list:

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -815,6 +815,65 @@ def test_universe_scan_lists_function_contract_rows(project: Path) -> None:
     assert result["gaps"] == []
 
 
+def test_full_tree_universe_carries_source_constructed_attribute_sidecars(
+    tmp_path: Path,
+) -> None:
+    """An incomplete body must keep its testimony without becoming complete."""
+    source = (
+        Path(__file__).parents[4]
+        / "examples/numpy-attribute-safety-showcase/good/src/numpy_box.py"
+    ).read_text(encoding="utf-8")
+    subject = tmp_path / "numpy_box.py"
+    subject.write_text(source, encoding="utf-8")
+
+    from sugar_lift_python_source import lift_source
+
+    source_rows = lift_source(source, subject.name).ir
+    source_shapes = next(
+        row["classShapes"] for row in source_rows if "classShapes" in row
+    )
+    source_loci = next(
+        row["panicLoci"]
+        for row in source_rows
+        if str(row.get("fnName") or "").endswith(".scaled_total")
+    )
+    assert len(source_shapes) == 1
+    assert sum("attributeSafety" in locus for locus in source_loci) == 2
+
+    file_memento = _enumerate("source_files", tmp_path)["nodes"][0]["memento"]
+    result = _enumerate("universe", tmp_path, at=file_memento, seek=False)
+    audits = [node["audit"] for node in result["nodes"]]
+    transported = next(
+        row
+        for row in audits
+        if any("attributeSafety" in locus for locus in row.get("panicLoci", []))
+    )
+
+    assert transported["panicLoci"] == source_loci
+    assert transported["classShapes"] == source_shapes
+    assert "post" not in transported, (
+        "transporting source testimony must not invent completion for the "
+        "temporally incomplete scaled_total body"
+    )
+    init = next(row for row in audits if row.get("name") == "__init__")
+    assert "post" in init
+
+
+def test_full_tree_universe_omits_empty_source_sidecars(tmp_path: Path) -> None:
+    """A class-free completed function must not acquire fabricated testimony."""
+    (tmp_path / "identity.py").write_text(
+        "def identity(value):\n    return value\n", encoding="utf-8"
+    )
+
+    file_memento = _enumerate("source_files", tmp_path)["nodes"][0]["memento"]
+    result = _enumerate("universe", tmp_path, at=file_memento, seek=False)
+
+    assert len(result["nodes"]) == 1
+    audit = result["nodes"][0]["audit"]
+    assert "panicLoci" not in audit
+    assert "classShapes" not in audit
+
+
 def test_callable_universe_identity_uses_content_and_qualified_spelling(
     tmp_path: Path,
 ) -> None:

--- a/implementations/rust/sugar-compiler/src/feed_from_tree.rs
+++ b/implementations/rust/sugar-compiler/src/feed_from_tree.rs
@@ -99,6 +99,8 @@ struct ClaimExtras {
     body_discharge_eligible: bool,
     body_discharge_refusal_reason: Option<String>,
     proofir_provenance: Option<Arc<CValue>>,
+    panic_loci: Vec<Arc<CValue>>,
+    class_shapes: Vec<Arc<CValue>>,
 }
 
 impl Default for ClaimExtras {
@@ -115,6 +117,8 @@ impl Default for ClaimExtras {
                 "feed_from_tree: body discharge not claimed (no IR policy)".into(),
             ),
             proofir_provenance: None,
+            panic_loci: Vec::new(),
+            class_shapes: Vec::new(),
         }
     }
 }
@@ -209,8 +213,8 @@ fn push_claim_with_slots(
         bridge_source_symbol: extras.bridge_source_symbol,
         body_discharge_eligible: extras.body_discharge_eligible,
         body_discharge_refusal_reason: extras.body_discharge_refusal_reason,
-        panic_loci: Vec::new(),
-        class_shapes: Vec::new(),
+        panic_loci: extras.panic_loci,
+        class_shapes: extras.class_shapes,
         source_warrants,
         proofir_provenance: extras.proofir_provenance,
         contract_name: contract_name.to_string(),
@@ -467,6 +471,26 @@ fn out_binding_from_ir_row(ir: &Json) -> String {
         .to_string()
 }
 
+fn source_sidecars_from_ir_row(
+    ir: &Json,
+) -> Result<(Vec<Arc<CValue>>, Vec<Arc<CValue>>), FeedError> {
+    fn array(ir: &Json, camel: &str, snake: &str) -> Result<Vec<Arc<CValue>>, FeedError> {
+        let Some(items) = ir
+            .get(camel)
+            .or_else(|| ir.get(snake))
+            .and_then(Json::as_array)
+        else {
+            return Ok(Vec::new());
+        };
+        items.iter().map(json_to_cvalue).collect()
+    }
+
+    Ok((
+        array(ir, "panicLoci", "panic_loci")?,
+        array(ir, "classShapes", "class_shapes")?,
+    ))
+}
+
 fn proofir_provenance_variants(ir: &Json) -> Result<Vec<Option<Arc<CValue>>>, FeedError> {
     let Some(provenance) = ir
         .get("proofirProvenance")
@@ -638,6 +662,7 @@ pub fn graph_from_fact(fact: &Fact) -> Result<ProofGraph, FeedError> {
         Some(ir) => {
             let (formals, formals_present) = formals_from_ir_row(ir);
             let (eligible, reason) = body_policy_from_ir(ir);
+            let (panic_loci, class_shapes) = source_sidecars_from_ir_row(ir)?;
             ClaimExtras {
                 emit_empty_formals: formals_present && formals.is_empty(),
                 formals,
@@ -647,6 +672,8 @@ pub fn graph_from_fact(fact: &Fact) -> Result<ProofGraph, FeedError> {
                 body_discharge_eligible: eligible,
                 body_discharge_refusal_reason: reason,
                 proofir_provenance: None,
+                panic_loci,
+                class_shapes,
             }
         }
         None => ClaimExtras::default(),
@@ -731,6 +758,7 @@ pub fn graph_from_universe(u: &Universe) -> Result<ProofGraph, FeedError> {
             }
         }
         let (formals, formals_present) = formals_from_ir_row(ir);
+        let (panic_loci, class_shapes) = source_sidecars_from_ir_row(ir)?;
         // Function-contracts: kind-derived default eligible; IR can refuse.
         let (eligible, reason) = body_policy_from_ir(ir);
         // #3587 sole-construction: do not drop IR proofirProvenance. Ambient
@@ -746,6 +774,8 @@ pub fn graph_from_universe(u: &Universe) -> Result<ProofGraph, FeedError> {
             body_discharge_eligible: eligible,
             body_discharge_refusal_reason: reason,
             proofir_provenance: None,
+            panic_loci,
+            class_shapes,
         };
         let provenance_variants = proofir_provenance_variants(ir)?;
         for proofir_provenance in provenance_variants {
@@ -967,6 +997,66 @@ mod silent_loss_3901_tests {
             c.contract_name,
             sorts.len()
         );
+    }
+
+    #[test]
+    fn graph_from_universe_carries_source_sidecars_without_fabricating_empty_ones() {
+        let panic_locus = json!({
+            "callee": "concept:panic-freedom.leaf.runtime-failure-site",
+            "subkind": "attribute-access",
+            "argTerm": {
+                "kind": "ctor",
+                "name": "python:attribute",
+                "args": [
+                    {"kind": "var", "name": "self"},
+                    {"kind": "const", "value": "value", "sort": {"kind": "primitive", "name": "String"}}
+                ]
+            },
+            "attributeSafety": {
+                "kind": "python:attribute-safety-obligation",
+                "receiverClass": "shape.Box",
+                "attribute": "value"
+            }
+        });
+        let class_shape = json!({
+            "kind": "python:class-shape",
+            "className": "shape.Box",
+            "status": "closed",
+            "openReasons": [],
+            "attributes": [{"name": "value", "presence": "guaranteed"}]
+        });
+        let carried = json!({
+            "kind": "function-contract",
+            "name": "shape.Box.read",
+            "post": {"kind": "atomic", "name": "true", "args": []},
+            "panicLoci": [panic_locus.clone()],
+            "classShapes": [class_shape.clone()]
+        });
+        let graph = graph_from_universe(&Universe::for_feed_test(
+            test_memento("shape.Box.read"),
+            Some(carried),
+            None,
+        ))
+        .expect("graph_from_universe");
+        let contract = first_contract(&graph);
+
+        assert_eq!(contract.panic_loci, Some(vec![panic_locus]));
+        assert_eq!(contract.class_shapes, Some(vec![class_shape]));
+
+        let absent = json!({
+            "kind": "function-contract",
+            "name": "identity",
+            "post": {"kind": "atomic", "name": "true", "args": []}
+        });
+        let graph = graph_from_universe(&Universe::for_feed_test(
+            test_memento("identity"),
+            Some(absent),
+            None,
+        ))
+        .expect("graph_from_universe");
+        let contract = first_contract(&graph);
+        assert!(contract.panic_loci.is_none());
+        assert!(contract.class_shapes.is_none());
     }
 
     /// #3587 sole-construction: IR proofirProvenance must reach the sealed


### PR DESCRIPTION
## Root cause

`python-source` already constructs the NumPy fixture testimony: 3 rows, 1 `classShapes` entry, 4 `panicLoci`, and 2 `attributeSafety` loci. Full-tree transport then lost it at two independent boundaries:

1. `BodyUniverseDto` had no slots for `panicLoci` or `classShapes`.
2. targeted `graph_from_universe` reconstructed the contract member with both collections hardcoded empty.

The proof therefore contained `__init__` but zero source sidecars, and prove reported one discharged witness row with zero attribute-safety rows.

## Change

- add source-owned `panicLoci` and `classShapes` sidecars to the full-tree DTO wire
- obtain them through the existing authoritative `sugar_lift_python_source.lift_source` construction door, cached by source identity
- preserve source testimony for an incomplete function in a pre-only carrier with body discharge still ineligible and no `post`; transporting testimony does not claim body completion
- thread both fields through the targeted Rust universe feed instead of substituting empty vectors
- omit both fields when the source producer constructs none

Predicted movement: the 2 demonstrated full-tree silent-drop entrances become 0. Floors preserved: no fabricated empty testimony, no inferred `scaled_total` postcondition, and no weakening of the source producer or verifier.

## Red / green evidence

Red before implementation:

- Python discrimination: 1 failed / 1 passed, exit 1. The carried arm found no transported attribute-safety row; the empty twin remained lawful.
- Rust targeted feed: 1 failed, exit 101. `panic_loci` was `None` instead of the carried value.

Fresh verification on head `f4baf615ec3dc4c126497b375de5eabd1444d256`, based on `6cb007a1bb2255c7fc5bdb4f734f60044055e615`:

- `bin/bpytest ...test_enumerate_rpc.py -k full_tree_universe... -q`: 2 passed / 43 deselected, exit 0, authenticated CPython 3.12.13 / pandas 3.0.3
- `bin/bcargo test ... -p sugar-compiler --lib graph_from_universe_ -- --nocapture`: 5 passed / 60 filtered, exit 0
- Black 26.5.1 check: exit 0
- cargo fmt check: exit 0
- tree diff check: four intended modified files, no deletions; `git diff --check` exit 0

## Controlled broader telemetry

The whole `test_enumerate_rpc.py` module has an independent pre-existing population filed as #7335. Bare `c593783cb6682686dfebaab1e406f1fe7527dfd1` produced 23 failed / 20 passed. This branch produced the identical 23 failure node IDs plus its two passing teeth: 23 failed / 22 passed. Membership delta is empty.

## Unmeasured

The live NumPy showcase did not execute: two attempts refused before the showcase with `crime=missing-rebuild-lock-pid`, exit 70. That lifecycle issue is under separate diagnosis. This PR does not claim showcase clearance or complete construction of `scaled_total`; it repairs and discriminates the transport boundary only.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve source testimony (panicLoci and classShapes) across full-tree transport
> - Adds `panic_loci` and `class_shapes` fields to `BodyUniverseDto` and emits them as `panicLoci`/`classShapes` in RPC output when non-empty.
> - Introduces cached source sidecar helpers in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/7336/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) that extract `panicLoci` and filtered `classShapes` from lifted source IR, keyed per source file to avoid recomputation.
> - For incomplete function bodies, `function_contract_rows` now emits a sidecar-only contract row carrying source testimony without asserting a post; for complete bodies, sidecars are attached to the first row.
> - Extends `ClaimExtras` in [feed_from_tree.rs](https://github.com/TSavo/sugar/pull/7336/files#diff-e78aee19ed4b4f3036fd2b9522bf63587485811d1259757eb4e128852849e164) to carry `panic_loci`/`class_shapes` read from IR rows, so constructed claims include these sidecars instead of always emitting empty arrays.
> - Behavioral Change: universe and fact claims backed by IR rows with sidecar keys now include those values; IR rows without them produce claims with neither field present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4baf61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->