### PR TITLE
Bind one demand-table meaning across every recensus shard (#7354)

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -225,6 +225,8 @@ jobs:
           python -u tools/plan_control_effect_recensus_shards.py \
             --enrolled-files "$OUT/enrolled-files.json" \
             --corpus-root "$LOCUS" \
+            --demand-table-corpus-root "$PANDAS_CORPUS" \
+            --demand-table-out "$OUT/demand-table.json" \
             --shard-count "$RECENSUS_SHARD_COUNT" \
             --measured-commit "$GITHUB_SHA" \
             --aggregate-hash "$AGG" \
@@ -243,6 +245,7 @@ jobs:
           name: control-effect-recensus-plan
           path: |
             .sugar/pandas-control-effect/plan.json
+            .sugar/pandas-control-effect/demand-table.json
             .sugar/pandas-control-effect/enrolled-files.json
             .sugar/pandas-control-effect/pin-meta.json
           if-no-files-found: error
@@ -322,6 +325,8 @@ jobs:
           OUT="$GITHUB_WORKSPACE/.sugar/pandas-control-effect"
           PLAN="$OUT/plan.json"
           test -f "$PLAN" || { echo "::error::plan.json missing"; exit 1; }
+          DEMAND_TABLE="$OUT/demand-table.json"
+          test -f "$DEMAND_TABLE" || { echo "::error::demand-table.json missing"; exit 78; }
           K="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["shardCount"])' "$PLAN")"
           if [[ "$K" != "$RECENSUS_SHARD_COUNT" ]]; then
             echo "::error::plan shardCount=$K != RECENSUS_SHARD_COUNT=$RECENSUS_SHARD_COUNT"
@@ -341,6 +346,7 @@ jobs:
               --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
               --out-dir "$OUT" \
               --plan-json "$PLAN" \
+              --demand-table-path "$DEMAND_TABLE" \
               --shard-index "$SHARD" \
               --partial-out "$OUT/partial-s$(printf '%02d' "$SHARD").json"
           echo "recensus phase=measure-shard status=done shard=$SHARD"

--- a/docs/contributing/battleaxe-timing.md
+++ b/docs/contributing/battleaxe-timing.md
@@ -163,8 +163,9 @@ bin/brun \
 Plan is not a measurement. Measure a seat with the production worker shape:
 
 ```bash
-# After plan.json exists under .sugar/pandas-control-effect/ (from the CI plan
-# job or tools/plan_control_effect_recensus_shards.py on battleaxe):
+# After plan.json and its plan-bound demand-table.json exist under
+# .sugar/pandas-control-effect/ (from the CI plan job or
+# tools/plan_control_effect_recensus_shards.py on battleaxe):
 SUGAR_BX_REQUIRE_QUIET=1 \
 SUGAR_BX_REQUIRE_CORPUS_PIN=docs/ledgers/pins/pandas-3.0.3.pin.json \
 SUGAR_BX_CORPUS_PYTHON=.venv-py312/bin/python \
@@ -185,6 +186,7 @@ bin/brun \
       --require-corpus-pin docs/ledgers/pins/pandas-3.0.3.pin.json \
       --out-dir "$OUT" \
       --plan-json "$OUT/plan.json" \
+      --demand-table-path "$OUT/demand-table.json" \
       --shard-index "$SHARD" \
       --partial-out "$OUT/partial-s$(printf %02d "$SHARD").json"
     cp "$OUT/partial-s$(printf %02d "$SHARD").json" /tmp/sugar-bx-measure.json

--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -28,6 +28,8 @@ from sugar_lift_py_tests.repo_root import (
     resolve_repo_root,
     sugar_lift_py_tests_package_root,
 )
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_python_source.canonical import cid_of_json
 
 # Sole True declaration for the kit (test_one_authoritative_scoreboard).
 SCOREBOARD_AUTHORITY = True
@@ -99,6 +101,34 @@ def canonical_cid(obj: Mapping[str, Any]) -> str:
     """Content id of a JSON-stable object (sort_keys, no host noise)."""
     rendered = json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
     return _blake3_512(rendered.encode("utf-8"))
+
+
+def _demand_table_claim(
+    testimony: Mapping[str, Any], *, owner: str
+) -> tuple[str, dict[str, object]]:
+    """Authenticate one payload CID plus its recomputable meaning preimage."""
+    content_cid = testimony.get("demandTableCid")
+    identity_raw = testimony.get("demandTableIdentity")
+    if not isinstance(content_cid, str) or not content_cid or not isinstance(
+        identity_raw, Mapping
+    ):
+        raise ValueError(
+            "demand-table-testimony-absent: "
+            f"{owner} must carry demandTableCid and demandTableIdentity"
+        )
+    try:
+        identity = DemandTableIdentityV1.from_mapping(identity_raw)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"demand-table-testimony-malformed: {owner} semantic identity: {error}"
+        ) from error
+    recomputed = cid_of_json(dict(identity.preimage()))
+    if identity.content_key != recomputed:
+        raise ValueError(
+            "demand-table-identity-content-key-mismatch: "
+            f"{owner} presented={identity.content_key!r} recomputed={recomputed!r}"
+        )
+    return content_cid, identity.as_dict()
 
 
 def _runtime_attestation_fields(
@@ -789,6 +819,7 @@ def build_plan(
     prior_misses: int,
     estimated_loads: Sequence[float],
     demand_table_cid: str | None = None,
+    demand_table_identity: Mapping[str, Any] | None = None,
     demand_table_path: str | None = None,
 ) -> dict[str, Any]:
     enrolled = sorted(enrolled_files)
@@ -820,10 +851,18 @@ def build_plan(
         "bins": bin_lists,
         "estimatedLoadS": [float(x) for x in estimated_loads],
     }
-    # Prebuilt provisional demand table: content-addressed once at plan time;
-    # every shard LOADS it so cold processes never re-walk the corpus (k=8).
-    if demand_table_cid is not None:
-        plan["demandTableCid"] = demand_table_cid
+    # One plan-time demand-table authority.  The payload CID and the complete
+    # meaning preimage are both inside planCid; a path is transport only.
+    if demand_table_cid is not None or demand_table_identity is not None:
+        claimed_cid, claimed_identity = _demand_table_claim(
+            {
+                "demandTableCid": demand_table_cid,
+                "demandTableIdentity": demand_table_identity,
+            },
+            owner="plan",
+        )
+        plan["demandTableCid"] = claimed_cid
+        plan["demandTableIdentity"] = claimed_identity
     if demand_table_path is not None:
         plan["demandTablePath"] = demand_table_path
     plan["planCid"] = canonical_cid({k: v for k, v in plan.items() if k != "planCid"})
@@ -838,6 +877,8 @@ def mint_partial(
     measured_commit: str | None = None,
     status: str = "completed",
     unmeasured_reason: str | None = None,
+    demand_table_cid: str | None = None,
+    demand_table_identity: Mapping[str, Any] | None = None,
     runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> dict[str, Any]:
     """Mint a shard partial. Never includes R_construction_panics top-level."""
@@ -905,6 +946,26 @@ def mint_partial(
                 else {"file": file, "type": cat, "message": cat}
             )
 
+    demand_reason: str | None = None
+    demand_claim: tuple[str, dict[str, object]] | None = None
+    try:
+        demand_claim = _demand_table_claim(
+            {
+                "demandTableCid": demand_table_cid,
+                "demandTableIdentity": demand_table_identity,
+            },
+            owner=f"partial s{shard_index:02d}",
+        )
+        plan_claim = _demand_table_claim(plan, owner="plan")
+        if demand_claim != plan_claim:
+            demand_reason = (
+                "demand-table-testimony-mismatch: "
+                f"partial s{shard_index:02d} claim={demand_claim!r} "
+                f"plan={plan_claim!r}"
+            )
+    except ValueError as error:
+        demand_reason = str(error)
+
     if runtime is None:
         status = "unmeasured"
         unmeasured_reason = str(
@@ -912,6 +973,9 @@ def mint_partial(
             or runtime_failure.get("runtimeIdentityMismatch")
             or "runtimeIdentity/v1 refused"
         )
+    if demand_reason is not None and unmeasured_reason is None:
+        status = "unmeasured"
+        unmeasured_reason = demand_reason
     measured = status == "completed" and files_complete and unmeasured_reason is None
     if not measured and unmeasured_reason is None:
         unmeasured_reason = (
@@ -971,6 +1035,9 @@ def mint_partial(
         "measured": measured,
         "unmeasuredReason": unmeasured_reason,
     }
+    if demand_claim is not None:
+        body["demandTableCid"] = demand_claim[0]
+        body["demandTableIdentity"] = demand_claim[1]
     if runtime is not None:
         body.update(runtime)
     else:
@@ -1240,6 +1307,7 @@ def seal_board_from_aggregate(
     source_stamp: Mapping[str, Any] | None = None,
     with_census: Mapping[str, Any] | None = None,
     frontier_attestation: Mapping[str, Any] | None = None,
+    demand_table_agreement: Mapping[str, Any] | None = None,
     runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> dict[str, Any]:
     """Mint the sealed authoritative board body. Sole mint of the class."""
@@ -1426,6 +1494,12 @@ def seal_board_from_aggregate(
         "composeSchema": COMPOSE_SCHEMA,
         **runtime,
     }
+    if demand_table_agreement is not None:
+        agreement = dict(demand_table_agreement)
+        plan_claim = agreement.get("plan") or {}
+        body["demandTableCid"] = plan_claim.get("demandTableCid")
+        body["demandTableIdentity"] = plan_claim.get("demandTableIdentity")
+        body["demandTableAgreement"] = agreement
     if frontier_attestation is not None:
         body["frontierAttestation"] = dict(frontier_attestation)
         body["frontierWidth"] = len(
@@ -1546,6 +1620,17 @@ def compose_from_partials(
     missing: list[str] = []
     reasons: dict[str, str] = {}
 
+    try:
+        plan_demand_claim = _demand_table_claim(plan, owner="plan")
+    except ValueError as error:
+        return "unmeasured", unmeasured_envelope(
+            plan=plan,
+            missing_shards=["plan"],
+            unmeasured_reasons={"plan": str(error)},
+            measured_commit=str(plan.get("measuredCommit") or ""),
+            runtime_attestation=runtime,
+        )
+
     for p in partials:
         try:
             idx = int(p["shardIndex"])
@@ -1554,6 +1639,7 @@ def compose_from_partials(
         by_index[idx] = p
 
     first_partial_runtime_cid: str | None = None
+    shard_demand_claims: dict[str, dict[str, object]] = {}
     for i in range(k):
         seat = f"s{i:02d}"
         p = by_index.get(i)
@@ -1572,6 +1658,24 @@ def compose_from_partials(
                 f"(want {MEASUREMENT_CLASS_SHARD})"
             )
             continue
+        try:
+            partial_demand_claim = _demand_table_claim(p, owner=f"partial {seat}")
+        except ValueError as error:
+            missing.append(seat)
+            reasons[seat] = str(error)
+            continue
+        if partial_demand_claim != plan_demand_claim:
+            missing.append(seat)
+            reasons[seat] = (
+                "demand-table-testimony-mismatch: "
+                f"partial {seat} claim={partial_demand_claim!r} "
+                f"plan={plan_demand_claim!r}"
+            )
+            continue
+        shard_demand_claims[seat] = {
+            "demandTableCid": partial_demand_claim[0],
+            "demandTableIdentity": partial_demand_claim[1],
+        }
         if p.get("status") == "unmeasured" or not p.get("measured"):
             missing.append(seat)
             reasons[seat] = str(
@@ -1705,6 +1809,17 @@ def compose_from_partials(
             Counter(agg["unrecognized_cm_kinds"]),
         )
 
+    demand_table_agreement = {
+        "schema": "demand-table-shard-agreement/v1",
+        "plan": {
+            "demandTableCid": plan_demand_claim[0],
+            "demandTableIdentity": plan_demand_claim[1],
+        },
+        "shards": dict(sorted(shard_demand_claims.items())),
+        "authenticatedShardCount": len(shard_demand_claims),
+        "expectedShardCount": k,
+        "allAgree": len(shard_demand_claims) == k,
+    }
     board = seal_board_from_aggregate(
         agg,
         plan=plan,
@@ -1721,6 +1836,7 @@ def compose_from_partials(
         source_stamp=source_stamp,
         with_census=with_census,
         frontier_attestation=frontier_attestation,
+        demand_table_agreement=demand_table_agreement,
         runtime_attestation=runtime,
     )
     if board.get("measurement") != "measured":
@@ -1758,6 +1874,8 @@ def compose_k1_from_rows(
     source_stamp: Mapping[str, Any] | None = None,
     with_census_fn=None,
     manifest_cid: str | None = None,
+    demand_table_cid: str | None = None,
+    demand_table_identity: Mapping[str, Any] | None = None,
     runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> tuple[str, dict[str, Any]]:
     """k=1 path: one full-bin partial + compose (serial observation, one seal door)."""
@@ -1788,12 +1906,16 @@ def compose_k1_from_rows(
         prior_hits=0,
         prior_misses=0,
         estimated_loads=[0.0],
+        demand_table_cid=demand_table_cid,
+        demand_table_identity=demand_table_identity,
     )
     partial = mint_partial(
         plan=plan,
         shard_index=0,
         terminal_rows=list(measured_rows),
         measured_commit=measured_commit,
+        demand_table_cid=demand_table_cid,
+        demand_table_identity=demand_table_identity,
         runtime_attestation=runtime,
     )
     return compose_from_partials(

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1121,35 +1121,15 @@ def main() -> int:
     from sugar_lift_py_tests.prebuilt_demand_table import (
         DemandTableArtifactRefusal,
         DemandTablePinMismatch,
+        PlanDemandTableRefusal,
         install_prebuilt_demand_table,
+        load_plan_bound_demand_table,
         load_prebuilt_demand_table,
         mint_prebuilt_demand_table,
+        publish_prebuilt_demand_table,
+        validate_prebuilt_demand_table,
         write_prebuilt_demand_table,
     )
-
-    def publish_demand_table(table, path: Path) -> None:
-        """Publish the derived payload through the authenticated CAS door."""
-        repo_root = resolve_repo_root()
-        completed = subprocess.run(
-            [
-                str(repo_root / "bin" / "sugarbin"),
-                "artifact", "publish", "--kind", "python-demand-table",
-                "--content-key", table.content_cid, "--input", str(path),
-                "--runtime", "cpython-3.12.13",
-            ],
-            cwd=repo_root, capture_output=True, text=True, check=False,
-        )
-        if completed.returncode != 0:
-            detail = (completed.stderr or completed.stdout).strip()[:800]
-            raise DemandTableArtifactRefusal(
-                "python-demand-table CAS publication refused: "
-                f"contentCid={table.content_cid} exit={completed.returncode} "
-                f"detail={detail}"
-            )
-        _narrate(
-            "RECENSUS DEMAND_TABLE published CAS "
-            f"contentCid={table.content_cid} runtime=cpython-3.12.13"
-        )
 
     pin_identity = {
         "distribution": observed_pin.distribution,
@@ -1158,13 +1138,30 @@ def main() -> int:
         "aggregateHash": observed_pin.aggregate_hash,
     }
     demand_table_cid: str | None = None
+    demand_table_identity: Mapping[str, object] | None = None
     # Plan may carry demandTableCid / demandTablePath for shard workers.
     plan_demand_path = args.demand_table_path
     plan_demand_cid = None
     if shard_plan is not None:
         plan_demand_cid = shard_plan.get("demandTableCid")
+        plan_demand_identity = shard_plan.get("demandTableIdentity")
         if plan_demand_path is None and shard_plan.get("demandTablePath"):
             plan_demand_path = Path(str(shard_plan["demandTablePath"]))
+        if (
+            plan_demand_path is None
+            or not isinstance(plan_demand_cid, str)
+            or not isinstance(plan_demand_identity, Mapping)
+        ):
+            print(
+                "plan-demand-table-testimony-absent: shard plan must carry "
+                "demandTableCid and demandTableIdentity and workflow must supply "
+                "the exact demand-table artifact path",
+                file=sys.stderr,
+                flush=True,
+            )
+            return 78
+    else:
+        plan_demand_identity = None
 
     if plan_demand_path is not None:
         _narrate(
@@ -1172,19 +1169,83 @@ def main() -> int:
             f"planCid={plan_demand_cid or 'none'}"
         )
         try:
-            prebuilt = load_prebuilt_demand_table(
-                plan_demand_path,
-                expected_corpus_pin=pin_identity,
-                expected_content_cid=plan_demand_cid,
+            from sugar_lift_py_tests.authenticated_pytest import (
+                authenticated_pandas_corpus,
             )
+
+            authenticated_corpus = authenticated_pandas_corpus()
+            if authenticated_corpus.root.resolve() != workspace_root.resolve():
+                raise DemandTableArtifactRefusal(
+                    "plan-demand-table-corpus-root-mismatch: "
+                    f"authenticated={authenticated_corpus.root} "
+                    f"worker={workspace_root}"
+                )
+            if shard_plan is not None:
+                prebuilt = load_plan_bound_demand_table(
+                    plan_demand_path,
+                    corpus=authenticated_corpus,
+                    expected_content_cid=str(plan_demand_cid),
+                    expected_semantic_identity=dict(plan_demand_identity),
+                )
+            else:
+                prebuilt = load_prebuilt_demand_table(
+                    plan_demand_path,
+                    expected_corpus_pin=pin_identity,
+                    expected_content_cid=plan_demand_cid,
+                )
+                validate_prebuilt_demand_table(prebuilt, authenticated_corpus)
         except (DemandTablePinMismatch, DemandTableArtifactRefusal) as refuse:
             print(str(refuse), file=sys.stderr, flush=True)
+            if shard_plan is not None:
+                # A shard that reached the plan but could not authenticate its
+                # assigned table still owes compose a receipt.  Preserve an
+                # observed lying claim when the artifact itself was readable;
+                # absence stays absent.  Compose can then distinguish mismatch
+                # from missing testimony instead of seeing a generic lost seat.
+                from compose_control_effect_board import mint_partial
+
+                observed_cid = (
+                    refuse.observed_content_cid
+                    if isinstance(refuse, PlanDemandTableRefusal)
+                    else None
+                )
+                observed_identity = (
+                    refuse.observed_semantic_identity
+                    if isinstance(refuse, PlanDemandTableRefusal)
+                    else None
+                )
+                assert args.shard_index is not None
+                partial = mint_partial(
+                    plan=shard_plan,
+                    shard_index=args.shard_index,
+                    terminal_rows=[],
+                    measured_commit=tip,
+                    status="unmeasured",
+                    unmeasured_reason=str(refuse),
+                    demand_table_cid=observed_cid,
+                    demand_table_identity=observed_identity,
+                    runtime_attestation=runtime_attestation,
+                )
+                partial_path = args.partial_out or (
+                    out / f"partial-s{args.shard_index:02d}.json"
+                )
+                partial_path.parent.mkdir(parents=True, exist_ok=True)
+                partial_path.write_text(
+                    json.dumps(partial, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                _narrate(
+                    "RECENSUS PARTIAL UNMEASURED demand-table authentication "
+                    f"shard={args.shard_index} reason={refuse} path={partial_path}"
+                )
+                return 2
             return 78
         contract_refs = _phase_call(
             "demand_table_load",
             lambda: install_prebuilt_demand_table(prebuilt, root=workspace_root),
         )
         demand_table_cid = prebuilt.content_cid
+        demand_table_identity = prebuilt.semantic_identity.as_dict()
         _narrate(
             "RECENSUS DEMAND_TABLE loaded "
             f"contentCid={demand_table_cid} rows={len(prebuilt.rows)} "
@@ -1231,7 +1292,11 @@ def main() -> int:
                 f"contentCid={table.content_cid}"
             )
             try:
-                publish_demand_table(table, write_path)
+                publish_prebuilt_demand_table(table, write_path)
+                _narrate(
+                    "RECENSUS DEMAND_TABLE published CAS "
+                    f"contentCid={table.content_cid} runtime=cpython-3.12.13"
+                )
             except DemandTableArtifactRefusal as refuse:
                 # Derivation is authenticated product input; CAS publication
                 # is only a sharing optimisation. Keep the local table, but
@@ -1243,9 +1308,9 @@ def main() -> int:
             if temporary_path is not None:
                 temporary_path.unlink(missing_ok=True)
             refs = install_prebuilt_demand_table(table, root=workspace_root)
-            return refs, table.content_cid
+            return refs, table.content_cid, table.semantic_identity.as_dict()
 
-        contract_refs, demand_table_cid = _phase_call(
+        contract_refs, demand_table_cid, demand_table_identity = _phase_call(
             "demand_table_derivation",
             _derive_and_maybe_write,
         )
@@ -1907,6 +1972,8 @@ def main() -> int:
             shard_index=args.shard_index,
             terminal_rows=measured_rows,
             measured_commit=tip_commit,
+            demand_table_cid=demand_table_cid,
+            demand_table_identity=demand_table_identity,
             runtime_attestation=runtime_attestation,
         )
         partial_path = args.partial_out or (
@@ -1955,6 +2022,8 @@ def main() -> int:
         },
         with_census_fn=_with_census_partition,
         manifest_cid=checkpoint.manifest_cid,
+        demand_table_cid=demand_table_cid,
+        demand_table_identity=demand_table_identity,
         runtime_attestation=runtime_attestation,
     )
     if seal_status != "sealed":

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -21,6 +21,7 @@ table must perform ZERO corpus walks (count them; do not time them).
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Mapping
@@ -31,6 +32,7 @@ from sugar_lift_py_tests.demand_table_identity import (
     DemandTableIdentityV1,
     demand_table_identity,
 )
+from sugar_lift_py_tests.repo_root import resolve_repo_root
 
 SCHEMA = "python-provisional-demand-table/v1"
 
@@ -45,6 +47,28 @@ class DemandTableArtifactRefusal(ValueError):
 
 class DemandTableSemanticIdentityMismatch(DemandTableArtifactRefusal):
     """Table meaning does not describe the authenticated current corpus."""
+
+
+class PlanDemandTableRefusal(DemandTableArtifactRefusal):
+    """A shard could not authenticate the exact table assigned by its plan."""
+
+    def __init__(
+        self,
+        reason_name: str,
+        detail: str,
+        *,
+        observed_table: "PrebuiltDemandTableV1 | None" = None,
+    ) -> None:
+        super().__init__(f"{reason_name}: {detail}")
+        self.reason_name = reason_name
+        self.observed_content_cid = (
+            observed_table.content_cid if observed_table is not None else None
+        )
+        self.observed_semantic_identity = (
+            observed_table.semantic_identity.as_dict()
+            if observed_table is not None
+            else None
+        )
 
 
 @dataclass(frozen=True)
@@ -208,6 +232,42 @@ def write_prebuilt_demand_table(table: PrebuiltDemandTableV1, path: Path) -> Pat
     return path
 
 
+def publish_prebuilt_demand_table(
+    table: PrebuiltDemandTableV1,
+    path: Path,
+    *,
+    runtime: str = "cpython-3.12.13",
+) -> None:
+    """Publish one already-written table through the authenticated CAS door."""
+    repo_root = resolve_repo_root()
+    completed = subprocess.run(
+        [
+            str(repo_root / "bin" / "sugarbin"),
+            "artifact",
+            "publish",
+            "--kind",
+            "python-demand-table",
+            "--content-key",
+            table.content_cid,
+            "--input",
+            str(path),
+            "--runtime",
+            runtime,
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()[:800]
+        raise DemandTableArtifactRefusal(
+            "python-demand-table CAS publication refused: "
+            f"contentCid={table.content_cid} exit={completed.returncode} "
+            f"detail={detail}"
+        )
+
+
 def load_prebuilt_demand_table(
     path: Path,
     *,
@@ -284,6 +344,77 @@ def load_prebuilt_demand_table(
             f"prebuilt demand table contentCid != plan demandTableCid: "
             f"artifact={presented!r} plan={expected_content_cid!r}"
         )
+    return table
+
+
+def load_plan_bound_demand_table(
+    path: Path,
+    *,
+    corpus: AuthenticatedPandasCorpus,
+    expected_content_cid: str,
+    expected_semantic_identity: Mapping[str, Any],
+) -> PrebuiltDemandTableV1:
+    """Load exactly the plan-assigned table; never derive a replacement.
+
+    Storage identity and semantic meaning are independent agreement axes.  A
+    missing artifact is absence testimony; a different CID or meaning is a
+    mismatch.  Neither condition has a minting arm.
+    """
+    try:
+        table = load_prebuilt_demand_table(
+            path,
+            expected_corpus_pin={
+                "distribution": corpus.distribution,
+                "version": corpus.version,
+                "fileCount": corpus.file_count,
+                "aggregateHash": corpus.manifest_cid,
+            },
+        )
+    except DemandTableArtifactRefusal as error:
+        reason = str(error)
+        if "missing path=" in reason or "unreadable path=" in reason:
+            name = "plan-demand-table-artifact-unavailable"
+        else:
+            name = "plan-demand-table-artifact-refusal"
+        raise PlanDemandTableRefusal(name, reason) from error
+
+    if table.content_cid != expected_content_cid:
+        raise PlanDemandTableRefusal(
+            "plan-demand-table-cid-mismatch",
+            f"artifact={table.content_cid!r} plan={expected_content_cid!r}",
+            observed_table=table,
+        )
+
+    try:
+        expected_identity = DemandTableIdentityV1.from_mapping(
+            expected_semantic_identity
+        )
+    except (TypeError, ValueError) as error:
+        raise PlanDemandTableRefusal(
+            "plan-demand-table-semantic-identity-malformed", str(error)
+        ) from error
+    expected_key = cid_of_json(dict(expected_identity.preimage()))
+    if expected_identity.content_key != expected_key:
+        raise PlanDemandTableRefusal(
+            "plan-demand-table-semantic-identity-malformed",
+            f"presented contentKey={expected_identity.content_key!r} "
+            f"recomputed={expected_key!r}",
+        )
+    if table.semantic_identity != expected_identity:
+        raise PlanDemandTableRefusal(
+            "plan-demand-table-semantic-mismatch",
+            f"artifact={table.semantic_identity.as_dict()!r} "
+            f"plan={expected_identity.as_dict()!r}",
+            observed_table=table,
+        )
+    try:
+        validate_prebuilt_demand_table(table, corpus)
+    except DemandTableSemanticIdentityMismatch as error:
+        raise PlanDemandTableRefusal(
+            "plan-demand-table-semantic-mismatch",
+            str(error),
+            observed_table=table,
+        ) from error
     return table
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 _SCRIPT = (
@@ -22,6 +24,31 @@ def _load_compose():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _demand_table_kwargs() -> dict[str, object]:
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:test-corpus",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:test-producer",
+        resolution_config_cid="blake3-512:test-config",
+        parser_identity="cpython-3.12",
+        file_count=4,
+    )
+    identity = DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    )
+    return {
+        "demand_table_cid": "blake3-512:test-table",
+        "demand_table_identity": identity.as_dict(),
+    }
 
 
 def test_functions_three_meanings_not_one_figure() -> None:
@@ -171,6 +198,7 @@ def test_seal_board_splits_file_and_residual_meanings() -> None:
         measured_commit="abc123",
         aggregate_hash="pin-hash",
         manifest_shape_cid="manifest",
+        **_demand_table_kwargs(),
     )
     assert status == "sealed", body.get("instrumentFailures")
     assert body["filesEnrolled"] == 4

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -14,6 +14,8 @@ import json
 import sys
 from pathlib import Path
 
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_python_source.canonical import cid_of_json
 from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 _SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
@@ -119,6 +121,31 @@ def _runtime_identity_object(*, suffix: str = "a"):
     )
 
 
+def _demand_table_kwargs() -> dict[str, object]:
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:test-corpus",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:test-producer",
+        resolution_config_cid="blake3-512:test-config",
+        parser_identity="cpython-3.12",
+        file_count=2,
+    )
+    identity = DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    )
+    return {
+        "demand_table_cid": "blake3-512:test-table",
+        "demand_table_identity": identity.as_dict(),
+    }
+
+
 def _require_runtime_parameter(module) -> None:
     assert (
         "runtime_attestation"
@@ -134,6 +161,7 @@ def _compose(module, row, *, runtime_attestation=None):
         measured_commit="4accd543",
         aggregate_hash="agg",
         manifest_shape_cid="manifest",
+        **_demand_table_kwargs(),
         runtime_attestation=(
             _runtime_attestation()
             if runtime_attestation is None
@@ -159,6 +187,7 @@ def test_compose_without_runtime_identity_refuses_before_width() -> None:
         measured_commit="4accd543",
         aggregate_hash="agg",
         manifest_shape_cid="manifest",
+        **_demand_table_kwargs(),
         runtime_attestation=None,
     )
     assert status == "unmeasured"
@@ -227,11 +256,13 @@ def test_partial_without_runtime_identity_refuses_at_compose() -> None:
         prior_hits=0,
         prior_misses=1,
         estimated_loads=[0.0],
+        **_demand_table_kwargs(),
     )
     partial = module.mint_partial(
         plan=plan,
         shard_index=0,
         terminal_rows=[("pandas/a.py", _row(module))],
+        **_demand_table_kwargs(),
         runtime_attestation=attestation,
     )
     for field in ("requiredRuntime", "runtimeIdentity", "runtimeCid"):
@@ -263,11 +294,13 @@ def test_non_recomputable_partial_runtime_cid_refuses() -> None:
         prior_hits=0,
         prior_misses=1,
         estimated_loads=[0.0],
+        **_demand_table_kwargs(),
     )
     partial = module.mint_partial(
         plan=plan,
         shard_index=0,
         terminal_rows=[("pandas/a.py", _row(module))],
+        **_demand_table_kwargs(),
         runtime_attestation=attestation,
     )
     partial["runtimeCid"] = "blake3-512:" + ("0" * 128)
@@ -299,18 +332,21 @@ def test_valid_but_disagreeing_shard_runtime_cids_refuse() -> None:
         prior_hits=0,
         prior_misses=2,
         estimated_loads=[0.0, 0.0],
+        **_demand_table_kwargs(),
     )
     partials = [
         module.mint_partial(
             plan=plan,
             shard_index=0,
             terminal_rows=[("pandas/a.py", _row(module))],
+            **_demand_table_kwargs(),
             runtime_attestation=left,
         ),
         module.mint_partial(
             plan=plan,
             shard_index=1,
             terminal_rows=[("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))],
+            **_demand_table_kwargs(),
             runtime_attestation=right,
         ),
     ]
@@ -339,11 +375,13 @@ def test_well_formed_shard_runtime_wrong_for_compose_authority_refuses() -> None
         prior_hits=0,
         prior_misses=1,
         estimated_loads=[0.0],
+        **_demand_table_kwargs(),
     )
     partial = module.mint_partial(
         plan=plan,
         shard_index=0,
         terminal_rows=[("pandas/a.py", _row(module))],
+        **_demand_table_kwargs(),
         runtime_attestation=forged,
     )
 
@@ -378,18 +416,21 @@ def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
         prior_hits=0,
         prior_misses=2,
         estimated_loads=[0.0, 0.0],
+        **_demand_table_kwargs(),
     )
     partials = [
         module.mint_partial(
             plan=plan,
             shard_index=0,
             terminal_rows=[("pandas/a.py", _row(module))],
+            **_demand_table_kwargs(),
             runtime_attestation=mutually_agreeing_wrong_runtime,
         ),
         module.mint_partial(
             plan=plan,
             shard_index=1,
             terminal_rows=[("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))],
+            **_demand_table_kwargs(),
             runtime_attestation=mutually_agreeing_wrong_runtime,
         ),
     ]

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -15,7 +15,9 @@ from sugar_lift_py_tests import lift_rpc as lr
 from sugar_lift_py_tests.prebuilt_demand_table import (
     DemandTableArtifactRefusal,
     DemandTablePinMismatch,
+    PlanDemandTableRefusal,
     install_prebuilt_demand_table,
+    load_plan_bound_demand_table,
     load_prebuilt_demand_table,
     mint_prebuilt_demand_table,
     validate_prebuilt_demand_table,
@@ -126,6 +128,50 @@ def test_validator_refuses_table_for_different_corpus(tmp_path: Path) -> None:
         DemandTableSemanticIdentityMismatch, match="semantic identity mismatch"
     ):
         validate_prebuilt_demand_table(table, _authenticated(other))
+
+
+def test_plan_bound_load_missing_artifact_never_derives_locally(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    handle = _authenticated(corpus)
+    identity = mint_prebuilt_demand_table(handle).semantic_identity.as_dict()
+    lr.reset_preconstruction_walk_count()
+
+    with pytest.raises(
+        DemandTableArtifactRefusal, match="plan-demand-table-artifact-unavailable"
+    ):
+        load_plan_bound_demand_table(
+            tmp_path / "missing.json",
+            corpus=handle,
+            expected_content_cid="blake3-512:plan-table",
+            expected_semantic_identity=identity,
+        )
+
+    assert lr.preconstruction_walk_count() == 0
+
+
+def test_plan_bound_load_cid_mismatch_never_derives_replacement(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    handle = _authenticated(corpus)
+    table = mint_prebuilt_demand_table(handle)
+    path = write_prebuilt_demand_table(table, tmp_path / "table.json")
+    walks_before = lr.preconstruction_walk_count()
+
+    with pytest.raises(
+        PlanDemandTableRefusal, match="plan-demand-table-cid-mismatch"
+    ) as caught:
+        load_plan_bound_demand_table(
+            path,
+            corpus=handle,
+            expected_content_cid="blake3-512:different-table",
+            expected_semantic_identity=table.semantic_identity.as_dict(),
+        )
+
+    assert caught.value.observed_content_cid == table.content_cid
+    assert (
+        caught.value.observed_semantic_identity
+        == table.semantic_identity.as_dict()
+    )
+    assert lr.preconstruction_walk_count() == walks_before
 
 
 def test_cold_process_with_prebuilt_table_performs_zero_corpus_walks(

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
@@ -1,0 +1,290 @@
+"""One demand-table meaning must bind every recensus shard.
+
+The truthful and lying twins are deliberately compose-side.  A plan and all
+eight partials may agree on every other seal while one table claim is absent or
+different; neither case may mint a frontier width.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from sugar_lift_py_tests.authenticated_pytest import runtime_cid_for_identity
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+_SCRIPT = _SCRIPTS / "compose_control_effect_board.py"
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        "compose_control_effect_board_demand_table_agreement", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runtime_attestation() -> dict[str, object]:
+    identity = {
+        "schema": "runtimeIdentity/v1",
+        "implementation": "cpython",
+        "version": "3.12.13",
+        "sysVersion": "3.12.13 demand-table-agreement-test",
+        "cacheTag": "cpython-312",
+        "SOABI": "cpython-312-x86_64-linux-gnu",
+        "hexVersion": "0x30c0df0",
+        "platformTag": "Linux-test-x86_64-with-glibc2.39",
+        "invokedExecutable": "/venv/bin/python",
+        "resolvedBaseExecutable": "/runtime/bin/python3.12",
+        "executableSha256": "a" * 64,
+    }
+    return {
+        "requiredRuntime": "cpython-3.12.13",
+        "runtimeIdentity": identity,
+        "runtimeCid": runtime_cid_for_identity(identity),
+    }
+
+
+def _demand_identity(*, suffix: str = "a") -> dict[str, object]:
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid=f"blake3-512:corpus-{suffix}",
+        schema_version="python-demand-table/v1",
+        producer_source_cid=f"blake3-512:producer-{suffix}",
+        resolution_config_cid=f"blake3-512:config-{suffix}",
+        parser_identity="cpython-3.12",
+        file_count=8,
+    )
+    return DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    ).as_dict()
+
+
+def _row(module, file: str) -> dict[str, object]:
+    input_key = {
+        "file": file,
+        "sourceCid": module.canonical_cid({"file": file}),
+        "function": {"qualname": "f", "coordinate": "1:0"},
+    }
+    return {
+        "category": "completed",
+        "functionsTotal": 1,
+        "functionsEnumerated": 1,
+        "functionsClean": 1,
+        "cleanRatioRefused": False,
+        "families": {},
+        "inputKey": input_key,
+        "rowId": module.canonical_cid({"inputKey": input_key}),
+        "stageId": module.STAGE_ENUMERATE_FILE_TERMINAL,
+        "observedEventType": "sugar_lift_py_tests.outcome.Complete",
+        "terminalKind": "constructed",
+        "observed_chain_length": 1,
+        "blocking_terminal_count": 0,
+        "final_terminal": "constructed",
+        "edgeWitnesses": {
+            module.EDGE_ENUMERATE_FILE: module.key_edge_witness(
+                stage_id=module.STAGE_ENUMERATE_FILE_TERMINAL,
+                input_keys=[input_key],
+                output_keys=[input_key],
+            ),
+            module.EDGE_WITH_PARTITION: module.key_edge_witness(
+                stage_id=module.STAGE_WITH_TALLY_PARTITION,
+                input_keys=[],
+                output_keys=[],
+            ),
+        },
+    }
+
+
+def _plan(module, *, cid: str, identity: dict[str, object]):
+    files = [f"pandas/f{i}.py" for i in range(8)]
+    return module.build_plan(
+        enrolled_files=files,
+        shard_count=8,
+        measured_commit="dc41472e64",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[[file] for file in files],
+        split_mode="fixture",
+        prior_hits=0,
+        prior_misses=8,
+        estimated_loads=[1.0] * 8,
+        demand_table_cid=cid,
+        demand_table_identity=identity,
+    )
+
+
+def _partials(
+    module,
+    plan,
+    *,
+    cid: str,
+    identity: dict[str, object],
+    lying_index: int | None = None,
+    absent_index: int | None = None,
+):
+    runtime = _runtime_attestation()
+    rows = []
+    for index, (file,) in enumerate(plan["bins"]):
+        observed_cid = None if index == absent_index else cid
+        observed_identity = None if index == absent_index else identity
+        if index == lying_index:
+            observed_cid = "blake3-512:different-table"
+            observed_identity = _demand_identity(suffix="b")
+        rows.append(
+            module.mint_partial(
+                plan=plan,
+                shard_index=index,
+                terminal_rows=[(file, _row(module, file))],
+                demand_table_cid=observed_cid,
+                demand_table_identity=observed_identity,
+                runtime_attestation=runtime,
+            )
+        )
+    return rows
+
+
+def _assert_unmeasured_without_width(body: dict[str, object]) -> None:
+    assert body["kind"] == "control-effect-recensus-unmeasured/v1"
+    assert body["status"] == "unmeasured"
+    assert body["measured"] is False
+    assert "frontierWidth" not in body
+    assert "bodyCid" not in body
+
+
+def test_eight_authenticated_shards_seal_one_demand_table_meaning() -> None:
+    module = _load()
+    cid = "blake3-512:table-a"
+    identity = _demand_identity()
+    plan = _plan(module, cid=cid, identity=identity)
+    assert plan["demandTableCid"] == cid
+    assert plan["demandTableIdentity"] == identity
+    assert plan["planCid"] == module.canonical_cid(
+        {key: value for key, value in plan.items() if key != "planCid"}
+    )
+
+    status, body = module.compose_from_partials(
+        plan,
+        _partials(module, plan, cid=cid, identity=identity),
+        runtime_attestation=_runtime_attestation(),
+    )
+
+    assert status == "sealed"
+    assert body["demandTableCid"] == cid
+    assert body["demandTableIdentity"] == identity
+    agreement = body["demandTableAgreement"]
+    assert agreement["authenticatedShardCount"] == 8
+    assert agreement["expectedShardCount"] == 8
+    assert agreement["allAgree"] is True
+    assert set(agreement["shards"]) == {f"s{i:02d}" for i in range(8)}
+    assert body["bodyCid"]
+
+
+def test_demand_table_meaning_moves_plan_partial_and_body_cids() -> None:
+    module = _load()
+    left_identity = _demand_identity(suffix="a")
+    right_identity = _demand_identity(suffix="b")
+    left_plan = _plan(module, cid="blake3-512:table-a", identity=left_identity)
+    right_plan = _plan(module, cid="blake3-512:table-b", identity=right_identity)
+    assert left_plan["planCid"] != right_plan["planCid"]
+
+    left_partial = _partials(
+        module,
+        left_plan,
+        cid="blake3-512:table-a",
+        identity=left_identity,
+    )[0]
+    right_partial = _partials(
+        module,
+        right_plan,
+        cid="blake3-512:table-b",
+        identity=right_identity,
+    )[0]
+    assert left_partial["partialCid"] != right_partial["partialCid"]
+
+    left_status, left_body = module.compose_from_partials(
+        left_plan,
+        _partials(
+            module,
+            left_plan,
+            cid="blake3-512:table-a",
+            identity=left_identity,
+        ),
+        runtime_attestation=_runtime_attestation(),
+    )
+    right_status, right_body = module.compose_from_partials(
+        right_plan,
+        _partials(
+            module,
+            right_plan,
+            cid="blake3-512:table-b",
+            identity=right_identity,
+        ),
+        runtime_attestation=_runtime_attestation(),
+    )
+    assert left_status == right_status == "sealed"
+    assert left_body["bodyCid"] != right_body["bodyCid"]
+
+
+def test_one_different_shard_table_refuses_as_mismatch() -> None:
+    module = _load()
+    cid = "blake3-512:table-a"
+    identity = _demand_identity()
+    plan = _plan(module, cid=cid, identity=identity)
+
+    status, body = module.compose_from_partials(
+        plan,
+        _partials(module, plan, cid=cid, identity=identity, lying_index=6),
+        runtime_attestation=_runtime_attestation(),
+    )
+
+    assert status == "unmeasured"
+    _assert_unmeasured_without_width(body)
+    assert "demand-table-testimony-mismatch" in body["unmeasuredReasons"]["s06"]
+
+
+def test_one_absent_shard_table_refuses_differently_from_mismatch() -> None:
+    module = _load()
+    cid = "blake3-512:table-a"
+    identity = _demand_identity()
+    plan = _plan(module, cid=cid, identity=identity)
+
+    status, body = module.compose_from_partials(
+        plan,
+        _partials(module, plan, cid=cid, identity=identity, absent_index=3),
+        runtime_attestation=_runtime_attestation(),
+    )
+
+    assert status == "unmeasured"
+    _assert_unmeasured_without_width(body)
+    reason = body["unmeasuredReasons"]["s03"]
+    assert "demand-table-testimony-absent" in reason
+    assert "demand-table-testimony-mismatch" not in reason
+
+
+def test_plan_refuses_semantic_identity_with_unrecomputable_content_key() -> None:
+    module = _load()
+    identity = _demand_identity()
+    identity["contentKey"] = "blake3-512:authored-not-recomputed"
+
+    try:
+        _plan(module, cid="blake3-512:table-a", identity=identity)
+    except ValueError as error:
+        assert "demand-table-identity-content-key-mismatch" in str(error)
+    else:
+        raise AssertionError("plan accepted an unrecomputable semantic identity")

--- a/tests/test_board_function_facts_c4.py
+++ b/tests/test_board_function_facts_c4.py
@@ -32,6 +32,10 @@ if str(PKG_SRC) not in sys.path:
     sys.path.insert(0, str(PKG_SRC))
 
 from sugar_lift_py_tests.c4 import board_function_facts as BFF  # noqa: E402
+from sugar_lift_py_tests.demand_table_identity import (  # noqa: E402
+    DemandTableIdentityV1,
+)
+from sugar_lift_python_source.canonical import cid_of_json  # noqa: E402
 
 SCRIPTS = ROOT / "implementations/python/sugar-lift-py-tests/scripts"
 
@@ -47,6 +51,31 @@ def _load(name: str, path: Path):
 
 TIP = "deadbeef"
 PIN = "pin-agg-hash-test"
+
+
+def _demand_table_kwargs() -> dict[str, object]:
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:test-corpus",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:test-producer",
+        resolution_config_cid="blake3-512:test-config",
+        parser_identity="cpython-3.12",
+        file_count=2,
+    )
+    identity = DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    )
+    return {
+        "demand_table_cid": "blake3-512:test-table",
+        "demand_table_identity": identity.as_dict(),
+    }
 
 
 def _mint_triple(
@@ -324,6 +353,7 @@ def test_compose_seal_uses_three_sealed_meanings() -> None:
         measured_commit="deadbeef",
         aggregate_hash="agg",
         manifest_shape_cid="cid",
+        **_demand_table_kwargs(),
     )
     assert status == "sealed"
     assert body["functionsTotal"] == 5

--- a/tests/test_control_effect_recensus_lpt_ci_matrix.py
+++ b/tests/test_control_effect_recensus_lpt_ci_matrix.py
@@ -47,6 +47,27 @@ def test_recensus_workflow_is_lpt_k8_matrix_not_serial_monolith() -> None:
     assert "Phase: measure shard partial only" in text
 
 
+def test_plan_publishes_one_demand_table_and_every_shard_loads_it() -> None:
+    """The matrix transports one plan-bound table; workers never mint eight."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    planner = (ROOT / "tools/plan_control_effect_recensus_shards.py").read_text(
+        encoding="utf-8"
+    )
+    worker = (
+        ROOT
+        / "implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py"
+    ).read_text(encoding="utf-8")
+
+    assert "--demand-table-out \"$OUT/demand-table.json\"" in workflow
+    assert ".sugar/pandas-control-effect/demand-table.json" in workflow
+    assert "--demand-table-path \"$DEMAND_TABLE\"" in workflow
+    assert "mint_prebuilt_demand_table(authenticated_corpus)" in planner
+    assert "publish_prebuilt_demand_table(demand_table" in planner
+    assert planner.index("mint_prebuilt_demand_table") < planner.index("build_plan(")
+    assert "load_plan_bound_demand_table(" in worker
+    assert "plan-demand-table-testimony-absent" in worker
+
+
 def test_compose_unmeasured_law_still_named_in_workflow() -> None:
     """Workflow copy must restate: never seal over finished shards alone."""
     text = WORKFLOW.read_text(encoding="utf-8")

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -44,6 +44,31 @@ COMPOSE = _load(
 )
 
 
+def _demand_table_kwargs() -> dict[str, object]:
+    identity = COMPOSE.DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:test-corpus",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:test-producer",
+        resolution_config_cid="blake3-512:test-config",
+        parser_identity="cpython-3.12",
+        file_count=2,
+    )
+    identity = COMPOSE.DemandTableIdentityV1(
+        content_key=COMPOSE.cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    )
+    return {
+        "demand_table_cid": "blake3-512:test-table",
+        "demand_table_identity": identity.as_dict(),
+    }
+
+
 def test_residual_failure_preserves_roster_functions_total(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -422,6 +447,7 @@ def test_compose_refuses_unattested_clean_board() -> None:
         measured_commit="deadbeef",
         aggregate_hash="agg",
         manifest_shape_cid="cid",
+        **_demand_table_kwargs(),
     )
     assert status == "unmeasured"
     assert body["status"] == "unmeasured"

--- a/tools/plan_control_effect_recensus_shards.py
+++ b/tools/plan_control_effect_recensus_shards.py
@@ -19,7 +19,11 @@ if str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 from sugar_repo_root import resolve_repo_root  # noqa: E402
 
-_SCRIPTS = resolve_repo_root() / "implementations/python/sugar-lift-py-tests/scripts"
+_REPO_ROOT = resolve_repo_root()
+_PACKAGE_SRC = _REPO_ROOT / "implementations/python/sugar-lift-py-tests/src"
+if str(_PACKAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_SRC))
+_SCRIPTS = _REPO_ROOT / "implementations/python/sugar-lift-py-tests/scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
@@ -29,6 +33,14 @@ from lpt_file_shards import (  # noqa: E402
     assign_files,
 )
 from compose_control_effect_board import build_plan  # noqa: E402
+from sugar_lift_py_tests.authenticated_pytest import (  # noqa: E402
+    authenticated_pandas_corpus,
+)
+from sugar_lift_py_tests.prebuilt_demand_table import (  # noqa: E402
+    mint_prebuilt_demand_table,
+    publish_prebuilt_demand_table,
+    write_prebuilt_demand_table,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -44,6 +56,18 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         required=True,
         help="filesystem root for content-addressed prior lookups",
+    )
+    parser.add_argument(
+        "--demand-table-corpus-root",
+        type=Path,
+        required=True,
+        help="authenticated corpus root whose demand table is derived once",
+    )
+    parser.add_argument(
+        "--demand-table-out",
+        type=Path,
+        required=True,
+        help="plan-time demand-table artifact carried to every shard",
     )
     parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
     parser.add_argument("--measured-commit", required=True)
@@ -69,6 +93,18 @@ def main(argv: list[str] | None = None) -> int:
         path_resolver={rel: path_resolver[rel] for rel in enrolled if rel in path_resolver and path_resolver[rel].is_file()},
         prior=ContentAddressedCostPrior(),
     )
+    authenticated_corpus = authenticated_pandas_corpus()
+    demanded_root = args.demand_table_corpus_root.resolve()
+    if authenticated_corpus.root.resolve() != demanded_root:
+        parser.error(
+            "--demand-table-corpus-root does not equal the authenticated pandas "
+            f"root: requested={demanded_root} authenticated={authenticated_corpus.root}"
+        )
+    demand_table = mint_prebuilt_demand_table(authenticated_corpus)
+    write_prebuilt_demand_table(demand_table, args.demand_table_out)
+    # Publication is part of plan authority, not a best-effort cache write. A
+    # plan that cannot publish the table it names must not mint planCid.
+    publish_prebuilt_demand_table(demand_table, args.demand_table_out)
     # If path resolver empty for all, equal-count still works via assign_files.
     plan = build_plan(
         enrolled_files=enrolled,
@@ -81,13 +117,16 @@ def main(argv: list[str] | None = None) -> int:
         prior_hits=assignment.prior_hits,
         prior_misses=assignment.prior_misses,
         estimated_loads=assignment.estimated_loads,
+        demand_table_cid=demand_table.content_cid,
+        demand_table_identity=demand_table.semantic_identity.as_dict(),
     )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(
         f"PLAN mode={assignment.mode} k={args.shard_count} "
         f"prior_hits={assignment.prior_hits} prior_misses={assignment.prior_misses} "
-        f"planCid={plan['planCid']} out={args.out}",
+        f"planCid={plan['planCid']} demandTableCid={demand_table.content_cid} "
+        f"demandMeaning={demand_table.semantic_identity.content_key} out={args.out}",
         flush=True,
     )
     print(assignment.job_log_line(population="control-effect-recensus"), flush=True)


### PR DESCRIPTION
## What changed

Bind the authoritative control-effect recensus to one plan-time demand-table meaning instead of allowing eight cold shard processes to mint independently.

- derive, write, and publish one authenticated demand table in the plan job;
- put both its payload `demandTableCid` and full recomputable `DemandTableIdentityV1` testimony inside `planCid`;
- carry the same pair inside every shard `partialCid`;
- require every worker to load and authenticate that exact artifact, with no local derivation fallback;
- seal the 8/8 agreement inside `bodyCid`;
- refuse absence and mismatch under distinct names, emitting an unmeasured envelope with neither `frontierWidth` nor `bodyCid`.

This is the buildable prerequisite from #7354. It does not choose any of the identity, projection, or enrollment rulings pending with T.

## Instrument and predicted movement

The new executable instrument has truthful and lying arms:

- eight agreeing authenticated shards seal;
- one shard claiming a different table refuses as `demand-table-testimony-mismatch`;
- one shard carrying no claim refuses as `demand-table-testimony-absent`;
- changing the table meaning moves plan, partial, and body CIDs;
- exact worker load authenticates the payload and semantic preimage without a replacement corpus walk;
- workflow source proves one plan-time publish and eight plan-bound loads.

Predicted epsilon: the next recensus can prove one demand-table meaning across all eight shards. No census was run, so no frontier-width delta is claimed.

## Evidence

Authenticated `bpytest` under CPython 3.12.13:

- focused #7354 set: **45 passed**;
- broader touched-file set: **71 passed, 2 failed**.

The two failures are pre-existing main reds, established by executing the exact nodes in a clean detached worktree at bare main `dc41472e64c417a1431d18b3fcee7543710e8ca6`:

1. `test_direct_board_mint_without_frontier_witness_is_unmeasured` raises because its authored aggregate fixture lacks the now-required `d3_residency_exposure` testimony.
2. `test_consumer_carries_pre_demand_and_real_audit_open_observations` installs a one-argument `get_resident` monkeypatch against the current two-argument `(source_cid, source_seat)` door.

Both failures reproduced identically on bare main. Neither test is changed or weakened in this PR; separate issues track the unguarded boundaries.

Additional checks: Python compile over every modified Python file, direct truthful/lying compose execution, plan-bound exact-load/no-rederive probe, and `git diff --check`.

## Limits

- No corpus census was run.
- No frontier width is claimed.
- CAS publication remains plan authority: if the plan cannot publish the table it names, it does not mint `planCid`.
- Existing untracked receipt directories are untouched.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bind one demand-table meaning across every recensus shard
> - The CI plan step in [control-effect-recensus.yml](.github/workflows/control-effect-recensus.yml) now derives, writes, and publishes a single authenticated demand-table artifact; shard jobs exit 78 if the artifact is absent.
> - [plan_control_effect_recensus_shards.py](tools/plan_control_effect_recensus_shards.py) authenticates the pandas corpus, mints a `PrebuiltDemandTableV1`, and embeds `demandTableCid` and `demandTableIdentity` into the plan JSON.
> - [control_effect_recensus.py](implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py) loads and validates the plan-bound demand table via `load_plan_bound_demand_table`; on refusal it mints an unmeasured partial with a diagnostic reason.
> - [compose_control_effect_board.py](implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py) enforces that every shard's demand-table testimony matches the plan's; mismatches produce unmeasured boards with specific `unmeasuredReason` values; sealed boards include a `demandTableAgreement` summary.
> - Risk: existing plans without `demandTableCid`/`demandTableIdentity` will cause shard workers to exit 78 rather than proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4291165.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->