### PR TITLE
Preserve exact enumerate seeks and workspace source authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -598,7 +598,7 @@ def _parameter_contract_link_unit_rows(root: Path) -> List[Dict[str, Any]]:
         file_rel = str(source_path.relative_to(root))
         # No broad skip: a source that cannot be read is a LOUD failure, never a
         # silently omitted file.
-        sf = _tree.source_file(source_path)
+        sf = _tree.source_file(source_path, root=root)
         for fn in sf.functions():
             try:
                 outcome = _tree.function_universe_outcome(fn)
@@ -2227,7 +2227,19 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         )
                         return
                     _src, _fname, file_cid = identity
-                    sf = _tree.source_file(full_path)
+                    # This entrance only mints the module memento.  It must not
+                    # trigger the provisional demand walk that the subsequent
+                    # facts entrance performs as part of the one roll call.
+                    # An explicit empty contract table is honest here: no
+                    # source sugar is constructed at this level.
+                    sf = open_source_file_for_construction(
+                        full_path,
+                        root=root,
+                        construction_context=tree_construction_context_for_workspace(
+                            root, contract_refs={}
+                        ),
+                        populate_derived=False,
+                    )
                     memento = _tree.module_definition_memento(sf, file_rel, file_cid)
                     _send_enumerate_result(
                         msg_id,
@@ -2285,33 +2297,8 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # annotation (contract name, formals) is meaning and arrives
                 # when FunctionDef.sugar() is written; syntax does not wait
                 # for it.
-                from sugar_lift_python_source.source_oracle import (
-                    SourceUnavailable,
-                    path_source,
-                )
-                from sugar_source_tree.tree import SourceFile as _TreeSourceFile
-
-                try:
-                    identity = path_source(str(full_path))
-                except SourceUnavailable as unavailable:
-                    _send_enumerate_result(
-                        msg_id, [], [{"memento": at, "reason": str(unavailable)}]
-                    )
-                    return
-                _source, _fname, file_cid = identity
-                requested_cid = at.get("source_cid") if at else None
-                if requested_cid and requested_cid != file_cid:
-                    _send_enumerate_result(
-                        msg_id,
-                        [],
-                        [
-                            {
-                                "memento": at,
-                                "reason": "source memento CID no longer matches file",
-                            }
-                        ],
-                    )
-                    return
+                from sugar_lift_py_tests import tree_enumerate as _tree
+                from sugar_lift_python_source.source_oracle import SourceUnavailable
                 # Always inject construction context. Leaving it None makes every
                 # With unconditionally RuntimeSelectedContextManager (false red);
                 # production bind_contract_refs replaces the provisional gap table.
@@ -2334,9 +2321,32 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     )
                 else:
                     construction_context = tree_construction_context_for_workspace(root)
-                tree_file = _TreeSourceFile(
-                    identity, construction_context=construction_context
-                )
+                try:
+                    tree_file = open_source_file_for_construction(
+                        full_path,
+                        root=root,
+                        construction_context=construction_context,
+                        populate_derived=False,
+                    )
+                except SourceUnavailable as unavailable:
+                    _send_enumerate_result(
+                        msg_id, [], [{"memento": at, "reason": str(unavailable)}]
+                    )
+                    return
+                file_cid = tree_file.unit.source_cid
+                requested_cid = at.get("source_cid") if at else None
+                if requested_cid and requested_cid != file_cid:
+                    _send_enumerate_result(
+                        msg_id,
+                        [],
+                        [
+                            {
+                                "memento": at,
+                                "reason": "source memento CID no longer matches file",
+                            }
+                        ],
+                    )
+                    return
                 from sugar_lift_python_source.manager_summary_derivation import (
                     populate_source_derived_resource_refs,
                 )
@@ -2464,7 +2474,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         ],
                     )
                     return
-                sf = _tree.source_file(full_path)
+                sf = _tree.source_file(full_path, root=root)
                 span = at.get("span") if isinstance(at, dict) else None
                 source_assert, assert_node = _tree.temporally_rewritten_assert(sf, span)
                 if source_assert is None or assert_node is None:
@@ -2599,7 +2609,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
                 from sugar_source_tree.panic import SugarNotWritten
 
-                sf = _tree.source_file(full_path)
+                sf = _tree.source_file(full_path, root=root)
                 term_table = TermTableBuilder()
                 universes = []  # (name, memento_dict, contract_dto)
                 gaps = []
@@ -2779,7 +2789,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
             if level in ("call_sites", "assertions", "facts"):
                 from sugar_lift_py_tests import tree_enumerate as _tree
 
-                sf = _tree.source_file(full_path)
+                sf = _tree.source_file(full_path, root=root)
 
                 if level in ("call_sites", "assertions"):
                     if seek:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2782,6 +2782,47 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 sf = _tree.source_file(full_path)
 
                 if level in ("call_sites", "assertions"):
+                    if seek:
+                        source_assert = _tree.find_assert(
+                            sf,
+                            at.get("span") if isinstance(at, dict) else None,
+                        )
+                        if source_assert is not None:
+                            memento = _tree.assert_memento(source_assert, file_rel)
+                            if at is not None and _memento_matches(memento, at):
+                                _send_enumerate_result(
+                                    msg_id,
+                                    [
+                                        {
+                                            "memento": memento,
+                                            "audit": None,
+                                            "payload": None,
+                                        }
+                                    ],
+                                    [],
+                                )
+                                _log_enumeration_demand(
+                                    str(level),
+                                    at,
+                                    cache="miss",
+                                    started=demand_started,
+                                )
+                                return
+                        _send_enumerate_result(
+                            msg_id,
+                            [],
+                            [
+                                {
+                                    "memento": at,
+                                    "reason": "no call site for exact memento",
+                                }
+                            ],
+                        )
+                        _log_enumeration_demand(
+                            str(level), at, cache="miss", started=demand_started
+                        )
+                        return
+
                     # at is the parent function (scan) — enumerate its assertions.
                     fn = _tree.find_function(
                         sf,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/tree_enumerate.py
@@ -18,14 +18,29 @@ import functools
 from pathlib import Path
 from typing import Any, Optional
 
-from sugar_lift_python_source.source_oracle import path_source
+from sugar_lift_python_source.source_oracle import workspace_path_source
 from sugar_source_tree.tree import SourceFile
 from sugar_source_tree.nodes import Assert, AsyncFunctionDef, FunctionDef
 
 
-def source_file(full_path: Path) -> SourceFile:
-    """The file's tree, over oracle-pinned source."""
-    return SourceFile(path_source(str(full_path)))
+def source_file(
+    full_path: Path,
+    *,
+    root: Path,
+    construction_context=None,
+) -> SourceFile:
+    """The file's tree over workspace-relative oracle-pinned source.
+
+    Enumeration levels that only walk syntax must not implicitly add a
+    construction context: doing so changes which call occurrences are
+    authenticated and can turn a completed function into a deeper native
+    operation demand.  The functions entrance, which does construct, owns the
+    separate ``open_source_file_for_construction`` call.
+    """
+    return SourceFile(
+        workspace_path_source(str(full_path), root=str(root)),
+        construction_context=construction_context,
+    )
 
 
 def functions_of(sf: SourceFile):

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -1041,6 +1041,54 @@ def test_exact_seek_for_unknown_callsite_is_a_loud_gap_not_substitution(
         assert result["gaps"][0]["memento"] == forged
 
 
+def test_assertion_exact_seek_returns_the_identical_observed_locus(
+    project: Path,
+) -> None:
+    """An exact assertion seek is identity, never a second parent scan."""
+    file_memento = _enumerate("source_files", project)["nodes"][0]["memento"]
+    function = next(
+        node["memento"]
+        for node in _enumerate("functions", project, at=file_memento)["nodes"]
+        if node["memento"]["function_name"] == "test_add"
+    )
+    observed = _enumerate("call_sites", project, at=function)["nodes"][0]
+
+    result = _enumerate(
+        "assertions", project, at=observed["memento"], seek=True
+    )
+
+    assert result["gaps"] == []
+    assert result["nodes"] == [observed]
+
+
+def test_unknown_exact_callsite_seek_is_a_named_miss(project: Path) -> None:
+    """Silence is not a valid answer for an exact locus the tree cannot find."""
+    file_memento = _enumerate("source_files", project)["nodes"][0]["memento"]
+    function = next(
+        node["memento"]
+        for node in _enumerate("functions", project, at=file_memento)["nodes"]
+        if node["memento"]["function_name"] == "test_add"
+    )
+    observed = _enumerate("call_sites", project, at=function)["nodes"][0]["memento"]
+    unknown = {
+        **observed,
+        "span": {
+            "start_line": 999,
+            "start_col": 0,
+            "end_line": 999,
+            "end_col": 1,
+        },
+        "source_cid": "blake3-512:not-an-observed-callsite",
+    }
+
+    result = _enumerate("call_sites", project, at=unknown, seek=True)
+
+    assert result["nodes"] == []
+    assert result["gaps"] == [
+        {"memento": unknown, "reason": "no call site for exact memento"}
+    ]
+
+
 def test_universe_seek_from_callsite_joins_by_bridge(project: Path) -> None:
     """CallSite-style seek: call:add → qualified mathy.add universe."""
     file_memento = _enumerate("source_files", project)["nodes"][0]["memento"]

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -360,6 +360,57 @@ def test_functions_finds_both_the_contract_owner_and_the_enclosing_test(
     assert names == ["mathy.add", "test_add"]
 
 
+def test_tree_enumerate_source_file_uses_the_workspace_relative_door(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Syntax enumeration opens through the root-relative source oracle."""
+    from sugar_lift_py_tests import tree_enumerate
+
+    source = tmp_path / "relative_owner.py"
+    source.write_text("def identity(value):\n    return value\n", encoding="utf-8")
+    opened = []
+    real_workspace_path_source = tree_enumerate.workspace_path_source
+
+    def observe_workspace_path_source(path, *, root):
+        opened.append((path, root))
+        return real_workspace_path_source(path, root=root)
+
+    monkeypatch.setattr(
+        tree_enumerate, "workspace_path_source", observe_workspace_path_source
+    )
+
+    source_file = tree_enumerate.source_file(source, root=tmp_path)
+
+    assert opened == [(str(source), str(tmp_path))]
+    assert source_file.unit.filename == "relative_owner.py"
+
+
+def test_functions_level_uses_the_canonical_construction_open(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The RPC functions entrance must not mint a second bare SourceFile."""
+    opened = []
+    real_open = lift_rpc.open_source_file_for_construction
+
+    def observe_open(path, **kwargs):
+        source_file = real_open(path, **kwargs)
+        opened.append((path, kwargs, source_file.unit.filename))
+        return source_file
+
+    monkeypatch.setattr(lift_rpc, "open_source_file_for_construction", observe_open)
+    file_memento = _enumerate("source_files", project)["nodes"][0]["memento"]
+
+    result = _enumerate("functions", project, at=file_memento)
+
+    assert len(result["nodes"]) == 2
+    assert len(opened) == 1
+    path, kwargs, filename = opened[0]
+    assert path == project / "mathy.py"
+    assert kwargs["root"] == project
+    assert kwargs["populate_derived"] is False
+    assert filename == "mathy.py"
+
+
 def test_call_sites_scoped_to_enclosing_function(project: Path) -> None:
     file_memento = _enumerate("source_files", project)["nodes"][0]["memento"]
     functions = {


### PR DESCRIPTION
## What changed

- Exact call-site and assertion seeks now resolve the asserted locus itself. An unknown exact locus returns a named no-call-site gap instead of nodes=[] and gaps=[].
- Syntax enumeration now gets source identity through workspace_path_source. The functions entrance separately uses open_source_file_for_construction with the workspace root, preserving the existing bridge refusal as the enforcement boundary.
- The audit module-memento entrance supplies an explicit empty contract table because it constructs no sugar. This preserves the one-construction/one-discharge roll-call law instead of launching a duplicate provisional demand walk.

## Why

The shared call_sites/assertions path interpreted every at value as a parent FunctionDef. Exact assertion loci therefore vanished silently. Separately, tree enumeration minted absolute SourceFile loci, so FunctionDef.bridge_source_symbol correctly refused before four tests could reach their subject.

The entrances remain intentionally split. Giving every syntax walk a construction context changed call-occurrence authentication and made the #7336 completed __init__ control incomplete. Workspace-relative identity belongs to every tree open; construction context belongs only to the functions construction entrance.

## Evidence

Authenticated CPython 3.12.13, pandas 3.0.3/1421 on base c2fa1d6bd012bd4131c6ba46e2b90d059cf5de5e:

- Six focused controls: 6 passed in 1.38s. These cover exact-hit, named-miss, workspace oracle, canonical functions open, roll-call construction count, and #7336 sidecar completion.
- Controlled full-file parent at 03bd7b4c2c: 23 failed, 22 passed.
- Branch after restack onto c2fa1d6bd0: 20 failed, 29 passed. Four tests are newly added; no failing node was added.
- All four absolute-locus target nodes moved past FunctionDef.bridge_source_symbol. Two now pass. test_fact_construction_rewrites_enclosing_temporal_scope now reaches an empty fact payload, and test_implication_seek_returns_one_linker_demand_for_resolved_call now reaches candidateCount=0. Those are deeper named work, not hidden by this PR.

This does not update the fifteen separately classified stale expectations and does not claim the two deeper terminals are fixed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve exact enumerate seeks and use workspace-relative source authority
> - Updates `tree_enumerate.source_file` in [tree_enumerate.py](https://github.com/TSavo/sugar/pull/7344/files#diff-1a883a4eea1b53f1ee91261df4ca5f694dfda233c883ddab24f920fd9610931e) to open files via `workspace_path_source` instead of `path_source`, requiring an explicit `root` argument so all source lookups are workspace-relative.
> - The `functions` enumerate level in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7344/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now opens source via `open_source_file_for_construction` with `populate_derived=False`, avoiding provisional demand walks.
> - Adds exact-seek handling for `call_sites` and `assertions`: a `seek=True` request returns the matching observed node on hit, or a named gap (`no call site for exact memento`) on miss.
> - Fixes enumeration paths that previously used `path_source` to use `open_source_file_for_construction` and handle `SourceUnavailable` by returning a gap instead of failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65ca15f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->