### PR TITLE
Route six non-Eq showcases through terminal testimony

### DIFF
--- a/examples/hashlib-md5-digest-size/run-logo-receipt.sh
+++ b/examples/hashlib-md5-digest-size/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/examples/numpy-attribute-safety-showcase/run.sh
+++ b/examples/numpy-attribute-safety-showcase/run.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 RUST="$REPO/implementations/rust"
 SUGAR=""
 VENV="${NUMPY_ATTR_SHOWCASE_VENV:-/tmp/sugar-numpy-attribute-safety-venv}"
@@ -268,7 +269,7 @@ run_suite() {
   run_pytest_axis "$suite" "$expect_pytest"
 
   echo "== mint $suite =="
-  (cd "$dir" && "$SUGAR" mint --out .) >/dev/null
+  (cd "$dir" && showcase_run_with_terminal sugar.mint "$SUGAR" mint --out .) >/dev/null
 
   local proof
   proof="$(find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -print -quit)"

--- a/examples/python-base64-federation/run.sh
+++ b/examples/python-base64-federation/run.sh
@@ -20,6 +20,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 RUST="$REPO/implementations/rust"
 TARGET_DIR="${CARGO_TARGET_DIR:-$RUST/target}"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
@@ -52,7 +53,7 @@ clean() { local d="$1"; find "$d" -maxdepth 1 -name 'blake3-512_*.proof' -delete
 echo
 echo "==================== VENDOR mints its .proof ===================="
 clean "$VENDOR"
-(cd "$VENDOR" && PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$VENDOR:$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
+(cd "$VENDOR" && showcase_run_with_terminal sugar.mint env PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$VENDOR:$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
   echo "FAIL: vendor mint"; exit 1; }
 VENDOR_PROOF="$(ls "$VENDOR"/blake3-512_*.proof 2>/dev/null | head -1)"
 [ -f "$VENDOR_PROOF" ] || { echo "FAIL: vendor produced no .proof"; exit 1; }
@@ -67,7 +68,7 @@ check_consumer() {
   mkdir -p "$dir/.sugar/imports"
   rm -f "$dir/.sugar/imports/"*.proof
   cp "$VENDOR_PROOF" "$dir/.sugar/imports/"
-  (cd "$dir" && PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$dir:$VENDOR:$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
+  (cd "$dir" && showcase_run_with_terminal sugar.mint env PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$dir:$VENDOR:$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
     echo "FAIL($twin): consumer mint"; return 1; }
   (cd "$dir" && PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$dir:$VENDOR:$PYTHON_SRC" \
     "$BIN" prove --allow-failed-components . --json) >"$dir/.prove.raw" 2>&1

--- a/examples/python-literal-base20/run.sh
+++ b/examples/python-literal-base20/run.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 RUST="$REPO/implementations/rust"
 TARGET_DIR="${CARGO_TARGET_DIR:-$RUST/target}"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
@@ -184,7 +185,7 @@ run_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" "$dir/.pytest_cache"
   rm -f "$dir"/.prove*.json "$dir"/.prove*.raw "$dir"/.verify*.json "$dir"/.verify*.raw
 
-  (cd "$dir" && PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
+  (cd "$dir" && showcase_run_with_terminal sugar.mint env PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
     echo "FAIL($twin): mint"
     return 1
   }

--- a/examples/python-literal-base64/run.sh
+++ b/examples/python-literal-base64/run.sh
@@ -16,6 +16,7 @@ set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 RUST="$REPO/implementations/rust"
 TARGET_DIR="${CARGO_TARGET_DIR:-$RUST/target}"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
@@ -184,7 +185,7 @@ run_twin() {
   rm -rf "$dir/.sugar/runs" "$dir/.sugar/witnesses" "$dir/__pycache__" "$dir/.pytest_cache"
   rm -f "$dir"/.prove*.json "$dir"/.prove*.raw "$dir"/.verify*.json "$dir"/.verify*.raw
 
-  (cd "$dir" && PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
+  (cd "$dir" && showcase_run_with_terminal sugar.mint env PATH="$PYTHON_BIN_DIR:$PATH" PYTHONPATH="$PYTHON_SRC" "$BIN" mint --out . --quiet) >/dev/null || {
     echo "FAIL($twin): mint"
     return 1
   }

--- a/examples/uuid-bytes-length/run-logo-receipt.sh
+++ b/examples/uuid-bytes-length/run-logo-receipt.sh
@@ -3,6 +3,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
+source "$REPO/scripts/showcase-terminal-identity.sh"
 BIN="$("$REPO/bin/sugarbin" --profile release)"
 export PYTHONPATH="$REPO/implementations/python/sugar-lift-py-tests/src:$REPO/implementations/python/sugar-lift-python-source/src${PYTHONPATH:+:$PYTHONPATH}"
 export PATH="$(dirname "$BIN"):${PATH:-}"
@@ -10,7 +11,7 @@ export PATH="$(dirname "$BIN"):${PATH:-}"
 dir="$HERE/dual"
 find "$dir" -maxdepth 1 -name 'blake3-512_*.proof' -delete 2>/dev/null || true
 rm -rf "$dir/.sugar/runs" 2>/dev/null || true
-(cd "$dir" && "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
+(cd "$dir" && showcase_run_with_terminal sugar.mint "$BIN" mint --out .) >/dev/null || { echo "FAIL: mint"; exit 1; }
 (cd "$dir" && "$BIN" prove --allow-failed-components --json .) >"$dir/.prove.raw" 2>"$dir/.prove.err" || true
 python3 - "$dir/.prove.raw" <<'INNER' || exit 1
 import json, re, sys

--- a/tests/test_showcase_terminal_producer.py
+++ b/tests/test_showcase_terminal_producer.py
@@ -46,6 +46,15 @@ EQ_PRODUCERS = (
     "examples/pandas-showcase/run.sh",
 )
 
+RAW_STRUCTURED_NON_EQ_PRODUCERS = (
+    "examples/hashlib-md5-digest-size/run-logo-receipt.sh",
+    "examples/uuid-bytes-length/run-logo-receipt.sh",
+    "examples/python-base64-federation/run.sh",
+    "examples/python-literal-base20/run.sh",
+    "examples/python-literal-base64/run.sh",
+    "examples/numpy-attribute-safety-showcase/run.sh",
+)
+
 
 def test_writer_is_additive_noop_before_consumer_supplies_path(
     monkeypatch: pytest.MonkeyPatch,
@@ -342,3 +351,13 @@ def test_shell_wrapper_publication_refusal_preserves_selected_exit(
         completed.stderr
     )
     assert not output.exists()
+
+
+@pytest.mark.parametrize("relative_path", RAW_STRUCTURED_NON_EQ_PRODUCERS)
+def test_raw_structured_non_eq_producer_walks_shared_terminal_door(
+    relative_path: str,
+) -> None:
+    source = (ROOT / relative_path).read_text(encoding="utf-8")
+
+    assert 'source "$REPO/scripts/showcase-terminal-identity.sh"' in source
+    assert "showcase_run_with_terminal sugar.mint" in source


### PR DESCRIPTION
## Outcome

Additively bind six non-Eq showcase mint entrances to the landed producer-owned terminal-testimony transport. The shared helper captures structured RPC terminal identity without changing consumer requirements or inventing terminal ownership in the scripts.

## Scope

Exact range: six producer scripts plus `tests/test_showcase_terminal_producer.py`, `+32/-7`.

- `examples/hashlib-md5-digest-size/run-logo-receipt.sh`
- `examples/numpy-attribute-safety-showcase/run.sh`
- `examples/python-base64-federation/run.sh`
- `examples/python-literal-base20/run.sh`
- `examples/python-literal-base64/run.sh`
- `examples/uuid-bytes-length/run-logo-receipt.sh`
- `tests/test_showcase_terminal_producer.py`

No transport files. No consumer files. No new category, kind, label, taxonomy, or residual bucket. No assertion, threshold, skip, or exit path is changed; each selected mint now passes through `showcase_run_with_terminal sugar.mint`.

## Evidence

- Exact-head authenticated producer module: `29/29` green.
- Six producer scripts: `bash -n` green.
- `git diff --check`: green.

The earlier six-producer remote run remains entrance-UNMEASURED because its raw `bash -lc` invocation had no task owner, selected the ordinary image, and enrolled neither managed preflight nor debug closure. This PR makes no runtime coverage claim from that run.

## Preflight

Head `7b4547517a2716f6eb0aae8b7a32da2589f2b022`; direct parent and merge-base current main `c62c2cd79c5839fb309091e0caea29c7a4d2eb13`; `0 behind / 1 ahead`. The borrowed transport commit `b2777df284` is absent from the range. Tree diff is exactly the seven intended modified files, with no deletions. Closing-account JSON remains present with SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route six non-Eq showcase mint steps through `showcase_run_with_terminal`
> - Six example run scripts now source [`scripts/showcase-terminal-identity.sh`](https://github.com/TSavo/sugar/pull/7343/files#diff-64fb3adbd292e8cae4b198009f17f02857b8405268d06b72d8d699f30bb249d9) and wrap their `sugar mint` invocations with `showcase_run_with_terminal 'sugar.mint'` instead of invoking the binary directly.
> - Scripts that previously set `PATH`/`PYTHONPATH` as command prefixes now pass those variables via `env` inside the wrapped call.
> - A new parametrized test in [`tests/test_showcase_terminal_producer.py`](https://github.com/TSavo/sugar/pull/7343/files#diff-8e087500d346f4ed81dcab7be3e40bef456c47db46363402bfc954f47f55086d) verifies each affected script sources the terminal identity script and contains the `showcase_run_with_terminal sugar.mint` wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b45475.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->