### PR TITLE
Add producer-owned showcase terminal testimony

### DIFF
--- a/scripts/showcase-terminal-identity.sh
+++ b/scripts/showcase-terminal-identity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Additive producer transport for exact showcase terminal testimony.
+#
+# This file is sourced by showcase scripts.  The caller selects the command
+# whose structured RPC refusal is the showcase terminal; this wrapper only
+# preserves and publishes that raw testimony.  It never infers an identity
+# from the command's exit status or from human-readable output.
+
+_showcase_terminal_script="${BASH_SOURCE[0]}"
+_showcase_terminal_repo_root="$(
+  cd "$(dirname "${_showcase_terminal_script}")/.." && pwd -P
+)"
+
+showcase_terminal_identity() {
+  python3 \
+    "${_showcase_terminal_repo_root}/tools/showcase_terminal_identity.py" \
+    "$@"
+}
+
+showcase_run_with_terminal() {
+  if [[ "$#" -lt 2 ]]; then
+    echo "showcase-terminal-identity: REFUSED: expected entrance and command" >&2
+    return 2
+  fi
+
+  local entrance="$1"
+  shift
+  local diagnostic
+  local command_status
+  local had_errexit=0
+  diagnostic="$(mktemp -t sugar-showcase-terminal.XXXXXX)" || return 2
+
+  case "$-" in
+    *e*) had_errexit=1 ;;
+  esac
+  set +e
+  "$@" 2>"${diagnostic}"
+  command_status=$?
+  if [[ "${had_errexit}" -eq 1 ]]; then
+    set -e
+  fi
+
+  cat "${diagnostic}" >&2
+  if [[ "${command_status}" -ne 0 ]]; then
+    showcase_terminal_identity \
+      --rpc-diagnostic "${diagnostic}" \
+      --repo-root "${_showcase_terminal_repo_root}" \
+      --entrance "${entrance}" || {
+        local identity_status=$?
+        rm -f -- "${diagnostic}"
+        return "${identity_status}"
+      }
+  fi
+
+  rm -f -- "${diagnostic}"
+  return "${command_status}"
+}

--- a/tests/test_showcase_terminal_producer.py
+++ b/tests/test_showcase_terminal_producer.py
@@ -1,0 +1,237 @@
+"""Producer-side teeth for the additive showcase terminal witness wire."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from repo_root_test_support import resolve_repo_root
+
+ROOT = resolve_repo_root()
+sys.path.insert(0, str(ROOT / "tools"))
+
+import showcase_terminal_identity  # noqa: E402
+import showcase_scope  # noqa: E402
+
+
+IDENTITY = {
+    "schemaVersion": 1,
+    "kind": "construction-panic",
+    "owner": "ComparisonOpSugar.Eq",
+    "coordinate": "fixture.py:4:11",
+    "observed": "undecided binary compare",
+    "requested": "authenticated exception coordinate",
+    "entrance": "sugar.enumerate:facts:auditFrontier",
+}
+
+
+def test_writer_is_additive_noop_before_consumer_supplies_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SHOWCASE_TERMINAL_WITNESS", raising=False)
+
+    assert showcase_terminal_identity.write_from_environment(IDENTITY) is False
+
+
+def test_writer_emits_exact_validated_identity_atomically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "terminal.json"
+    monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
+
+    assert showcase_terminal_identity.write_from_environment(IDENTITY) is True
+    assert json.loads(output.read_text(encoding="utf-8")) == IDENTITY
+
+
+def test_writer_refuses_empty_or_unknown_identity_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "terminal.json"
+    monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
+    empty_owner = dict(IDENTITY)
+    empty_owner["owner"] = ""
+    unknown = dict(IDENTITY)
+    unknown["normalizedCategory"] = "panic"
+
+    with pytest.raises(
+        showcase_terminal_identity.TerminalIdentityRefusal,
+        match="nonempty owner",
+    ):
+        showcase_terminal_identity.write_from_environment(empty_owner)
+    with pytest.raises(
+        showcase_terminal_identity.TerminalIdentityRefusal,
+        match="unsupported fields",
+    ):
+        showcase_terminal_identity.write_from_environment(unknown)
+    assert not output.exists()
+
+
+def test_writer_refuses_to_replace_a_prior_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "terminal.json"
+    monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
+    assert showcase_terminal_identity.write_from_environment(IDENTITY) is True
+
+    with pytest.raises(
+        showcase_terminal_identity.TerminalIdentityRefusal,
+        match="already exists",
+    ):
+        showcase_terminal_identity.write_from_environment(IDENTITY)
+
+
+def test_rpc_terminal_projection_preserves_raw_identity_and_canonical_coordinate(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    diagnostic = {
+        "code": -32603,
+        "message": "construction refused",
+        "data": {
+            "exception_type": "ConstructionPanic",
+            "stage": "dispatch",
+            "diagnostic": {
+                "owner": "ComparisonOpSugar.Eq",
+                "blame": str(repo / "examples/demo/test_logo.py:4:11"),
+                "observed": "undecided binary compare",
+                "requested": "authenticated exception coordinate",
+            },
+        },
+    }
+
+    assert showcase_terminal_identity.identity_from_rpc_text(
+        "prefix " + json.dumps(diagnostic) + " suffix",
+        repo_root=repo,
+        entrance="sugar.mint",
+    ) == {
+        "schemaVersion": 1,
+        "kind": "ConstructionPanic",
+        "owner": "ComparisonOpSugar.Eq",
+        "coordinate": "examples/demo/test_logo.py:4:11",
+        "observed": "undecided binary compare",
+        "requested": "authenticated exception coordinate",
+        "entrance": "sugar.mint",
+    }
+
+
+def test_rpc_terminal_projection_refuses_generic_error_without_owner(
+    tmp_path: Path,
+) -> None:
+    diagnostic = {
+        "code": -32603,
+        "message": "RuntimeError: opaque failure",
+        "data": {"exception_type": "RuntimeError", "stage": "dispatch"},
+    }
+
+    with pytest.raises(
+        showcase_terminal_identity.TerminalIdentityRefusal,
+        match="lacks diagnostic owner",
+    ):
+        showcase_terminal_identity.identity_from_rpc_text(
+            json.dumps(diagnostic),
+            repo_root=tmp_path,
+            entrance="sugar.mint",
+        )
+
+
+def test_scope_runner_supplies_additive_channel_without_consuming_it(
+    tmp_path: Path,
+) -> None:
+    script_name = "examples/failing/run.sh"
+    script = tmp_path / script_name
+    script.parent.mkdir(parents=True)
+    script.write_text(
+        "#!/usr/bin/env sh\n"
+        f"python3 {ROOT / 'tools/showcase_terminal_identity.py'} "
+        "--kind construction-panic --owner PlantedOwner "
+        "--coordinate fixture.py:1:0\n"
+        "exit 7\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    manifest = tmp_path / "retirements.json"
+    manifest.write_text(
+        '{"schemaVersion":1,"retirements":[]}\n', encoding="utf-8"
+    )
+    attr_dir = tmp_path / "attr"
+    receipt = tmp_path / "scope.json"
+
+    assert (
+        showcase_scope.run_shard(
+            repo_root=tmp_path,
+            manifest_path=manifest,
+            enrolled=[script_name],
+            shard_count=1,
+            shard_index=0,
+            attr_dir=attr_dir,
+            receipt_path=receipt,
+        )
+        == 1
+    )
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["outcomes"] == [
+        {"path": script_name, "outcome": "failed", "exitCode": 7}
+    ]
+    terminal_files = list(attr_dir.glob("*.terminal-witness"))
+    assert len(terminal_files) == 1
+    assert json.loads(terminal_files[0].read_text(encoding="utf-8")) == {
+        "schemaVersion": 1,
+        "kind": "construction-panic",
+        "owner": "PlantedOwner",
+        "coordinate": "fixture.py:1:0",
+    }
+
+
+def test_shell_wrapper_publishes_selected_rpc_terminal_and_preserves_exit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "terminal.json"
+    diagnostic = {
+        "code": -32603,
+        "message": "construction refused",
+        "data": {
+            "exception_type": "ConstructionPanic",
+            "stage": "dispatch",
+            "diagnostic": {
+                "owner": "ComparisonOpSugar.Eq",
+                "blame": str(ROOT / "examples/demo/test_logo.py:4:11"),
+                "observed": "undecided binary compare",
+                "requested": "authenticated exception coordinate",
+            },
+        },
+    }
+    command = (
+        f"source {ROOT / 'scripts/showcase-terminal-identity.sh'}; "
+        "showcase_run_with_terminal sugar.mint bash -c "
+        # Quote for the outer shell without allowing it to expand the planted
+        # JSON.  The selected child, not its parent, owns the raw diagnostic.
+        + shlex.quote("printf '%s\\n' \"$PLANTED_RPC_ERROR\" >&2; exit 7")
+    )
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={
+            "PATH": str(Path(sys.executable).parent) + ":/usr/bin:/bin",
+            "SHOWCASE_TERMINAL_WITNESS": str(output),
+            "PLANTED_RPC_ERROR": json.dumps(diagnostic),
+        },
+    )
+
+    assert completed.returncode == 7
+    assert json.loads(output.read_text(encoding="utf-8"))["owner"] == (
+        "ComparisonOpSugar.Eq"
+    )
+    assert json.loads(output.read_text(encoding="utf-8"))["coordinate"] == (
+        "examples/demo/test_logo.py:4:11"
+    )

--- a/tools/showcase_scope.py
+++ b/tools/showcase_scope.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from showcase_terminal_identity import TERMINAL_WITNESS_ENV
+
 SCHEMA_VERSION = 1
 RETIREMENT_REASON = "out of scope per scope ruling - Java"
 SUBJECT_WITNESS_ENV = "SHOWCASE_SUBJECT_WITNESS"
@@ -295,14 +297,24 @@ def run_shard(
 
         log_path = attr_dir / _safe_log_name(path)
         witness_path = attr_dir / (_safe_log_name(path) + ".subject-witness")
+        terminal_witness_path = attr_dir / (
+            _safe_log_name(path) + ".terminal-witness"
+        )
         try:
             witness_path.unlink()
+        except FileNotFoundError:
+            pass
+        try:
+            terminal_witness_path.unlink()
         except FileNotFoundError:
             pass
         subject_id = path
         process_env = os.environ.copy()
         process_env[SUBJECT_WITNESS_ENV] = str(witness_path.resolve())
         process_env[SUBJECT_ID_ENV] = subject_id
+        # Producer rollout is deliberately additive.  The consumer does not
+        # interpret this file until the producer population has landed.
+        process_env[TERMINAL_WITNESS_ENV] = str(terminal_witness_path.resolve())
         try:
             proc = subprocess.run(
                 [str(repo_root / path)],

--- a/tools/showcase_terminal_identity.py
+++ b/tools/showcase_terminal_identity.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Producer-owned wire for exact showcase terminal identities.
+
+The writer is deliberately additive: producers may call it before the showcase
+consumer supplies an output path.  Once supplied, the path accepts exactly one
+validated terminal identity.  A later observation cannot replace the first
+terminal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import NoReturn
+
+
+TERMINAL_WITNESS_ENV = "SHOWCASE_TERMINAL_WITNESS"
+TERMINAL_IDENTITY_SCHEMA_VERSION = 1
+_REQUIRED_FIELDS = ("schemaVersion", "kind", "owner")
+_OPTIONAL_FIELDS = ("coordinate", "observed", "requested", "entrance")
+_ALLOWED_FIELDS = frozenset((*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS))
+
+
+class TerminalIdentityRefusal(ValueError):
+    """The producer could not publish an exact terminal identity."""
+
+
+def _refuse(reason: str) -> NoReturn:
+    raise TerminalIdentityRefusal(reason)
+
+
+def validate_terminal_identity(raw: Mapping[str, object]) -> dict[str, object]:
+    """Return the canonical raw identity or refuse a lossy/malformed value."""
+
+    unsupported = sorted(set(raw) - _ALLOWED_FIELDS)
+    if unsupported:
+        _refuse(f"unsupported fields: {', '.join(unsupported)}")
+
+    missing = [field for field in _REQUIRED_FIELDS if field not in raw]
+    if missing:
+        _refuse(f"missing required fields: {', '.join(missing)}")
+
+    if raw["schemaVersion"] != TERMINAL_IDENTITY_SCHEMA_VERSION:
+        _refuse(
+            "schemaVersion must be "
+            f"{TERMINAL_IDENTITY_SCHEMA_VERSION}, got {raw['schemaVersion']!r}"
+        )
+
+    for field in ("kind", "owner"):
+        value = raw[field]
+        if not isinstance(value, str) or not value.strip():
+            _refuse(f"terminal identity requires nonempty {field}")
+
+    for field in _OPTIONAL_FIELDS:
+        if field not in raw:
+            continue
+        value = raw[field]
+        if not isinstance(value, str) or not value.strip():
+            _refuse(f"terminal identity requires nonempty {field} when present")
+
+    # Preserve raw producer testimony.  Fixed field order makes the bytes
+    # deterministic without normalizing any identity-bearing string.
+    return {
+        field: raw[field]
+        for field in (*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS)
+        if field in raw
+    }
+
+
+def _json_objects(text: str) -> Sequence[object]:
+    decoder = json.JSONDecoder()
+    objects: list[object] = []
+    for offset, character in enumerate(text):
+        if character != "{":
+            continue
+        try:
+            value, _end = decoder.raw_decode(text[offset:])
+        except ValueError:
+            continue
+        objects.append(value)
+    return objects
+
+
+def _rpc_error_payload(value: object) -> Mapping[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    nested = value.get("error")
+    if isinstance(nested, dict):
+        return nested
+    if "code" in value and "message" in value:
+        return value
+    return None
+
+
+def _canonical_coordinate(value: str, repo_root: Path) -> str:
+    prefix = str(repo_root.resolve()) + os.sep
+    return value[len(prefix) :] if value.startswith(prefix) else value
+
+
+def identity_from_rpc_text(
+    text: str,
+    *,
+    repo_root: Path,
+    entrance: str,
+) -> dict[str, object]:
+    """Project one structured RPC terminal selected by its showcase producer.
+
+    The caller owns *which* failing command is the showcase terminal.  This
+    function only projects the structured error returned by that command; it
+    never classifies prose or overlapping scoreboard counters.
+    """
+
+    error: Mapping[str, object] | None = None
+    diagnostic: Mapping[str, object] | None = None
+    data: Mapping[str, object] | None = None
+    for value in _json_objects(text):
+        candidate = _rpc_error_payload(value)
+        if candidate is None:
+            continue
+        candidate_data = candidate.get("data")
+        if not isinstance(candidate_data, dict):
+            continue
+        candidate_diagnostic = candidate_data.get("diagnostic")
+        if isinstance(candidate_diagnostic, dict):
+            error = candidate
+            data = candidate_data
+            diagnostic = candidate_diagnostic
+            break
+        if error is None:
+            error = candidate
+            data = candidate_data
+
+    if error is None or data is None:
+        _refuse("selected command emitted no structured RPC error")
+    if diagnostic is None:
+        _refuse("structured RPC error lacks diagnostic owner")
+
+    kind = data.get("exception_type")
+    owner = diagnostic.get("owner")
+    identity: dict[str, object] = {
+        "schemaVersion": TERMINAL_IDENTITY_SCHEMA_VERSION,
+        "kind": kind,
+        "owner": owner,
+        "entrance": entrance,
+    }
+    blame = diagnostic.get("blame")
+    if isinstance(blame, str) and blame.strip():
+        identity["coordinate"] = _canonical_coordinate(blame, repo_root)
+    for field in ("observed", "requested"):
+        value = diagnostic.get(field)
+        if isinstance(value, str) and value.strip():
+            identity[field] = value
+    return validate_terminal_identity(identity)
+
+
+def _publish_once(output: Path, identity: Mapping[str, object]) -> None:
+    if not output.is_absolute():
+        _refuse(f"{TERMINAL_WITNESS_ENV} must be an absolute path: {output}")
+    if not output.parent.is_dir():
+        _refuse(f"terminal witness parent does not exist: {output.parent}")
+
+    payload = json.dumps(identity, sort_keys=False, separators=(",", ":")) + "\n"
+    temporary_path: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{output.name}.",
+            suffix=".tmp",
+            dir=output.parent,
+        )
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            # A hard link installs the complete bytes atomically and, unlike
+            # os.replace(), refuses if another terminal already owns the path.
+            os.link(temporary_path, output)
+        except FileExistsError:
+            _refuse(f"terminal witness already exists: {output}")
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def write_from_environment(raw: Mapping[str, object]) -> bool:
+    """Validate and optionally publish one terminal identity.
+
+    Returns ``False`` only when no consumer has supplied an output path.  An
+    invalid producer identity refuses even in that additive/no-consumer mode.
+    """
+
+    identity = validate_terminal_identity(raw)
+    output_value = os.environ.get(TERMINAL_WITNESS_ENV)
+    if output_value is None:
+        return False
+    if not output_value:
+        _refuse(f"{TERMINAL_WITNESS_ENV} must not be empty")
+    _publish_once(Path(output_value), identity)
+    return True
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Publish one exact showcase terminal identity"
+    )
+    parser.add_argument("--kind")
+    parser.add_argument("--owner")
+    parser.add_argument("--coordinate")
+    parser.add_argument("--observed")
+    parser.add_argument("--requested")
+    parser.add_argument("--entrance")
+    parser.add_argument("--rpc-diagnostic", type=Path)
+    parser.add_argument("--repo-root", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        if arguments.rpc_diagnostic is not None:
+            if arguments.kind is not None or arguments.owner is not None:
+                _refuse("RPC projection cannot also accept authored kind/owner")
+            if arguments.repo_root is None or arguments.entrance is None:
+                _refuse("RPC projection requires --repo-root and --entrance")
+            identity = identity_from_rpc_text(
+                arguments.rpc_diagnostic.read_text(
+                    encoding="utf-8", errors="replace"
+                ),
+                repo_root=arguments.repo_root,
+                entrance=arguments.entrance,
+            )
+        else:
+            identity = {
+                "schemaVersion": TERMINAL_IDENTITY_SCHEMA_VERSION,
+                "kind": arguments.kind,
+                "owner": arguments.owner,
+            }
+            for field in _OPTIONAL_FIELDS:
+                value = getattr(arguments, field)
+                if value is not None:
+                    identity[field] = value
+        write_from_environment(identity)
+    except (OSError, TerminalIdentityRefusal) as error:
+        _parser().exit(2, f"showcase-terminal-identity: REFUSED: {error}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Scope

Purely additive producer transport for structured showcase terminal identity. The shard runner supplies one per-script channel; the writer validates and atomically publishes exactly one raw identity; the shell helper projects only selected structured RPC testimony and preserves the selected command exit code.

Consumer outcomes and body schema are unchanged. The consumer requirement remains held.

## Boundary

This lands capability, not producer coverage. At this commit 0 of 46 active showcase scripts emit the witness. Receipts do not yet carry terminal identity until producer slices roll out, and the consumer requirement must not land first because that would turn every unwitnessed failure into unmeasured. Historical receipts are not backfilled and A2 counters are not used to invent identities.

## Evidence

- exact head `a96ba2234d62ed9a2d49827e920f99623e164e6f`
- parent and merge-base `f207c4de986296f99941c6415543a13f1b15b0fe`, 0 behind / 1 ahead
- full tree adds three producer files and changes only the additive channel in `tools/showcase_scope.py`
- 8/8 authenticated after rebase
- no consumer outcome/body change
- no file deletion
- closing-account digest remains `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`

Predicted epsilon: producer slices can land independently against a stable transport while current pass/fail receipts remain unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add producer-owned terminal identity capture and publish for showcase RPC failures
> - Adds [showcase_terminal_identity.py](https://github.com/TSavo/sugar/pull/7338/files#diff-baf253f7288497a61b535eb741f5a634f6b0a7ef6c641b818fbc1fc78b8dfe2e) with CLI and library functions to validate, project from RPC stderr, and atomically publish a structured terminal identity JSON to a path supplied via the `SHOWCASE_TERMINAL_WITNESS` environment variable.
> - Adds [showcase-terminal-identity.sh](https://github.com/TSavo/sugar/pull/7338/files#diff-64fb3adbd292e8cae4b198009f17f02857b8405268d06b72d8d699f30bb249d9) with `showcase_run_with_terminal`, which runs a command, mirrors its stderr, and on non-zero exit calls the Python tool to publish an RPC-derived terminal identity while preserving the original exit code.
> - Updates [showcase_scope.py](https://github.com/TSavo/sugar/pull/7338/files#diff-a53f2b440efec2dccc0f7d623e336ef165ba9c85a4a4cd077cb811bec9b931ea) to set `SHOWCASE_TERMINAL_WITNESS` per subject before execution and remove any prior witness file, giving each script an opportunity to write a terminal identity.
> - Adds [tests/test_showcase_terminal_producer.py](https://github.com/TSavo/sugar/pull/7338/files#diff-8e087500d346f4ed81dcab7be3e40bef456c47db46363402bfc954f47f55086d) covering validation, atomic write semantics, RPC projection, scope runner integration, and shell wrapper behavior.
> - Risk: `_publish_once` refuses to overwrite an existing witness file via hard-link semantics; a leftover file from a prior run will cause a `TerminalIdentityRefusal` unless the scope runner cleans it up first.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2777df.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->