### PR TITLE
Construct exact verification property attendance gaps

### DIFF
--- a/examples/std-core-showcase/run.sh
+++ b/examples/std-core-showcase/run.sh
@@ -813,10 +813,16 @@ echo "proof: $(basename "$proof_path")"
 echo "== verify std/core selected source slice =="
 (cd "$PROJECT" && "$SUGAR" verify --project . --json) > "$PROJECT/.verify.json" || true
 
-python3 - "$PROJECT/.verify.json" "$TARGET_POINTER_WIDTH" "$TARGET_POINTER_BYTES" <<'PY'
+python3 - "$PROJECT/.verify.json" "$TARGET_POINTER_WIDTH" "$TARGET_POINTER_BYTES" "$REPO" <<'PY'
 import json
 import re
 import sys
+
+sys.path.insert(0, sys.argv[4])
+from tools.showcase_terminal_identity import (
+    VerificationPropertyAttendanceGap,
+    publish_verification_property_attendance,
+)
 
 path = sys.argv[1]
 target_pointer_width = sys.argv[2]
@@ -980,10 +986,20 @@ mem_location_needles = [
     "consistency:size_of::<usize>#panic_callsite#euf#c:callresult_size_of___usize__panic_callsite_a0()::assertion",
     "consistency:size_of::<* const usize>#panic_callsite#euf#c:callresult_size_of_____const_usize__panic_callsite_a0()::assertion",
 ]
-missing = [
-    needle for needle in needles
-    if not any(needle in (r.get("property") or "") for r in euf_rows)
-]
+attendance = publish_verification_property_attendance(
+    required=needles,
+    observed=[
+        needle
+        for needle in needles
+        if any(needle in (r.get("property") or "") for r in euf_rows)
+    ],
+    entrance="sugar.verify",
+)
+missing = (
+    list(attendance.missing_identities)
+    if isinstance(attendance, VerificationPropertyAttendanceGap)
+    else []
+)
 missing_type_id = [
     needle for needle in type_id_needles
     if not any(needle == (r.get("property") or "") for r in rows)

--- a/tests/test_showcase_attendance_gap.py
+++ b/tests/test_showcase_attendance_gap.py
@@ -1,0 +1,103 @@
+"""Both arms of producer-owned verification-property attendance."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from repo_root_test_support import resolve_repo_root
+
+ROOT = resolve_repo_root()
+sys.path.insert(0, str(ROOT / "tools"))
+
+import showcase_terminal_identity  # noqa: E402
+
+
+class VerificationPropertyAttendanceTests(unittest.TestCase):
+    def constructor(self):
+        constructor = getattr(
+            showcase_terminal_identity,
+            "construct_verification_property_attendance",
+            None,
+        )
+        self.assertTrue(
+            callable(constructor),
+            "verification-property attendance constructor is missing",
+        )
+        return constructor
+
+    def publisher(self):
+        publisher = getattr(
+            showcase_terminal_identity,
+            "publish_verification_property_attendance",
+            None,
+        )
+        self.assertTrue(
+            callable(publisher),
+            "verification-property attendance publisher is missing",
+        )
+        return publisher
+
+    def test_full_attendance_constructs_complete_without_a_terminal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            witness = Path(directory) / "terminal.json"
+            with patch.dict(
+                os.environ,
+                {"SHOWCASE_TERMINAL_WITNESS": str(witness)},
+            ):
+                result = self.publisher()(
+                    required=("claim:a", "claim:b"),
+                    observed=("claim:b", "claim:a", "claim:extra"),
+                    entrance="sugar.verify",
+                )
+
+            self.assertEqual(result.required_identities, ("claim:a", "claim:b"))
+            self.assertFalse(witness.exists())
+
+    def test_gap_carries_and_publishes_every_exact_missing_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            witness = Path(directory) / "terminal.json"
+            with patch.dict(
+                os.environ,
+                {"SHOWCASE_TERMINAL_WITNESS": str(witness)},
+            ):
+                result = self.publisher()(
+                    required=("claim:a", "claim:b", "claim:c", "claim:d"),
+                    observed=("claim:c", "claim:a", "claim:extra"),
+                    entrance="sugar.verify",
+                )
+
+            self.assertEqual(result.first_missing, "claim:b")
+            self.assertEqual(result.remaining_missing, ("claim:d",))
+            self.assertEqual(result.missing_identities, ("claim:b", "claim:d"))
+            self.assertEqual(
+                json.loads(witness.read_text(encoding="utf-8")),
+                {
+                    "schemaVersion": 1,
+                    "kind": "verification-property-attendance-gap",
+                    "owner": "VerificationPropertyAttendanceGap",
+                    "coordinate": "claim:b",
+                    "entrance": "sugar.verify",
+                    "missingIdentities": ["claim:b", "claim:d"],
+                },
+            )
+
+    def test_gap_type_cannot_be_constructed_without_a_first_identity(self) -> None:
+        gap_type = getattr(
+            showcase_terminal_identity,
+            "VerificationPropertyAttendanceGap",
+            None,
+        )
+        self.assertTrue(callable(gap_type), "attendance gap type is missing")
+
+        with self.assertRaises(TypeError):
+            gap_type()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/showcase_terminal_identity.py
+++ b/tools/showcase_terminal_identity.py
@@ -14,6 +14,7 @@ import json
 import os
 import tempfile
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
 
@@ -22,11 +23,45 @@ TERMINAL_WITNESS_ENV = "SHOWCASE_TERMINAL_WITNESS"
 TERMINAL_IDENTITY_SCHEMA_VERSION = 1
 _REQUIRED_FIELDS = ("schemaVersion", "kind", "owner")
 _OPTIONAL_FIELDS = ("coordinate", "observed", "requested", "entrance")
-_ALLOWED_FIELDS = frozenset((*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS))
+_STRUCTURED_FIELDS = ("missingIdentities",)
+_ALLOWED_FIELDS = frozenset(
+    (*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS, *_STRUCTURED_FIELDS)
+)
 
 
 class TerminalIdentityRefusal(ValueError):
     """The producer could not publish an exact terminal identity."""
+
+
+@dataclass(frozen=True)
+class VerificationPropertyAttendanceComplete:
+    """Positive testimony that every declared property identity was observed."""
+
+    required_identities: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class VerificationPropertyAttendanceGap:
+    """A measured absence with a structurally required first identity."""
+
+    first_missing: str
+    remaining_missing: tuple[str, ...]
+
+    @property
+    def missing_identities(self) -> tuple[str, ...]:
+        return (self.first_missing, *self.remaining_missing)
+
+    def terminal_identity(self, *, entrance: str) -> dict[str, object]:
+        return validate_terminal_identity(
+            {
+                "schemaVersion": TERMINAL_IDENTITY_SCHEMA_VERSION,
+                "kind": "verification-property-attendance-gap",
+                "owner": "VerificationPropertyAttendanceGap",
+                "coordinate": self.first_missing,
+                "entrance": entrance,
+                "missingIdentities": list(self.missing_identities),
+            }
+        )
 
 
 def _refuse(reason: str) -> NoReturn:
@@ -62,13 +97,84 @@ def validate_terminal_identity(raw: Mapping[str, object]) -> dict[str, object]:
         if not isinstance(value, str) or not value.strip():
             _refuse(f"terminal identity requires nonempty {field} when present")
 
+    missing_identities = raw.get("missingIdentities")
+    if raw["kind"] == "verification-property-attendance-gap":
+        if (
+            not isinstance(missing_identities, Sequence)
+            or isinstance(missing_identities, (str, bytes))
+            or not missing_identities
+            or any(
+                not isinstance(identity, str) or not identity
+                for identity in missing_identities
+            )
+        ):
+            _refuse(
+                "verification-property-attendance-gap requires nonempty "
+                "missingIdentities"
+            )
+        if raw.get("coordinate") != missing_identities[0]:
+            _refuse("attendance-gap coordinate must be its first missing identity")
+    elif missing_identities is not None:
+        _refuse("missingIdentities belong only to an attendance-gap terminal")
+
     # Preserve raw producer testimony.  Fixed field order makes the bytes
     # deterministic without normalizing any identity-bearing string.
-    return {
+    canonical = {
         field: raw[field]
         for field in (*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS)
         if field in raw
     }
+    if missing_identities is not None:
+        canonical["missingIdentities"] = list(missing_identities)
+    return canonical
+
+
+def construct_verification_property_attendance(
+    *,
+    required: Sequence[str],
+    observed: Sequence[str],
+) -> VerificationPropertyAttendanceComplete | VerificationPropertyAttendanceGap:
+    """Construct exact complete attendance or a nonempty measured absence."""
+
+    for label, identities in (("required", required), ("observed", observed)):
+        if any(not isinstance(identity, str) or not identity for identity in identities):
+            _refuse(f"{label} property identities must be nonempty strings")
+    if len(set(required)) != len(required):
+        _refuse("required property identities must be unique")
+
+    required_identities = tuple(required)
+    observed_identities = set(observed)
+    missing = tuple(
+        identity
+        for identity in required_identities
+        if identity not in observed_identities
+    )
+    if not missing:
+        return VerificationPropertyAttendanceComplete(
+            required_identities=required_identities
+        )
+    first_missing, *remaining_missing = missing
+    return VerificationPropertyAttendanceGap(
+        first_missing=first_missing,
+        remaining_missing=tuple(remaining_missing),
+    )
+
+
+def publish_verification_property_attendance(
+    *,
+    required: Sequence[str],
+    observed: Sequence[str],
+    entrance: str,
+) -> VerificationPropertyAttendanceComplete | VerificationPropertyAttendanceGap:
+    """Publish only the successfully measured nonempty-absence arm."""
+
+    attendance = construct_verification_property_attendance(
+        required=required,
+        observed=observed,
+    )
+    if isinstance(attendance, VerificationPropertyAttendanceGap):
+        write_from_environment(attendance.terminal_identity(entrance=entrance))
+    return attendance
 
 
 def _json_objects(text: str) -> Sequence[object]:


### PR DESCRIPTION
## What changed

- construct verification-property attendance as a closed complete-or-gap result
- make a gap structurally require a first missing identity and retain every remaining identity in declared order
- extend the additive terminal witness with structured `missingIdentities`
- route the std-core-showcase required-minus-observed self-check through that constructor

## Why

The std/core showcase already computed the exact required-minus-observed property set, but flattened that structured absence authority into prose. Downstream could not distinguish a measured attendance gap from an ownerless failure.

This is the sixth buildable case from #7342. It needed a construct rather than an exemption, and that construct is now present at the producer that owns the exact absence set.

`VerificationPropertyAttendanceComplete` carries the required identities and emits no terminal. `VerificationPropertyAttendanceGap` has a required `first_missing` field plus `remaining_missing`; there is no zero-identity constructor shape. Its terminal is an attendance-gap measurement, not a failure category, and carries the complete ordered identity set rather than an authored count.

This is separate from #7349. The #7349 branch and PR body were narrowed by force-with-lease to exclude this commit before this PR was opened.

## Red / green receipt

Base: `f5b3e48d067cd92444c12652fa57e78e56d345ce`

RED, tests only:

```text
bin/brun -- python3 tests/test_showcase_attendance_gap.py
exit 1; 3 tests ran; 3 expected failures
```

The failures named the missing complete-arm publisher, missing gap-arm publisher, and missing structurally nonempty gap type. An earlier `bin/brun python3 ...` invocation omitted the required `--`, exited 2 before execution, and was discarded.

The receipt deliberately uses the stdlib-only raw `brun` entrance. Its payload does not invoke sugarbin, so it avoids the poisoned shared binary rebuild-lock parent rather than working around or mutating that state.

GREEN, head `79177abc7ffd3fb9ea6ccb64af9da6b494f7283d`:

```text
bin/brun -- python3 tests/test_showcase_attendance_gap.py
exit 0; 3 tests ran; 3 passed
```

The green arms prove:

- full attendance preserves exact required identities and emits no witness
- a real gap preserves and publishes the exact ordered missing identities
- the gap type cannot be called without a first missing identity

Also green, unpiped: `python3 -m py_compile`, `bash -n examples/std-core-showcase/run.sh`, and `git diff --check`.

## Not claimed

- this does not call the measured absence a product failure
- this does not carry or author an attendance count
- this does not claim the full std/core showcase now clears; its sugarbin-dependent run remains outside this focused receipt while the shared battleaxe binary-lock parent is poisoned


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Construct exact verification property attendance gaps in `showcase_terminal_identity`
> - Adds `construct_verification_property_attendance` and `publish_verification_property_attendance` to [showcase_terminal_identity.py](https://github.com/TSavo/sugar/pull/7350/files#diff-baf253f7288497a61b535eb741f5a634f6b0a7ef6c641b818fbc1fc78b8dfe2e), returning either a `VerificationPropertyAttendanceComplete` or `VerificationPropertyAttendanceGap` based on required vs. observed identities.
> - `VerificationPropertyAttendanceGap` exposes `first_missing`, `remaining_missing`, and `missing_identities`, and can produce a validated terminal identity dict via `terminal_identity(entrance=...)`.
> - When a gap exists, `publish_verification_property_attendance` writes a `verification-property-attendance-gap` terminal identity to the environment-configured witness file; no write occurs on complete attendance.
> - Extends `validate_terminal_identity` to enforce `missingIdentities` structure for `verification-property-attendance-gap` kind, requiring coordinate to equal the first missing identity.
> - Updates [examples/std-core-showcase/run.sh](https://github.com/TSavo/sugar/pull/7350/files#diff-feef36d3242082b8fcfa41b21e179e015427718a6d7d2f212149c73a31631eb3) to derive `missing` from the returned gap object instead of computing it manually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79177ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->