### PR TITLE
Refuse missing demand-table agreement at the board mint

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -131,6 +131,115 @@ def _demand_table_claim(
     return content_cid, identity.as_dict()
 
 
+_DEMAND_TABLE_AGREEMENT_FIELDS = frozenset(
+    {
+        "schema",
+        "plan",
+        "shards",
+        "authenticatedShardCount",
+        "expectedShardCount",
+        "allAgree",
+    }
+)
+
+
+def _validate_demand_table_agreement(
+    agreement: Mapping[str, Any] | None,
+    *,
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Close the mint boundary over one plan claim and every shard claim."""
+    if not isinstance(agreement, Mapping):
+        raise ValueError(
+            "demand-table-agreement-absent: sealed mint requires the shard "
+            "agreement testimony produced by compose"
+        )
+    fields = set(agreement)
+    if fields != _DEMAND_TABLE_AGREEMENT_FIELDS:
+        raise ValueError(
+            "demand-table-agreement-malformed: closed fields differ "
+            f"missing={sorted(_DEMAND_TABLE_AGREEMENT_FIELDS - fields)} "
+            f"extra={sorted(fields - _DEMAND_TABLE_AGREEMENT_FIELDS)}"
+        )
+    if agreement.get("schema") != "demand-table-shard-agreement/v1":
+        raise ValueError(
+            "demand-table-agreement-malformed: schema must be "
+            "demand-table-shard-agreement/v1"
+        )
+    agreement_plan = agreement.get("plan")
+    shards = agreement.get("shards")
+    if not isinstance(agreement_plan, Mapping) or not isinstance(shards, Mapping):
+        raise ValueError(
+            "demand-table-agreement-malformed: plan and shards must be objects"
+        )
+    try:
+        plan_claim = _demand_table_claim(plan, owner="plan")
+        agreement_plan_claim = _demand_table_claim(
+            agreement_plan, owner="demand-table agreement plan"
+        )
+    except ValueError as error:
+        raise ValueError(f"demand-table-agreement-malformed: {error}") from error
+    if agreement_plan_claim != plan_claim:
+        raise ValueError(
+            "demand-table-testimony-mismatch: agreement plan claim differs "
+            f"agreement={agreement_plan_claim!r} plan={plan_claim!r}"
+        )
+
+    expected = int(plan["shardCount"])
+    expected_seats = {f"s{i:02d}" for i in range(expected)}
+    presented_seats = set(shards)
+    authenticated_count = agreement.get("authenticatedShardCount")
+    expected_count = agreement.get("expectedShardCount")
+    if (
+        type(authenticated_count) is not int
+        or type(expected_count) is not int
+        or authenticated_count != expected
+        or expected_count != expected
+        or presented_seats != expected_seats
+        or agreement.get("allAgree") is not True
+    ):
+        raise ValueError(
+            "demand-table-agreement-incomplete: "
+            f"authenticated={authenticated_count!r} expected={expected_count!r} "
+            f"planExpected={expected} missing={sorted(expected_seats - presented_seats)} "
+            f"extra={sorted(presented_seats - expected_seats)} "
+            f"allAgree={agreement.get('allAgree')!r}"
+        )
+
+    normalized_shards: dict[str, dict[str, object]] = {}
+    for seat in sorted(expected_seats):
+        raw_claim = shards[seat]
+        if not isinstance(raw_claim, Mapping):
+            raise ValueError(
+                f"demand-table-agreement-malformed: shard {seat} claim is not an object"
+            )
+        try:
+            shard_claim = _demand_table_claim(raw_claim, owner=f"agreement {seat}")
+        except ValueError as error:
+            raise ValueError(f"demand-table-agreement-malformed: {error}") from error
+        if shard_claim != plan_claim:
+            raise ValueError(
+                "demand-table-testimony-mismatch: "
+                f"agreement {seat} claim={shard_claim!r} plan={plan_claim!r}"
+            )
+        normalized_shards[seat] = {
+            "demandTableCid": shard_claim[0],
+            "demandTableIdentity": shard_claim[1],
+        }
+
+    return {
+        "schema": "demand-table-shard-agreement/v1",
+        "plan": {
+            "demandTableCid": plan_claim[0],
+            "demandTableIdentity": plan_claim[1],
+        },
+        "shards": normalized_shards,
+        "authenticatedShardCount": expected,
+        "expectedShardCount": expected,
+        "allAgree": True,
+    }
+
+
 def _runtime_attestation_fields(
     runtime_attestation: Mapping[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -1326,6 +1435,32 @@ def seal_board_from_aggregate(
             measured_commit=measured_commit,
             runtime_failure=runtime_failure,
         )
+    if plan is None:
+        return unmeasured_envelope(
+            plan=plan,
+            missing_shards=["plan"],
+            unmeasured_reasons={
+                "plan": (
+                    "demand-table-agreement-absent: sealed mint requires a "
+                    "plan carrying the authoritative demand-table claim"
+                )
+            },
+            measured_commit=measured_commit,
+            runtime_attestation=runtime,
+        )
+    try:
+        authenticated_demand_table_agreement = _validate_demand_table_agreement(
+            demand_table_agreement,
+            plan=plan,
+        )
+    except ValueError as error:
+        return unmeasured_envelope(
+            plan=plan,
+            missing_shards=["plan"],
+            unmeasured_reasons={"plan": str(error)},
+            measured_commit=measured_commit,
+            runtime_attestation=runtime,
+        )
     file_names = list(agg["enrolled_files"])
     families = Counter(agg["families"])
     backend_defects = Counter(agg["backend_defects"])
@@ -1494,12 +1629,10 @@ def seal_board_from_aggregate(
         "composeSchema": COMPOSE_SCHEMA,
         **runtime,
     }
-    if demand_table_agreement is not None:
-        agreement = dict(demand_table_agreement)
-        plan_claim = agreement.get("plan") or {}
-        body["demandTableCid"] = plan_claim.get("demandTableCid")
-        body["demandTableIdentity"] = plan_claim.get("demandTableIdentity")
-        body["demandTableAgreement"] = agreement
+    plan_claim = authenticated_demand_table_agreement["plan"]
+    body["demandTableCid"] = plan_claim["demandTableCid"]
+    body["demandTableIdentity"] = plan_claim["demandTableIdentity"]
+    body["demandTableAgreement"] = authenticated_demand_table_agreement
     if frontier_attestation is not None:
         body["frontierAttestation"] = dict(frontier_attestation)
         body["frontierWidth"] = len(

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -51,6 +51,35 @@ def _demand_table_kwargs() -> dict[str, object]:
     }
 
 
+def _direct_plan_and_agreement(mod, files: list[str]):
+    demand = _demand_table_kwargs()
+    plan = mod.build_plan(
+        enrolled_files=files,
+        shard_count=1,
+        measured_commit="abc123",
+        aggregate_hash="pin-hash",
+        manifest_shape_cid="manifest",
+        bins=[files],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=len(files),
+        estimated_loads=[0.0],
+        **demand,
+    )
+    claim = {
+        "demandTableCid": demand["demand_table_cid"],
+        "demandTableIdentity": demand["demand_table_identity"],
+    }
+    return plan, {
+        "schema": "demand-table-shard-agreement/v1",
+        "plan": claim,
+        "shards": {"s00": claim},
+        "authenticatedShardCount": 1,
+        "expectedShardCount": 1,
+        "allAgree": True,
+    }
+
+
 def test_functions_three_meanings_not_one_figure() -> None:
     """Population / enumerated / clean are three sealed facts, not one int."""
     from sugar_lift_py_tests.c4.board_function_facts import (
@@ -261,13 +290,18 @@ def test_direct_board_mint_without_frontier_witness_is_unmeasured() -> None:
         "terminal_count": 3,
         "manifest_cid": None,
     }
+    agg["d3_residency_exposure"] = mod.aggregate_d3_residency_exposure(
+        [], enrolled_files=agg["enrolled_files"]
+    )
+    plan, agreement = _direct_plan_and_agreement(mod, agg["enrolled_files"])
     body = mod.seal_board_from_aggregate(
         agg,
-        plan=None,
-        per_shard_cids=None,
-        compose_cid=None,
+        plan=plan,
+        per_shard_cids={"s00": "partial-0"},
+        compose_cid="blake3-512:compose",
         measured_commit="abc123",
         aggregate_hash="pin-hash",
+        demand_table_agreement=agreement,
     )
     assert body["measurement"] == "unmeasured"
     assert body["kind"] == "measurement-conservation-failure-v1"

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -146,6 +146,36 @@ def _demand_table_kwargs() -> dict[str, object]:
     }
 
 
+def _direct_plan_and_agreement(module, files: list[str]):
+    demand = _demand_table_kwargs()
+    plan = module.build_plan(
+        enrolled_files=files,
+        shard_count=1,
+        measured_commit="4accd543",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[files],
+        split_mode="test",
+        prior_hits=0,
+        prior_misses=len(files),
+        estimated_loads=[0.0],
+        **demand,
+    )
+    claim = {
+        "demandTableCid": demand["demand_table_cid"],
+        "demandTableIdentity": demand["demand_table_identity"],
+    }
+    agreement = {
+        "schema": "demand-table-shard-agreement/v1",
+        "plan": claim,
+        "shards": {"s00": claim},
+        "authenticatedShardCount": 1,
+        "expectedShardCount": 1,
+        "allAgree": True,
+    }
+    return plan, agreement
+
+
 def _require_runtime_parameter(module) -> None:
     assert (
         "runtime_attestation"
@@ -713,15 +743,17 @@ def test_aggregate_panic_magnitude_cannot_disagree_with_attested_keys() -> None:
     )
     attestation, failures = module.attest_frontier_rows([("pandas/a.py", row)])
     assert failures == []
+    plan, agreement = _direct_plan_and_agreement(module, ["pandas/a.py"])
     body = module.seal_board_from_aggregate(
         aggregate,
-        plan=None,
-        per_shard_cids=None,
-        compose_cid=None,
+        plan=plan,
+        per_shard_cids={"s00": "partial-0"},
+        compose_cid="blake3-512:compose",
         measured_commit="4accd543",
         aggregate_hash="agg",
         manifest_shape_cid="manifest",
         frontier_attestation=attestation,
+        demand_table_agreement=agreement,
         runtime_attestation=_runtime_attestation(),
     )
     assert body["measurement"] == "unmeasured"

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
@@ -167,6 +167,82 @@ def _assert_unmeasured_without_width(body: dict[str, object]) -> None:
     assert "bodyCid" not in body
 
 
+def _direct_seal(
+    module,
+    *,
+    demand_table_agreement,
+) -> dict[str, object]:
+    cid = "blake3-512:table-a"
+    identity = _demand_identity()
+    plan = _plan(module, cid=cid, identity=identity)
+    measured_rows = [
+        (file, _row(module, file)) for file in plan["enrolledFiles"]
+    ]
+    aggregate = module.aggregate_terminal_rows(
+        measured_rows,
+        enrolled_files=plan["enrolledFiles"],
+        manifest_cid="manifest",
+    )
+    frontier, failures = module.attest_frontier_rows(measured_rows)
+    assert failures == []
+    return module.seal_board_from_aggregate(
+        aggregate,
+        plan=plan,
+        per_shard_cids={f"s{i:02d}": f"partial-{i}" for i in range(8)},
+        compose_cid="blake3-512:compose",
+        measured_commit="dc41472e64",
+        frontier_attestation=frontier,
+        demand_table_agreement=demand_table_agreement,
+        runtime_attestation=_runtime_attestation(),
+    )
+
+
+def test_direct_seal_refuses_absent_demand_table_agreement() -> None:
+    module = _load()
+
+    body = _direct_seal(module, demand_table_agreement=None)
+
+    _assert_unmeasured_without_width(body)
+    assert "demand-table-agreement-absent" in body["unmeasuredReasons"]["plan"]
+
+
+def test_direct_seal_refuses_malformed_demand_table_agreement() -> None:
+    module = _load()
+
+    body = _direct_seal(
+        module,
+        demand_table_agreement={
+            "schema": "demand-table-shard-agreement/v1",
+            "allAgree": True,
+        },
+    )
+
+    _assert_unmeasured_without_width(body)
+    assert "demand-table-agreement-malformed" in body["unmeasuredReasons"]["plan"]
+
+
+def test_direct_seal_refuses_seven_of_eight_demand_table_agreement() -> None:
+    module = _load()
+    cid = "blake3-512:table-a"
+    identity = _demand_identity()
+    claim = {"demandTableCid": cid, "demandTableIdentity": identity}
+
+    body = _direct_seal(
+        module,
+        demand_table_agreement={
+            "schema": "demand-table-shard-agreement/v1",
+            "plan": claim,
+            "shards": {f"s{i:02d}": claim for i in range(7)},
+            "authenticatedShardCount": 7,
+            "expectedShardCount": 8,
+            "allAgree": False,
+        },
+    )
+
+    _assert_unmeasured_without_width(body)
+    assert "demand-table-agreement-incomplete" in body["unmeasuredReasons"]["plan"]
+
+
 def test_eight_authenticated_shards_seal_one_demand_table_meaning() -> None:
     module = _load()
     cid = "blake3-512:table-a"


### PR DESCRIPTION
## Finding

#7356 correctly bound one demand-table meaning at plan, shard, and compose, but its lower sole mint door still accepted `demand_table_agreement=None`. That put a precondition on main which looked enforced and was not: a direct `seal_board_from_aggregate` call could construct a sealed measured body without the advertised 8/8 agreement.

The bypass exposure interval begins at squash merge `a5c26f374b61d2f237e2f9ffa0d61b5381cdf5ff` and ends only when this fix-forward lands. This is not a revert; the plan/shard/compose binding remains correct.

## Fix

Close the sole measured-body mint before body construction. It validates the closed `demand-table-shard-agreement/v1` testimony against the authoritative plan and refuses three distinct facts:

- absent agreement: nothing claimed;
- malformed agreement: testimony cannot be authenticated;
- incomplete agreement: not all plan seats authenticated the same claim, planted as 7 of 8.

A refusal is unmeasured and carries neither `frontierWidth` nor `bodyCid`. A valid agreement is normalized and attached unconditionally inside the body seal domain.

## Discriminator

Hockney independently found the bypass by calling `seal_board_from_aggregate` directly with a valid plan carrying demand identity, 8 complete terminal rows, valid frontier attestation, authenticated runtime, per-shard CIDs, and `demand_table_agreement=None`. That exact lower-door shape is now a regression tooth and refuses by name. Malformed and 7-of-8 direct-mint twins prove this is closed conservation rather than a presence check.

The previous 45/45 suite only exercised the guarded compose path. Green there proved the guard, not the mint boundary.

## Other-door audit

Source audit found one production `control-effect-construction-recensus` / `control-effect-recensus` body mint: `seal_board_from_aggregate`. Its only production caller is `compose_from_partials`; all other callers are focused tests. No third production door to this measured body was found.

## Evidence

Authenticated `bpytest` under CPython 3.12.13: **50 passed**. This includes direct mint absence, malformed, and 7-of-8 refusals; truthful 8-of-8 sealing; compose mismatch/absence; exact load/no re-derive; CID-domain; workflow binding; frontier-magnitude refusal; and the direct no-frontier-witness refusal kept on its intended channel.

Python compile over the touched modules and `git diff --check` are green.

The direct frontier fixture now supplies both truthful D3 testimony and truthful demand-table agreement so it continues testing the frontier-witness boundary instead of turning false-green at this new earlier mint guard. The unrelated dead one-argument `get_resident` control remains tracked separately in #7357.

## Scope

No census was run and no frontier width is claimed. Existing receipt artifacts are untouched. Credit to Hockney for the adversarial sole-mint discriminator and independent verification request.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refuse missing or invalid demand-table agreement at the board mint
> - Adds `_validate_demand_table_agreement` to enforce presence, schema, field completeness, and per-shard claim consistency for demand-table shard agreements, returning a normalized agreement object on success.
> - Updates `seal_board_from_aggregate` to require both a plan and a valid demand-table agreement; returns an unmeasured envelope with a reason under `unmeasuredReasons.plan` on absence or validation failure.
> - On success, always writes `demandTableCid`, `demandTableIdentity`, and `demandTableAgreement` from the validated agreement into the board body.
> - Adds tests covering absent, malformed, and incomplete (7-of-8 shards) agreements in [test_recensus_demand_table_agreement.py](https://github.com/TSavo/sugar/pull/7359/files#diff-af6147bb42b0e7ac0e0054b498ea880e1b6f72e469511da0e2c07d6c20f81b65).
> - Behavioral Change: callers that previously passed `demand_table_agreement=None` now receive an unmeasured result instead of a measured one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ff47e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sealed boards now require complete, authenticated agreement from every required shard.
  * Validated plans and shard claims are consistently included in successfully sealed boards.

* **Bug Fixes**
  * Invalid, incomplete, missing, or malformed demand-table agreements no longer produce measured sealed boards.
  * Boards with unresolved agreement issues now clearly remain unmeasured and omit frontier measurements.
  * Improved handling of direct board sealing when required plan or agreement details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->