### PR TITLE
Authenticate rebuild-lock creation states

### DIFF
--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -1646,21 +1646,43 @@ _stamp_short() {
 # log()) within 30s and every 30s after. CI is not a TTY — never gate these.
 acquire_rebuild_single_flight() {
   local stamp="$1" name="$2" lock_parent lockdir waited=0 stale_s age
-  local wait_start holder stamp_short now elapsed announced=0 missing_dir_retries=0
+  local wait_start holder stamp_short now elapsed announced=0
+  local state_observation state state_detail
   _rebuild_lock_dir=""
   _rebuild_heartbeat_pid=""
   lock_parent="$(cache_dir)/.rebuild-locks"
-  if ! mkdir -p "$lock_parent" 2>/dev/null; then
-    log "crime=uncreatable-rebuild-lock-path owner=bin/sugarbin path=$lock_parent replacement=provide a writable declared cache root before binary resolution"
+  if ! state_observation="$(python3 "$script_dir/../tools/rebuild_lock_state.py" publish-parent "$lock_parent" 2>&1)"; then
+    log "crime=rebuild-lock-state-helper-failed owner=tools/rebuild_lock_state.py path=$lock_parent detail=$state_observation replacement=restore the declared lock-state classifier before binary resolution"
     return 70
   fi
+  IFS=$'\t' read -r state state_detail <<<"$state_observation"
+  case "$state" in
+    ready) ;;
+    create-refused)
+      log "crime=rebuild-lock-create-refused owner=bin/sugarbin path=$lock_parent state=$state observation=$state_detail replacement=provide a creatable declared rebuild-lock root before binary resolution"
+      return 70
+      ;;
+    unshareable)
+      log "crime=unshareable-rebuild-lock-path owner=bin/sugarbin path=$lock_parent state=$state observation=$state_detail replacement=regenerate only the derived rebuild-lock parent as shared-writable; do not mutate the binary cache"
+      return 70
+      ;;
+    *)
+      log "crime=unknown-rebuild-lock-parent-state owner=tools/rebuild_lock_state.py path=$lock_parent state=${state:-absent} observation=$state_detail replacement=restore the closed rebuild-lock parent protocol"
+      return 70
+      ;;
+  esac
   # Directory name IS the lock: mkdir succeeds for exactly one contender.
   lockdir="$lock_parent/$(platform_key)-${profile}-$(stamp_for_filename "$stamp")-${bin_name}.lock"
   stale_s="$(_rebuild_lock_stale_seconds)"
   stamp_short="$(_stamp_short "$stamp")"
   wait_start="$(date +%s)"
   while true; do
-    if mkdir "$lockdir" 2>/dev/null; then
+    if ! state_observation="$(python3 "$script_dir/../tools/rebuild_lock_state.py" create "$lockdir" 2>&1)"; then
+      log "crime=rebuild-lock-state-helper-failed owner=tools/rebuild_lock_state.py path=$lockdir detail=$state_observation replacement=restore the declared lock-state classifier before binary resolution"
+      return 70
+    fi
+    IFS=$'\t' read -r state state_detail <<<"$state_observation"
+    if [[ "$state" == acquired ]]; then
       if ! printf '%s\n' "$$" >"$lockdir/pid" 2>/dev/null \
         || ! : >"$lockdir/heartbeat" 2>/dev/null; then
         rm -rf "$lockdir" 2>/dev/null || true
@@ -1688,18 +1710,22 @@ acquire_rebuild_single_flight() {
       fi
       return 0
     fi
-    # A failed mkdir proves contention only at that instant. The winner may
-    # publish and release before this waiter observes the lock; retry that
-    # lawful disappearance instead of misclassifying it as missing testimony.
-    if [[ ! -d "$lockdir" ]]; then
-      missing_dir_retries=$((missing_dir_retries + 1))
-      if (( missing_dir_retries >= 40 )); then
-        log "crime=missing-rebuild-lock-pid owner=bin/sugarbin path=$lockdir/pid lock=$lockdir holder_pid=unknown reason=lock-absent-after-bounded-retry replacement=repair the declared lock root; an absent holder record is not peer contention"
-        return 70
-      fi
+    if [[ "$state" == released ]]; then
       continue
     fi
-    missing_dir_retries=0
+    if [[ "$state" == create-refused ]]; then
+      log "crime=rebuild-lock-create-refused owner=bin/sugarbin path=$lockdir state=$state observation=$state_detail replacement=repair the declared shared-writable lock root; create refusal is not peer contention"
+      return 70
+    fi
+    if [[ "$state" != contended ]]; then
+      log "crime=unknown-rebuild-lock-state owner=tools/rebuild_lock_state.py path=$lockdir state=${state:-absent} observation=$state_detail replacement=restore the closed rebuild-lock lifecycle protocol"
+      return 70
+    fi
+    # Contention is authenticated EEXIST. The winner may release between that
+    # observation and the holder read; retry the lawful released state.
+    if [[ ! -d "$lockdir" ]]; then
+      continue
+    fi
     # A lock directory that still exists gets one bounded chance to publish
     # its PID. Absence after that is not an unknown holder to wait on forever.
     if [[ ! -f "$lockdir/pid" ]]; then

--- a/tests/sugarbin_rebuild_single_flight.sh
+++ b/tests/sugarbin_rebuild_single_flight.sh
@@ -11,7 +11,9 @@ set -euo pipefail
 
 repo="${1:?usage: sugarbin_rebuild_single_flight.sh REPO_ROOT}"
 sugarbin="$repo/bin/sugarbin"
+lock_state="$repo/tools/rebuild_lock_state.py"
 [[ -x "$sugarbin" ]] || { echo "missing $sugarbin" >&2; exit 1; }
+[[ -f "$lock_state" ]] || { echo "missing $lock_state" >&2; exit 1; }
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -29,7 +31,12 @@ acquire_body="$(sed -n '/^acquire_rebuild_single_flight()/,/^release_rebuild_sin
 grep -Fq 'stamp_for_filename "$stamp"' <<<"$acquire_body" || fail 'lock key does not include stamp'
 grep -Fq 'bin_name' <<<"$acquire_body" || fail 'lock key does not include bin_name'
 grep -Fq 'platform_key' <<<"$acquire_body" || fail 'lock key does not include platform'
-grep -Fq 'mkdir "$lockdir"' <<<"$acquire_body" || fail 'lock must use atomic mkdir'
+grep -Fq 'rebuild_lock_state.py' <<<"$acquire_body" \
+  || fail 'lock acquisition must use the errno-preserving atomic-create door'
+grep -Fq 'crime=rebuild-lock-create-refused' <<<"$acquire_body" \
+  || fail 'create refusal must not collapse into EEXIST contention'
+grep -Fq 'crime=unshareable-rebuild-lock-path' <<<"$acquire_body" \
+  || fail 'foreign-mode lock parent must refuse before contention'
 # kill -0 alone is forbidden as reclaim (PID namespace lie / wedge).
 if grep -E 'kill -0' <<<"$acquire_body" | grep -vq 'heartbeat'; then
   # allow only if not the reclaim path — reclaim must use heartbeat age
@@ -187,6 +194,115 @@ SUGAR_BINARY_SOURCE_STAMP="$production_stamp" \
   >"$tmp/production-good.out" 2>"$tmp/production-good.err" \
   || fail 'production acquire/release arm refused'
 [[ ! -e "$production_lock" ]] || fail 'production acquire/release arm left lock residue'
+production_parent="$production_cache/.rebuild-locks"
+parent_mode="$(stat -c %a "$production_parent" 2>/dev/null || stat -f %Lp "$production_parent")"
+[[ "${parent_mode: -3}" == 777 ]] \
+  || fail "production lock parent is not shared-writable: mode=$parent_mode"
+
+# Never-created and create-refused are distinct states. A fresh path above
+# acquired and released normally. This planted EACCES arm exercises the same
+# errno-preserving door without relying on the test runner's uid (battleaxe
+# may execute the surrounding shell as root).
+python3 - "$lock_state" <<'PY'
+import errno
+import importlib.util
+import pathlib
+import stat
+import tempfile
+from unittest import mock
+import sys
+
+path = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("rebuild_lock_state", path)
+if spec is None or spec.loader is None:
+    raise SystemExit("cannot load rebuild-lock state helper")
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+with mock.patch.object(
+    module.os,
+    "mkdir",
+    side_effect=PermissionError(errno.EACCES, "Permission denied"),
+):
+    result = module.create_lock_directory(pathlib.Path("/fixture/lock"))
+if result.state != "create-refused":
+    raise SystemExit(f"EACCES collapsed into {result.state}")
+if result.errno_name != "EACCES" or result.errno_number != errno.EACCES:
+    raise SystemExit(f"EACCES testimony lost: {result}")
+if "Permission denied" not in result.detail:
+    raise SystemExit(f"EACCES detail lost: {result}")
+with tempfile.TemporaryDirectory() as directory:
+    parent = pathlib.Path(directory) / "shared-parent"
+    result = module.publish_lock_parent(parent)
+    if result.state != "ready" or stat.S_IMODE(parent.stat().st_mode) != 0o777:
+        raise SystemExit(f"shared parent was not published as 0777: {result}")
+    lock = parent / "one.lock"
+    result = module.create_lock_directory(lock)
+    if result.state != "acquired" or stat.S_IMODE(lock.stat().st_mode) != 0o777:
+        raise SystemExit(f"shared lock was not published as 0777: {result}")
+    if module.create_lock_directory(lock).state != "contended":
+        raise SystemExit("existing lock directory did not classify as contended")
+with tempfile.TemporaryDirectory() as directory:
+    parent = pathlib.Path(directory) / "foreign-parent"
+    parent.mkdir(mode=0o755)
+    if module.publish_lock_parent(parent).state != "unshareable":
+        raise SystemExit("0755 parent did not refuse as unshareable")
+with mock.patch.object(module.os, "mkdir", side_effect=FileExistsError(errno.EEXIST, "exists")):
+    if module.create_lock_directory(pathlib.Path("/fixture/released")).state != "released":
+        raise SystemExit("released EEXIST winner did not classify as released")
+PY
+
+# Created-unpublished: EEXIST is real contention, but its winner never wrote a
+# holder record. This must terminate once after the bounded publication grace.
+mkdir -m 0777 "$production_lock"
+python3 - "$sugarbin" "$production_cache" "$production_stamp" \
+  "$production_lock" <<'PY'
+import os
+import subprocess
+import sys
+
+sugarbin, cache, stamp, lock = sys.argv[1:]
+env = os.environ.copy()
+env.update(
+    {
+        "SUGAR_BINARY_CACHE_DIR": cache,
+        "SUGAR_BINARY_SOURCE_STAMP": stamp,
+    }
+)
+try:
+    result = subprocess.run(
+        [
+            sugarbin,
+            "preflight-lock",
+            "--bin",
+            "sugar",
+            "--profile",
+            "debug",
+            "--platform",
+            "fixture",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+except subprocess.TimeoutExpired as error:
+    raise SystemExit(f"created-unpublished arm did not terminate: {error.stderr}")
+if result.returncode != 70:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit(f"expected exit 70, observed {result.returncode}")
+terminal = "crime=missing-rebuild-lock-pid"
+if result.stderr.count(terminal) != 1:
+    print(result.stderr, file=sys.stderr)
+    raise SystemExit("expected exactly one created-unpublished terminal")
+for testimony in (lock + "/pid", "holder_pid=unknown"):
+    if testimony not in result.stderr:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit(f"missing created-unpublished testimony: {testimony}")
+PY
+rm -rf "$production_lock"
 
 mkdir -p "$production_lock"
 printf 'dead\n' >"$production_lock/pid"
@@ -266,30 +382,21 @@ for testimony in (lock, "holder_pid=dead", "heartbeat_age_s=999999"):
 PY
 
 rm -rf "$production_lock"
-mkdir -p "$tmp/refuse-lock-mkdir-bin"
-cat >"$tmp/refuse-lock-mkdir-bin/mkdir" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$#" == 1 && "$1" == "${LOCK_TO_REFUSE:?}" ]]; then
-  exit 77
-fi
-exec /bin/mkdir "$@"
-EOF
-chmod +x "$tmp/refuse-lock-mkdir-bin/mkdir"
+create_refused_cache="$tmp/create-refused-cache"
+mkdir -p "$create_refused_cache"
+printf 'not-a-directory\n' >"$create_refused_cache/.rebuild-locks"
 
-python3 - "$sugarbin" "$production_cache" "$production_stamp" \
-  "$production_lock" "$tmp/refuse-lock-mkdir-bin" \
-  "$tmp/production-missing-pid.json" <<'PY'
+python3 - "$sugarbin" "$create_refused_cache" "$production_stamp" \
+  "$tmp/production-create-refused.json" <<'PY'
 import json
 import os
 import subprocess
 import sys
 
-sugarbin, cache, stamp, lock, refuse_bin, receipt = sys.argv[1:]
+sugarbin, cache, stamp, receipt = sys.argv[1:]
 env = os.environ.copy()
 env.update(
     {
-        "LOCK_TO_REFUSE": lock,
-        "PATH": refuse_bin + os.pathsep + env["PATH"],
         "SUGAR_BINARY_CACHE_DIR": cache,
         "SUGAR_BINARY_SOURCE_STAMP": stamp,
     }
@@ -317,7 +424,7 @@ except subprocess.TimeoutExpired as error:
     stderr = error.stderr or ""
     if isinstance(stderr, bytes):
         stderr = stderr.decode(errors="replace")
-    print("production missing-pid arm did not terminate within 5s", file=sys.stderr)
+    print("production create-refused arm did not terminate within 5s", file=sys.stderr)
     print(stderr, file=sys.stderr)
     raise SystemExit(1)
 json.dump(
@@ -328,90 +435,53 @@ json.dump(
 if result.returncode != 70:
     print(result.stderr, file=sys.stderr)
     raise SystemExit(f"expected exit 70, observed {result.returncode}")
-terminal = "crime=missing-rebuild-lock-pid"
+terminal = "crime=rebuild-lock-create-refused"
 if result.stderr.count(terminal) != 1:
     print(result.stderr, file=sys.stderr)
-    raise SystemExit("expected exactly one named missing-pid terminal")
-for testimony in (lock + "/pid", "holder_pid=unknown"):
+    raise SystemExit("expected exactly one named create-refused terminal")
+for testimony in ("state=create-refused", '"errno_name":"ENOTDIR"'):
     if testimony not in result.stderr:
         print(result.stderr, file=sys.stderr)
         raise SystemExit(f"missing terminal testimony: {testimony}")
 PY
 
-# A failed mkdir only proves contention at that instant. The peer can publish
-# and release the whole lock before this waiter reads pid. That lawful absence
-# is not malformed lock state: the waiter must retry, then acquire normally.
+# A real peer can publish and release the whole lock while this waiter is
+# observing it. Drive the production door until it narrates contention, then
+# release; the waiter must retry and acquire rather than invent a missing PID.
 rm -rf "$production_lock"
-mkdir -p "$tmp/released-peer-mkdir-bin"
-cat >"$tmp/released-peer-mkdir-bin/mkdir" <<'EOF'
-#!/usr/bin/env bash
-if [[ "$#" == 1 && "$1" == "${LOCK_TO_RELEASE:?}" \
-      && ! -e "${RELEASED_PEER_STATE:?}" ]]; then
-  : >"$RELEASED_PEER_STATE"
-  /bin/mkdir "$LOCK_TO_RELEASE"
-  printf 'peer\n' >"$LOCK_TO_RELEASE/pid"
-  : >"$LOCK_TO_RELEASE/heartbeat"
-  /bin/rm -rf "$LOCK_TO_RELEASE"
-  exit 1
+mkdir -m 0777 "$production_lock"
+printf 'peer\n' >"$production_lock/pid"
+: >"$production_lock/heartbeat"
+SUGAR_BINARY_CACHE_DIR="$production_cache" \
+SUGAR_BINARY_SOURCE_STAMP="$production_stamp" \
+  "$sugarbin" preflight-lock --bin sugar --profile debug --platform fixture \
+  >"$tmp/released-peer.out" 2>"$tmp/released-peer.err" &
+released_waiter=$!
+observed_wait=0
+for _ in $(seq 1 100); do
+  if grep -Fq 'phase=resolve-wait ' "$tmp/released-peer.err" 2>/dev/null; then
+    observed_wait=1
+    break
+  fi
+  sleep 0.02
+done
+[[ "$observed_wait" == 1 ]] || {
+  kill "$released_waiter" 2>/dev/null || true
+  wait "$released_waiter" 2>/dev/null || true
+  fail 'released-peer arm never observed authenticated contention'
+}
+rm -rf "$production_lock"
+wait "$released_waiter" || {
+  cat "$tmp/released-peer.err" >&2
+  fail 'released peer was misclassified as malformed lock'
+}
+grep -Fq 'phase=resolve-wait-acquired' "$tmp/released-peer.err" \
+  || fail 'released-peer waiter did not reacquire after lawful release'
+if grep -Fq 'crime=missing-rebuild-lock-pid' "$tmp/released-peer.err"; then
+  cat "$tmp/released-peer.err" >&2
+  fail 'released peer emitted missing-pid crime'
 fi
-exec /bin/mkdir "$@"
-EOF
-chmod +x "$tmp/released-peer-mkdir-bin/mkdir"
 
-python3 - "$sugarbin" "$production_cache" "$production_stamp" \
-  "$production_lock" "$tmp/released-peer-mkdir-bin" \
-  "$tmp/released-peer-state" <<'PY'
-import os
-import subprocess
-import sys
-
-sugarbin, cache, stamp, lock, fake_bin, state = sys.argv[1:]
-env = os.environ.copy()
-env.update(
-    {
-        "LOCK_TO_RELEASE": lock,
-        "PATH": fake_bin + os.pathsep + env["PATH"],
-        "RELEASED_PEER_STATE": state,
-        "SUGAR_BINARY_CACHE_DIR": cache,
-        "SUGAR_BINARY_SOURCE_STAMP": stamp,
-    }
-)
-try:
-    result = subprocess.run(
-        [
-            sugarbin,
-            "preflight-lock",
-            "--bin",
-            "sugar",
-            "--profile",
-            "debug",
-            "--platform",
-            "fixture",
-        ],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        timeout=8,
-        check=False,
-    )
-except subprocess.TimeoutExpired as error:
-    stderr = error.stderr or ""
-    if isinstance(stderr, bytes):
-        stderr = stderr.decode(errors="replace")
-    print("released-peer retry arm did not terminate within 8s", file=sys.stderr)
-    print(stderr, file=sys.stderr)
-    raise SystemExit(1)
-if result.returncode != 0:
-    print(result.stderr, file=sys.stderr)
-    raise SystemExit(
-        f"released peer was misclassified as malformed lock: {result.returncode}"
-    )
-if "crime=missing-rebuild-lock-pid" in result.stderr:
-    print(result.stderr, file=sys.stderr)
-    raise SystemExit("released peer emitted missing-pid crime")
-PY
-
-echo 'PASS: production rebuild lock completes, released peer retries, and both failure terminals terminate'
+echo 'PASS: lock lifecycle covers never-created, create-refused, created-unpublished, published-live, published-dead, released, and unreclaimable states'
 
 echo 'PASS: R_shelf_rebuild_single_flight — one build, waiter cell, dead-winner reclaim'

--- a/tools/rebuild_lock_state.py
+++ b/tools/rebuild_lock_state.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Classify rebuild-lock publication without discarding operating-system facts."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+import stat
+
+
+@dataclass(frozen=True)
+class LockStateResult:
+    state: str
+    path: str
+    errno_name: str | None = None
+    errno_number: int | None = None
+    detail: str | None = None
+    mode: str | None = None
+    uid: int | None = None
+    gid: int | None = None
+
+
+def _refused(path: Path, error: OSError) -> LockStateResult:
+    number = error.errno
+    return LockStateResult(
+        state="create-refused",
+        path=str(path),
+        errno_name=errno.errorcode.get(number, "UNKNOWN") if number else "UNKNOWN",
+        errno_number=number,
+        detail=str(error),
+    )
+
+
+def _mkdir_shared(path: Path) -> None:
+    previous = os.umask(0)
+    try:
+        os.mkdir(path, 0o777)
+    finally:
+        os.umask(previous)
+
+
+def create_lock_directory(path: Path) -> LockStateResult:
+    """Atomically acquire *path*, distinguishing EEXIST from create refusal."""
+
+    try:
+        _mkdir_shared(path)
+    except FileExistsError as error:
+        if path.is_dir():
+            return LockStateResult(state="contended", path=str(path))
+        if not path.exists():
+            # The EEXIST winner lawfully released between mkdir and observation.
+            return LockStateResult(state="released", path=str(path))
+        return _refused(
+            path,
+            NotADirectoryError(
+                errno.ENOTDIR,
+                "existing rebuild-lock path is not a directory",
+                str(path),
+            ),
+        )
+    except OSError as error:
+        return _refused(path, error)
+    return LockStateResult(state="acquired", path=str(path), mode="0777")
+
+
+def publish_lock_parent(path: Path) -> LockStateResult:
+    """Create and authenticate the cross-identity rebuild-lock namespace."""
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        return _refused(path, error)
+    try:
+        _mkdir_shared(path)
+    except FileExistsError:
+        pass
+    except OSError as error:
+        return _refused(path, error)
+
+    try:
+        metadata = path.stat()
+    except OSError as error:
+        return _refused(path, error)
+    if not stat.S_ISDIR(metadata.st_mode):
+        return _refused(
+            path,
+            NotADirectoryError(
+                errno.ENOTDIR,
+                "rebuild-lock parent is not a directory",
+                str(path),
+            ),
+        )
+
+    mode = stat.S_IMODE(metadata.st_mode)
+    testimony = {
+        "mode": f"{mode:04o}",
+        "uid": metadata.st_uid,
+        "gid": metadata.st_gid,
+    }
+    if mode != 0o777 or not os.access(path, os.W_OK | os.X_OK):
+        return LockStateResult(
+            state="unshareable",
+            path=str(path),
+            detail="rebuild-lock parent must be writable across host/container identities",
+            **testimony,
+        )
+    return LockStateResult(state="ready", path=str(path), **testimony)
+
+
+def _emit(result: LockStateResult) -> None:
+    body = {key: value for key, value in asdict(result).items() if value is not None}
+    print(f"{result.state}\t{json.dumps(body, sort_keys=True, separators=(',', ':'))}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("operation", choices=("create", "publish-parent"))
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args()
+    if args.operation == "create":
+        _emit(create_lock_directory(args.path))
+    else:
+        _emit(publish_lock_parent(args.path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Finding

A child `mkdir` EACCES was discarded, retried forty times as if it were EEXIST contention, and finally misreported as `missing-rebuild-lock-pid`. On battleaxe the requested 67b604 lock never existed: `.rebuild-locks` was uid1001:gid1001 mode 0755, non-writable to host uid1000, with one uid1001 `newfeedface` residue. This is create refusal, not a missing holder.

## Repair

- one atomic-create door preserves `errno_name`, errno number, and original detail
- EEXIST alone enters contention; lawful release retries; all other OS errors terminate once as `crime=rebuild-lock-create-refused`
- the shared parent and each lock directory publish as 0777, which is required for cross-identity stale reclaim
- an existing private parent refuses as `crime=unshareable-rebuild-lock-path`; the binary cache is never redirected or deleted

## Executable lifecycle account

The focused contract exercises all declared states: never-created, create-refused, created-unpublished, published-live, published-dead, released, and unreclaimable. The planted EACCES twin retains `EACCES` and `Permission denied`; the released-peer arm observes real contention before removing the peer lock and proves reacquisition.

Exact head evidence after restack:

- `bash tests/sugarbin_rebuild_single_flight.sh "$PWD"`: green; 8 contenders -> 1 build, dead-winner reclaim, all seven lifecycle arms
- Black 26.5.1 clean
- `py_compile`, `bash -n`, and diff-check clean
- zero file deletions
- closing-account digest remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`

## Live residue boundary

The poisoned parent was inventoried but not mutated: active `sugarbin` processes were present. At a quiescent boundary, quarantine only `.rebuild-locks` and its single uid1001 `newfeedface` residue, regenerate the parent through this door, and leave the binaries cache and content-addressed shelf untouched.

Predicted epsilon: the 67b604 never-created condition stops recurring after the parent is regenerated; any future create refusal is early, finite, and names the OS cause instead of inventing a missing PID.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate rebuild-lock creation states via a Python helper in `acquire_rebuild_single_flight`
> - Replaces direct `mkdir`-based lock acquisition in [`bin/sugarbin`](https://github.com/TSavo/sugar/pull/7337/files#diff-2b8f7e68bdef16827d284767f61c9a26ffa589c12f114f50129677d05e35383b) with calls to the new [`tools/rebuild_lock_state.py`](https://github.com/TSavo/sugar/pull/7337/files#diff-925688d26b4d77ca984a9fc8f6e39626b39bf9c4850831867d0dcf8ecf2358a3) helper, which classifies outcomes as `acquired`, `contended`, `released`, `create-refused`, or `unshareable`.
> - `publish_lock_parent` verifies the lock parent directory is shared-writable (mode 0777) before acquisition, returning `unshareable` with POSIX metadata testimony if not.
> - `create_lock_directory` uses atomic `mkdir` with `umask(0)` and distinguishes `released` (EEXIST but path gone) from `contended` (EEXIST and still a directory), enabling retry on authenticated `released` instead of counting missing directories.
> - Shell logic exits with code 70 on `create-refused`, `unshareable`, or any unexpected state, and removes the old `missing_dir_retries` loop.
> - Behavioral Change: lock acquisition now requires the parent directory to be published as 0777 before proceeding; a non-0777 parent causes a terminal `unshareable` failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae817be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->