### PR TITLE
Authenticate loaded source identity in showcase receipts

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -43,7 +43,10 @@ from sugar_lift_py_tests.kit_rpc import (
     SuppressedAuditLocusDto,
 )
 from sugar_lift_py_tests.kit_rpc.rpc_value import to_rpc_value
-from sugar_lift_py_tests.source_provenance import kit_source_provenance
+from sugar_lift_py_tests.source_provenance import (
+    kit_source_provenance,
+    loaded_python_source_identity,
+)
 from sugar_source_tree.panic import SourceTreePanic
 
 KIT_ID = "python"
@@ -2948,6 +2951,7 @@ def _handle_initialize(msg_id: Any) -> None:
                 "kit_id": KIT_ID,
                 "component_protocol_version": COMPONENT_PROTOCOL_VERSION,
                 "kit_source": kit_source_provenance(),
+                "loaded_source_identity": loaded_python_source_identity(),
             },
         }
     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_provenance.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_provenance.py
@@ -4,7 +4,22 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
+
+_PYTHON_PACKAGE_PATHS: tuple[tuple[str, str], ...] = (
+    (
+        "sugar_lift_py_tests",
+        "implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests",
+    ),
+    (
+        "sugar_lift_python_source",
+        "implementations/python/sugar-lift-python-source/src/sugar_lift_python_source",
+    ),
+    (
+        "sugar_source_tree",
+        "implementations/python/sugar-source-tree/src/sugar_source_tree",
+    ),
+)
 
 
 def _git(root: Path, *args: str) -> str | None:
@@ -82,6 +97,108 @@ def kit_package_roots() -> list[Path]:
         Path(sugar_lift_python_source.__file__).resolve().parent,
         Path(sugar_source_tree.__file__).resolve().parent,
     ]
+
+
+def _canonical_content_cid(root: Path) -> str:
+    """Content identity in the in-memory CID spelling, never path spelling."""
+    return _content_identity([root]).replace("blake3-512_", "blake3-512:", 1)
+
+
+def _loaded_package_origins() -> dict[str, Path]:
+    import sugar_lift_py_tests
+    import sugar_lift_python_source
+    import sugar_source_tree
+
+    modules = {
+        "sugar_lift_py_tests": sugar_lift_py_tests,
+        "sugar_lift_python_source": sugar_lift_python_source,
+        "sugar_source_tree": sugar_source_tree,
+    }
+    origins: dict[str, Path] = {}
+    for package, module in modules.items():
+        raw_origin = getattr(module, "__file__", None)
+        if not raw_origin:
+            raise RuntimeError(
+                "LoadedPythonSourceIdentityConstructionGapV1: "
+                f"loaded package {package!r} has no module origin"
+            )
+        origins[package] = Path(raw_origin).resolve()
+    return origins
+
+
+def _declared_package_roots(repo_root: Path | None = None) -> dict[str, Path]:
+    from sugar_lift_py_tests.repo_root import resolve_repo_root
+
+    root = Path(repo_root).resolve() if repo_root is not None else resolve_repo_root()
+    return {
+        package: (root / relative).resolve()
+        for package, relative in _PYTHON_PACKAGE_PATHS
+    }
+
+
+def _package_identity_rows(
+    roots: Mapping[str, Path], *, origins: Mapping[str, Path] | None = None
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for package in sorted(roots):
+        root = Path(roots[package]).resolve()
+        origin = (
+            Path(origins[package]).resolve()
+            if origins is not None
+            else (root / "__init__.py").resolve()
+        )
+        rows.append(
+            {
+                "subject": package,
+                "origin": str(origin),
+                "root": str(root),
+                "contentCid": _canonical_content_cid(root),
+            }
+        )
+    return rows
+
+
+def loaded_python_source_identity(
+    *,
+    declared_package_roots: Mapping[str, Path] | None = None,
+    loaded_package_origins: Mapping[str, Path] | None = None,
+) -> dict[str, object]:
+    """Describe the checkout declared by the run and packages actually loaded.
+
+    Origins are testimony, not identity: an installed copy may live at a
+    different path while carrying the same bytes. The consumer authenticates
+    the package roster and per-package content CIDs and retains both origin
+    inventories in the receipt.
+    """
+    declared = (
+        _declared_package_roots()
+        if declared_package_roots is None
+        else {
+            name: Path(root).resolve() for name, root in declared_package_roots.items()
+        }
+    )
+    loaded_origins = (
+        _loaded_package_origins()
+        if loaded_package_origins is None
+        else {
+            name: Path(origin).resolve()
+            for name, origin in loaded_package_origins.items()
+        }
+    )
+    if set(declared) != set(loaded_origins):
+        raise RuntimeError(
+            "LoadedPythonSourceIdentityConstructionGapV1: declared and loaded "
+            f"package rosters differ: declared={sorted(declared)!r} "
+            f"loaded={sorted(loaded_origins)!r}"
+        )
+    loaded_roots = {
+        package: origin.parent for package, origin in loaded_origins.items()
+    }
+    return {
+        "schema": "loaded-source-identity/v1",
+        "declared": _package_identity_rows(declared),
+        "loaded": _package_identity_rows(loaded_roots, origins=loaded_origins),
+    }
 
 
 def source_stamp_for_sugar_cli(repo_root: Path | None = None) -> str | None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_provenance.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_provenance.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from sugar_lift_py_tests.source_provenance import source_provenance_for_roots
+from sugar_lift_py_tests.source_provenance import (
+    loaded_python_source_identity,
+    source_provenance_for_roots,
+)
 
 
 def _git(root: Path, *args: str) -> str:
@@ -54,3 +57,66 @@ def test_non_git_source_provenance_is_content_addressed(tmp_path: Path) -> None:
     assert provenance["dirty"] is False
     assert str(provenance["identity"]).startswith("blake3-512:")
     assert len(str(provenance["identity"])) == len("blake3-512:") + 128
+
+
+def _python_package_tree(root: Path, package: str, marker: str) -> Path:
+    package_root = root / "src" / package
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text(f"MARKER = {marker!r}\n")
+    return package_root
+
+
+def test_loaded_python_source_identity_carries_actual_origins_and_content_cids(
+    tmp_path: Path,
+) -> None:
+    declared = tmp_path / "declared"
+    loaded = tmp_path / "loaded"
+    package_names = (
+        "sugar_lift_py_tests",
+        "sugar_lift_python_source",
+        "sugar_source_tree",
+    )
+    declared_roots = {
+        name: _python_package_tree(declared / name, name, "same")
+        for name in package_names
+    }
+    loaded_roots = {
+        name: _python_package_tree(loaded / name, name, "same")
+        for name in package_names
+    }
+
+    identity = loaded_python_source_identity(
+        declared_package_roots=declared_roots,
+        loaded_package_origins={
+            name: root / "__init__.py" for name, root in loaded_roots.items()
+        },
+    )
+
+    assert identity["schema"] == "loaded-source-identity/v1"
+    assert [row["subject"] for row in identity["declared"]] == list(package_names)
+    assert [row["subject"] for row in identity["loaded"]] == list(package_names)
+    for declared_row, loaded_row in zip(
+        identity["declared"], identity["loaded"], strict=True
+    ):
+        assert declared_row["contentCid"] == loaded_row["contentCid"]
+        assert declared_row["origin"] != loaded_row["origin"]
+        assert str(loaded_row["origin"]).endswith("/__init__.py")
+
+
+def test_loaded_python_source_identity_exposes_stale_content_without_forging_status(
+    tmp_path: Path,
+) -> None:
+    declared_root = _python_package_tree(
+        tmp_path / "declared", "sugar_lift_py_tests", "current"
+    )
+    stale_root = _python_package_tree(
+        tmp_path / "stale", "sugar_lift_py_tests", "historical"
+    )
+
+    identity = loaded_python_source_identity(
+        declared_package_roots={"sugar_lift_py_tests": declared_root},
+        loaded_package_origins={"sugar_lift_py_tests": stale_root / "__init__.py"},
+    )
+
+    assert identity["declared"][0]["contentCid"] != identity["loaded"][0]["contentCid"]
+    assert "matched" not in identity

--- a/implementations/rust/sugar-cli/src/cmd_mint.rs
+++ b/implementations/rust/sugar-cli/src/cmd_mint.rs
@@ -1074,8 +1074,7 @@ impl MintKit {
             };
 
             let response = session
-                .response_projection()
-                .clone_response_for_compatibility()
+                .clone_response_for_receipt()
                 .map_err(|error| KitError::Transformation(error.to_string()))?;
             assert_oracle_ready_if_requested(&step.surface, &response)
                 .map_err(KitError::Transformation)?;
@@ -1177,8 +1176,7 @@ impl MintKit {
                 }
             };
             let response = session
-                .response_projection()
-                .clone_response_for_compatibility()
+                .clone_response_for_receipt()
                 .map_err(|error| KitError::Transformation(error.to_string()))?;
             assert_oracle_ready_if_requested(&step.surface, &response)
                 .map_err(KitError::Transformation)?;
@@ -1260,8 +1258,7 @@ impl MintKit {
             };
 
             let response = session
-                .response_projection()
-                .clone_response_for_compatibility()
+                .clone_response_for_receipt()
                 .map_err(|error| KitError::Transformation(error.to_string()))?;
             assert_oracle_ready_if_requested(&step.surface, &response)
                 .map_err(KitError::Transformation)?;
@@ -1437,10 +1434,14 @@ fn finalize_toolchain_plan_memento(
                 elapsed_ms = cid_started.elapsed().as_millis(),
                 "lift-report graph progress"
             );
-            json!({
+            let mut receipt = json!({
                 "surface": output.surface,
                 "actualOutputCid": output_cid,
-            })
+            });
+            if let Some(identity) = output.response.get("loadedSourceIdentity") {
+                receipt["loadedSourceIdentity"] = identity.clone();
+            }
+            receipt
         })
         .collect();
     let expected_output_cids: Vec<Value> = tool_outputs
@@ -8301,6 +8302,19 @@ mod tests {
 
     #[test]
     fn finalize_toolchain_plan_adds_output_cids_to_the_letter_not_self_cids() {
+        let loaded_source_identity = json!({
+            "schema": "loaded-source-identity/v1",
+            "declared": [{
+                "subject": "python-source-kit",
+                "origin": "/checkout/sugar_lift_py_tests/__init__.py",
+                "contentCid": format!("blake3-512:{}", "a".repeat(128))
+            }],
+            "loaded": [{
+                "subject": "python-source-kit",
+                "origin": "/venv/sugar_lift_py_tests/__init__.py",
+                "contentCid": format!("blake3-512:{}", "a".repeat(128))
+            }]
+        });
         let base = json!({
             "kind": "component-plan",
             "schemaVersion": "1",
@@ -8316,7 +8330,8 @@ mod tests {
             response: json!({
                 "kind": "ir-document",
                 "ir": [],
-                "diagnostics": []
+                "diagnostics": [],
+                "loadedSourceIdentity": loaded_source_identity
             }),
         }];
 
@@ -8335,6 +8350,11 @@ mod tests {
                 .pointer("/toolOutputs/0/actualOutputCid")
                 .and_then(Value::as_str),
             Some(response_cid.as_str())
+        );
+        assert_eq!(
+            finalized.pointer("/toolOutputs/0/loadedSourceIdentity"),
+            Some(&loaded_source_identity),
+            "the durable plan receipt must carry what the Python plugin actually loaded"
         );
         assert!(
             finalized.get("planCid").is_none(),

--- a/implementations/rust/sugar-cli/src/lift_plugin.rs
+++ b/implementations/rust/sugar-cli/src/lift_plugin.rs
@@ -34,6 +34,7 @@ pub(crate) struct LiftPluginSession {
     pub claim: DomainClaim,
     #[allow(dead_code)] // consumed by the binary-only cmd_lift report provenance gate
     pub initialize_response: Option<Value>,
+    pub loaded_source_identity: Option<Value>,
 }
 
 impl LiftPluginSession {
@@ -42,7 +43,26 @@ impl LiftPluginSession {
         Ok(Self {
             claim,
             initialize_response: None,
+            loaded_source_identity: None,
         })
+    }
+
+    pub(crate) fn clone_response_for_receipt(&self) -> Result<Value, LiftPluginError> {
+        let mut response = self
+            .response_projection()
+            .clone_response_for_compatibility()?;
+        if let Some(identity) = self.loaded_source_identity.as_ref() {
+            let object = response.as_object_mut().ok_or_else(|| {
+                LiftPluginError::diagnostic(
+                    LiftPluginDiagnosticKind::InvalidResponsePayload,
+                    "DomainClaim.payload",
+                    "accepted loaded-source identity cannot be attached to a non-object response",
+                    "Emit an object-shaped lift response so authenticated loaded-source testimony can enter the durable receipt.",
+                )
+            })?;
+            object.insert("loadedSourceIdentity".to_string(), identity.clone());
+        }
+        Ok(response)
     }
 
     pub(crate) fn response_projection(&self) -> LiftResponseProjection<'_> {
@@ -272,7 +292,7 @@ pub(crate) fn dispatch_lift(
         );
     }
 
-    let initialize_response = if surface == "python" {
+    let (initialize_response, loaded_source_identity) = if surface == "python" {
         let rendezvous = Kit::rendezvous(LiftManifest::resolved(
             surface.to_string(),
             manifest.name.clone(),
@@ -282,10 +302,14 @@ pub(crate) fn dispatch_lift(
             manifest.method.clone(),
         ))
         .map_err(lift_error_from_rendezvous)?;
-        enforce_python_kit_source(surface, rendezvous.initialize_response())?;
-        Some(rendezvous.initialize_response().clone())
+        let loaded_source_identity =
+            enforce_python_kit_source(surface, rendezvous.initialize_response())?;
+        (
+            Some(rendezvous.initialize_response().clone()),
+            loaded_source_identity,
+        )
     } else {
-        None
+        (None, None)
     };
 
     let lift_params = build_lift_params(project_root, surface, options);
@@ -330,6 +354,7 @@ pub(crate) fn dispatch_lift(
 
     let mut session = LiftPluginSession::from_claim(core_session.claim)?;
     session.initialize_response = initialize_response.or(Some(core_session.initialize_response));
+    session.loaded_source_identity = loaded_source_identity;
     Ok(session)
 }
 
@@ -397,7 +422,7 @@ pub(crate) fn dispatch_lift_path(
     ));
 
     let initialize_response = kit.initialize_response().clone();
-    enforce_python_kit_source(surface, &initialize_response)?;
+    let loaded_source_identity = enforce_python_kit_source(surface, &initialize_response)?;
     let before = current_rss_kib();
 
     // There is no lift RPC. Full-tree "lift" is enumerate(SourceTree) via
@@ -439,6 +464,7 @@ pub(crate) fn dispatch_lift_path(
     trace_lift_plugin_claim_checkpoint("dispatch_lift_path.before_response_projection", &claim);
     let mut session = LiftPluginSession::from_claim(claim)?;
     session.initialize_response = Some(initialize_response);
+    session.loaded_source_identity = loaded_source_identity;
     Ok(session)
 }
 
@@ -520,12 +546,144 @@ fn binary_source_stamp() -> &'static str {
     option_env!("SUGAR_BUILD_STAMP").unwrap_or("unknown")
 }
 
+#[derive(Debug, Deserialize)]
+struct LoadedSourceIdentityV1 {
+    schema: String,
+    declared: Vec<LoadedSourceIdentityEntryV1>,
+    loaded: Vec<LoadedSourceIdentityEntryV1>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoadedSourceIdentityEntryV1 {
+    subject: String,
+    origin: String,
+    content_cid: String,
+}
+
+fn loaded_source_identity_refusal(name: &str, detail: impl std::fmt::Display) -> LiftPluginError {
+    LiftPluginError::SplitPipeline(format!("{name}: {detail}"))
+}
+
+fn content_cid_is_well_formed(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix("blake3-512:") else {
+        return false;
+    };
+    hex.len() == 128 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Authenticate a source kit's generic declared/loaded identity relation.
+///
+/// The producer owns language-specific origin discovery. This boundary knows
+/// only opaque subjects, their observed origins, and their content CIDs, so a
+/// source kit for any language can satisfy the same contract.
+fn authenticate_loaded_source_identity(
+    initialize_response: &Value,
+) -> Result<Option<Value>, LiftPluginError> {
+    if initialize_response.get("kit_source").is_none() {
+        return Ok(None);
+    }
+    let testimony = initialize_response
+        .get("loaded_source_identity")
+        .ok_or_else(|| {
+            loaded_source_identity_refusal(
+                "LoadedSourceIdentityAbsentV1",
+                "source-authenticated kit initialize response carried no loaded-source identity",
+            )
+        })?;
+    let parsed: LoadedSourceIdentityV1 =
+        serde_json::from_value(testimony.clone()).map_err(|error| {
+            loaded_source_identity_refusal(
+                "LoadedSourceIdentityMismatchV1",
+                format!("loaded-source testimony is malformed: {error}"),
+            )
+        })?;
+    if parsed.schema != "loaded-source-identity/v1" {
+        return Err(loaded_source_identity_refusal(
+            "LoadedSourceIdentityMismatchV1",
+            format!(
+                "unsupported loaded-source schema {:?}; expected loaded-source-identity/v1",
+                parsed.schema
+            ),
+        ));
+    }
+
+    fn indexed<'a>(
+        side: &str,
+        entries: &'a [LoadedSourceIdentityEntryV1],
+    ) -> Result<std::collections::BTreeMap<&'a str, &'a LoadedSourceIdentityEntryV1>, LiftPluginError>
+    {
+        if entries.is_empty() {
+            return Err(loaded_source_identity_refusal(
+                "LoadedSourceIdentityMismatchV1",
+                format!("{side} loaded-source inventory is empty"),
+            ));
+        }
+        let mut indexed = std::collections::BTreeMap::new();
+        for entry in entries {
+            if entry.subject.is_empty()
+                || entry.origin.is_empty()
+                || !content_cid_is_well_formed(&entry.content_cid)
+            {
+                return Err(loaded_source_identity_refusal(
+                    "LoadedSourceIdentityMismatchV1",
+                    format!(
+                        "{side} loaded-source entry is invalid: subject={:?} origin={:?} contentCid={:?}",
+                        entry.subject, entry.origin, entry.content_cid
+                    ),
+                ));
+            }
+            if indexed.insert(entry.subject.as_str(), entry).is_some() {
+                return Err(loaded_source_identity_refusal(
+                    "LoadedSourceIdentityMismatchV1",
+                    format!(
+                        "{side} loaded-source inventory repeats subject {:?}",
+                        entry.subject
+                    ),
+                ));
+            }
+        }
+        Ok(indexed)
+    }
+
+    let declared = indexed("declared", &parsed.declared)?;
+    let loaded = indexed("loaded", &parsed.loaded)?;
+    if declared.keys().ne(loaded.keys()) {
+        return Err(loaded_source_identity_refusal(
+            "LoadedSourceIdentityMismatchV1",
+            format!(
+                "declared and loaded source rosters differ: declared={:?} loaded={:?}",
+                declared.keys().collect::<Vec<_>>(),
+                loaded.keys().collect::<Vec<_>>()
+            ),
+        ));
+    }
+    for (subject, declared_entry) in declared {
+        let loaded_entry = loaded
+            .get(subject)
+            .expect("equal subject rosters established above");
+        if declared_entry.content_cid != loaded_entry.content_cid {
+            return Err(loaded_source_identity_refusal(
+                "LoadedSourceIdentityMismatchV1",
+                format!(
+                    "subject={subject:?} declaredContentCid={} loadedContentCid={} declaredOrigin={:?} loadedOrigin={:?}",
+                    declared_entry.content_cid,
+                    loaded_entry.content_cid,
+                    declared_entry.origin,
+                    loaded_entry.origin
+                ),
+            ));
+        }
+    }
+    Ok(Some(testimony.clone()))
+}
+
 fn enforce_python_kit_source(
     surface: &str,
     initialize_response: &Value,
-) -> Result<(), LiftPluginError> {
+) -> Result<Option<Value>, LiftPluginError> {
     if surface != "python" {
-        return Ok(());
+        return Ok(None);
     }
     let identity = initialize_response
         .pointer("/kit_source/identity")
@@ -547,13 +705,14 @@ fn enforce_python_kit_source(
         if let Ok(mut slot) = last_python_kit_source_slot().lock() {
             *slot = initialize_response.get("kit_source").cloned();
         }
-        return Ok(());
+        return authenticate_loaded_source_identity(initialize_response);
     }
     refuse_split_pipeline(identity, binary).map_err(LiftPluginError::SplitPipeline)?;
+    let loaded_source_identity = authenticate_loaded_source_identity(initialize_response)?;
     if let Ok(mut slot) = last_python_kit_source_slot().lock() {
         *slot = initialize_response.get("kit_source").cloned();
     }
-    Ok(())
+    Ok(loaded_source_identity)
 }
 
 fn last_python_kit_source_slot() -> &'static Mutex<Option<Value>> {
@@ -1252,6 +1411,135 @@ mod tests {
             }
             other => panic!("expected typed diagnostic, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn accepted_loaded_source_identity_enters_the_response_receipt_only_when_carried() {
+        let response = json!({
+            "kind": "ir-document",
+            "ir": [],
+            "diagnostics": []
+        });
+        let request =
+            build_lift_params(Path::new("."), "new-language", LiftPluginOptions::default())
+                .to_wire_value()
+                .expect("LiftRequest serializes");
+        let term = Term::Const {
+            value: response,
+            sort: Sort::Primitive {
+                name: "LiftPluginResponse".to_string(),
+            },
+        };
+        let kit = LiftPluginKit::new("new-language", Vec::new(), None);
+        let input = Input::Spec(request);
+        let claim = kit
+            .claim_from_response_term(&input, term)
+            .expect("lift response becomes a primitive claim");
+        let mut session = LiftPluginSession::from_claim(claim)
+            .expect("claim payload becomes a lift response projection");
+
+        assert!(
+            session
+                .clone_response_for_receipt()
+                .expect("response without testimony still projects")
+                .get("loadedSourceIdentity")
+                .is_none(),
+            "not-carried must remain distinct from carried-and-matched"
+        );
+
+        let cid = format!("blake3-512:{}", "a".repeat(128));
+        let accepted =
+            loaded_source_initialize(&cid, &cid, "/installed/new_language/__init__.source")
+                ["loaded_source_identity"]
+                .clone();
+        session.loaded_source_identity = Some(accepted.clone());
+        assert_eq!(
+            session
+                .clone_response_for_receipt()
+                .expect("accepted testimony enters the response")
+                .get("loadedSourceIdentity"),
+            Some(&accepted)
+        );
+    }
+
+    fn loaded_source_initialize(
+        declared_cid: &str,
+        loaded_cid: &str,
+        loaded_origin: &str,
+    ) -> Value {
+        json!({
+            "kit_source": {
+                "identity": "fixture-source-stamp",
+                "kind": "sourceStamp",
+                "dirty": false
+            },
+            "loaded_source_identity": {
+                "schema": "loaded-source-identity/v1",
+                "declared": [{
+                    "subject": "new-language-kit",
+                    "origin": "/declared/sugar_lift_py_tests/__init__.py",
+                    "contentCid": declared_cid
+                }],
+                "loaded": [{
+                    "subject": "new-language-kit",
+                    "origin": loaded_origin,
+                    "contentCid": loaded_cid
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn loaded_source_identity_distinguishes_absent_mismatched_and_matched() {
+        let absent = authenticate_loaded_source_identity(&json!({
+            "kit_source": {"identity": "declared-source", "kind": "sourceStamp"}
+        }))
+        .expect_err("missing loaded-source testimony must refuse");
+        assert!(
+            absent.to_string().contains("LoadedSourceIdentityAbsentV1"),
+            "absence must have its own refusal name: {absent}"
+        );
+
+        let current = format!("blake3-512:{}", "a".repeat(128));
+        let stale = format!("blake3-512:{}", "b".repeat(128));
+        let mismatch = authenticate_loaded_source_identity(&loaded_source_initialize(
+            &current,
+            &stale,
+            "/stale/sugar_lift_py_tests/__init__.py",
+        ))
+        .expect_err("declared-current/loaded-stale testimony must refuse");
+        let mismatch_text = mismatch.to_string();
+        assert!(
+            mismatch_text.contains("LoadedSourceIdentityMismatchV1"),
+            "mismatch must have its own refusal name: {mismatch_text}"
+        );
+        assert!(mismatch_text.contains("new-language-kit"));
+        assert!(mismatch_text.contains("/stale/sugar_lift_py_tests/__init__.py"));
+
+        let matched = authenticate_loaded_source_identity(&loaded_source_initialize(
+            &current,
+            &current,
+            "/venv/site-packages/sugar_lift_py_tests/__init__.py",
+        ))
+        .expect("matching content identity must be accepted")
+        .expect("python carries accepted loaded-source testimony");
+        assert_eq!(
+            matched["schema"], "loaded-source-identity/v1",
+            "the accepted testimony, including the actual origin, is the receipt payload"
+        );
+        assert_eq!(
+            matched["loaded"][0]["origin"],
+            "/venv/site-packages/sugar_lift_py_tests/__init__.py"
+        );
+    }
+
+    #[test]
+    fn unrelated_surface_has_no_loaded_source_obligation() {
+        assert_eq!(
+            authenticate_loaded_source_identity(&json!({}))
+                .expect("unrelated surface is outside this membrane"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #7360.

## Construction

- The Python kit constructs loaded-source-identity/v1 from the declared checkout package roots and the resolved origins plus content CIDs of the three packages actually imported.
- The Rust boundary authenticates the generic declared/loaded relation over opaque subjects. It has no Python-shaped identity API, so a newly invented source kit can present the same relation.
- Missing testimony refuses as LoadedSourceIdentityAbsentV1. Carried but malformed, roster-divergent, or CID-divergent testimony refuses as LoadedSourceIdentityMismatchV1. Matching content is accepted even when an installed origin path differs.
- Accepted testimony is inserted into the plugin response and copied into the durable toolOutputs plan receipt.

## Red then green

Red on 8e1d346f1081549eea931454667c73b2d07f1b31:
- bin/bpytest implementations/python/sugar-lift-py-tests/tests/test_source_provenance.py -q exited 2 because loaded_python_source_identity did not exist.
- bin/bcargo test --manifest-path implementations/rust/Cargo.toml -p sugar-cli loaded_python_source_identity_distinguishes_absent_mismatched_and_matched -- --exact exited 101 because the authentication door did not exist.

Reproduced after restack on cd866d512dce245b68e4cc01f441abca4f6f58fb:
- focused authenticated bpytest constructor twins: 2 passed.
- bcargo --lib loaded_source_identity: 2 passed.
- unrelated-surface mayhem arm: 1 passed.
- durable plan-receipt projection: 1 passed.
- untouched e75 showcase seat: exit 1 at mint with LoadedSourceIdentityAbsentV1, before any product verdict.
- fully current source seat: identity membrane accepted, mint produced a proof, and unpiped rg found schema loaded-source-identity/v1 in that proof. The showcase later exited 1 on an unrelated BIN_DIR/witness terminal.

The mismatch tooth plants declared-current and loaded-stale content CIDs and requires the exact stale origin in the named refusal. The historical e75 code predates the carrier, so its real process arm is ABSENT rather than MISMATCHED.

## Shot accounting

Predicted epsilon: the live showcase loaded-source identity gap goes from one unauthenticated boundary to zero; future receipts become classifiable by the source they actually consumed. Historical exposure remains open because old receipts have no recoverable identity. No venv was deleted, repaired, or mutated.

Not claimed: no NumPy showcase verdict, no reclassification of historical receipts, and no claim that the downstream BIN_DIR/witness failure is part of this change. The separate battleaxe bin-test sync gap for tracked docs/render-path-census.md is #7362.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authenticate loaded source identity in lift plugin showcase receipts
> - Adds `authenticate_loaded_source_identity` in [lift_plugin.rs](https://github.com/TSavo/sugar/pull/7363/files#diff-fe181985bfab2ea39f3380841730d83ced2e2ab58e12142c2dcaa6c4a4d16777) to validate that a plugin's reported loaded-source identity matches its declared kit source, refusing the pipeline on absence or mismatch of content CIDs, subjects, or schema.
> - Adds `loaded_python_source_identity` in [source_provenance.py](https://github.com/TSavo/sugar/pull/7363/files#diff-dceafcd85fb4985a481bb50bc7b508bd9b61755837c44b28481eda691a36a38a) to compute a structured identity object with per-package content CIDs and file origins for declared vs. actually loaded Python sources.
> - The lift plugin session now stores the accepted loaded-source identity and attaches it as `loadedSourceIdentity` via a new `clone_response_for_receipt` method when building per-plugin receipt responses.
> - The Python RPC initialize handler in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7363/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) returns `loaded_source_identity` alongside `kit_source` in its response.
> - Risk: pipelines using Python kit sources that omit or mismatch `loadedSourceIdentity` will now be refused at the enforcement step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e050c0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->