### PR TITLE
Preserve showcase terminal streams and selected exits

### DIFF
--- a/scripts/showcase-terminal-identity.sh
+++ b/scripts/showcase-terminal-identity.sh
@@ -26,32 +26,43 @@ showcase_run_with_terminal() {
   local entrance="$1"
   shift
   local diagnostic
+  local stdout_capture
+  local stderr_capture
   local command_status
   local had_errexit=0
-  diagnostic="$(mktemp -t sugar-showcase-terminal.XXXXXX)" || return 2
+  stdout_capture="$(mktemp -t sugar-showcase-stdout.XXXXXX)" || return 2
+  stderr_capture="$(mktemp -t sugar-showcase-stderr.XXXXXX)" || {
+    rm -f -- "${stdout_capture}"
+    return 2
+  }
+  diagnostic="$(mktemp -t sugar-showcase-terminal.XXXXXX)" || {
+    rm -f -- "${stdout_capture}" "${stderr_capture}"
+    return 2
+  }
 
   case "$-" in
     *e*) had_errexit=1 ;;
   esac
   set +e
-  "$@" 2>"${diagnostic}"
+  "$@" >"${stdout_capture}" 2>"${stderr_capture}"
   command_status=$?
   if [[ "${had_errexit}" -eq 1 ]]; then
     set -e
   fi
 
-  cat "${diagnostic}" >&2
+  cat "${stdout_capture}"
+  cat "${stderr_capture}" >&2
   if [[ "${command_status}" -ne 0 ]]; then
+    {
+      cat "${stdout_capture}"
+      cat "${stderr_capture}"
+    } >"${diagnostic}"
     showcase_terminal_identity \
       --rpc-diagnostic "${diagnostic}" \
       --repo-root "${_showcase_terminal_repo_root}" \
-      --entrance "${entrance}" || {
-        local identity_status=$?
-        rm -f -- "${diagnostic}"
-        return "${identity_status}"
-      }
+      --entrance "${entrance}" || true
   fi
 
-  rm -f -- "${diagnostic}"
+  rm -f -- "${stdout_capture}" "${stderr_capture}" "${diagnostic}"
   return "${command_status}"
 }

--- a/tests/test_showcase_terminal_producer.py
+++ b/tests/test_showcase_terminal_producer.py
@@ -263,3 +263,82 @@ def test_eq_producer_routes_its_selected_mint_through_raw_terminal_writer(
     assert script.count('source "$REPO/scripts/showcase-terminal-identity.sh"') == 1
     assert script.count("showcase_run_with_terminal sugar.mint ") == 1
     assert "ComparisonOpSugar.Eq" not in script
+
+
+def test_shell_wrapper_reads_structured_stdout_and_replays_both_streams(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "terminal.json"
+    diagnostic = {
+        "code": -32001,
+        "message": "sugar not written",
+        "data": {
+            "exception_type": "SugarNotWritten",
+            "stage": "dispatch",
+            "diagnostic": {
+                "owner": "binary_operation_exception_floor",
+                "observed": "CallSiteValue >> TermValue",
+                "requested": "authenticated exceptional exit",
+            },
+        },
+    }
+    command = (
+        f"source {ROOT / 'scripts/showcase-terminal-identity.sh'}; "
+        "showcase_run_with_terminal sugar.mint bash -c "
+        + shlex.quote(
+            "printf 'stdout-before\\n'; "
+            "printf '%s\\n' \"$PLANTED_RPC_ERROR\"; "
+            "printf 'stderr-before\\n' >&2; exit 17"
+        )
+    )
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={
+            "PATH": str(Path(sys.executable).parent) + ":/usr/bin:/bin",
+            "SHOWCASE_TERMINAL_WITNESS": str(output),
+            "PLANTED_RPC_ERROR": json.dumps(diagnostic),
+        },
+    )
+
+    assert completed.returncode == 17
+    assert "stdout-before\n" in completed.stdout
+    assert json.dumps(diagnostic) in completed.stdout
+    assert "stderr-before\n" in completed.stderr
+    assert json.loads(output.read_text(encoding="utf-8"))["owner"] == (
+        "binary_operation_exception_floor"
+    )
+
+
+def test_shell_wrapper_publication_refusal_preserves_selected_exit(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "terminal.json"
+    command = (
+        f"source {ROOT / 'scripts/showcase-terminal-identity.sh'}; "
+        "showcase_run_with_terminal sugar.mint bash -c "
+        + shlex.quote(
+            "printf 'ordinary stdout\\n'; "
+            "printf 'ownerless failure\\n' >&2; exit 19"
+        )
+    )
+    completed = subprocess.run(
+        ["bash", "-c", command],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={
+            "PATH": str(Path(sys.executable).parent) + ":/usr/bin:/bin",
+            "SHOWCASE_TERMINAL_WITNESS": str(output),
+        },
+    )
+
+    assert completed.returncode == 19
+    assert completed.stdout == "ordinary stdout\n"
+    assert "ownerless failure\n" in completed.stderr
+    assert "REFUSED: selected command emitted no structured RPC error" in (
+        completed.stderr
+    )
+    assert not output.exists()


### PR DESCRIPTION
## Outcome

Fix forward after #7338: the additive producer helper now authenticates structured terminal testimony from either stdout or stderr, replays both streams exactly, and always preserves the selected command exit. A terminal-witness publication refusal cannot replace the product command status.

## Scope

Two modified files only, `+99/-9`:

- `scripts/showcase-terminal-identity.sh`
- `tests/test_showcase_terminal_producer.py`

No consumer changes. No producer-script binding changes. No new terminal category, kind, label, taxonomy, or residual bucket.

## Discrimination

- Structured terminal on stdout is published; stdout and stderr are replayed; selected exit `17` survives.
- Ownerless publication refusal emits no witness; selected exit `19` survives.
- Existing structured-stderr publication arm remains green.
- All 13 landed Eq producer bindings remain covered.

Authenticated exact-head evidence: `23/23` green under CPython 3.12.13 / pandas 3.0.3.

## Correction boundary

The earlier six-producer run is not stream-placement evidence. All six subjects closed at the unmanaged entrance because `git` and required debug components were absent before enumeration. That run remains entrance-UNMEASURED and supports no product-terminal claim. This PR is justified by the independently measured exit-replacement defect and planted both-stream/ownerless arms.

## Preflight

Head `1bcd2bc0fd05a6cf88c0528d1d5e62ff13194ff6`; direct parent and merge-base current main `5ba479adc82eb9097c69b83c867fdf2c758bf6ba`; `0 behind / 1 ahead`; tree diff exactly the two intended modified files; no deletions; diff-check clean. Closing-account JSON remains present with SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve selected command's stdout, stderr, and exit code in `showcase_run_with_terminal`
> - `showcase_run_with_terminal` in [showcase-terminal-identity.sh](https://github.com/TSavo/sugar/pull/7341/files#diff-64fb3adbd292e8cae4b198009f17f02857b8405268d06b72d8d699f30bb249d9) now captures stdout and stderr to separate temp files, then replays each to its respective stream after the command completes.
> - On non-zero exit, both captured streams are concatenated into the diagnostic file passed to `showcase_terminal_identity`.
> - The original command's exit code is now preserved and returned even if `showcase_terminal_identity` fails (its exit is ignored with `|| true`).
> - New tests in [test_showcase_terminal_producer.py](https://github.com/TSavo/sugar/pull/7341/files#diff-8e087500d346f4ed81dcab7be3e40bef456c47db46363402bfc954f47f55086d) cover stream replay with structured RPC errors and verify that publication refusal preserves the selected exit code without creating a witness file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bcd2bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output capture and error handling for terminal command execution
  * Enhanced diagnostic messages when command execution fails
  * Fixed cleanup of temporary files in edge cases

* **Tests**
  * Added comprehensive test coverage for stream handling and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->