### PR TITLE
Add dormant showcase terminal-state substrate

### DIFF
--- a/docs/superpowers/plans/2026-08-04-showcase-terminal-state-substrate.md
+++ b/docs/superpowers/plans/2026-08-04-showcase-terminal-state-substrate.md
@@ -1,0 +1,136 @@
+# Showcase Terminal State Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the dormant three-state showcase terminal contract without activating `run_shard` enforcement.
+
+**Architecture:** The producer witness file becomes a closed `ShowcaseTerminalStateV1` envelope. Existing producer identities are wrapped as `witnessed`; `no-owner-possible` exists only as an explicit producer-owned pending-ruling shape; `terminal-construct-missing` has no exemption variant. Dormant scope helpers validate exact terminal-state conservation and classify cross-run terminal transitions, while the live runner continues its additive, non-consuming behavior.
+
+**Tech Stack:** Python 3, pytest through authenticated `bin/bpytest`, JSON witness files, existing `showcase_terminal_identity` and `showcase_scope` authorities.
+
+## Global Constraints
+
+- Do not activate terminal-state enforcement in `tools/showcase_scope.py::run_shard`.
+- Missing files never mint `no-owner-possible`; only explicit producer testimony can construct that state.
+- `terminal-construct-missing` has no exemption or waiver arm.
+- Malformed testimony raises `ScopeRefusal`; it is not a fourth terminal state.
+- Terminal-state conservation is exact: `terminalWitnessed + noOwnerPossible + terminalConstructMissing == nonzero executed rows`, with no overlap.
+- Preserve existing showcase exit behavior and additive producer publication.
+- Do not add a path allowlist or encode the historical nine as current authority.
+
+---
+
+### Task 1: Closed Producer Envelope
+
+**Files:**
+- Modify: `tools/showcase_terminal_identity.py`
+- Modify: `tests/test_showcase_terminal_producer.py`
+- Test: `tests/test_showcase_terminal_state.py`
+
+**Interfaces:**
+- Consumes: existing `validate_terminal_identity(raw)` and `write_from_environment(raw)` producer door.
+- Produces: `validate_showcase_terminal_state(raw)`, `witnessed_terminal_state(identity)`, `no_owner_possible_terminal_state(...)`, and `terminal_construct_missing_state(...)` returning canonical JSON dictionaries.
+
+- [x] **Step 1: Write red envelope tests**
+
+Add tests proving an existing identity is published as:
+
+```python
+{
+    "schemaVersion": 1,
+    "state": "witnessed",
+    "terminalIdentity": IDENTITY,
+}
+```
+
+Add strict-shape tests proving `no-owner-possible` requires explicit producer contract, entrance, named reason, and `pending-ruling`; `terminal-construct-missing` accepts only its expected contract and named missing reason; and fields from two variants in one envelope refuse.
+
+- [x] **Step 2: Run red teeth**
+
+Run: `bin/bpytest -q tests/test_showcase_terminal_state.py tests/test_showcase_terminal_producer.py`
+
+Expected: focused failures because the state schema and witnessed envelope do not exist.
+
+- [x] **Step 3: Implement the minimal closed schema and writer wrapper**
+
+Implement exact field sets per `state`, canonical field order, and strict validation. Change only the shared writer boundary so existing identity-producing callers publish `witnessed_terminal_state(validate_terminal_identity(raw))`. Do not change producer selection or runner consumption.
+
+- [x] **Step 4: Re-run focused teeth**
+
+Run: `bin/bpytest -q tests/test_showcase_terminal_state.py tests/test_showcase_terminal_producer.py`
+
+Expected: all selected tests pass.
+
+---
+
+### Task 2: Dormant Conservation and Join Substrate
+
+**Files:**
+- Modify: `tools/showcase_scope.py`
+- Test: `tests/test_showcase_terminal_state.py`
+
+**Interfaces:**
+- Consumes: canonical `ShowcaseTerminalStateV1` dictionaries.
+- Produces: `validate_terminal_state_conservation(outcomes, counts)` and `classify_terminal_transition(before, after)`.
+
+- [x] **Step 1: Write red conservation teeth**
+
+Plant a balanced population containing one row in each terminal state. Plant a nonzero row without any terminal state and require a named conservation refusal. Plant a `witnessed` envelope carrying `no-owner-possible` fields and require a no-overlap refusal.
+
+- [x] **Step 2: Write red transition teeth**
+
+Prove witnessed rows distinguish `cleared`, `still-failing-same-terminal`, and `moved-to-named-terminal`. Prove either non-witness state yields an explicit `unmeasured` transition carrying the state, never an inferred identity.
+
+- [x] **Step 3: Run red teeth**
+
+Run: `bin/bpytest -q tests/test_showcase_terminal_state.py`
+
+Expected: failures naming absent conservation and transition helpers.
+
+- [x] **Step 4: Implement dormant validation and transition classification**
+
+Derive terminal-state counts from nonzero executed rows, reject terminal state on pass/retired rows, reject missing state, compare every claimed count, and classify transitions without reading prose or A2 counters. Do not call these helpers from `run_shard`, `seal_shard_body`, or attendance yet.
+
+- [x] **Step 5: Re-run focused teeth**
+
+Run: `bin/bpytest -q tests/test_showcase_terminal_state.py`
+
+Expected: all selected tests pass.
+
+---
+
+### Task 3: Activation Exclusion and Final Verification
+
+**Files:**
+- Modify: `tests/test_showcase_terminal_state.py`
+- Verify: `tools/showcase_scope.py`
+
+**Interfaces:**
+- Consumes: the completed dormant substrate.
+- Produces: structural evidence that live `run_shard` still supplies but does not consume `SHOWCASE_TERMINAL_WITNESS`.
+
+- [x] **Step 1: Add an activation-exclusion tooth**
+
+Assert the live runner still records a nonzero producer as the legacy failed row without adding `terminalState`, while the terminal witness file contains the new envelope. This proves the producer schema is live and enforcement is not.
+
+- [x] **Step 2: Run the focused authenticated module**
+
+Run: `bin/bpytest -q tests/test_showcase_terminal_state.py tests/test_showcase_terminal_producer.py tests/test_showcase_retirement.py`
+
+Expected: all selected tests pass.
+
+- [x] **Step 3: Audit forbidden activation and vocabulary**
+
+Run:
+
+```bash
+git diff --check
+git diff origin/main -- tools/showcase_scope.py
+rg -n "allowlist|exempt" tools/showcase_terminal_identity.py tools/showcase_scope.py tests/test_showcase_terminal_state.py
+```
+
+Expected: clean diff; no `run_shard` consumption of terminal state; no exemption arm on `terminal-construct-missing`.
+
+- [ ] **Step 4: Commit and push the substrate**
+
+Commit only the plan, schema, validators, and focused tests. Push the exact branch head and report the full 40-character remote SHA, parent, focused receipt, and explicit nonclaim that enforcement remains inactive.

--- a/tests/test_showcase_attendance_gap.py
+++ b/tests/test_showcase_attendance_gap.py
@@ -79,11 +79,15 @@ class VerificationPropertyAttendanceTests(unittest.TestCase):
                 json.loads(witness.read_text(encoding="utf-8")),
                 {
                     "schemaVersion": 1,
-                    "kind": "verification-property-attendance-gap",
-                    "owner": "VerificationPropertyAttendanceGap",
-                    "coordinate": "claim:b",
-                    "entrance": "sugar.verify",
-                    "missingIdentities": ["claim:b", "claim:d"],
+                    "state": "witnessed",
+                    "terminalIdentity": {
+                        "schemaVersion": 1,
+                        "kind": "verification-property-attendance-gap",
+                        "owner": "VerificationPropertyAttendanceGap",
+                        "coordinate": "claim:b",
+                        "entrance": "sugar.verify",
+                        "missingIdentities": ["claim:b", "claim:d"],
+                    },
                 },
             )
 

--- a/tests/test_showcase_terminal_producer.py
+++ b/tests/test_showcase_terminal_producer.py
@@ -72,7 +72,11 @@ def test_writer_emits_exact_validated_identity_atomically(
     monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
 
     assert showcase_terminal_identity.write_from_environment(IDENTITY) is True
-    assert json.loads(output.read_text(encoding="utf-8")) == IDENTITY
+    assert json.loads(output.read_text(encoding="utf-8")) == {
+        "schemaVersion": 1,
+        "state": "witnessed",
+        "terminalIdentity": IDENTITY,
+    }
 
 
 def test_writer_refuses_empty_or_unknown_identity_fields(
@@ -211,9 +215,13 @@ def test_scope_runner_supplies_additive_channel_without_consuming_it(
     assert len(terminal_files) == 1
     assert json.loads(terminal_files[0].read_text(encoding="utf-8")) == {
         "schemaVersion": 1,
-        "kind": "construction-panic",
-        "owner": "PlantedOwner",
-        "coordinate": "fixture.py:1:0",
+        "state": "witnessed",
+        "terminalIdentity": {
+            "schemaVersion": 1,
+            "kind": "construction-panic",
+            "owner": "PlantedOwner",
+            "coordinate": "fixture.py:1:0",
+        },
     }
 
 
@@ -255,10 +263,14 @@ def test_shell_wrapper_publishes_selected_rpc_terminal_and_preserves_exit(
     )
 
     assert completed.returncode == 7
-    assert json.loads(output.read_text(encoding="utf-8"))["owner"] == (
+    assert json.loads(output.read_text(encoding="utf-8"))["terminalIdentity"][
+        "owner"
+    ] == (
         "ComparisonOpSugar.Eq"
     )
-    assert json.loads(output.read_text(encoding="utf-8"))["coordinate"] == (
+    assert json.loads(output.read_text(encoding="utf-8"))["terminalIdentity"][
+        "coordinate"
+    ] == (
         "examples/demo/test_logo.py:4:11"
     )
 
@@ -316,7 +328,9 @@ def test_shell_wrapper_reads_structured_stdout_and_replays_both_streams(
     assert "stdout-before\n" in completed.stdout
     assert json.dumps(diagnostic) in completed.stdout
     assert "stderr-before\n" in completed.stderr
-    assert json.loads(output.read_text(encoding="utf-8"))["owner"] == (
+    assert json.loads(output.read_text(encoding="utf-8"))["terminalIdentity"][
+        "owner"
+    ] == (
         "binary_operation_exception_floor"
     )
 

--- a/tests/test_showcase_terminal_state.py
+++ b/tests/test_showcase_terminal_state.py
@@ -1,0 +1,238 @@
+"""Dormant three-state contract for showcase terminal testimony."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from repo_root_test_support import resolve_repo_root
+
+ROOT = resolve_repo_root()
+sys.path.insert(0, str(ROOT / "tools"))
+
+import showcase_scope  # noqa: E402
+import showcase_terminal_identity  # noqa: E402
+
+
+IDENTITY = {
+    "schemaVersion": 1,
+    "kind": "ConstructionPanic",
+    "owner": "ComparisonOpSugar.Eq",
+    "coordinate": "fixture.py:4:11",
+    "observed": "undecided binary compare",
+    "requested": "authenticated exception coordinate",
+    "entrance": "sugar.enumerate:facts:auditFrontier",
+}
+
+
+def witnessed() -> dict[str, object]:
+    return showcase_terminal_identity.witnessed_terminal_state(IDENTITY)
+
+
+def no_owner_possible() -> dict[str, object]:
+    return showcase_terminal_identity.no_owner_possible_terminal_state(
+        producer_contract="ownerless-rpc-terminal/v1",
+        entrance="sugar.verify",
+        reason="producer-contract-has-no-owner",
+    )
+
+
+def construct_missing() -> dict[str, object]:
+    return showcase_terminal_identity.terminal_construct_missing_state(
+        expected_contract="SHOWCASE_TERMINAL_WITNESS/v1",
+        reason="terminal-state-absent",
+    )
+
+
+def failed(path: str, state: dict[str, object]) -> dict[str, object]:
+    outcome = "failed" if state["state"] == "witnessed" else "unmeasured"
+    row: dict[str, object] = {
+        "path": path,
+        "outcome": outcome,
+        "exitCode": 7,
+        "terminalState": state,
+    }
+    if outcome == "unmeasured":
+        row["reason"] = state["state"]
+    return row
+
+
+def passed(path: str) -> dict[str, object]:
+    return {
+        "path": path,
+        "outcome": "passed",
+        "exitCode": 0,
+        "subjectWitness": {"schemaVersion": 1, "subjectId": path},
+    }
+
+
+def test_existing_identity_publishes_as_witnessed_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = tmp_path / "terminal.json"
+    monkeypatch.setenv("SHOWCASE_TERMINAL_WITNESS", str(output))
+
+    assert showcase_terminal_identity.write_from_environment(IDENTITY) is True
+    assert json.loads(output.read_text(encoding="utf-8")) == {
+        "schemaVersion": 1,
+        "state": "witnessed",
+        "terminalIdentity": IDENTITY,
+    }
+
+
+def test_closed_state_shapes_preserve_negative_and_missing_as_distinct() -> None:
+    assert no_owner_possible() == {
+        "schemaVersion": 1,
+        "state": "no-owner-possible",
+        "producerContract": "ownerless-rpc-terminal/v1",
+        "entrance": "sugar.verify",
+        "reason": "producer-contract-has-no-owner",
+        "disposition": "pending-ruling",
+    }
+    assert construct_missing() == {
+        "schemaVersion": 1,
+        "state": "terminal-construct-missing",
+        "expectedContract": "SHOWCASE_TERMINAL_WITNESS/v1",
+        "reason": "terminal-state-absent",
+    }
+    assert "terminalIdentity" not in no_owner_possible()
+    assert "terminalIdentity" not in construct_missing()
+    assert "exemption" not in construct_missing()
+
+
+def test_one_envelope_cannot_claim_two_states() -> None:
+    overlapped = witnessed()
+    overlapped.update(
+        {
+            "producerContract": "ownerless-rpc-terminal/v1",
+            "entrance": "sugar.verify",
+            "reason": "producer-contract-has-no-owner",
+            "disposition": "pending-ruling",
+        }
+    )
+
+    with pytest.raises(
+        showcase_terminal_identity.TerminalIdentityRefusal,
+        match="witnessed terminal state fields",
+    ):
+        showcase_terminal_identity.validate_showcase_terminal_state(overlapped)
+
+
+def test_malformed_terminal_state_becomes_scope_refusal_not_a_fourth_state() -> None:
+    malformed = witnessed()
+    malformed["terminalIdentity"] = {"schemaVersion": 1, "kind": "gap"}
+    rows = [failed("examples/malformed/run.sh", malformed)]
+
+    with pytest.raises(showcase_scope.ScopeRefusal, match="terminal state malformed"):
+        showcase_scope.validate_terminal_state_conservation(
+            rows,
+            {
+                "terminalWitnessed": 1,
+                "noOwnerPossible": 0,
+                "terminalConstructMissing": 0,
+            },
+        )
+
+
+def test_terminal_state_conservation_closes_exactly() -> None:
+    rows = [
+        failed("examples/witnessed/run.sh", witnessed()),
+        failed("examples/no-owner/run.sh", no_owner_possible()),
+        failed("examples/missing/run.sh", construct_missing()),
+        passed("examples/passed/run.sh"),
+    ]
+
+    assert showcase_scope.validate_terminal_state_conservation(
+        rows,
+        {
+            "terminalWitnessed": 1,
+            "noOwnerPossible": 1,
+            "terminalConstructMissing": 1,
+        },
+    ) == {
+        "terminalWitnessed": 1,
+        "noOwnerPossible": 1,
+        "terminalConstructMissing": 1,
+    }
+
+
+def test_nonzero_row_in_no_state_refuses_conservation() -> None:
+    rows = [{"path": "examples/missing/run.sh", "outcome": "failed", "exitCode": 7}]
+
+    with pytest.raises(
+        showcase_scope.ScopeRefusal,
+        match="nonzero executed showcase lacks terminal state",
+    ):
+        showcase_scope.validate_terminal_state_conservation(
+            rows,
+            {
+                "terminalWitnessed": 0,
+                "noOwnerPossible": 0,
+                "terminalConstructMissing": 0,
+            },
+        )
+
+
+def test_row_in_two_states_refuses_before_balanced_counts_can_hide_it() -> None:
+    overlapped = witnessed()
+    overlapped["expectedContract"] = "SHOWCASE_TERMINAL_WITNESS/v1"
+    overlapped["reason"] = "terminal-state-absent"
+
+    with pytest.raises(showcase_scope.ScopeRefusal, match="terminal state malformed"):
+        showcase_scope.validate_terminal_state_conservation(
+            [failed("examples/overlap/run.sh", overlapped)],
+            {
+                "terminalWitnessed": 1,
+                "noOwnerPossible": 0,
+                "terminalConstructMissing": 0,
+            },
+        )
+
+
+def test_join_distinguishes_cleared_same_and_moved_witnesses() -> None:
+    moved_identity = dict(IDENTITY)
+    moved_identity["owner"] = "ReceiverFieldStoreStateSugar"
+    moved_identity["coordinate"] = "fixture.py:8:4"
+
+    before = failed("examples/demo/run.sh", witnessed())
+    assert showcase_scope.classify_terminal_transition(
+        before,
+        passed("examples/demo/run.sh"),
+    )["transition"] == "cleared"
+    assert showcase_scope.classify_terminal_transition(
+        before,
+        failed("examples/demo/run.sh", witnessed()),
+    )["transition"] == "still-failing-same-terminal"
+    moved = showcase_scope.classify_terminal_transition(
+        before,
+        failed(
+            "examples/demo/run.sh",
+            showcase_terminal_identity.witnessed_terminal_state(moved_identity),
+        ),
+    )
+    assert moved["transition"] == "moved-to-named-terminal"
+    assert moved["beforeTerminalIdentity"] == IDENTITY
+    assert moved["afterTerminalIdentity"] == moved_identity
+
+
+@pytest.mark.parametrize("state_name", ["no-owner-possible", "construct-missing"])
+def test_join_keeps_nonwitness_state_explicitly_unmeasured(
+    state_name: str,
+) -> None:
+    state = (
+        no_owner_possible()
+        if state_name == "no-owner-possible"
+        else construct_missing()
+    )
+    joined = showcase_scope.classify_terminal_transition(
+        failed("examples/demo/run.sh", witnessed()),
+        failed("examples/demo/run.sh", state),
+    )
+
+    assert joined["transition"] == "unmeasured"
+    assert joined["afterTerminalState"] == state
+    assert "afterTerminalIdentity" not in joined

--- a/tools/showcase_scope.py
+++ b/tools/showcase_scope.py
@@ -11,7 +11,11 @@ import sys
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from showcase_terminal_identity import TERMINAL_WITNESS_ENV
+from showcase_terminal_identity import (
+    TERMINAL_WITNESS_ENV,
+    TerminalIdentityRefusal,
+    validate_showcase_terminal_state,
+)
 
 SCHEMA_VERSION = 1
 RETIREMENT_REASON = "out of scope per scope ruling - Java"
@@ -137,6 +141,151 @@ def _write_json_atomic(path: Path, payload: object) -> None:
     temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
     temporary.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     temporary.replace(path)
+
+
+_TERMINAL_STATE_COUNT_KEYS = (
+    "terminalWitnessed",
+    "noOwnerPossible",
+    "terminalConstructMissing",
+)
+_TERMINAL_STATE_COUNT_BY_STATE = {
+    "witnessed": "terminalWitnessed",
+    "no-owner-possible": "noOwnerPossible",
+    "terminal-construct-missing": "terminalConstructMissing",
+}
+
+
+def _canonical_terminal_state(raw: object, *, path: str) -> dict[str, object]:
+    if not isinstance(raw, Mapping):
+        raise ScopeRefusal(f"terminal state malformed for {path}: expected object")
+    try:
+        return validate_showcase_terminal_state(raw)
+    except TerminalIdentityRefusal as exc:
+        raise ScopeRefusal(f"terminal state malformed for {path}: {exc}") from exc
+
+
+def validate_terminal_state_conservation(
+    outcomes: object,
+    counts: object,
+) -> dict[str, int]:
+    """Validate the dormant three-state partition over nonzero executed rows."""
+
+    if not isinstance(outcomes, list) or not isinstance(counts, Mapping):
+        raise ScopeRefusal("terminal state conservation requires outcomes and counts")
+    if frozenset(counts) != frozenset(_TERMINAL_STATE_COUNT_KEYS):
+        raise ScopeRefusal(
+            "terminal state conservation count fields do not close: "
+            f"observed={sorted(counts)}"
+        )
+    derived = {key: 0 for key in _TERMINAL_STATE_COUNT_KEYS}
+    nonzero_executed = 0
+    for ordinal, raw in enumerate(outcomes):
+        if not isinstance(raw, Mapping):
+            raise ScopeRefusal(f"terminal state outcome {ordinal} must be an object")
+        path = raw.get("path")
+        if not isinstance(path, str) or not path:
+            raise ScopeRefusal(f"terminal state outcome {ordinal} has missing path")
+        outcome = raw.get("outcome")
+        exit_code = raw.get("exitCode")
+        state_raw = raw.get("terminalState")
+        if outcome == "retired":
+            if state_raw is not None:
+                raise ScopeRefusal(f"retired showcase claims terminal state: {path}")
+            continue
+        if not isinstance(exit_code, int):
+            raise ScopeRefusal(f"executed showcase lacks integer exitCode: {path}")
+        if exit_code == 0:
+            if state_raw is not None:
+                raise ScopeRefusal(f"zero-exit showcase claims terminal state: {path}")
+            continue
+        nonzero_executed += 1
+        if state_raw is None:
+            raise ScopeRefusal(
+                f"nonzero executed showcase lacks terminal state: {path}"
+            )
+        state = _canonical_terminal_state(state_raw, path=path)
+        state_name = state["state"]
+        assert isinstance(state_name, str)
+        count_key = _TERMINAL_STATE_COUNT_BY_STATE[state_name]
+        derived[count_key] += 1
+        if state_name == "witnessed" and outcome != "failed":
+            raise ScopeRefusal(f"witnessed terminal must be failed outcome: {path}")
+        if state_name != "witnessed" and outcome != "unmeasured":
+            raise ScopeRefusal(
+                f"nonwitness terminal state must be unmeasured outcome: {path}"
+            )
+    if sum(derived.values()) != nonzero_executed:
+        raise ScopeRefusal(
+            "terminal state conservation failed: "
+            f"classified={sum(derived.values())} nonzero={nonzero_executed}"
+        )
+    for key, value in derived.items():
+        if counts.get(key) != value:
+            raise ScopeRefusal(
+                f"terminal state conservation mismatch for {key}: "
+                f"claimed={counts.get(key)!r} observed={value}"
+            )
+    return derived
+
+
+def classify_terminal_transition(
+    before: Mapping[str, object],
+    after: Mapping[str, object],
+) -> dict[str, object]:
+    """Classify one dormant cross-run transition without inferring identity."""
+
+    before_path = before.get("path")
+    after_path = after.get("path")
+    if not isinstance(before_path, str) or before_path != after_path:
+        raise ScopeRefusal(
+            "terminal transition requires the same nonempty showcase path"
+        )
+    before_state = _canonical_terminal_state(
+        before.get("terminalState"),
+        path=before_path,
+    )
+    if after.get("outcome") == "passed":
+        if after.get("terminalState") is not None:
+            raise ScopeRefusal(
+                f"cleared showcase retains terminal state: {before_path}"
+            )
+        if before_state["state"] != "witnessed":
+            return {
+                "path": before_path,
+                "transition": "unmeasured",
+                "beforeTerminalState": before_state,
+            }
+        return {
+            "path": before_path,
+            "transition": "cleared",
+            "beforeTerminalIdentity": before_state["terminalIdentity"],
+        }
+    after_state = _canonical_terminal_state(
+        after.get("terminalState"),
+        path=before_path,
+    )
+    if (
+        before_state["state"] != "witnessed"
+        or after_state["state"] != "witnessed"
+    ):
+        return {
+            "path": before_path,
+            "transition": "unmeasured",
+            "beforeTerminalState": before_state,
+            "afterTerminalState": after_state,
+        }
+    before_identity = before_state["terminalIdentity"]
+    after_identity = after_state["terminalIdentity"]
+    return {
+        "path": before_path,
+        "transition": (
+            "still-failing-same-terminal"
+            if before_identity == after_identity
+            else "moved-to-named-terminal"
+        ),
+        "beforeTerminalIdentity": before_identity,
+        "afterTerminalIdentity": after_identity,
+    }
 
 
 def _validate_outcomes(outcomes: object, counts: object) -> None:

--- a/tools/showcase_terminal_identity.py
+++ b/tools/showcase_terminal_identity.py
@@ -21,11 +21,28 @@ from typing import NoReturn
 
 TERMINAL_WITNESS_ENV = "SHOWCASE_TERMINAL_WITNESS"
 TERMINAL_IDENTITY_SCHEMA_VERSION = 1
+TERMINAL_STATE_SCHEMA_VERSION = 1
 _REQUIRED_FIELDS = ("schemaVersion", "kind", "owner")
 _OPTIONAL_FIELDS = ("coordinate", "observed", "requested", "entrance")
 _STRUCTURED_FIELDS = ("missingIdentities",)
 _ALLOWED_FIELDS = frozenset(
     (*_REQUIRED_FIELDS, *_OPTIONAL_FIELDS, *_STRUCTURED_FIELDS)
+)
+_WITNESSED_STATE_FIELDS = frozenset(
+    ("schemaVersion", "state", "terminalIdentity")
+)
+_NO_OWNER_POSSIBLE_STATE_FIELDS = frozenset(
+    (
+        "schemaVersion",
+        "state",
+        "producerContract",
+        "entrance",
+        "reason",
+        "disposition",
+    )
+)
+_TERMINAL_CONSTRUCT_MISSING_STATE_FIELDS = frozenset(
+    ("schemaVersion", "state", "expectedContract", "reason")
 )
 
 
@@ -127,6 +144,169 @@ def validate_terminal_identity(raw: Mapping[str, object]) -> dict[str, object]:
     if missing_identities is not None:
         canonical["missingIdentities"] = list(missing_identities)
     return canonical
+
+
+def _require_terminal_state_fields(
+    raw: Mapping[str, object],
+    expected: frozenset[str],
+    *,
+    label: str,
+) -> None:
+    observed = frozenset(raw)
+    if observed != expected:
+        missing = sorted(expected - observed)
+        unsupported = sorted(observed - expected)
+        _refuse(
+            f"{label} terminal state fields do not close: "
+            f"missing={missing} unsupported={unsupported}"
+        )
+
+
+def _require_nonempty_state_string(
+    raw: Mapping[str, object],
+    field: str,
+    *,
+    label: str,
+) -> str:
+    value = raw[field]
+    if not isinstance(value, str) or not value.strip():
+        _refuse(f"{label} terminal state requires nonempty {field}")
+    return value
+
+
+def validate_showcase_terminal_state(
+    raw: Mapping[str, object],
+) -> dict[str, object]:
+    """Return one canonical closed terminal state or refuse mixed testimony."""
+
+    if raw.get("schemaVersion") != TERMINAL_STATE_SCHEMA_VERSION:
+        _refuse(
+            "terminal state schemaVersion must be "
+            f"{TERMINAL_STATE_SCHEMA_VERSION}"
+        )
+    state = raw.get("state")
+    if state == "witnessed":
+        _require_terminal_state_fields(
+            raw,
+            _WITNESSED_STATE_FIELDS,
+            label="witnessed",
+        )
+        identity = raw["terminalIdentity"]
+        if not isinstance(identity, Mapping):
+            _refuse("witnessed terminal state requires terminalIdentity object")
+        return {
+            "schemaVersion": TERMINAL_STATE_SCHEMA_VERSION,
+            "state": "witnessed",
+            "terminalIdentity": validate_terminal_identity(identity),
+        }
+    if state == "no-owner-possible":
+        _require_terminal_state_fields(
+            raw,
+            _NO_OWNER_POSSIBLE_STATE_FIELDS,
+            label="no-owner-possible",
+        )
+        producer_contract = _require_nonempty_state_string(
+            raw,
+            "producerContract",
+            label="no-owner-possible",
+        )
+        entrance = _require_nonempty_state_string(
+            raw,
+            "entrance",
+            label="no-owner-possible",
+        )
+        reason = _require_nonempty_state_string(
+            raw,
+            "reason",
+            label="no-owner-possible",
+        )
+        if raw["disposition"] != "pending-ruling":
+            _refuse(
+                "no-owner-possible terminal state disposition must be "
+                "pending-ruling"
+            )
+        return {
+            "schemaVersion": TERMINAL_STATE_SCHEMA_VERSION,
+            "state": "no-owner-possible",
+            "producerContract": producer_contract,
+            "entrance": entrance,
+            "reason": reason,
+            "disposition": "pending-ruling",
+        }
+    if state == "terminal-construct-missing":
+        _require_terminal_state_fields(
+            raw,
+            _TERMINAL_CONSTRUCT_MISSING_STATE_FIELDS,
+            label="terminal-construct-missing",
+        )
+        expected_contract = _require_nonempty_state_string(
+            raw,
+            "expectedContract",
+            label="terminal-construct-missing",
+        )
+        reason = _require_nonempty_state_string(
+            raw,
+            "reason",
+            label="terminal-construct-missing",
+        )
+        return {
+            "schemaVersion": TERMINAL_STATE_SCHEMA_VERSION,
+            "state": "terminal-construct-missing",
+            "expectedContract": expected_contract,
+            "reason": reason,
+        }
+    _refuse(f"unsupported showcase terminal state: {state!r}")
+
+
+def witnessed_terminal_state(
+    identity: Mapping[str, object],
+) -> dict[str, object]:
+    """Wrap one producer-owned terminal identity without reconstructing it."""
+
+    return validate_showcase_terminal_state(
+        {
+            "schemaVersion": TERMINAL_STATE_SCHEMA_VERSION,
+            "state": "witnessed",
+            "terminalIdentity": identity,
+        }
+    )
+
+
+def no_owner_possible_terminal_state(
+    *,
+    producer_contract: str,
+    entrance: str,
+    reason: str,
+) -> dict[str, object]:
+    """Construct the pending shape for explicit producer-owned negative testimony."""
+
+    return validate_showcase_terminal_state(
+        {
+            "schemaVersion": TERMINAL_STATE_SCHEMA_VERSION,
+            "state": "no-owner-possible",
+            "producerContract": producer_contract,
+            "entrance": entrance,
+            "reason": reason,
+            "disposition": "pending-ruling",
+        }
+    )
+
+
+def terminal_construct_missing_state(
+    *,
+    expected_contract: str,
+    reason: str,
+) -> dict[str, object]:
+    """Construct measured terminal debt; this type has no exemption arm."""
+
+    return validate_showcase_terminal_state(
+        {
+            "schemaVersion": TERMINAL_STATE_SCHEMA_VERSION,
+            "state": "terminal-construct-missing",
+            "expectedContract": expected_contract,
+            "reason": reason,
+        }
+    )
 
 
 def construct_verification_property_attendance(
@@ -263,13 +443,13 @@ def identity_from_rpc_text(
     return validate_terminal_identity(identity)
 
 
-def _publish_once(output: Path, identity: Mapping[str, object]) -> None:
+def _publish_once(output: Path, state: Mapping[str, object]) -> None:
     if not output.is_absolute():
         _refuse(f"{TERMINAL_WITNESS_ENV} must be an absolute path: {output}")
     if not output.parent.is_dir():
         _refuse(f"terminal witness parent does not exist: {output.parent}")
 
-    payload = json.dumps(identity, sort_keys=False, separators=(",", ":")) + "\n"
+    payload = json.dumps(state, sort_keys=False, separators=(",", ":")) + "\n"
     temporary_path: Path | None = None
     try:
         descriptor, temporary_name = tempfile.mkstemp(
@@ -300,13 +480,13 @@ def write_from_environment(raw: Mapping[str, object]) -> bool:
     invalid producer identity refuses even in that additive/no-consumer mode.
     """
 
-    identity = validate_terminal_identity(raw)
+    state = witnessed_terminal_state(validate_terminal_identity(raw))
     output_value = os.environ.get(TERMINAL_WITNESS_ENV)
     if output_value is None:
         return False
     if not output_value:
         _refuse(f"{TERMINAL_WITNESS_ENV} must not be empty")
-    _publish_once(Path(output_value), identity)
+    _publish_once(Path(output_value), state)
     return True
 
 


### PR DESCRIPTION
## Summary

- add the closed `ShowcaseTerminalStateV1` envelope with exactly three states: `witnessed`, producer-authenticated `no-owner-possible`, and measured `terminal-construct-missing` debt
- wrap existing producer-owned terminal identities as witnessed without reconstructing them
- add dormant exact conservation and cross-run join helpers that distinguish cleared, same-terminal, moved-terminal, and explicitly unmeasured outcomes
- keep malformed testimony as `ScopeRefusal`, never a fourth semantic state

## Enforcement deliberately inactive

This PR does **not** activate terminal-state enforcement. `run_shard` is untouched and has no production call to the new conservation or join helpers. A focused tooth proves the live runner still emits its legacy failed row without `terminalState` while the additive producer file carries the new envelope.

Activation remains gated on all three prerequisites:

1. #7349 is restacked and landed.
2. A producer-owned negative-testimony door exists for the **current** no-owner terminals; a missing witness file can never mint `no-owner-possible`.
3. T rules the disposition in #7342.

`terminal-construct-missing` has no exemption, waiver, or allowlist arm. Its only green retirement is producer construction.

## Instrument and floors

- Red instrument: 10/10 focused teeth failed before the substrate existed, naming the missing schema, validators, conservation, and join doors.
- Green evidence on exact head `763dad507a8ad0d00ddcfd0bd77219f157cc6d25`: `bin/bpytest -q tests/test_showcase_terminal_state.py tests/test_showcase_terminal_producer.py tests/test_showcase_attendance_gap.py tests/test_showcase_retirement.py` => 62 passed under authenticated CPython 3.12.13.
- Conservation is exact: `terminalWitnessed + noOwnerPossible + terminalConstructMissing == nonzero executed rows`. A planted overlap refuses even when authored counts balance; a planted nonzero row in no state refuses.
- Existing showcase exit behavior and additive witness publication are preserved. No path allowlist, historical population, consumer activation, or taxonomy exemption is introduced.

Predicted impact: the dormant type and validators become available on main; current showcase verdicts and receipt enforcement remain unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dormant terminal-state envelope substrate to showcase witness publication
> - Introduces a versioned terminal-state envelope format (`schemaVersion=1`, `state`, nested `terminalIdentity`) in [showcase_terminal_identity.py](https://github.com/TSavo/sugar/pull/7352/files#diff-baf253f7288497a61b535eb741f5a634f6b0a7ef6c641b818fbc1fc78b8dfe2e), replacing raw identity objects as the published artifact.
> - Adds `validate_showcase_terminal_state` for strict validation of three closed envelope shapes: `witnessed`, `no-owner-possible`, and `terminal-construct-missing`.
> - Adds `validate_terminal_state_conservation` and `classify_terminal_transition` in [showcase_scope.py](https://github.com/TSavo/sugar/pull/7352/files#diff-a53f2b440efec2dccc0f7d623e336ef165ba9c85a4a4cd077cb811bec9b931ea) for partition-consistency checks and cross-run transition classification.
> - Updates `write_from_environment` to wrap validated identity in a `witnessed` envelope before writing the `SHOWCASE_TERMINAL_WITNESS` file.
> - Behavioral Change: existing consumers reading the terminal witness file now receive a `{schemaVersion, state, terminalIdentity}` envelope instead of a raw identity object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 763dad5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured terminal-state reporting for showcase results, including witnessed, no-owner-possible, and terminal-construct-missing states.
  * Added validation to ensure terminal-state counts remain consistent across executed showcase runs.
  * Added cross-run transition reporting for cleared, unchanged, moved, and unmeasured outcomes.

* **Bug Fixes**
  * Updated terminal witness output and attendance-gap records to use the standardized state format.

* **Tests**
  * Expanded coverage for valid, invalid, and transitioning terminal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->