### PR TITLE
Publish raw Eq showcase terminal witnesses

### DIFF
--- a/examples/binascii-hexlify/run-logo-receipt.sh
+++ b/examples/binascii-hexlify/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/examples/hashlib-sha256-digest-length/run-logo-receipt.sh
+++ b/examples/hashlib-sha256-digest-length/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/examples/hashlib-sha256-hexdigest/run-logo-receipt.sh
+++ b/examples/hashlib-sha256-hexdigest/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/examples/hmac-compare-digest/run-logo-receipt.sh
+++ b/examples/hmac-compare-digest/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/examples/itsdangerous-token-padding/run-logo-receipt.sh
+++ b/examples/itsdangerous-token-padding/run-logo-receipt.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 PYTHON_SRC="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src"
 
@@ -108,7 +109,7 @@ run_logo_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" "$dir/.pytest_cache"
   rm -f "$dir"/.prove*.json "$dir"/.prove*.raw "$dir"/.prove*.err
 
-  (cd "$dir" && "$BIN" mint --out . ) >/dev/null || {
+  (cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out . ) >/dev/null || {
     echo "FAIL($twin): mint"
     return 1
   }

--- a/examples/itsdangerous-token-padding/run.sh
+++ b/examples/itsdangerous-token-padding/run.sh
@@ -24,6 +24,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 TARGET_DIR="${CARGO_TARGET_DIR:-$REPO/implementations/rust/target}"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 
@@ -1422,7 +1423,7 @@ run_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" 2>/dev/null
   rm -f "$dir"/.prove*.json "$dir"/.verify*.json 2>/dev/null
 
-  ( cd "$dir" && "$BIN" mint --out . ) >/dev/null || { echo "FAIL: mint ($twin)"; return 1; }
+  ( cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out . ) >/dev/null || { echo "FAIL: mint ($twin)"; return 1; }
   ( cd "$dir" && "$BIN" verify --allow-failed-components --project . --json > .verify.json ) || true
   [ -s "$dir/.verify.json" ] || { echo "FAIL: no verify receipt ($twin)"; return 1; }
 

--- a/examples/pandas-showcase/run.sh
+++ b/examples/pandas-showcase/run.sh
@@ -23,6 +23,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 
 # The witness lifter RUNS pandas's tests, so it needs pandas + the kit deps in a
@@ -54,7 +55,7 @@ rm -rf .sugar/runs .sugar/witnesses 2>/dev/null || true
 rm -f .verify.raw .verify.json 2>/dev/null || true
 
 echo "== mint (plain-pytest + pandas.testing + pytest-witness over the project) =="
-"$BIN" mint --out . --quiet
+showcase_run_with_terminal sugar.mint "$BIN" mint --out . --quiet
 
 echo "== prove (consistency AND witness) =="
 report="$(PATH="$VENV/bin:$PATH" "$BIN" prove --allow-failed-components . 2>/dev/null)"

--- a/examples/python-urlsafe-seam/run.sh
+++ b/examples/python-urlsafe-seam/run.sh
@@ -28,6 +28,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 TARGET_DIR="${CARGO_TARGET_DIR:-$REPO/implementations/rust/target}"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 VENV="${PYTHON_URLSAFE_SEAM_VENV:-/tmp/python-urlsafe-seam-venv}"
@@ -78,7 +79,7 @@ run_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" 2>/dev/null
   rm -f "$dir"/.prove*.json "$dir"/.verify*.json 2>/dev/null
 
-  ( cd "$dir" && PATH="$VENV/bin:$PATH" PYTHONPATH="$PYTHON_SRC" "$BIN" mint --out . ) >/dev/null || { echo "FAIL: mint ($twin)"; return 1; }
+  ( cd "$dir" && PATH="$VENV/bin:$PATH" PYTHONPATH="$PYTHON_SRC" showcase_run_with_terminal sugar.mint "$BIN" mint --out . ) >/dev/null || { echo "FAIL: mint ($twin)"; return 1; }
   ( cd "$dir" && PATH="$VENV/bin:$PATH" PYTHONPATH="$PYTHON_SRC" \
       "$BIN" verify --allow-failed-components --project . --json > .verify.json ) || true
   [ -s "$dir/.verify.json" ] || { echo "FAIL: no verify receipt ($twin)"; return 1; }

--- a/examples/sklearn-showcase/run.sh
+++ b/examples/sklearn-showcase/run.sh
@@ -4,6 +4,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 
 # The witness lifter RUNS sklearn tests, so it needs scikit-learn + the kit deps
@@ -30,7 +31,7 @@ rm -rf .sugar/runs .sugar/witnesses 2>/dev/null || true
 rm -f .verify.raw .verify.json 2>/dev/null || true
 
 echo "== mint (plain-pytest + sklearn.utils._testing + pytest-witness over the project) =="
-"$BIN" mint --out . --quiet
+showcase_run_with_terminal sugar.mint "$BIN" mint --out . --quiet
 
 echo "== prove (consistency AND witness) =="
 report="$(PATH="$VENV/bin:$PATH" "$BIN" prove --allow-failed-components . 2>/dev/null)"

--- a/examples/stdlib-base32-padding/run-logo-receipt.sh
+++ b/examples/stdlib-base32-padding/run-logo-receipt.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 PYTHON_SRC="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src"
 
@@ -108,7 +109,7 @@ run_logo_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" "$dir/.pytest_cache"
   rm -f "$dir"/.prove*.json "$dir"/.prove*.raw "$dir"/.prove*.err
 
-  (cd "$dir" && "$BIN" mint --out . ) >/dev/null || {
+  (cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out . ) >/dev/null || {
     echo "FAIL($twin): mint"
     return 1
   }

--- a/examples/stdlib-base64-padding/run-logo-receipt.sh
+++ b/examples/stdlib-base64-padding/run-logo-receipt.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 PYTHON_SRC="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src"
 
@@ -108,7 +109,7 @@ run_logo_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" "$dir/.pytest_cache"
   rm -f "$dir"/.prove*.json "$dir"/.prove*.raw "$dir"/.prove*.err
 
-  (cd "$dir" && "$BIN" mint --out . ) >/dev/null || {
+  (cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out . ) >/dev/null || {
     echo "FAIL($twin): mint"
     return 1
   }

--- a/examples/struct-calcsize/run-logo-receipt.sh
+++ b/examples/struct-calcsize/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/examples/zlib-crc32/run-logo-receipt.sh
+++ b/examples/zlib-crc32/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/tests/test_showcase_terminal_producer.py
+++ b/tests/test_showcase_terminal_producer.py
@@ -30,6 +30,23 @@ IDENTITY = {
 }
 
 
+EQ_PRODUCERS = (
+    "examples/zlib-crc32/run-logo-receipt.sh",
+    "examples/struct-calcsize/run-logo-receipt.sh",
+    "examples/itsdangerous-token-padding/run.sh",
+    "examples/python-urlsafe-seam/run.sh",
+    "examples/itsdangerous-token-padding/run-logo-receipt.sh",
+    "examples/binascii-hexlify/run-logo-receipt.sh",
+    "examples/sklearn-showcase/run.sh",
+    "examples/stdlib-base64-padding/run-logo-receipt.sh",
+    "examples/hmac-compare-digest/run-logo-receipt.sh",
+    "examples/hashlib-sha256-hexdigest/run-logo-receipt.sh",
+    "examples/stdlib-base32-padding/run-logo-receipt.sh",
+    "examples/hashlib-sha256-digest-length/run-logo-receipt.sh",
+    "examples/pandas-showcase/run.sh",
+)
+
+
 def test_writer_is_additive_noop_before_consumer_supplies_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -235,3 +252,14 @@ def test_shell_wrapper_publishes_selected_rpc_terminal_and_preserves_exit(
     assert json.loads(output.read_text(encoding="utf-8"))["coordinate"] == (
         "examples/demo/test_logo.py:4:11"
     )
+
+
+@pytest.mark.parametrize("relative_path", EQ_PRODUCERS)
+def test_eq_producer_routes_its_selected_mint_through_raw_terminal_writer(
+    relative_path: str,
+) -> None:
+    script = (ROOT / relative_path).read_text(encoding="utf-8")
+
+    assert script.count('source "$REPO/scripts/showcase-terminal-identity.sh"') == 1
+    assert script.count("showcase_run_with_terminal sugar.mint ") == 1
+    assert "ComparisonOpSugar.Eq" not in script


### PR DESCRIPTION
## What changed

- Source the additive `SHOWCASE_TERMINAL_WITNESS` producer transport from the 13 active showcase scripts whose current first unexpected raw terminal is `ComparisonOpSugar.Eq`.
- Route only each producer-selected `sugar mint` command through `showcase_run_with_terminal sugar.mint`.
- Add one binding tooth per producer and require zero hardcoded terminal owners in the scripts.

The scripts do not manufacture identity from exit codes, prose, A2 classifications, or coordinates. The shared helper projects the raw structured RPC diagnostic at execution; a diagnostic without an owner remains unmeasured.

## Transport dependency

This producer slice depends on the follow-up transport repair for ownerless diagnostics. In the currently landed helper, publication refusal can replace the selected producer's original product exit status with helper exit 2. The Eq producers carry structured owners in the measured population, but this PR does not claim an ownerless path is impossible; the fix-forward must preserve the original producer exit while leaving the outcome unmeasured.

## Measured rollout ceiling

Inventory measured on all 46 active producers using run `30889722931` raw shard logs and current script boundaries:

- 12/46 passed and require no terminal witness.
- 19/46 failed with a raw structured kind and owner: this PR owns the 13 Eq producers; the transport rollout owns the other 6.
- 15/46 remain honestly unmeasured: 9 expose structured failure text without a diagnostic owner, and 6 know only receipt/status prose at their failure point.
- 0 produced-then-discarded kind+owner cases were authenticated.

Therefore 31/46 outcomes in the pinned run become measurable after the producer rollout; the consumer requirement must not be read as full-surface measurement.

The upstream trace found 0/9 deeper structured owners at `7863ea5843`: two Python constructed-value category gaps originated as ownerless exceptions, five `rust-fn-contracts` wrong-level refusals originated as bare strings, one retired Python lift entrance originated as a typed path diagnostic whose schema has no owner field, and one cargo-test failure originated as a bare string containing child output. A wider helper cannot recover an owner none of those producers constructed. On current main, the five `rust-fn-contracts` wrong-level refusals have since been removed by explicitly serving `parameter-contract-link-units`; their next terminal is unmeasured until the showcase reruns. Thus the historical 31/46 ceiling does not rise to 40 through carrier work alone, but it is not a current-main outcome count.

## Shot accounting

- `R_unwitnessed_raw_eq_producers`: predicted epsilon `-13`.
- Floors preserved: no inferred identity, no consumer enforcement, no hardcoded owner/coordinate, and ownerless diagnostics remain unmeasured.

## Verification

- Red before binding: 13/13 producer arms failed because the shared writer was not reached.
- `bin/bpytest tests/test_showcase_terminal_producer.py -q`: 21 passed under authenticated CPython 3.12.13 / pandas 3.0.3.
- `bash -n` over all 13 changed producer scripts: exit 0.
- Source audit: 13 helper sources, 13 selected wrapper calls, 0 hardcoded `ComparisonOpSugar.Eq` identities.
- Restack proof: head parent and merge-base are both `ea6ff2145acddfd237f5053eb12220b47a35a732`; range-diff is patch-identical; tree diff contains only 13 producer scripts plus their producer test and no transport implementation files.
