### PR TITLE
Preserve typed verify effects across showcase receipts

### DIFF
--- a/docs/superpowers/plans/2026-08-04-showcase-verify-effect-carrier.md
+++ b/docs/superpowers/plans/2026-08-04-showcase-verify-effect-carrier.md
@@ -1,0 +1,145 @@
+# Showcase Verify-Effect Carrier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve every constructed `VerifyEffect` variant through verification receipts and construct an exact terminal for nonempty required-property attendance gaps.
+
+**Architecture:** Replace the report wire's implicit optional effect with a total `VerifyEffectCarrier::{Effect(VerifyEffect), NoEffect}`. Every `ReportRow` constructor must state one arm, making “not carried” unrepresentable; receipt JSON preserves the full effect variant, and the showcase selector projects only structured variant/property authority. Separately, a closed Python attendance result constructs either complete attendance or a nonempty gap over exact required-minus-observed property identities.
+
+**Tech Stack:** Rust (`serde`, `sugar-verifier`), Python 3, pytest, Bash showcase producers.
+
+## Global Constraints
+
+- Base all source testimony on `c62c2cd79c5839fb309091e0caea29c7a4d2eb13` or a named later main pin.
+- Never infer terminal identity from exit codes, prose, reason strings, or overlapping counters.
+- Preserve the exact `VerifyEffect` variant; a generic refusal label is forbidden.
+- The carrier has exactly `Effect(VerifyEffect)` and positively stated `NoEffect`; an omitted carrier must not compile.
+- Write red discrimination teeth before production changes and run only focused battleaxe tests.
+- Keep the attendance-gap constructor separate from the effect-carrier commit.
+
+---
+
+### Task 1: Total typed-effect report carrier
+
+**Files:**
+- Modify: `implementations/rust/sugar-verifier/src/effects.rs`
+- Modify: `implementations/rust/sugar-verifier/src/types.rs`
+- Modify: `implementations/rust/sugar-verifier/src/report.rs`
+- Modify: `implementations/rust/sugar-verifier/src/runner.rs`
+- Modify: direct `ReportRow` fixture constructors named by the compiler
+- Test: `implementations/rust/sugar-verifier/src/report.rs`
+
+**Interfaces:**
+- Consumes: `ConsistencyResult.effect: Option<VerifyEffect>` at the authoritative producer boundary.
+- Produces: `VerifyEffectCarrier::{Effect(VerifyEffect), NoEffect}` on every `ReportRow`; JSON `verifyEffect` retaining carrier state and the exact enum variant.
+
+- [ ] **Step 1: Write the failing carrier discrimination tests**
+
+Add focused tests proving two distinct `VerifyEffect` variants serialize distinctly, explicit `NoEffect` serializes positively, and no `ReportRow` can be built without a carrier.
+
+- [ ] **Step 2: Run the focused Rust tooth and record RED**
+
+Run: `bin/bcargo test -p sugar-verifier report::tests::verify_effect_carrier -- --nocapture`
+
+Expected: nonzero because `VerifyEffectCarrier`/`verifyEffect` do not exist on the pinned base.
+
+- [ ] **Step 3: Add the closed carrier and exhaustive variant serialization**
+
+Define `VerifyEffectCarrier` with only `Effect(VerifyEffect)` and `NoEffect`. Serialize the carrier and the complete `VerifyEffect` enum structurally; do not collapse variants to reason text.
+
+- [ ] **Step 4: Make `ReportRow` require the carrier**
+
+Add a non-optional carrier field. Update the sole report constructors and compiler-named fixtures to pass `NoEffect` positively when no verification effect occurred.
+
+- [ ] **Step 5: Seat both runner entrances through one producer conversion**
+
+Expose one `ConsistencyResult` method that matches its authoritative option into the closed carrier. Both runner loops and the warm/cold wire twin call that method; no caller authors a tag.
+
+- [ ] **Step 6: Run the focused Rust tooth and record GREEN**
+
+Run: `bin/bcargo test -p sugar-verifier report::tests::verify_effect_carrier -- --nocapture`
+
+Expected: zero with the two effect variants distinct and `NoEffect` explicit.
+
+- [ ] **Step 7: Commit the carrier repair**
+
+Commit only the Rust carrier, projection, required constructor updates, and carrier teeth.
+
+### Task 2: Structured receipt terminal selector and five bindings
+
+**Files:**
+- Modify: `tools/showcase_terminal_identity.py`
+- Modify: `tools/showcase/durable_consistency.py`
+- Modify: `examples/std-core-string-predicates/run.sh`
+- Test: `tests/test_showcase_terminal_producer.py`
+
+**Interfaces:**
+- Consumes: receipt rows containing total `verifyEffect` carrier JSON.
+- Produces: first unexpected raw terminal identity derived from the exact effect variant and authenticated property fields, or a positive no-terminal result for fully discharged rows.
+
+- [ ] **Step 1: Write failing selector twins**
+
+Plant one refused row whose `verifyEffect` carrier is absent and assert named refusal; plant two distinct effect variants and assert distinct terminal kinds; plant a discharged `NoEffect` row and assert no terminal.
+
+- [ ] **Step 2: Run the focused Python tooth and record RED**
+
+Run: `bin/bpytest tests/test_showcase_terminal_producer.py -q`
+
+Expected: nonzero because the receipt selector does not exist.
+
+- [ ] **Step 3: Implement the receipt selector without prose inference**
+
+Validate the carrier state and structured effect variant. Derive owner only from the effect's structured property authority; use `propertyCid`/property as structured coordinates, never parse `reason`.
+
+- [ ] **Step 4: Bind the five producers at their shared doors**
+
+Have `require_substantive_discharge` publish the first unexpected effect before its existing prose failure, covering url/semver/num-integer/bitflags. Bind std-core-string at its structured `failed_good` row selection. Preserve existing exit behavior.
+
+- [ ] **Step 5: Run Python teeth and shell syntax checks**
+
+Run: `bin/bpytest tests/test_showcase_terminal_producer.py -q`
+
+Run unpiped: `bash -n examples/std-core-string-predicates/run.sh examples/url-showcase/run.sh examples/semver-showcase/run.sh examples/num-integer-showcase/run.sh examples/bitflags-showcase/run.sh`
+
+- [ ] **Step 6: Commit the selector and five thin bindings**
+
+Commit only the shared selector/helper binding, std-core-string binding, and focused tests.
+
+### Task 3: Nonempty verification-property attendance gap
+
+**Files:**
+- Modify: `tools/showcase_terminal_identity.py`
+- Modify: `examples/std-core-showcase/run.sh`
+- Test: `tests/test_showcase_terminal_producer.py`
+
+**Interfaces:**
+- Consumes: declared required property identities and observed receipt property identities.
+- Produces: a closed complete-attendance result or `VerificationPropertyAttendanceGap` containing a nonempty ordered missing set and its terminal projection.
+
+- [ ] **Step 1: Write failing complete/gap twins**
+
+Assert exact required-minus-observed membership and order for the gap arm. Assert complete attendance constructs positively and publishes no terminal.
+
+- [ ] **Step 2: Run the focused Python tooth and record RED**
+
+Run: `bin/bpytest tests/test_showcase_terminal_producer.py -q`
+
+Expected: nonzero because the attendance constructor does not exist.
+
+- [ ] **Step 3: Implement the closed attendance constructor**
+
+Construct complete or nonempty gap from structured identities. Project the first missing identity in declared order to witness/v1 while retaining the complete gap in the constructed value; never parse printed prose.
+
+- [ ] **Step 4: Replace the std-core hand check with the constructor**
+
+Keep the existing human-readable missing-property output, but derive it from the constructed gap and publish its terminal before exit.
+
+- [ ] **Step 5: Run focused tests and syntax check**
+
+Run: `bin/bpytest tests/test_showcase_terminal_producer.py -q`
+
+Run unpiped: `bash -n examples/std-core-showcase/run.sh`
+
+- [ ] **Step 6: Commit the attendance construct separately**
+
+Commit only the central attendance constructor, std-core binding, and its twins.

--- a/examples/bitflags-showcase/run.sh
+++ b/examples/bitflags-showcase/run.sh
@@ -48,6 +48,7 @@ from tools.showcase.json_get import load_receipt
 statuses = require_substantive_discharge(
     load_receipt(path).get("rows", []),
     suite=suite,
+    entrance="sugar.prove",
 )
 print(",".join(statuses))
 PY
@@ -140,7 +141,7 @@ consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
 )
 substantive = (
-    require_substantive_discharge(rows, suite=suite)
+    require_substantive_discharge(rows, suite=suite, entrance="sugar.verify")
     if expect_consistency == "DISCHARGE"
     else []
 )

--- a/examples/num-integer-showcase/run.sh
+++ b/examples/num-integer-showcase/run.sh
@@ -48,6 +48,7 @@ from tools.showcase.json_get import load_receipt
 statuses = require_substantive_discharge(
     load_receipt(path).get("rows", []),
     suite=suite,
+    entrance="sugar.prove",
 )
 print(",".join(statuses))
 PY
@@ -140,7 +141,7 @@ consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
 )
 substantive = (
-    require_substantive_discharge(rows, suite=suite)
+    require_substantive_discharge(rows, suite=suite, entrance="sugar.verify")
     if expect_consistency == "DISCHARGE"
     else []
 )

--- a/examples/semver-showcase/run.sh
+++ b/examples/semver-showcase/run.sh
@@ -48,6 +48,7 @@ from tools.showcase.json_get import load_receipt
 statuses = require_substantive_discharge(
     load_receipt(path).get("rows", []),
     suite=suite,
+    entrance="sugar.prove",
 )
 print(",".join(statuses))
 PY
@@ -140,7 +141,7 @@ consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
 )
 substantive = (
-    require_substantive_discharge(rows, suite=suite)
+    require_substantive_discharge(rows, suite=suite, entrance="sugar.verify")
     if expect_consistency == "DISCHARGE"
     else []
 )

--- a/examples/std-core-string-predicates/run.sh
+++ b/examples/std-core-string-predicates/run.sh
@@ -199,10 +199,13 @@ PY
 run_mint_verify "$GOOD" GOOD
 run_mint_verify "$BAD" BAD
 
-python3 - "$GOOD/.verify.json" "$BAD/.verify.json" <<'PY'
+python3 - "$GOOD/.verify.json" "$BAD/.verify.json" "$REPO" <<'PY'
 import json
 import re
 import sys
+
+sys.path.insert(0, sys.argv[3])
+from tools.showcase_terminal_identity import publish_verification_receipt_terminal
 
 def receipt(path):
     text = open(path, encoding="utf-8").read()
@@ -264,6 +267,7 @@ if missing:
     print("GOOD missing required rows:", ", ".join(missing), file=sys.stderr)
     raise SystemExit(1)
 if failed_good:
+    publish_verification_receipt_terminal(failed_good, entrance="sugar.verify")
     print("GOOD has non-discharged #euf# rows:", file=sys.stderr)
     for row in failed_good:
         print(f"{row.get('status')} {row.get('property')} {row.get('reason')}", file=sys.stderr)

--- a/examples/url-showcase/run.sh
+++ b/examples/url-showcase/run.sh
@@ -48,6 +48,7 @@ from tools.showcase.json_get import load_receipt
 statuses = require_substantive_discharge(
     load_receipt(path).get("rows", []),
     suite=suite,
+    entrance="sugar.prove",
 )
 print(",".join(statuses))
 PY
@@ -140,7 +141,7 @@ consistency = check_durable_consistency(
     rows, suite=suite, expect=expect_consistency
 )
 substantive = (
-    require_substantive_discharge(rows, suite=suite)
+    require_substantive_discharge(rows, suite=suite, entrance="sugar.verify")
     if expect_consistency == "DISCHARGE"
     else []
 )

--- a/implementations/rust/sugar-cli/src/cmd_lift.rs
+++ b/implementations/rust/sugar-cli/src/cmd_lift.rs
@@ -11342,6 +11342,7 @@ mod tests {
                     "solverVendorMementoCid": "blake3-512:vendor"
                 }]
             })),
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
         report
     }

--- a/implementations/rust/sugar-cli/src/cmd_verify.rs
+++ b/implementations/rust/sugar-cli/src/cmd_verify.rs
@@ -1975,6 +1975,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
         report
     }

--- a/implementations/rust/sugar-cli/src/report_fmt.rs
+++ b/implementations/rust/sugar-cli/src/report_fmt.rs
@@ -417,6 +417,7 @@ mod tests {
             discharge_method: Some("reflexive".into()),
             body_discharge_tier: Some("body-eq-same-callee".into()),
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
 
         let j = report_to_json(&r);
@@ -454,6 +455,7 @@ mod tests {
                     }
                 ]
             })),
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
 
         let j = report_to_json(&r);
@@ -527,6 +529,7 @@ mod tests {
                     ]
                 }],
             })),
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
 
         let j = report_to_json(&r);
@@ -551,6 +554,7 @@ mod tests {
             discharge_method: Some("reflexive".into()),
             body_discharge_tier: None,
             verification: Some(json!({ "kind": "body-eq" })),
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
         let j = report_to_json(&r);
         assert_eq!(j["rows"][0]["verification"]["kind"], "body-eq");
@@ -631,6 +635,7 @@ mod tests {
             discharge_method: Some("hash-tier".into()),
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
         r.toolchain_plans.push(ToolchainPlanReport {
             plan_memento_cid: "blake3-512:plan-member".into(),
@@ -661,6 +666,7 @@ mod tests {
             discharge_method: Some("consistency".into()),
             body_discharge_tier: None,
             verification: Some(json!({ "kind": "consistency" })),
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
 
         assert_eq!(report_exit_code(&r), crate::EXIT_OK);
@@ -684,6 +690,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
 
         let j = report_to_json(&r);
@@ -705,6 +712,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
 
         let j = report_to_json(&r);

--- a/implementations/rust/sugar-cli/src/source_partition.rs
+++ b/implementations/rust/sugar-cli/src/source_partition.rs
@@ -716,6 +716,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         }];
         let entries = row_line_accounting(&rows);
         assert_eq!(entries.len(), 1);
@@ -736,6 +737,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         }];
         assert!(row_line_accounting(&rows).is_empty());
     }
@@ -754,6 +756,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         }];
         let entries = row_line_accounting(&rows);
         assert_eq!(entries.len(), 1);

--- a/implementations/rust/sugar-compiler/src/outcome.rs
+++ b/implementations/rust/sugar-compiler/src/outcome.rs
@@ -154,6 +154,7 @@ mod tests {
             discharge_method: None,
             body_discharge_tier: None,
             verification: None,
+            verify_effect: sugar_verifier::VerifyEffectCarrier::NoEffect,
         });
         report
     }

--- a/implementations/rust/sugar-verifier/src/consistency.rs
+++ b/implementations/rust/sugar-verifier/src/consistency.rs
@@ -9193,15 +9193,7 @@ mod tests {
                 .iter()
                 .map(|cr| {
                     let mut report = crate::types::Report::default();
-                    crate::report::add_consistency_with_verification(
-                        &cr.contract_cid,
-                        &cr.property_name,
-                        cr.verdict,
-                        &cr.reason,
-                        cr.verification.as_ref().map(|v| v.to_json()),
-                        cr.locus.clone(),
-                        &mut report,
-                    );
+                    crate::report::add_consistency_result(cr, &mut report);
                     serde_json::to_string(&crate::report::row_to_json(&report.rows[0]))
                         .expect("row_to_json serialize")
                 })

--- a/implementations/rust/sugar-verifier/src/effects.rs
+++ b/implementations/rust/sugar-verifier/src/effects.rs
@@ -8,6 +8,7 @@
 
 use std::fmt;
 
+use serde::Serialize;
 use serde_json::{json, Value as Json};
 
 use crate::types::ObligationVerdict;
@@ -24,7 +25,12 @@ pub struct VerifyEffectBoundary {
     pub verification: Option<Json>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
 pub enum VerifyEffect {
     MissingProvenanceKind {
         contract_cid: String,
@@ -66,7 +72,12 @@ pub enum VerifyEffect {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
 pub enum WitnessDischargeGround {
     PackageRecompute {
         error: String,
@@ -80,7 +91,12 @@ pub enum WitnessDischargeGround {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
 pub enum WitnessVerificationCheck {
     ComponentPlanFailed { reason: String },
     EnvelopeIntegrityMismatch,
@@ -95,6 +111,39 @@ pub enum WitnessVerificationOutcome {
     Verified { resolved_by: String },
     Refused(VerifyEffect),
     BrokenOracle { reason: String },
+}
+
+/// Total report-wire seat for verifier effects.
+///
+/// `Option<VerifyEffect>` is authoritative inside `ConsistencyResult`: `None`
+/// there means the producer constructed a result with no effect.  It is not a
+/// lawful transport, because omitting the field at a projection boundary also
+/// looks like `None`.  Every report row therefore states either the exact
+/// variant or positive no-effect testimony.  There is no not-carried arm.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", content = "effect", rename_all = "kebab-case")]
+pub enum VerifyEffectCarrier {
+    Effect(VerifyEffect),
+    NoEffect,
+}
+
+impl VerifyEffectCarrier {
+    pub fn from_producer(verdict: ObligationVerdict, effect: Option<&VerifyEffect>) -> Self {
+        match effect {
+            Some(effect) => {
+                assert_eq!(
+                    effect.to_legacy_boundary().verdict,
+                    verdict,
+                    "ConsistencyResult verdict disagrees with its VerifyEffect"
+                );
+                Self::Effect(effect.clone())
+            }
+            None if verdict == ObligationVerdict::Refused => {
+                panic!("refused ConsistencyResult lost its VerifyEffect")
+            }
+            None => Self::NoEffect,
+        }
+    }
 }
 
 impl VerifyEffect {

--- a/implementations/rust/sugar-verifier/src/lib.rs
+++ b/implementations/rust/sugar-verifier/src/lib.rs
@@ -66,8 +66,8 @@ pub use domain_claim_shape_report::{
     StatedClaimOutcome, TrichotomyError,
 };
 pub use effects::{
-    VerifyEffect, VerifyEffectBoundary, WitnessDischargeGround, WitnessVerificationCheck,
-    WitnessVerificationOutcome,
+    VerifyEffect, VerifyEffectBoundary, VerifyEffectCarrier, WitnessDischargeGround,
+    WitnessVerificationCheck, WitnessVerificationOutcome,
 };
 pub use runner::{
     LegacyZ3Fallback, PlanArtifactInput, ProofRunArtifact, ProofRunArtifactError, Runner,

--- a/implementations/rust/sugar-verifier/src/report.rs
+++ b/implementations/rust/sugar-verifier/src/report.rs
@@ -5,6 +5,8 @@
 
 use serde_json::{json, Value as Json};
 
+use crate::consistency::ConsistencyResult;
+use crate::effects::VerifyEffectCarrier;
 use crate::types::{
     CallSite, LoadError, MementoCid, MementoPool, ObligationVerdict, Report, ReportRow,
     SourceLocus, ToolchainPlanReport,
@@ -34,6 +36,7 @@ pub fn row_to_json(row: &ReportRow) -> Json {
         "dischargeMethod": row.discharge_method,
         "bodyDischargeTier": row.body_discharge_tier,
         "verification": verification_with_fol(row.verification.as_ref()),
+        "verifyEffect": row.verify_effect,
         "file": row.callsite.file,
         "line": row.callsite.line,
         "column": row.callsite.source_column,
@@ -73,6 +76,7 @@ pub fn add_callsite_with_discharge(
         discharge_method,
         body_discharge_tier,
         verification: None,
+        verify_effect: VerifyEffectCarrier::NoEffect,
     });
     if verdict == ObligationVerdict::Discharged {
         r.discharged += 1;
@@ -124,6 +128,7 @@ pub fn add_self_post_with_method(
         discharge_method,
         body_discharge_tier: None,
         verification: None,
+        verify_effect: VerifyEffectCarrier::NoEffect,
     });
     if verdict == ObligationVerdict::Discharged {
         r.discharged += 1;
@@ -153,7 +158,31 @@ pub fn add_consistency(
     reason: &str,
     r: &mut Report,
 ) {
-    add_consistency_with_verification(contract_cid, property_name, verdict, reason, None, None, r);
+    add_consistency_with_verification(
+        contract_cid,
+        property_name,
+        verdict,
+        reason,
+        VerifyEffectCarrier::from_producer(verdict, None),
+        None,
+        None,
+        r,
+    );
+}
+
+/// Project one constructed consistency result through the sole report door.
+/// Taking the whole producer value prevents callers from omitting its effect.
+pub fn add_consistency_result(result: &ConsistencyResult, r: &mut Report) {
+    add_consistency_with_verification(
+        &result.contract_cid,
+        &result.property_name,
+        result.verdict,
+        &result.reason,
+        VerifyEffectCarrier::from_producer(result.verdict, result.effect.as_ref()),
+        result.verification.as_ref().map(|value| value.to_json()),
+        result.locus.clone(),
+        r,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -162,6 +191,7 @@ pub fn add_consistency_with_verification(
     property_name: &str,
     verdict: ObligationVerdict,
     reason: &str,
+    verify_effect: VerifyEffectCarrier,
     verification: Option<Json>,
     locus: Option<SourceLocus>,
     r: &mut Report,
@@ -189,6 +219,7 @@ pub fn add_consistency_with_verification(
         discharge_method: Some("consistency".to_string()),
         body_discharge_tier: None,
         verification,
+        verify_effect,
     });
     if verdict == ObligationVerdict::Discharged {
         r.discharged += 1;
@@ -729,6 +760,8 @@ fn fol_line(rendered: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::consistency::ConsistencyResult;
+    use crate::effects::VerifyEffect;
     use serde_json::json;
 
     fn cid(seed: &str) -> MementoCid {
@@ -738,6 +771,85 @@ mod tests {
 
     fn cid_string(seed: &str) -> String {
         cid(seed).to_string()
+    }
+
+    fn consistency_result(
+        verdict: ObligationVerdict,
+        effect: Option<VerifyEffect>,
+    ) -> ConsistencyResult {
+        ConsistencyResult {
+            contract_cid: cid_string("effect-carrier"),
+            property_name: "method:contains#euf#fixture::assertion".to_string(),
+            verdict,
+            reason: "fixture refusal".to_string(),
+            effect,
+            witnessed: false,
+            verification: None,
+            locus: None,
+            dropped_ambient_posts: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn verify_effect_carrier_preserves_the_exact_variant() {
+        let no_sibling = consistency_result(
+            ObligationVerdict::Refused,
+            Some(VerifyEffect::NoSiblingToContradict {
+                contract_cid: cid_string("effect-carrier"),
+                property_name: "method:contains#euf#fixture::assertion".to_string(),
+                constraint_count: 1,
+            }),
+        );
+        let independent_kind = consistency_result(
+            ObligationVerdict::Refused,
+            Some(VerifyEffect::MissingIndependentKindWitness {
+                contract_cid: cid_string("effect-carrier"),
+                property_name: "method:contains#euf#fixture::assertion".to_string(),
+            }),
+        );
+
+        let wire = |result: &ConsistencyResult| {
+            let mut report = Report::default();
+            add_consistency_result(result, &mut report);
+            row_to_json(&report.rows[0])
+        };
+        let no_sibling_wire = wire(&no_sibling);
+        let independent_kind_wire = wire(&independent_kind);
+
+        assert_eq!(no_sibling_wire["verifyEffect"]["state"], "effect");
+        assert_eq!(
+            no_sibling_wire["verifyEffect"]["effect"]["kind"],
+            "no-sibling-to-contradict"
+        );
+        assert_eq!(
+            independent_kind_wire["verifyEffect"]["effect"]["kind"],
+            "missing-independent-kind-witness"
+        );
+        assert_ne!(
+            no_sibling_wire["verifyEffect"], independent_kind_wire["verifyEffect"],
+            "the carrier must not flatten distinct VerifyEffect variants"
+        );
+    }
+
+    #[test]
+    fn verify_effect_carrier_states_no_effect_positively() {
+        let result = consistency_result(ObligationVerdict::Discharged, None);
+        let mut report = Report::default();
+        add_consistency_result(&result, &mut report);
+
+        assert_eq!(
+            row_to_json(&report.rows[0])["verifyEffect"],
+            json!({"state": "no-effect"})
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "refused ConsistencyResult lost its VerifyEffect")]
+    fn verify_effect_carrier_refuses_a_dropped_refused_effect() {
+        let dropped = consistency_result(ObligationVerdict::Refused, None);
+        let mut report = Report::default();
+
+        add_consistency_result(&dropped, &mut report);
     }
 
     #[test]
@@ -752,6 +864,7 @@ mod tests {
             "encodeBase64#euf#c:call:encodeBase64(s:'xyz')::assertion",
             ObligationVerdict::Unsatisfied,
             "test assertions contradictory about callsite",
+            VerifyEffectCarrier::NoEffect,
             None,
             Some(SourceLocus {
                 file: "test_consumer.py".to_string(),
@@ -800,6 +913,7 @@ mod tests {
             "tests/consumer_test.rs::consumer_asserts_block_width_at_3::block_width#euf#c:callresult_block_width_a1(i:3)::assertion",
             ObligationVerdict::Unsatisfied,
             "contradictory",
+            VerifyEffectCarrier::NoEffect,
             Some(json!({
                 "kind": "consistency",
                 "linkedPosts": [{
@@ -874,6 +988,7 @@ mod tests {
             "some::assertion",
             ObligationVerdict::Unsatisfied,
             "contradictory",
+            VerifyEffectCarrier::NoEffect,
             Some(json!({
                 "kind": "consistency",
                 "linkedPosts": [{

--- a/implementations/rust/sugar-verifier/src/runner.rs
+++ b/implementations/rust/sugar-verifier/src/runner.rs
@@ -516,15 +516,7 @@ impl Runner {
                     n_residue.fetch_add(1, Ordering::Relaxed);
                 }
             }
-            report_stage::add_consistency_with_verification(
-                &cr.contract_cid,
-                &cr.property_name,
-                cr.verdict,
-                &cr.reason,
-                cr.verification.as_ref().map(|v| v.to_json()),
-                cr.locus.clone(),
-                &mut report,
-            );
+            report_stage::add_consistency_result(cr, &mut report);
         }
         report_stage::add_toolchain_plans(&pool, &mut report);
 
@@ -809,15 +801,7 @@ impl Runner {
                     n_residue.fetch_add(1, Ordering::Relaxed);
                 }
             }
-            report_stage::add_consistency_with_verification(
-                &cr.contract_cid,
-                &cr.property_name,
-                cr.verdict,
-                &cr.reason,
-                cr.verification.as_ref().map(|v| v.to_json()),
-                cr.locus.clone(),
-                &mut report,
-            );
+            report_stage::add_consistency_result(cr, &mut report);
         }
         report_stage::add_toolchain_plans(&pool, &mut report);
 

--- a/implementations/rust/sugar-verifier/src/types.rs
+++ b/implementations/rust/sugar-verifier/src/types.rs
@@ -7,6 +7,8 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as Json;
 
+use crate::effects::VerifyEffectCarrier;
+
 pub use sugar_proof_envelope::{
     compute_formula_cid, AnchoredMember, AtomCid, BundleScopedCallsiteKey, ContractBodyCid,
     EffectSiteAnnotation, ImplicationKey, ImplicationResult, LoadError, MemberKind, MementoCid,
@@ -292,6 +294,7 @@ pub struct ReportRow {
     pub discharge_method: Option<String>,
     pub body_discharge_tier: Option<String>,
     pub verification: Option<Json>,
+    pub verify_effect: VerifyEffectCarrier,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/tests/test_showcase_terminal_producer.py
+++ b/tests/test_showcase_terminal_producer.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(ROOT / "tools"))
 
 import showcase_terminal_identity  # noqa: E402
 import showcase_scope  # noqa: E402
+from tools.showcase import durable_consistency  # noqa: E402
 
 
 IDENTITY = {
@@ -53,6 +54,14 @@ RAW_STRUCTURED_NON_EQ_PRODUCERS = (
     "examples/python-literal-base20/run.sh",
     "examples/python-literal-base64/run.sh",
     "examples/numpy-attribute-safety-showcase/run.sh",
+)
+
+
+VERIFY_EFFECT_PRODUCERS = (
+    "examples/url-showcase/run.sh",
+    "examples/semver-showcase/run.sh",
+    "examples/num-integer-showcase/run.sh",
+    "examples/bitflags-showcase/run.sh",
 )
 
 
@@ -171,6 +180,164 @@ def test_rpc_terminal_projection_refuses_generic_error_without_owner(
             repo_root=tmp_path,
             entrance="sugar.mint",
         )
+
+
+def _verification_row(
+    *,
+    status: str,
+    verify_effect: object = ...,
+    property_name: str = "consistency:fixture::claim",
+    property_cid: str = "blake3-512_fixture",
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "status": status,
+        "property": property_name,
+        "propertyCid": property_cid,
+    }
+    if verify_effect is not ...:
+        row["verifyEffect"] = verify_effect
+    return row
+
+
+def test_verification_receipt_selector_preserves_exact_effect_variant() -> None:
+    no_sibling = _verification_row(
+        status="refused",
+        verify_effect={
+            "state": "effect",
+            "effect": {
+                "kind": "no-sibling-to-contradict",
+                "contractCid": "blake3-512_contract",
+                "propertyName": "consistency:fixture::claim",
+                "constraintCount": 1,
+            },
+        },
+    )
+    missing_kind = _verification_row(
+        status="refused",
+        verify_effect={
+            "state": "effect",
+            "effect": {
+                "kind": "missing-independent-kind-witness",
+                "contractCid": "blake3-512_contract",
+                "propertyName": "consistency:fixture::claim",
+            },
+        },
+    )
+
+    first = showcase_terminal_identity.select_verification_receipt_terminal(
+        [no_sibling], entrance="sugar.verify"
+    )
+    second = showcase_terminal_identity.select_verification_receipt_terminal(
+        [missing_kind], entrance="sugar.verify"
+    )
+
+    assert first.identity == {
+        "schemaVersion": 1,
+        "kind": "verify-effect:no-sibling-to-contradict",
+        "owner": "consistency:fixture::claim",
+        "coordinate": "blake3-512_fixture",
+        "entrance": "sugar.verify",
+    }
+    assert second.identity["kind"] == (
+        "verify-effect:missing-independent-kind-witness"
+    )
+    assert first.identity["kind"] != second.identity["kind"]
+
+
+def test_verification_receipt_selector_names_dropped_refused_effect() -> None:
+    with pytest.raises(
+        showcase_terminal_identity.TerminalIdentityRefusal,
+        match="refused verification row has no verifyEffect carrier",
+    ):
+        showcase_terminal_identity.select_verification_receipt_terminal(
+            [_verification_row(status="refused")],
+            entrance="sugar.verify",
+        )
+
+
+def test_verification_receipt_selector_constructs_positive_no_terminal() -> None:
+    result = showcase_terminal_identity.select_verification_receipt_terminal(
+        [
+            _verification_row(
+                status="discharged",
+                verify_effect={"state": "no-effect"},
+            )
+        ],
+        entrance="sugar.verify",
+    )
+
+    assert result.row_count == 1
+    assert not hasattr(result, "identity")
+
+
+def test_substantive_refusal_publishes_effect_before_existing_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "terminal.json"
+    monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
+    row = _verification_row(
+        status="refused",
+        verify_effect={
+            "state": "effect",
+            "effect": {
+                "kind": "no-sibling-to-contradict",
+                "propertyName": "consistency:fixture::claim",
+                "constraintCount": 1,
+            },
+        },
+    )
+
+    with pytest.raises(SystemExit, match="expected substantive"):
+        durable_consistency.require_substantive_discharge(
+            [row], suite="fixture", entrance="sugar.verify"
+        )
+
+    terminal_state = json.loads(output.read_text(encoding="utf-8"))
+    assert terminal_state["schemaVersion"] == 1
+    assert terminal_state["state"] == "witnessed"
+    assert terminal_state["terminalIdentity"]["kind"] == (
+        "verify-effect:no-sibling-to-contradict"
+    )
+
+
+def test_substantive_discharge_does_not_publish_a_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "terminal.json"
+    monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
+    row = _verification_row(
+        status="discharged",
+        verify_effect={"state": "no-effect"},
+    )
+
+    assert durable_consistency.require_substantive_discharge(
+        [row], suite="fixture", entrance="sugar.verify"
+    ) == ["discharged"]
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("relative_path", VERIFY_EFFECT_PRODUCERS)
+def test_bulk_verify_effect_producer_binds_both_receipt_entrances(
+    relative_path: str,
+) -> None:
+    script = (ROOT / relative_path).read_text(encoding="utf-8")
+
+    assert script.count('entrance="sugar.prove"') == 1
+    assert script.count('entrance="sugar.verify"') == 1
+
+
+def test_std_core_string_effect_producer_binds_selected_failed_rows() -> None:
+    script = (
+        ROOT / "examples/std-core-string-predicates/run.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "from tools.showcase_terminal_identity import " in script
+    assert (
+        'publish_verification_receipt_terminal(failed_good, entrance="sugar.verify")'
+        in script
+    )
 
 
 def test_scope_runner_supplies_additive_channel_without_consuming_it(

--- a/tools/showcase/durable_consistency.py
+++ b/tools/showcase/durable_consistency.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping, Sequence
 
+from ..showcase_terminal_identity import publish_verification_receipt_terminal
+
 VACUOUS_MARKERS = (
     "vacuous",
     "no sibling to contradict",
@@ -49,6 +51,7 @@ def require_substantive_discharge(
     rows: Sequence[Mapping[str, Any]],
     *,
     suite: str,
+    entrance: str = "verification-receipt",
 ) -> list[str]:
     """Require a nonempty substantive population whose every row discharged."""
     substantive = [row for row in rows if is_substantive_consistency_row(row)]
@@ -59,6 +62,7 @@ def require_substantive_discharge(
             "PASS requires a nonempty substantive population"
         )
     if any(status != "discharged" for status in statuses):
+        publish_verification_receipt_terminal(substantive, entrance=entrance)
         raise SystemExit(
             f"FAIL[{suite}]: expected substantive consistency rows all discharged, "
             f"got {statuses}"

--- a/tools/showcase_terminal_identity.py
+++ b/tools/showcase_terminal_identity.py
@@ -81,6 +81,20 @@ class VerificationPropertyAttendanceGap:
         )
 
 
+@dataclass(frozen=True)
+class SelectedVerificationTerminal:
+    """The first producer-constructed verification effect in receipt order."""
+
+    identity: dict[str, object]
+
+
+@dataclass(frozen=True)
+class NoVerificationTerminal:
+    """Positive testimony that every inspected row carried no effect."""
+
+    row_count: int
+
+
 def _refuse(reason: str) -> NoReturn:
     raise TerminalIdentityRefusal(reason)
 
@@ -441,6 +455,76 @@ def identity_from_rpc_text(
         if isinstance(value, str) and value.strip():
             identity[field] = value
     return validate_terminal_identity(identity)
+
+
+def select_verification_receipt_terminal(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    entrance: str,
+) -> SelectedVerificationTerminal | NoVerificationTerminal:
+    """Select the first exact verifier effect, or prove there was none.
+
+    ``verifyEffect`` is a total carrier on current receipts.  A non-discharged
+    row without it is proof that a projection dropped producer testimony, not
+    evidence that no effect occurred.  This selector never reconstructs an
+    effect from legacy ``reason`` prose.
+    """
+
+    for row in rows:
+        status = row.get("status")
+        if not isinstance(status, str) or not status:
+            _refuse("verification row requires nonempty status")
+
+        carrier = row.get("verifyEffect")
+        if not isinstance(carrier, Mapping):
+            _refuse(f"{status} verification row has no verifyEffect carrier")
+        state = carrier.get("state")
+        if state == "no-effect":
+            if status != "discharged":
+                _refuse(
+                    f"{status} verification row carries positive no-effect testimony"
+                )
+            continue
+        if state != "effect":
+            _refuse(f"verification row has unknown verifyEffect state {state!r}")
+
+        if status == "discharged":
+            _refuse("discharged verification row unexpectedly carries a VerifyEffect")
+        effect = carrier.get("effect")
+        if not isinstance(effect, Mapping):
+            _refuse("verifyEffect state=effect requires a structured effect")
+        variant = effect.get("kind")
+        if not isinstance(variant, str) or not variant:
+            _refuse("structured VerifyEffect requires nonempty kind")
+
+        effect_owner = effect.get("propertyName")
+        row_owner = row.get("property")
+        owner = effect_owner if isinstance(effect_owner, str) else row_owner
+        identity: dict[str, object] = {
+            "schemaVersion": TERMINAL_IDENTITY_SCHEMA_VERSION,
+            "kind": f"verify-effect:{variant}",
+            "owner": owner,
+            "entrance": entrance,
+        }
+        property_cid = row.get("propertyCid")
+        if isinstance(property_cid, str) and property_cid:
+            identity["coordinate"] = property_cid
+        return SelectedVerificationTerminal(validate_terminal_identity(identity))
+
+    return NoVerificationTerminal(row_count=len(rows))
+
+
+def publish_verification_receipt_terminal(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    entrance: str,
+) -> SelectedVerificationTerminal | NoVerificationTerminal:
+    """Publish the selected verifier effect when a consumer supplied a path."""
+
+    selected = select_verification_receipt_terminal(rows, entrance=entrance)
+    if isinstance(selected, SelectedVerificationTerminal):
+        write_from_environment(selected.identity)
+    return selected
 
 
 def _publish_once(output: Path, state: Mapping[str, object]) -> None:


### PR DESCRIPTION
## What changed

- make the verification report wire total with `VerifyEffectCarrier::{Effect, NoEffect}`
- serialize the complete `VerifyEffect` variant instead of dropping it at `ReportRow`
- project the first unexpected structured effect into the showcase terminal witness from five active producers
- publish that identity through main's closed `witnessed` terminal-state envelope

## Root cause

Production `ConsistencyResult` values with verdict `Refused` already carried `Some(VerifyEffect)`, but both runner projections constructed `ReportRow` without that value. The downstream `None` was indistinguishable from a legitimate no-effect result. The report type now requires either the exact variant or positive `NoEffect` testimony, and `Refused + None` refuses as a dropped effect.

## Historical cost

The archived std-core-string-predicates row retains enough structured reason testimony to authenticate `NoSiblingToContradict`. The exact historical variants for url, semver, num-integer, and bitflags were dropped before archival and are permanently unrecoverable. This change prevents future destruction; it does not manufacture those four lost variants.

This implements the five row-backed producer cases from #7342. The separate attendance-gap constructor is already on main via #7350 and remained intact through this rebase. The closed terminal-state substrate from #7352 is also main authority: effect identities publish as `state=witnessed`, not as the superseded raw top-level shape. This PR does not activate terminal-state enforcement or decide the nine-case no-owner exemption-versus-permanent-refusal ruling.

## Rebased evidence

Exact base and merge base: `d9bdf9b469d81e0b3783d32138558d70ec681c79`.
Exact head: `0e88175c82c082dde033f760ee9b6862420e744f`.

- `bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p sugar-verifier report::tests::verify_effect_carrier -- --nocapture` — unpiped exit 0, 3 passed, 0 failed. Covers exact variant, positive no-effect, and the expected `Refused + None` panic.
- `bin/bcargo check --manifest-path implementations/rust/Cargo.toml -p sugar-cli -p sugar-compiler` — unpiped exit 0.
- `bin/brun -- python3 -m pytest -q tests/test_showcase_terminal_state.py tests/test_showcase_terminal_producer.py tests/test_showcase_attendance_gap.py tests/test_showcase_retirement.py` — unpiped exit 0, 72 passed in 1.29s. This includes the landed #7352 envelope twins plus this branch's selector and producer teeth.
- Before adapting the branch tooth, the same focused selector slice failed for its own reason at 1 failed / 9 passed: production emitted #7352's correct `witnessed` envelope while the stale assertion read top-level `kind`. The tooth now asserts `state=witnessed` and `terminalIdentity.kind`; the rerun is green.
- direct `brun` source compilation plus `bash -n` over the five producer scripts — unpiped exit 0.
- `git diff --check` — exit 0.
- parent and merge base both equal current main; the tree diff contains only the effect-carrier plan, Rust carrier/projection, selector, five producers, and focused tests.
- `.receipts/first-sealed-frontier-1b3ac2dd9/closing-account.json` remains present at SHA-256 `20c96121eb1fe9715a5aa63dd74218eaefd15f5b52c6295378c91514fa5afaf1`.

One remote pytest-cache permission warning did not affect execution. An earlier `py_compile` hygiene attempt exited 1 before syntax checking because an existing remote `tools/__pycache__` was not writable; it is not counted as a code verdict. The source-only `compile(..., "exec")` rerun exited 0 without mutating that residue.

## Preserved floors

- no terminal identity is inferred from exit codes, prose, reasons, or counters
- effect variants remain exhaustive and distinct; no generic refusal bucket was added
- `NoEffect` is stated positively; not-carried has no transport arm
- existing showcase failure exits remain the consumer behavior
- #7352's closed terminal-state envelope remains the one publication surface

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve typed verify effects across showcase receipts by adding `VerifyEffectCarrier` to report rows
> - Introduces `VerifyEffectCarrier` enum in [effects.rs](https://github.com/TSavo/sugar/pull/7349/files#diff-ab8790e692695229fd8f27222c6df0b10b0a963fec48646cde7992f5f01b1348) with variants `Effect(VerifyEffect)` and `NoEffect`, serialized as a tagged JSON object with `state`/`effect` fields.
> - Adds `verify_effect: VerifyEffectCarrier` to `ReportRow` in [types.rs](https://github.com/TSavo/sugar/pull/7349/files#diff-95be33d0e415ef1101a14e569f37a7c67925da3b4f414ad656f3effbcc1a3635) and emits it as `verifyEffect` in JSON rows via [report.rs](https://github.com/TSavo/sugar/pull/7349/files#diff-0ee6c283907cde0046715c66019db1c627eadb7fb94fa550193f0ce62e2e8582).
> - Adds `select_verification_receipt_terminal` and `publish_verification_receipt_terminal` to [showcase_terminal_identity.py](https://github.com/TSavo/sugar/pull/7349/files#diff-baf253f7288497a61b535eb741f5a634f6b0a7ef6c641b818fbc1fc78b8dfe2e) to derive and publish a structured terminal identity from verification receipt rows.
> - Updates `require_substantive_discharge` in [durable_consistency.py](https://github.com/TSavo/sugar/pull/7349/files#diff-95f301f457fd4a5c303624473dac3fdffe614c7dbb3d6734a2da11d3a55c7f10) to accept an `entrance` parameter and publish a verification receipt terminal on failure.
> - Adds `entrance` arguments to `require_substantive_discharge` calls across all showcase `run.sh` scripts (`sugar.prove` / `sugar.verify`).
> - Risk: `VerifyEffectCarrier::from_producer` panics if a refused consistency result is missing its `VerifyEffect`, enforcing that refused rows always carry a structured effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e88175.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->