### PR TITLE
Exercise the real resident-cache D3 door

### DIFF
--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -112,12 +112,26 @@ def test_residual_failure_preserves_roster_functions_total(
 def test_consumer_carries_pre_demand_and_real_audit_open_observations(
     tmp_path: Path, monkeypatch
 ) -> None:
-    """D3 exposure is carried per file without another SourceFile open."""
+    """D3 observes the real CID-and-seat resident without another prepare."""
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.process_resident_file import (
+        clear_process_resident_files,
+        get_resident,
+        prepare_count_for,
+    )
+    from sugar_source_tree.tree import SourceFile
+
     src = tmp_path / "pkg/mod.py"
     src.parent.mkdir()
     src.write_text("def a(): pass\n", encoding="utf-8")
     nodes = [{"memento": {"function_name": "a"}}]
-    sentinel = object()
+
+    measured_path = src.resolve()
+    _source, source_seat, source_cid = path_source(str(measured_path))
+    clear_process_resident_files()
+    SourceFile.from_path(measured_path)
+    assert get_resident(source_cid, source_seat) is not None
+    assert prepare_count_for(source_cid, source_seat) == 1
 
     monkeypatch.setattr(CONSUMER, "demand_function_roster", lambda **_k: (nodes, []))
     monkeypatch.setattr(
@@ -130,10 +144,6 @@ def test_consumer_carries_pre_demand_and_real_audit_open_observations(
     )
     monkeypatch.setattr(CONSUMER, "count_ast_function_defs", lambda _p: 1)
     monkeypatch.setattr(
-        "sugar_source_tree.process_resident_file.get_resident",
-        lambda _cid: sentinel,
-    )
-    monkeypatch.setattr(
         CONSUMER,
         "_take_d3_audit_open_observation",
         lambda source_cid: {
@@ -145,21 +155,28 @@ def test_consumer_carries_pre_demand_and_real_audit_open_observations(
         },
     )
 
-    row = CONSUMER.measure_file_via_enumerate(
-        workspace_root=tmp_path,
-        file_rel="pkg/mod.py",
-    )
+    try:
+        row = CONSUMER.measure_file_via_enumerate(
+            workspace_root=tmp_path,
+            file_rel="pkg/mod.py",
+            contract_refs=[],
+        )
 
-    assert row["d3Residency"] == {
-        "sourceCid": row["inputKey"]["sourceCid"],
-        "reached": True,
-        "presentBeforeDemand": True,
-        "presentAtAuditOpen": True,
-        "auditOpenReusedResident": True,
-        "rootReporterSeatedAtAuditOpen": False,
-        "collectorRegisteredAtAuditExit": False,
-        "presenceConfirmed": True,
-    }
+        assert row["inputKey"]["sourceCid"] == source_cid
+        assert row["d3Residency"] == {
+            "sourceCid": source_cid,
+            "reached": True,
+            "presentBeforeDemand": True,
+            "presentAtAuditOpen": True,
+            "auditOpenReusedResident": True,
+            "rootReporterSeatedAtAuditOpen": False,
+            "collectorRegisteredAtAuditExit": False,
+            "presenceConfirmed": True,
+        }
+        assert get_resident(source_cid, source_seat) is not None
+        assert prepare_count_for(source_cid, source_seat) == 1
+    finally:
+        clear_process_resident_files()
 
 
 def test_d3_residency_aggregate_keeps_counts_and_file_coordinates() -> None:


### PR DESCRIPTION
## Finding

The D3 residency tooth monkeypatched `get_resident` with the retired one-argument signature. Since #7300 / `9bdeb936d1f3d9395c0a7bbff2a6a2c39277ee8e`, the production identity is `(sourceCid, sourceSeat)`, so the tooth stopped during an earlier construction walk and never reached the observation boundary it claimed to guard.

A monkeypatch here only proved its simulation. The repair removes that simulation entirely.

## Change

The tooth now:

- derives the real source CID and absolute source seat through `path_source`;
- clears and populates the real process-resident cache through `SourceFile.from_path`;
- asserts the exact two-coordinate `get_resident` lookup is present;
- measures D3 with explicit per-file contract testimony so an unrelated corpus-wide fallback cannot preempt the subject;
- proves D3 observed the same CID/seat and did not pay a second prepare;
- clears the real cache in `finally`.

Production code is unchanged.

## Red/green bite

The repaired tooth was mutation-tested against the boundary it guards. Changing only the production D3 lookup from the authenticated absolute seat to `file_rel` makes the exact node red:

- `presentBeforeDemand`: expected `true`, observed `false`;
- `presenceConfirmed`: expected `true`, observed `false`.

Restoring the production lookup returns the suite to green. This is a semantic wrong-seat failure, not a signature crash or mock assertion.

## Evidence

Authenticated `bpytest` under CPython 3.12.13 / pandas 3.0.3:

- full target module plus adjacent resident-cache and real D3 miss/hit teeth: **19 passed**;
- focused real-door subset: **6 passed**.

`python -m py_compile tests/test_recensus_enumerate_mass_and_clean.py` and `git diff --check` are green.

## Scope

One test file only. No production change, census run, or corpus measurement is claimed. Exposure is the interval from #7300 until this tooth lands and resumes guarding the two-coordinate door. Closes #7357.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use real resident-cache registry in `test_consumer_carries_pre_demand_and_real_audit_open_observations`
> Replaces the `get_resident` monkeypatch with a real `SourceFile` resident setup in [test_recensus_enumerate_mass_and_clean.py](https://github.com/TSavo/sugar/pull/7361/files#diff-d65b388615b9fcbe6b7499321bd6ec112ebc34a06d1c34fb64496641a2e358fc), so the test exercises the actual process-resident file registry.
>
> - Initializes a `SourceFile` resident via `path_source`, `clear_process_resident_files`, and `prepare_count_for` before invoking the subject under test.
> - Adds assertions that `inputKey.sourceCid` matches the computed `source_cid` and that the resident remains present with `prepare_count` equal to 1 after the call.
> - Wraps the test body in `try/finally` to guarantee `clear_process_resident_files()` cleans up global state.
> - Passes explicit `contract_refs=[]` to `measure_file_via_enumerate`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a1c3a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->