### PR TITLE
Retain lexical call rows through Call substitution

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -10431,7 +10431,7 @@ class Compare(Expression):
 
 class Call(Expression):
     def substitute(self, scope: "dict[str, Node]") -> "Node":
-        rewritten = super().substitute(scope)
+        rewritten = self._substitute_children(scope)
         if (
             rewritten is not self
             and isinstance(rewritten, Call)
@@ -10444,12 +10444,6 @@ class Call(Expression):
     args: Tuple[Expression, ...]
     keywords: Tuple[Keyword, ...]
     _child_fields = ("func", "args", "keywords")
-
-    def substitute(self, scope):
-        """A call binds nothing: recurse into the callee, args, and keywords.
-        (A receiver `v.c(1)` substitutes through `func`, its Attribute; the
-        chain rewrites naturally as the receiver's own tree is substituted.)"""
-        return self._substitute_children(scope)
 
     def receiver(self) -> Optional[Expression]:
         """The object a method call is invoked on, when the callee is an

--- a/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
@@ -652,6 +652,86 @@ def test_nested_rows_are_in_producer_order_and_module_calls_are_absent(
     assert first.call_occurrence_identity != second.call_occurrence_identity
 
 
+def test_rewritten_nested_call_retains_its_exact_lexical_row(
+    constructed_module_door,
+) -> None:
+    source_file = _file(
+        "def outer(value):\n"
+        "    def child(argument):\n"
+        "        return argument\n"
+        "    sentinel = 1\n"
+        "    return child(value)\n"
+    )
+    call = next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Call" and getattr(node.func, "id", None) == "child"
+    )
+    constant = next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Constant" and node.value == 1
+    )
+    (row,) = source_file.unit.lexical_call_rows_for(call)
+
+    rewritten = call.substitute({"value": constant})
+
+    assert rewritten is not call
+    assert len(rewritten.args) == 1
+    assert rewritten.args[0].value == 1
+    assert source_file.unit.lexical_call_rows_for(rewritten) == (row,)
+
+
+def test_rewritten_call_without_lexical_row_stays_unenrolled(
+    constructed_module_door,
+) -> None:
+    source_file = _file(
+        "def outer(value):\n"
+        "    sentinel = 1\n"
+        "    return external(value)\n"
+    )
+    call = next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Call" and getattr(node.func, "id", None) == "external"
+    )
+    constant = next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Constant" and node.value == 1
+    )
+    assert source_file.unit.lexical_call_rows_for(call) == ()
+
+    rewritten = call.substitute({"value": constant})
+
+    assert rewritten is not call
+    assert len(rewritten.args) == 1
+    assert rewritten.args[0].value == 1
+    assert source_file.unit.lexical_call_rows_for(rewritten) == ()
+
+
+def test_unchanged_nested_call_keeps_identity_and_lexical_row(
+    constructed_module_door,
+) -> None:
+    source_file = _file(
+        "def outer():\n"
+        "    def child():\n"
+        "        return 1\n"
+        "    return child()\n"
+    )
+    call = next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Call" and getattr(node.func, "id", None) == "child"
+    )
+    (row,) = source_file.unit.lexical_call_rows_for(call)
+
+    unchanged = call.substitute({})
+
+    assert unchanged is call
+    assert source_file.unit.lexical_call_rows_for(unchanged) == (row,)
+
+
 def test_parameter_assignment_delete_and_rebind_do_not_authorize_nested_call(
     constructed_module_door,
 ) -> None:


### PR DESCRIPTION
## Discovery warning

Rows that have been absent for a week return under this repair. Counts may rise and terminals may move. Those are panics that were already occurring and being discarded, **not regressions introduced by retention**. Restoring a row makes previously absent evidence visible; it does not create the underlying product terminal.

## Evidence state

- **Production-identical validation tree:** 3/3 discrimination arms green — row-bearing rewrite retains its exact row, no-row rewrite stays inert, and unchanged substitution returns the identical `Call` with its relation intact.
- **Committed post-incidence:** at `54f57ac8db01fa4f1266f05c7185d5e4e4b5f2f6`, the same 54/54 row-bearing rewrites report `strandedRows=0`.
- **Final repair:** re-pinned as `a6c1da0e6b0de7cf3520c5634671e3ffb6bf9d61` on current main `027c7d39ccea8d5836bc4dfe261eec77afe1f640`.
- **Final-tree focused run:** **NO VERDICT** — exit 70 before pytest on poisoned rebuild-lock residue. This is infrastructure refusal, not a product red, and is never rounded up to green.

## Finding

`Call.substitute` carried two definitions. The later generic definition bound at runtime and stranded every enrolled lexical-call row whenever substitution rebuilt the `Call`. The earlier retaining definition was not merely shadowed: it was dead from birth and wrong from birth. Its first line, `super().substitute(scope)`, delegates through `Expression` to abstract `Node.substitute`, which deliberately raises `SubstituteNotWritten`. Execution against a real nested lexical call confirmed it could never have protected one row.

The retention store landed first; the broken retaining body followed twelve seconds later. Source presence therefore never represented a viable protection: had the earlier body ever bound, the first rewritten `Call` would have crashed. This is why the repair changes its delegation rather than merely deleting the shadow.

## Change and minimality

There is now one `Call.substitute` door. The retaining body uses the already-live `_substitute_children(scope)` delegation, then retains the exact enrolled lexical-call row when a rewrite produces another `Call`.

The production change is one delegation swap and deletion of the later duplicate definition. It is confined to `Call` (+1/-7). `Node.substitute` is untouched and its loud `SubstituteNotWritten` refusal remains intact.

Three discrimination arms pin the boundary:

- a rewritten enrolled call retains its exact occurrence row;
- a rewritten call with no enrolled row still substitutes and remains unenrolled;
- `substitute({})` returns the identical call with its existing row intact.

## Controlled comparison

The 54-to-zero comparison is same-lineage and differs only by the repair:

- pre-repair validation commit `e7cd9105438f25d159497b27dd238d1226f00700`;
- post-repair validation commit `54f57ac8db01fa4f1266f05c7185d5e4e4b5f2f6`, whose direct parent is that pre-repair commit;
- both are rooted at production pin `d9bdf9b469d81e0b3783d32138558d70ec681c79` and carry the same exact Fenster instrument lineage ending at upstream instrument head `947c4ce91c1510c5b64e73117f2ec986c63508ee`;
- both use authenticated pandas 3.0.3 aggregate `bbb70a76f4032eda3362102c8bd872ca769b6f8143a91f60a36374fa1066b76c`;
- the unchanged instrument selected the same blind ten files at both commits;
- pre: `rowBearingRewrote=54`, `strandedRows=54`;
- post: `rowBearingRewrote=54`, `strandedRows=0`, with every per-file stranded count zero.

The base did **not** move between the pre and post arms. The post commit adds only this repair and its three focused teeth to the pre validation lineage, so the controlled comparison is valid. The repair was then restacked without the instrument commits onto current main.

The final branch carries no Fenster instrument files. A final-head bpytest retry is infrastructure-unmeasured because the known rebuild-lock residue refused before pytest with `crime=unshareable-rebuild-lock-path`, uid/gid 1001 and mode 0755. Kujan has the exact residue. This PR does **not** claim that the 54-to-zero comparison executed at final head `a6c1da0e6b`.

## Claim boundary

This measures **54 restored rows, not 54 moved terminals**. Restored relations and first-terminal movement are different populations. No terminal movement is claimed without a terminal-identity measurement.

The separate Hockney five-file receipt plus Fenster ten-file receipt establish the existing bounded pre-repair 74/74 incidence across fifteen named files under two selection rules. This PR does not author a new aggregate, extrapolate corpus magnitude, or claim every restored row changes a first terminal.

The broader corpus and terminal deltas remain unmeasured. This closes the repair precondition in #7345 and enables an honest rerun of the receipt partition documented in #7351.
