### PR TITLE
Key semantic node relations by source occurrence (#7346, #7347, #7348)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/comprehension_sugar.py
@@ -56,6 +56,24 @@ class ComprehensionGeneratorSugar:
     filters: tuple[ConstructedTermSugar, ...]
     target_coordinates: tuple = dataclass_field(default=(), compare=False)
     target_pattern: object | None = dataclass_field(default=None, compare=False)
+    target_pattern_enrollment: object = dataclass_field(kw_only=True, compare=False)
+    """The PRODUCER's closed enrollment answer, minted by #7348's authority.
+
+    This is `SourceUnit.target_pattern_enrollment(consumer)`:
+    `TargetPatternEnrolledV1 | TargetPatternNotEnrolledV1`. It is the fact that
+    separates "no pattern was ever owed" from "an owed pattern was lost"
+    (#7347). Required, with no default -- a default would have re-created the
+    very ambiguity this field exists to remove.
+
+    It is the CONSUMER-level answer, and this sugar reads it as a per-slot one.
+    That is sound in exactly this domain and nowhere else: `_finite_map`
+    consults it only when `target.coordinates` is set, which
+    `_comprehension_target` produces only for a Tuple/List of plain Names, and
+    such a site always owns a binding leaf -- so an enrolled comprehension
+    consumer necessarily owed a pattern for THIS slot. `covers()` is pinned by
+    a tooth. This sugar mints no enrollment value of its own and adapts between
+    no shapes; #7348 owns the type, the authority, and its reasons.
+    """
 
     def __post_init__(self) -> None:
         require_constructed_term_sugar(
@@ -64,6 +82,23 @@ class ComprehensionGeneratorSugar:
         for filter_sugar in self.filters:
             require_constructed_term_sugar(
                 filter_sugar, owner="ComprehensionGeneratorSugar.filters"
+            )
+        from sugar_source_tree.nodes import (
+            TargetPatternEnrolledV1,
+            TargetPatternEnrollmentV1,
+        )
+
+        if not isinstance(self.target_pattern_enrollment, TargetPatternEnrollmentV1):
+            raise TypeError(
+                "ComprehensionGeneratorSugar.target_pattern_enrollment requires the "
+                "producer's TargetPatternEnrollmentV1; got "
+                f"{type(self.target_pattern_enrollment).__name__}"
+            )
+        if self.target_pattern is not None and not isinstance(
+            self.target_pattern_enrollment, TargetPatternEnrolledV1
+        ):
+            raise ValueError(
+                "a target pattern cannot exist for an unenrolled consumer"
             )
         if self.target_pattern is not None:
             from sugar_source_tree.nodes import TargetPatternV1
@@ -183,9 +218,59 @@ class ComprehensionSugar(ConstructedTermSugar):
         refuses at the UnaryOp producer.
         """
         if index == 0 and len(self.generators) == 1 and not generator.filters:
-            finite = self._finite_map(generator, iterable, ctx)
-            if finite is not None:
-                return finite
+            from sugar_lift_py_tests.sugar.finite_projection import (
+                FiniteProjectionNonSuccessV1,
+                FiniteProjectionRefusalV1,
+                NotProjected,
+                Projected,
+                require_finite_projection_decision,
+            )
+
+            decision = require_finite_projection_decision(
+                self._finite_map(generator, iterable, ctx),
+                owner="ComprehensionSugar._finite_map",
+            )
+            # EXHAUSTIVE. Only the two LAWFUL non-application reasons may fall
+            # through to symbolic construction; the other two are construction
+            # refusals and may never reach ``Complete`` (#7347).
+            match decision:
+                case Projected(outcome=outcome):
+                    return outcome
+                case NotProjected(
+                    reason=FiniteProjectionNonSuccessV1.LAWFULLY_INAPPLICABLE
+                ):
+                    pass
+                case NotProjected(
+                    reason=(
+                        FiniteProjectionNonSuccessV1.PROJECTION_UNAVAILABLE_IN_CONTEXT
+                    )
+                ):
+                    pass
+                case NotProjected(
+                    reason=FiniteProjectionNonSuccessV1.AUTHENTICATED_LOOKUP_FAILED
+                ):
+                    raise FiniteProjectionRefusalV1(
+                        FiniteProjectionNonSuccessV1.AUTHENTICATED_LOOKUP_FAILED,
+                        construct=self.kind,
+                        coordinate=generator.binding_coordinate_cid,
+                        shape=_target_shape_name(generator.target),
+                        site=self.site,
+                    )
+                case NotProjected(
+                    reason=FiniteProjectionNonSuccessV1.REPLACEMENT_FAILED
+                ):
+                    raise FiniteProjectionRefusalV1(
+                        FiniteProjectionNonSuccessV1.REPLACEMENT_FAILED,
+                        construct=self.kind,
+                        coordinate=generator.binding_coordinate_cid,
+                        shape=_target_shape_name(generator.target),
+                        site=self.site,
+                    )
+                case _:
+                    raise TypeError(
+                        "unhandled FiniteProjectionDecisionV1 variant "
+                        f"{decision!r}: add a match arm, never a fallthrough"
+                    )
         return self._desugar_filters(generator, 0, (), iterable, index, resolved, ctx)
 
     def _finite_map(self, generator, iterable, ctx):
@@ -204,6 +289,12 @@ class ComprehensionSugar(ConstructedTermSugar):
             ctor,
         )
         from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.finite_projection import (
+            FiniteProjectionNonSuccessV1,
+            NotProjected,
+            Projected,
+        )
+        from sugar_source_tree.nodes import TargetPatternEnrolledV1
 
         members = None
         if isinstance(iterable, (TupleValue, ListValue)):
@@ -216,13 +307,33 @@ class ComprehensionSugar(ConstructedTermSugar):
         ):
             members = iterable.finite_elements
         if members is None:
-            return None
+            return NotProjected(FiniteProjectionNonSuccessV1.LAWFULLY_INAPPLICABLE)
         target = generator.target
         if target.coordinates is not None and generator.target_pattern is None:
-            return None
+            # The producer's OWN enrollment answer decides which fact this is.
+            # ENROLLED + missing pattern is a stranded authenticated lookup, not
+            # an absence, and it may not be spent as a symbolic Complete.
+            if isinstance(
+                generator.target_pattern_enrollment, TargetPatternEnrolledV1
+            ):
+                return NotProjected(
+                    FiniteProjectionNonSuccessV1.AUTHENTICATED_LOOKUP_FAILED
+                )
+            return NotProjected(FiniteProjectionNonSuccessV1.LAWFULLY_INAPPLICABLE)
         if ctx is None or not hasattr(ctx, "temporal"):
-            return None
+            return NotProjected(
+                FiniteProjectionNonSuccessV1.PROJECTION_UNAVAILABLE_IN_CONTEXT
+            )
         from dataclasses import replace
+
+        try:
+            # Probe the sole context-replacement capability the projection
+            # needs BEFORE entering the recursion. Inside ``project`` a failure
+            # would have to travel back through ``Outcome.and_then``, which is
+            # exactly how this cause used to be laundered into a bare ``None``.
+            replace(ctx, temporal=ctx.temporal)
+        except TypeError:
+            return NotProjected(FiniteProjectionNonSuccessV1.REPLACEMENT_FAILED)
 
         owner = str(self.site)
 
@@ -287,10 +398,7 @@ class ComprehensionSugar(ConstructedTermSugar):
                     temporal = temporal.bind_value(leaf.source_name, value)
             elif target.source_name is not None:
                 temporal = temporal.bind_value(target.source_name, member)
-            try:
-                inner_ctx = replace(ctx, temporal=temporal)
-            except TypeError:
-                return None
+            inner_ctx = replace(ctx, temporal=temporal)
             if self.key is not None:
                 return self.key.desugar(inner_ctx).and_then(
                     lambda key: self.element.desugar(inner_ctx).and_then(
@@ -310,10 +418,10 @@ class ComprehensionSugar(ConstructedTermSugar):
                 )
             )
 
-        # Outcome.and_then owns terminal/guarded propagation. ``None`` is the
-        # sole finite-projection-unavailable result; every constructed outcome
-        # propagates unchanged through its own continuation law.
-        return project(0, ())
+        # Outcome.and_then owns terminal/guarded propagation. Every constructed
+        # outcome propagates unchanged through its own continuation law and is
+        # TRANSPORTED by ``Projected`` -- which is not a non-success cause.
+        return Projected(project(0, ()))
 
     def _desugar_filters(
         self, generator, filter_index, filters, iterable, index, resolved, ctx
@@ -418,6 +526,14 @@ class ComprehensionSugar(ConstructedTermSugar):
             symbol_kind="coordinate",
         )
         return Complete(ComprehensionValue(term))
+
+
+def _target_shape_name(target: ComprehensionTargetSugar) -> str:
+    """The SHAPE a refusal names: a bound name, or a destructuring arity."""
+    if target.source_name is not None:
+        return f"name:{target.source_name}"
+    assert target.coordinates is not None
+    return f"destructure:{len(target.coordinates)}"
 
 
 def _projection(element, index: int, arity: int):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/finite_projection.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/finite_projection.py
@@ -1,0 +1,175 @@
+"""The closed finite-projection decision for comprehensions (#7347).
+
+`ComprehensionSugar._finite_map` used to answer `Outcome | None`, and the bare
+`None` stood for AT LEAST FOUR DISTINCT FACTS:
+
+1. the iterable genuinely has no finite-member roster;
+2. a destructuring target's authenticated `TargetPatternV1` was not found;
+3. the context carries no temporal projection capability;
+4. replacing the temporal context failed.
+
+`_after_iterable` erased all four into one symbolic fallback and `_complete`
+issued `Complete(ComprehensionValue(term))` with `finite_elements=None`. A
+comprehension whose finite projection was LOST TO A STRANDED LOOKUP therefore
+reported the same verdict as a genuinely unbounded one, and no downstream
+consumer could tell them apart.
+
+THE LAW. Lawful inapplicability may produce `Complete`. A FAILED AUTHENTICATED
+LOOKUP MAY NOT: it must refuse, naming construct, coordinate and shape.
+
+The carrier is closed on purpose, and the closure is TYPE-LEVEL rather than
+guarded. `FiniteProjectionNonSuccessV1` is an `Enum`, so a fifth cause cannot
+be minted at a callsite -- it requires editing this module, which makes every
+exhaustive `match` over it fail loudly until it is revisited. A guard can be
+bypassed by a new callsite; a missing constructor cannot.
+
+`Projected` transports the existing `Outcome` and is NOT a fifth non-success
+cause. Absence and lookup-failure never share a representation here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class FiniteProjectionNonSuccessV1(Enum):
+    """Why a finite projection was not produced. Closed; exhaustively matched."""
+
+    LAWFULLY_INAPPLICABLE = "lawfully-inapplicable"
+    """The iterable exposes no finite-member roster.
+
+    Symbolic `Complete` is HONEST here: `ComprehensionValue.finite_elements`
+    documents `None` as "no exact finite-member testimony exists".
+    """
+
+    PROJECTION_UNAVAILABLE_IN_CONTEXT = "projection-unavailable-in-context"
+    """The context carries no temporal projection capability.
+
+    A DIFFERENT lawful reason from `LAWFULLY_INAPPLICABLE`: the iterable may be
+    a perfectly exact roster; this construction simply cannot be evaluated
+    against the context it was handed. Kept apart so the two are never
+    conflated by a later reader.
+    """
+
+    AUTHENTICATED_LOOKUP_FAILED = "authenticated-lookup-failed"
+    """An ENROLLED consumer's `TargetPatternV1` was not found.
+
+    A CONSTRUCTION REFUSAL. The producer OWED testimony for this slot
+    (#7348's `TargetPatternEnrolledV1`) and the lookup came back empty --
+    the relation is stranded, not absent. This must NEVER reach `Complete`.
+    """
+
+    REPLACEMENT_FAILED = "replacement-failed"
+    """The temporal context could not be replaced. Its own typed terminal.
+
+    Not a statement about the iterable and not a lawful inapplicability: the
+    projection machinery itself failed, and saying "not finite" instead would
+    blame the source for a defect in the evaluator.
+    """
+
+
+@dataclass(frozen=True)
+class Projected:
+    """A finite projection was produced. Transports the existing `Outcome`."""
+
+    outcome: object
+
+    def __post_init__(self) -> None:
+        if self.outcome is None:
+            raise TypeError("Projected transports an Outcome, never None")
+        from sugar_lift_py_tests.outcome.outcome import Outcome
+
+        if not isinstance(self.outcome, Outcome):
+            raise TypeError(
+                "Projected transports an Outcome; got "
+                f"{type(self.outcome).__name__}"
+            )
+
+
+@dataclass(frozen=True)
+class NotProjected:
+    """No finite projection, WITH the producer-owned cause still attached."""
+
+    reason: FiniteProjectionNonSuccessV1
+
+    def __post_init__(self) -> None:
+        if type(self.reason) is not FiniteProjectionNonSuccessV1:
+            raise TypeError(
+                "NotProjected requires an exact FiniteProjectionNonSuccessV1; "
+                f"got {type(self.reason).__name__}"
+            )
+
+
+FiniteProjectionDecisionV1 = Projected | NotProjected
+
+
+class FiniteProjectionRefusalV1(Exception):
+    """A finite-projection decision that may not become a verdict.
+
+    Named, and carrying the three things a reader needs to act: the CONSTRUCT
+    (comprehension kind), the COORDINATE (the generator's binding coordinate)
+    and the SHAPE (the target shape whose pattern was owed).
+    """
+
+    def __init__(
+        self,
+        reason: FiniteProjectionNonSuccessV1,
+        *,
+        construct: str,
+        coordinate: str,
+        shape: str,
+        site: object = None,
+    ) -> None:
+        self.reason = require_finite_projection_non_success(
+            reason, owner="FiniteProjectionRefusalV1.reason"
+        )
+        self.construct = construct
+        self.coordinate = coordinate
+        self.shape = shape
+        self.site = site
+        super().__init__(
+            f"{reason.value}: construct={construct} coordinate={coordinate} "
+            f"shape={shape} site={site!r}"
+        )
+
+
+def require_finite_projection_non_success(
+    value: object, *, owner: str
+) -> FiniteProjectionNonSuccessV1:
+    if type(value) is not FiniteProjectionNonSuccessV1:
+        raise TypeError(
+            f"{owner} requires an exact FiniteProjectionNonSuccessV1; "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def require_finite_projection_decision(value: object, *, owner: str):
+    """Reject `None`, foreign values, and undeclared variants at the boundary.
+
+    This is the memo boundary #7347 asks for. It exists so that a future cause
+    cannot arrive as a bare sentinel: it must be a declared variant of the
+    type, which in turn forces a new match arm.
+    """
+    if value is None:
+        raise TypeError(f"{owner} requires a FiniteProjectionDecisionV1, never None")
+    if type(value) is Projected:
+        return value
+    if type(value) is NotProjected:
+        require_finite_projection_non_success(value.reason, owner=owner)
+        return value
+    raise TypeError(
+        f"{owner} requires Projected or NotProjected; got {type(value).__name__}"
+    )
+
+
+__all__ = [
+    "FiniteProjectionDecisionV1",
+    "FiniteProjectionNonSuccessV1",
+    "FiniteProjectionRefusalV1",
+    "NotProjected",
+    "Projected",
+    "require_finite_projection_decision",
+    "require_finite_projection_non_success",
+]

--- a/implementations/python/sugar-lift-py-tests/tests/producer_minted_enrollment.py
+++ b/implementations/python/sugar-lift-py-tests/tests/producer_minted_enrollment.py
@@ -1,0 +1,45 @@
+"""Producer-minted enrollment values for tests. No test mints its own.
+
+`TargetPatternEnrolledV1` / `TargetPatternNotEnrolledV1` (#7348) are guarded by
+an authority sentinel: only `SourceUnit.target_pattern_enrollment` may
+construct them. That is the point, so these helpers ASK the producer rather
+than fabricating a stand-in -- a hand-rolled double here would be a second
+enrollment authority wearing a test costume.
+"""
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_source_tree.nodes import TargetPatternEnrolledV1, TargetPatternNotEnrolledV1
+from sugar_source_tree.tree import SourceFile
+
+
+def enrollment_source_file(source: str, label: str = "tests/enrollment_fixture.py"):
+    return SourceFile(
+        (source, label, blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def producer_not_enrolled():
+    """A real, producer-minted `TargetPatternNotEnrolledV1`."""
+    source = "def build(items):\n    return items\n"
+    node = next(
+        candidate
+        for candidate in enrollment_source_file(source).nodes()
+        if candidate.kind == "Return"
+    )
+    answer = node.unit.target_pattern_enrollment(node)
+    assert isinstance(answer, TargetPatternNotEnrolledV1), answer
+    return answer
+
+
+def producer_enrolled(source: str, kind: str):
+    """A real, producer-minted `TargetPatternEnrolledV1` for `kind` in `source`."""
+    node = next(
+        candidate
+        for candidate in enrollment_source_file(source).nodes()
+        if candidate.kind == kind
+    )
+    answer = node.unit.target_pattern_enrollment(node)
+    assert isinstance(answer, TargetPatternEnrolledV1), answer
+    return node, answer

--- a/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_comprehension_temporal_scope.py
@@ -28,6 +28,7 @@ from sugar_lift_py_tests.sugar.comprehension_sugar import (
 from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
 from sugar_source_tree.tree import SourceFile
 from sugar_source_tree.nodes import TargetPatternConstructionGapV1
+from producer_minted_enrollment import producer_not_enrolled
 
 
 @dataclass(frozen=True)
@@ -60,6 +61,7 @@ def _comprehension(element_outcome):
                     site="synthetic-comprehension-iterable",
                 ),
                 filters=(),
+                target_pattern_enrollment=producer_not_enrolled(),
             ),
         ),
         element=_ConstructedOutcomeSugar(

--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_term_sugar.py
@@ -25,6 +25,7 @@ from sugar_lift_py_tests.sugar.comprehension_sugar import (
     ComprehensionSugar,
     ComprehensionTargetSugar,
 )
+from producer_minted_enrollment import producer_not_enrolled
 from sugar_lift_py_tests.sugar.equality_op_sugar import EqualityOpSugar
 from sugar_lift_py_tests.sugar.if_exp_sugar import IfExpSugar
 from sugar_lift_py_tests.sugar.fstring_sugar import FormattedValueSugar, JoinedStrSugar
@@ -88,6 +89,7 @@ def _comprehension_generator(iterable, *, filters=()):
         binding_coordinate_cid="blake3-512:" + "g" * 128,
         iterable=iterable,
         filters=filters,
+        target_pattern_enrollment=producer_not_enrolled(),
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_finite_projection_decision.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finite_projection_decision.py
@@ -99,8 +99,14 @@ _KIND_NODE = {
 }
 
 
-def _rewritten(kind: str):
-    source_file = _source_file(_REWRITE_SOURCES[kind])
+def _rewritten(kind: str, *, tag: str = ""):
+    # #7364: SourceUnits are memoized by (source_cid, filename), so two fixtures
+    # with byte-identical text SHARE ONE UNIT -- and a test that drops a row
+    # would corrupt its neighbours.  ``tag`` keeps each fixture's text distinct.
+    source = _REWRITE_SOURCES[kind]
+    if tag:
+        source += f"# unique fixture bytes: {tag}\n"
+    source_file = _source_file(source)
     node = next(
         candidate
         for candidate in source_file.nodes()
@@ -109,6 +115,25 @@ def _rewritten(kind: str):
     rewritten = node.substitute({"y": _symbolic_binding()})
     assert rewritten is not node, "fixture did not rewrite the comprehension"
     assert rewritten.kind == _KIND_NODE[kind], "fixture unrolled to a display"
+    return node, rewritten
+
+
+def _stranded(kind: str, tag: str):
+    """A rewritten consumer whose producer row is EXPLICITLY dropped.
+
+    A rewrite alone no longer strands anything: #7346-A keys the relation by
+    ``SourceOccurrenceIdentityV1``, and ``shadow.rewrite`` borrows the origin's
+    span, so the rewrite joins its own row.  The refusal these teeth pin is a
+    property of a FAILED AUTHENTICATED LOOKUP, not of the rewrite that used to
+    cause one -- so the row is now removed on purpose, and the teeth below bite
+    on exactly the same refusal as before.
+    """
+    from sugar_source_tree.occurrence import SourceOccurrenceIdentityV1
+
+    node, rewritten = _rewritten(kind, tag=f"stranded-{kind}-{tag}")
+    rewritten.unit._target_patterns_by_consumer.pop(
+        SourceOccurrenceIdentityV1.of(rewritten)
+    )
     return node, rewritten
 
 
@@ -211,15 +236,32 @@ def test_producer_publishes_enrollment_for_a_destructuring_comprehension():
     assert enrollment.covers(node.generators[0].target)
 
 
-def test_a_rewritten_consumer_stays_enrolled_although_its_row_is_gone():
-    """The two facts are separable: still OWED, no longer FOUND."""
-    _, rewritten = _rewritten("py.setcomp")
+def test_a_rewritten_consumer_keeps_both_its_enrollment_and_its_row():
+    """#7346-A: a rewrite is no longer a way to lose a row.
+
+    The relation is keyed by source occurrence and ``shadow.rewrite`` borrows
+    the origin's span, so the rewritten consumer is the SAME occurrence and
+    joins the producer's row -- with no per-consumer retention call.
+    """
+    origin, rewritten = _rewritten("py.setcomp")
 
     assert isinstance(
         rewritten.unit.target_pattern_enrollment(rewritten), TargetPatternEnrolledV1
     )
+    assert rewritten.unit.require_target_patterns(
+        rewritten
+    ) == origin.unit.require_target_patterns(origin)
+
+
+def test_an_enrolled_consumer_whose_row_is_gone_stays_owed_and_refuses():
+    """The two facts are still separable: still OWED, no longer FOUND."""
+    _, stranded = _stranded("py.setcomp", "owed-but-not-found")
+
+    assert isinstance(
+        stranded.unit.target_pattern_enrollment(stranded), TargetPatternEnrolledV1
+    )
     with pytest.raises(TargetPatternConstructionGapV1):
-        rewritten.unit.require_target_patterns(rewritten)
+        stranded.unit.require_target_patterns(stranded)
 
 
 # --------------------------------------------------------------------------
@@ -234,12 +276,12 @@ def test_a_rewritten_consumer_stays_enrolled_although_its_row_is_gone():
 
 @pytest.mark.parametrize("kind", sorted(_REWRITE_SOURCES))
 def test_stranded_target_pattern_never_reaches_a_complete_verdict(kind):
-    _, rewritten = _rewritten(kind)
+    _, stranded = _stranded(kind, "never-reaches-complete")
 
     with pytest.raises(
         (TargetPatternConstructionGapV1, FiniteProjectionRefusalV1)
     ) as refused:
-        rewritten.sugar().desugar(None)
+        stranded.sugar().desugar(None)
 
     # On the merged tree the producer-side door is the one that bites.
     assert isinstance(refused.value, TargetPatternConstructionGapV1)

--- a/implementations/python/sugar-lift-py-tests/tests/test_finite_projection_decision.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_finite_projection_decision.py
@@ -1,0 +1,398 @@
+"""Teeth for the closed finite-projection decision (#7347).
+
+The defect: `_finite_map` answered a bare `None` for at least four distinct
+facts, `_after_iterable` erased all four into one symbolic fallback, and the
+comprehension issued `Complete(ComprehensionValue, finite_elements=None)`. A
+comprehension whose finite projection was lost to a STRANDED AUTHENTICATED
+LOOKUP was therefore indistinguishable, at the verdict, from a genuinely
+unbounded one.
+
+Both arms are pinned here on purpose. Lawful inapplicability MUST still reach
+symbolic `Complete`; a failed authenticated lookup MUST refuse. A test that
+only shows the refusal proves nothing about whether the lawful arm survived.
+"""
+
+from dataclasses import dataclass, replace
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.floor.comprehension_value import ComprehensionValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.comprehension_sugar import (
+    ComprehensionGeneratorSugar,
+    ComprehensionSugar,
+    ComprehensionTargetSugar,
+)
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_py_tests.sugar.finite_projection import (
+    FiniteProjectionNonSuccessV1,
+    FiniteProjectionRefusalV1,
+    NotProjected,
+    Projected,
+    require_finite_projection_decision,
+)
+from sugar_source_tree.nodes import (
+    TargetPatternConstructionGapV1,
+    TargetPatternEnrolledV1,
+)
+from producer_minted_enrollment import producer_enrolled, producer_not_enrolled
+from sugar_source_tree.tree import SourceFile
+
+
+@dataclass(frozen=True)
+class _InertSugar(ConstructedTermSugar):
+    """A well-formed iterable sugar, so a constructor raise has ONE cause."""
+
+    @classmethod
+    def witnesses(cls):
+        return ()
+
+    def desugar(self, ctx=None):
+        del ctx
+        return Complete(None)
+
+    def to_term(self, *, owner: str):
+        del owner
+        raise AssertionError("inert sugar is never termed")
+
+
+def _source_file(source: str):
+    return SourceFile(
+        (
+            source,
+            "tests/finite_projection_decision_fixture.py",
+            blake3_512_of(source.encode()),
+        ),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+    )
+
+
+def _symbolic_binding():
+    """A real Node to bind a name to, whose value is not ground."""
+    source = "def g(seed):\n    return seed\n"
+    return next(
+        node
+        for node in _source_file(source).root.walk()
+        if node.kind == "Name" and node.id == "seed"
+    )
+
+
+_REWRITE_SOURCES = {
+    # A finite literal iterable, a DESTRUCTURING target, and an element that
+    # mentions a free name. Substituting that name rewrites the comprehension
+    # (fresh parent ref) while keeping the iterable exactly finite -- the exact
+    # shape #7347 executed.
+    "py.setcomp": "def build(y):\n    return {(a, b, y) for a, b in [(1, 2), (3, 4)]}\n",
+    "py.dictcomp": (
+        "def build(y):\n    return {(a, y): b for a, b in [(1, 2), (3, 4)]}\n"
+    ),
+    "py.generatorexp": (
+        "def build(y):\n    return ((a, b, y) for a, b in [(1, 2), (3, 4)])\n"
+    ),
+}
+_KIND_NODE = {
+    "py.setcomp": "SetComp",
+    "py.dictcomp": "DictComp",
+    "py.generatorexp": "GeneratorExp",
+}
+
+
+def _rewritten(kind: str):
+    source_file = _source_file(_REWRITE_SOURCES[kind])
+    node = next(
+        candidate
+        for candidate in source_file.nodes()
+        if candidate.kind == _KIND_NODE[kind]
+    )
+    rewritten = node.substitute({"y": _symbolic_binding()})
+    assert rewritten is not node, "fixture did not rewrite the comprehension"
+    assert rewritten.kind == _KIND_NODE[kind], "fixture unrolled to a display"
+    return node, rewritten
+
+
+# --------------------------------------------------------------------------
+# The carrier is closed at the TYPE, not at a guard.
+# --------------------------------------------------------------------------
+
+
+def test_the_non_success_reasons_are_exactly_the_four_ruled_causes():
+    assert {reason.value for reason in FiniteProjectionNonSuccessV1} == {
+        "lawfully-inapplicable",
+        "projection-unavailable-in-context",
+        "authenticated-lookup-failed",
+        "replacement-failed",
+    }
+
+
+def test_the_decision_boundary_rejects_none():
+    with pytest.raises(TypeError):
+        require_finite_projection_decision(None, owner="tooth")
+
+
+def test_the_decision_boundary_rejects_a_foreign_value():
+    with pytest.raises(TypeError):
+        require_finite_projection_decision(Complete(None), owner="tooth")
+
+
+def test_not_projected_rejects_an_undeclared_reason():
+    with pytest.raises(TypeError):
+        NotProjected("authenticated-lookup-failed")
+    with pytest.raises(TypeError):
+        NotProjected(None)
+
+
+def test_projected_transports_an_outcome_and_never_none():
+    with pytest.raises(TypeError):
+        Projected(None)
+    with pytest.raises(TypeError):
+        Projected(object())
+
+
+def test_enrollment_values_are_producer_minted_and_cannot_be_forged():
+    """#7348 owns the type and its authority. This sugar mints nothing."""
+    from sugar_source_tree.nodes import TargetPatternNotEnrolledV1
+
+    with pytest.raises(TargetPatternConstructionGapV1):
+        TargetPatternNotEnrolledV1(
+            consumer_occurrence=None, reason="consumer-shape-not-enrolled"
+        )
+    assert isinstance(producer_not_enrolled(), TargetPatternNotEnrolledV1)
+
+
+def _generator(**overrides):
+    fields = dict(
+        target=ComprehensionTargetSugar(source_name="x"),
+        binding_coordinate_cid="cid",
+        iterable=_InertSugar(),
+        filters=(),
+        target_pattern_enrollment=producer_not_enrolled(),
+    )
+    fields.update(overrides)
+    return ComprehensionGeneratorSugar(**fields)
+
+
+def test_generator_sugar_requires_a_producer_enrollment_answer():
+    # The control: every other field is well-formed, so a raise can only be
+    # about the enrollment answer.
+    assert _generator() is not None
+
+    fields = dict(
+        target=ComprehensionTargetSugar(source_name="x"),
+        binding_coordinate_cid="cid",
+        iterable=_InertSugar(),
+        filters=(),
+    )
+    with pytest.raises(TypeError) as missing:
+        ComprehensionGeneratorSugar(**fields)
+    assert "target_pattern_enrollment" in str(missing.value)
+
+    with pytest.raises(TypeError) as absent:
+        _generator(target_pattern_enrollment=None)
+    assert "target_pattern_enrollment" in str(absent.value)
+
+    with pytest.raises(TypeError) as foreign:
+        _generator(target_pattern_enrollment="enrolled")
+    assert "target_pattern_enrollment" in str(foreign.value)
+
+
+# --------------------------------------------------------------------------
+# The producer publishes enrollment; this reader never reconstructs it.
+# --------------------------------------------------------------------------
+
+
+def test_producer_publishes_enrollment_for_a_destructuring_comprehension():
+    node, enrollment = producer_enrolled(_REWRITE_SOURCES["py.setcomp"], "SetComp")
+
+    assert isinstance(enrollment, TargetPatternEnrolledV1)
+    # The consumer-level answer covers THIS generator slot -- the assumption
+    # `_finite_map` rests on, pinned rather than argued.
+    assert enrollment.covers(node.generators[0].target)
+
+
+def test_a_rewritten_consumer_stays_enrolled_although_its_row_is_gone():
+    """The two facts are separable: still OWED, no longer FOUND."""
+    _, rewritten = _rewritten("py.setcomp")
+
+    assert isinstance(
+        rewritten.unit.target_pattern_enrollment(rewritten), TargetPatternEnrolledV1
+    )
+    with pytest.raises(TargetPatternConstructionGapV1):
+        rewritten.unit.require_target_patterns(rewritten)
+
+
+# --------------------------------------------------------------------------
+# ARM ONE: a failed authenticated lookup refuses and never reaches Complete.
+#
+# THE JOIN. On the merged tree #7348's `_recurrence_generators` reads the row
+# STRICTLY, so a stranded comprehension now refuses at SUGAR CONSTRUCTION,
+# before `_finite_map` is ever called. The verdict-level defect is closed
+# twice over, and these two teeth say which door bites where.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", sorted(_REWRITE_SOURCES))
+def test_stranded_target_pattern_never_reaches_a_complete_verdict(kind):
+    _, rewritten = _rewritten(kind)
+
+    with pytest.raises(
+        (TargetPatternConstructionGapV1, FiniteProjectionRefusalV1)
+    ) as refused:
+        rewritten.sugar().desugar(None)
+
+    # On the merged tree the producer-side door is the one that bites.
+    assert isinstance(refused.value, TargetPatternConstructionGapV1)
+    assert refused.value.reason == "foreign-target-occurrence"
+
+
+@pytest.mark.parametrize("kind", sorted(_REWRITE_SOURCES))
+def test_the_projection_arm_still_refuses_an_enrolled_slot_without_its_pattern(kind):
+    """The backstop, exercised directly.
+
+    #7348 closed the producer path that USED to reach here. The decision arm
+    stays because the invariant is a property of the projection, not of one
+    caller: any future callsite that hands `_finite_map` an enrolled slot with
+    no pattern must refuse, not spend a `Complete`.
+    """
+    from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+    node, enrollment = producer_enrolled(_REWRITE_SOURCES[kind], _KIND_NODE[kind])
+    sugar = node.sugar()
+    stranded = replace(
+        sugar.generators[0],
+        target_coordinates=(),
+        target_pattern=None,
+    )
+    assert stranded.target.coordinates is not None
+    assert isinstance(stranded.target_pattern_enrollment, TargetPatternEnrolledV1)
+
+    decision = sugar._finite_map(stranded, TupleValue(()), None)
+
+    assert decision == NotProjected(
+        FiniteProjectionNonSuccessV1.AUTHENTICATED_LOOKUP_FAILED
+    )
+    with pytest.raises(FiniteProjectionRefusalV1) as refused:
+        sugar._after_iterable(stranded, TupleValue(()), 0, (), None)
+    assert (
+        refused.value.reason
+        is FiniteProjectionNonSuccessV1.AUTHENTICATED_LOOKUP_FAILED
+    )
+    assert refused.value.construct == kind
+    assert refused.value.coordinate
+    assert refused.value.shape == "destructure:2"
+
+
+# --------------------------------------------------------------------------
+# ARM TWO: the lawful arms are untouched. Symbolic Complete stays lawful.
+# --------------------------------------------------------------------------
+
+
+def test_a_genuinely_unbounded_comprehension_still_completes_symbolically():
+    source = "def build(items):\n    return {a for a in items}\n"
+    node = next(
+        candidate for candidate in _source_file(source).nodes()
+        if candidate.kind == "SetComp"
+    )
+
+    outcome = node.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+    assert isinstance(outcome.value, ComprehensionValue)
+    assert outcome.value.finite_elements is None
+
+
+def test_the_listcomp_retention_control_still_projects_finite_elements():
+    source = (
+        "def build():\n"
+        "    return [(left, right) for left, right in [(1, 2), (3, 4)]]\n"
+    )
+    call_source = source + "build()\n"
+    call = tuple(
+        node
+        for node in _source_file(call_source).nodes()
+        if node.kind == "Call" and node.func.kind == "Name" and node.func.id == "build"
+    )[-1]
+
+    outcome = call.sugar().desugar(None)
+
+    assert isinstance(outcome, Complete)
+
+
+def test_a_lawful_reason_is_not_spent_as_a_refusal():
+    """`_finite_map` answers a typed non-success, not a bare sentinel."""
+    source = "def build(items):\n    return {a for a in items}\n"
+    node = next(
+        candidate for candidate in _source_file(source).nodes()
+        if candidate.kind == "SetComp"
+    )
+    sugar = node.sugar()
+    generator = sugar.generators[0]
+
+    decision = sugar._finite_map(generator, object(), None)
+
+    require_finite_projection_decision(decision, owner="tooth")
+    assert decision == NotProjected(
+        FiniteProjectionNonSuccessV1.LAWFULLY_INAPPLICABLE
+    )
+
+
+def test_projection_unavailable_in_context_is_its_own_reason():
+    """A finite iterable plus a context with no temporal projection."""
+    from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+    source = "def build(items):\n    return {a for a in items}\n"
+    node = next(
+        candidate for candidate in _source_file(source).nodes()
+        if candidate.kind == "SetComp"
+    )
+    sugar = node.sugar()
+
+    decision = sugar._finite_map(sugar.generators[0], TupleValue(()), None)
+
+    assert decision == NotProjected(
+        FiniteProjectionNonSuccessV1.PROJECTION_UNAVAILABLE_IN_CONTEXT
+    )
+
+
+def test_replacement_failure_is_its_own_reason_and_never_a_finite_verdict():
+    """A context that carries `temporal` but cannot be replaced."""
+    from sugar_lift_py_tests.floor.tuple_value import TupleValue
+
+    class _UnreplaceableContext:
+        temporal = object()
+
+    source = "def build(items):\n    return {a for a in items}\n"
+    node = next(
+        candidate for candidate in _source_file(source).nodes()
+        if candidate.kind == "SetComp"
+    )
+    sugar = node.sugar()
+
+    decision = sugar._finite_map(
+        sugar.generators[0], TupleValue(()), _UnreplaceableContext()
+    )
+
+    assert decision == NotProjected(FiniteProjectionNonSuccessV1.REPLACEMENT_FAILED)
+    with pytest.raises(FiniteProjectionRefusalV1) as refused:
+        sugar._after_iterable(
+            sugar.generators[0], TupleValue(()), 0, (), _UnreplaceableContext()
+        )
+    assert refused.value.reason is FiniteProjectionNonSuccessV1.REPLACEMENT_FAILED
+
+
+def test_swapped_target_coordinates_still_refuse():
+    """A pre-existing refusal, re-run: this change weakens nothing."""
+    from sugar_source_tree.nodes import TargetPatternConstructionGapV1
+
+    source = "def build():\n    return [(left, right) for left, right in [(1, 2)]]\n"
+    comprehension = next(
+        node for node in _source_file(source).nodes() if node.kind == "ListComp"
+    ).sugar()
+    generator = comprehension.generators[0]
+
+    with pytest.raises(TargetPatternConstructionGapV1):
+        replace(
+            generator,
+            target_coordinates=tuple(reversed(generator.target_coordinates)),
+        )

--- a/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_module_prefix_one_roll_materialization.py
@@ -80,7 +80,7 @@ def test_module_prefix_tables_are_from_one_reporter_roll(monkeypatch, name) -> N
             assert binding.unit is unit
 
     assign = source_file.root.body[1]
-    patterns = unit.target_patterns_for(assign)
+    patterns = unit.require_target_patterns(assign)
     assert len(patterns) == 1
     assert patterns[0].consumer_occurrence is assign
     assert patterns[0].source_unit is unit

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -50,6 +50,7 @@ from .nodes import (
     Typeable,
     resolve_kind,
 )
+from .occurrence import SourceOccurrenceIdentityV1
 from .operators import Operator
 from .panic import BackendDefect, backend_defect
 from .reporter import NULL_REPORTER, AuditReporter
@@ -507,6 +508,8 @@ class _ConstructedModuleV1(_SealedBackendRelation):
     root: object
     closed_roll_call: object
     function_nodes: tuple[object, ...]
+    # Keyed by SourceOccurrenceIdentityV1, never by the producer's Node shell:
+    # a rewritten shell over the same occurrence must join this row (#7346-A).
     function_class_owners: tuple[tuple[object, object | None], ...]
     lexical_call_rows: tuple[object, ...]
     provider_member_rows: tuple[object, ...]
@@ -741,7 +744,9 @@ class Backend:
         positions = {
             id(node): position for position, node in enumerate(constructed_nodes)
         }
-        function_class_owners_list: list[tuple[Node, ClassDef | None]] = []
+        function_class_owners_list: list[
+            tuple[SourceOccurrenceIdentityV1, ClassDef | None]
+        ] = []
         for function in function_nodes:
             position = positions[id(function)]
             ancestor_position = parent_positions[position]
@@ -754,7 +759,9 @@ class Backend:
                     class_owner = ancestor
                     break
                 ancestor_position = parent_positions[ancestor_position]
-            function_class_owners_list.append((function, class_owner))
+            function_class_owners_list.append(
+                (SourceOccurrenceIdentityV1.of(function), class_owner)
+            )
         function_class_owners = tuple(function_class_owners_list)
         unit.bind_typed_module(
             root,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/backend.py
@@ -48,6 +48,7 @@ from .nodes import (
     Node,
     SourceUnit,
     Typeable,
+    mint_lexical_call_enrollment,
     resolve_kind,
 )
 from .occurrence import SourceOccurrenceIdentityV1
@@ -512,6 +513,10 @@ class _ConstructedModuleV1(_SealedBackendRelation):
     # a rewritten shell over the same occurrence must join this row (#7346-A).
     function_class_owners: tuple[tuple[object, object | None], ...]
     lexical_call_rows: tuple[object, ...]
+    # Closed producer decision for EVERY call occurrence, keyed by
+    # SourceOccurrenceIdentityV1 (#7346-A/#7348). A rewritten shell over the
+    # same occurrence joins; a miss is a refusal, never "not enrolled".
+    lexical_call_enrollments: tuple[tuple[object, object], ...]
     provider_member_rows: tuple[object, ...]
     leaf_assertion_rows: tuple[object, ...]
     construction_event_receipt: object
@@ -826,11 +831,29 @@ class Backend:
                         events.append((position, target.id, None))
 
         lexical_rows = []
+        # The SAME walk publishes its closed applicability decision for EVERY
+        # call occurrence, not only the positive rows (#7348).  Each `continue`
+        # below is a decision this walk already made; it is now named and
+        # published instead of discarded.  No consumer re-derives it.
+        lexical_enrollments: list[tuple[object, object]] = []
+
+        def publish(call_node, reason: str | None) -> None:
+            lexical_enrollments.append(
+                (
+                    SourceOccurrenceIdentityV1.of(call_node),
+                    mint_lexical_call_enrollment(call_node, reason),
+                )
+            )
+
         for call_position, call in enumerate(constructed_nodes):
-            if not isinstance(call, Call) or not isinstance(call.func, Name):
+            if not isinstance(call, Call):
+                continue
+            if not isinstance(call.func, Name):
+                publish(call, "non-name-callee")
                 continue
             call_scope_position = scope_at_position[call_position]
             if call_scope_position == module_position:
+                publish(call, "module-scope-call")
                 continue
             search_scope = call_scope_position
             definition = None
@@ -860,7 +883,14 @@ class Backend:
                 if search_scope == module_position:
                     break
             if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+                publish(
+                    call,
+                    "no-lexical-binding-in-scope"
+                    if definition_scope_position is None
+                    else "binding-not-a-function-definition",
+                )
                 continue
+            publish(call, None)
             row = object.__new__(_BackendLexicalCallRowV1)
             _close_private(
                 row,
@@ -874,6 +904,7 @@ class Backend:
             )
             lexical_rows.append(row)
         lexical_call_rows = tuple(lexical_rows)
+        lexical_call_enrollments = tuple(lexical_enrollments)
 
         provider_rows = []
         for node in constructed_nodes:
@@ -1022,6 +1053,7 @@ class Backend:
             function_nodes=function_nodes,
             function_class_owners=function_class_owners,
             lexical_call_rows=lexical_call_rows,
+            lexical_call_enrollments=lexical_call_enrollments,
             provider_member_rows=provider_member_rows,
             leaf_assertion_rows=leaf_assertion_rows,
             construction_event_receipt=receipt,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1319,8 +1319,38 @@ def _cv2_entries(value: object) -> tuple[str, list[tuple[Any, object]]]:
     arm is a typed gap, never reflection over ``__dict__`` and never
     ``.wire()``.
     """
-    from sugar_source_tree.nodes import TargetPatternV1
+    from sugar_source_tree.nodes import (
+        TargetPatternEnrolledV1,
+        TargetPatternNotEnrolledV1,
+        TargetPatternV1,
+    )
 
+    # The closed producer-owned enrollment outcome (#7348) is seated INTO the
+    # constructed comprehension sugar, so it is a constructed value and needs a
+    # NAMED category -- reflection over its slots is exactly what this function
+    # refuses to do.  The two variants carry different content and different
+    # type tags, so no encoding of one can ever be read as the other.
+    if type(value) is TargetPatternEnrolledV1:
+        return (
+            _cv2_type_tag(value),
+            [
+                ("consumer", value.consumer_occurrence.fragment),
+                # Order and arity are authenticated by the tuple arm: dropping,
+                # duplicating or reordering an enrolled target changes the CID.
+                (
+                    "enrolledTargets",
+                    tuple(target.fragment for target in value.enrolled_targets),
+                ),
+            ],
+        )
+    if type(value) is TargetPatternNotEnrolledV1:
+        return (
+            _cv2_type_tag(value),
+            [
+                ("consumer", value.consumer_occurrence.fragment),
+                ("reason", value.reason),
+            ],
+        )
     if (
         type(value) is TargetPatternV1
         and value.receipt is not None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -10259,6 +10259,9 @@ class ListComp(Expression):
                     filters=tuple(guard.sugar() for guard in gen.ifs),
                     target_coordinates=target_coordinates,
                     target_pattern=target_pattern,
+                    target_pattern_enrollment=self.unit.target_pattern_enrollment(
+                        self
+                    ),
                 )
             )
         return tuple(specs)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -203,6 +203,130 @@ class TargetPatternConstructionGapV1(TypeError):
         self.actual_coordinates = actual_coordinates
 
 
+_TARGET_PATTERN_ENROLLMENT_AUTHORITY = object()
+
+
+class TargetPatternEnrollmentV1:
+    """Closed producer-owned applicability outcome for the target relation.
+
+    ``SourceUnit.bind_typed_module`` already decides, during its one structural
+    walk, whether a constructed node is a target-pattern consumer.  Before this
+    type existed the walk published only positive rows, so a consumer that
+    wanted the applicability answer had to read the relation and treat an empty
+    tuple as "not enrolled" -- which also swallowed "the table was never built"
+    and "the enrolled row was stranded by a rewrite".
+
+    Exactly two variants exist and only the producer may mint them.  This type
+    answers *"is this shape enrolled?"* and nothing else; *"did my lookup find
+    the row?"* is answered separately and loudly by ``require_target_pattern``
+    / ``require_target_patterns``.  The two questions never share a value.
+    """
+
+    __slots__ = ("consumer_occurrence",)
+
+    _variants_closed = False
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        if TargetPatternEnrollmentV1._variants_closed:
+            raise TargetPatternConstructionGapV1(
+                "target-pattern-enrollment-variant-not-closed",
+                consumer_occurrence=cls,
+                target_occurrence=None,
+            )
+
+    def __init__(self, *, consumer_occurrence, _authority=None) -> None:
+        if _authority is not _TARGET_PATTERN_ENROLLMENT_AUTHORITY:
+            raise TargetPatternConstructionGapV1(
+                "target-pattern-enrollment-not-producer-minted",
+                consumer_occurrence=consumer_occurrence,
+                target_occurrence=None,
+            )
+        object.__setattr__(self, "consumer_occurrence", consumer_occurrence)
+
+    def __setattr__(self, name, value):  # pragma: no cover - immutability guard
+        raise TargetPatternConstructionGapV1(
+            "target-pattern-enrollment-is-immutable",
+            consumer_occurrence=self.consumer_occurrence,
+            target_occurrence=None,
+        )
+
+
+class TargetPatternEnrolledV1(TargetPatternEnrollmentV1):
+    """This occurrence is an enrolled target-pattern consumer.
+
+    ``enrolled_targets`` are the exact target occurrences the producer minted a
+    ``TargetPatternV1`` for.  The row itself is deliberately NOT carried here:
+    binding the product into the outcome requires the durable occurrence
+    identity ruled in #7346, which has not landed.  Until then the row is read
+    strictly and separately, so a stranded row refuses instead of degrading
+    into this value.
+    """
+
+    __slots__ = ("enrolled_targets", "_projection_sites")
+
+    def __init__(self, *, consumer_occurrence, projection_sites, _authority=None):
+        super().__init__(
+            consumer_occurrence=consumer_occurrence, _authority=_authority
+        )
+        sites = tuple(projection_sites)
+        object.__setattr__(self, "_projection_sites", sites)
+        object.__setattr__(
+            self, "enrolled_targets", tuple(target for target, _ in sites)
+        )
+        if not self.enrolled_targets:
+            raise TargetPatternConstructionGapV1(
+                "enrolled-target-pattern-consumer-without-targets",
+                consumer_occurrence=consumer_occurrence,
+                target_occurrence=None,
+            )
+
+    def covers(self, target) -> bool:
+        return any(
+            candidate is target or candidate.ref is target.ref
+            for candidate in self.enrolled_targets
+        )
+
+    def __repr__(self) -> str:
+        return f"TargetPatternEnrolledV1(targets={len(self.enrolled_targets)})"
+
+
+_TARGET_PATTERN_NON_ENROLLMENT_REASONS = frozenset(
+    {
+        # The node kind (or, for ``Assign``, every one of its targets) carries
+        # no lexical binding pattern at all.
+        "consumer-shape-not-enrolled",
+        # Candidate targets exist for this shape, but none of them introduces a
+        # lexical binding leaf (e.g. ``self.a, self.b = ...``: pure store).
+        "no-binding-leaf-target",
+    }
+)
+
+
+class TargetPatternNotEnrolledV1(TargetPatternEnrollmentV1):
+    """This occurrence is lawfully outside the target-pattern relation."""
+
+    __slots__ = ("reason",)
+
+    def __init__(self, *, consumer_occurrence, reason, _authority=None):
+        super().__init__(
+            consumer_occurrence=consumer_occurrence, _authority=_authority
+        )
+        if reason not in _TARGET_PATTERN_NON_ENROLLMENT_REASONS:
+            raise TargetPatternConstructionGapV1(
+                "target-pattern-non-enrollment-reason-not-declared",
+                consumer_occurrence=consumer_occurrence,
+                target_occurrence=None,
+            )
+        object.__setattr__(self, "reason", reason)
+
+    def __repr__(self) -> str:
+        return f"TargetPatternNotEnrolledV1({self.reason!r})"
+
+
+TargetPatternEnrollmentV1._variants_closed = True
+
+
 _TARGET_PATTERN_RECEIPT_AUTHORITY = object()
 
 
@@ -763,31 +887,17 @@ class SourceUnit:
         patterns_by_target = {}
         constructed_count = 0
         for consumer in constructed_nodes:
-            targets = ()
-            if isinstance(consumer, Assign):
-                targets = tuple(
-                    (target, ("targets", target_index))
-                    for target_index, target in enumerate(consumer.targets)
-                    if isinstance(target, (Tuple_, List))
-                    and self._is_binding_target_pattern(target)
-                )
-            elif isinstance(consumer, For):
-                targets = ((consumer.target, ("target",)),)
-            elif isinstance(consumer, (ListComp, SetComp, DictComp, GeneratorExp)):
-                targets = tuple(
-                    (generator.target, ("generators", index, "target"))
-                    for index, generator in enumerate(consumer.generators)
-                )
-            if not targets:
+            # ONE decision, published.  The walk and every consumer of the
+            # applicability question call the same function; nobody re-derives
+            # enrollment from node kinds or from an empty relation read.
+            enrollment = self.target_pattern_enrollment(consumer)
+            if not isinstance(enrollment, TargetPatternEnrolledV1):
                 continue
             owned = tuple(
-                pattern
-                for target, prefix in targets
-                if (pattern := self._construct_target_pattern(consumer, target, prefix))
-                is not None
+                self._construct_target_pattern(consumer, target, prefix)
+                for target, prefix in enrollment._projection_sites
             )
-            if owned:
-                patterns[consumer.ref] = owned
+            patterns[consumer.ref] = owned
             patterns_by_target.update(
                 (pattern.target_occurrence.ref, pattern) for pattern in owned
             )
@@ -810,6 +920,71 @@ class SourceUnit:
                 SourceUnit._is_binding_target_pattern(child) for child in target.elts
             )
         return False
+
+    @staticmethod
+    def _owns_binding_leaf(target) -> bool:
+        """True when this target introduces at least one lexical binding leaf.
+
+        ``_construct_target_pattern`` mints a product exactly when this holds.
+        One predicate serves both the producer walk and the published
+        enrollment outcome, so there is no second answer to enrollment.
+        """
+        if isinstance(target, Name):
+            return True
+        if isinstance(target, Starred):
+            return SourceUnit._owns_binding_leaf(target.value)
+        if isinstance(target, (Tuple_, List)):
+            return any(
+                SourceUnit._owns_binding_leaf(child) for child in target.elts
+            )
+        return False
+
+    def target_pattern_enrollment(self, consumer) -> TargetPatternEnrollmentV1:
+        """The producer's ONE closed applicability decision for a consumer.
+
+        Total and lookup-free: it answers "is this shape enrolled?" without
+        touching the relation table, so it cannot be confused with "did my
+        lookup find the row?".  ``bind_typed_module`` calls this same function
+        while walking, which is what makes it authoritative rather than a
+        reconstruction.
+        """
+        sites = ()
+        if isinstance(consumer, Assign):
+            sites = tuple(
+                (target, ("targets", target_index))
+                for target_index, target in enumerate(consumer.targets)
+                if isinstance(target, (Tuple_, List))
+                and self._is_binding_target_pattern(target)
+            )
+        elif isinstance(consumer, For):
+            sites = ((consumer.target, ("target",)),)
+        elif isinstance(consumer, (ListComp, SetComp, DictComp, GeneratorExp)):
+            sites = tuple(
+                (generator.target, ("generators", index, "target"))
+                for index, generator in enumerate(consumer.generators)
+            )
+        if not sites:
+            return TargetPatternNotEnrolledV1(
+                consumer_occurrence=consumer,
+                reason="consumer-shape-not-enrolled",
+                _authority=_TARGET_PATTERN_ENROLLMENT_AUTHORITY,
+            )
+        binding_sites = tuple(
+            (target, prefix)
+            for target, prefix in sites
+            if self._owns_binding_leaf(target)
+        )
+        if not binding_sites:
+            return TargetPatternNotEnrolledV1(
+                consumer_occurrence=consumer,
+                reason="no-binding-leaf-target",
+                _authority=_TARGET_PATTERN_ENROLLMENT_AUTHORITY,
+            )
+        return TargetPatternEnrolledV1(
+            consumer_occurrence=consumer,
+            projection_sites=binding_sites,
+            _authority=_TARGET_PATTERN_ENROLLMENT_AUTHORITY,
+        )
 
     def _construct_target_pattern(
         self, consumer, target, prefix
@@ -842,7 +1017,14 @@ class SourceUnit:
 
         visit(target, prefix)
         if not ordered:
-            return None
+            # Unreachable: the producer only mints for sites the published
+            # enrollment decision named.  Loud rather than ``None`` so the two
+            # can never silently diverge.
+            raise TargetPatternConstructionGapV1(
+                "enrolled-target-without-binding-leaf",
+                consumer_occurrence=consumer,
+                target_occurrence=target,
+            )
         owner_cid = (
             consumer.owned_loop_target.target_cid
             if isinstance(consumer, For) and consumer.owned_loop_target is not None
@@ -865,15 +1047,59 @@ class SourceUnit:
             coordinates=coordinates,
         )
 
-    def target_patterns_for(self, consumer: "Node") -> tuple[TargetPatternV1, ...]:
+    def _seated_target_patterns(self, consumer):
+        """Raw relation read.  ``None`` means exactly one thing: lookup missed.
+
+        Callers never see this; every public reader turns a miss into a typed
+        refusal.  Non-enrollment is not expressible here -- that question is
+        answered by ``target_pattern_enrollment`` and by nothing else.
+        """
         patterns = self._target_patterns_by_consumer
         if patterns is None:
-            return ()
-        return patterns.get(consumer.ref, ())
+            raise TargetPatternConstructionGapV1(
+                "target-pattern-table-not-built",
+                consumer_occurrence=consumer,
+                target_occurrence=None,
+            )
+        return patterns.get(consumer.ref)
+
+    def require_target_patterns(
+        self, consumer: "Node"
+    ) -> tuple[TargetPatternV1, ...]:
+        """Strict read of an ENROLLED consumer's producer-owned products.
+
+        Three facts that used to collapse into one empty tuple now have three
+        distinct representations:
+
+        * table never built  -> ``target-pattern-table-not-built`` refusal;
+        * lawfully not enrolled -> ``TargetPatternNotEnrolledV1`` (a value,
+          obtained from ``target_pattern_enrollment``, never from here);
+        * enrolled but stranded -> ``foreign-target-occurrence`` refusal.
+        """
+        enrollment = self.target_pattern_enrollment(consumer)
+        if not isinstance(enrollment, TargetPatternEnrolledV1):
+            raise TargetPatternConstructionGapV1(
+                "not-an-enrolled-target-pattern-consumer",
+                consumer_occurrence=consumer,
+                target_occurrence=None,
+            )
+        owned = self._seated_target_patterns(consumer)
+        if not owned:
+            raise TargetPatternConstructionGapV1(
+                "foreign-target-occurrence",
+                consumer_occurrence=consumer,
+                target_occurrence=None,
+            )
+        return owned
 
     def retain_target_patterns(self, source_consumer, rewritten_consumer) -> None:
         """Seat one rewrite with its exact source consumer's immutable products."""
-        owned = self.target_patterns_for(source_consumer)
+        enrollment = self.target_pattern_enrollment(source_consumer)
+        owned = (
+            self._seated_target_patterns(source_consumer)
+            if isinstance(enrollment, TargetPatternEnrolledV1)
+            else None
+        )
         if not owned or type(rewritten_consumer) is not type(source_consumer):
             raise TargetPatternConstructionGapV1(
                 "foreign-target-consumer-rewrite",
@@ -884,9 +1110,16 @@ class SourceUnit:
         patterns[rewritten_consumer.ref] = owned
 
     def require_target_pattern(self, consumer, target) -> TargetPatternV1:
-        for pattern in self.target_patterns_for(consumer):
-            if pattern.target_occurrence.ref is target.ref:
-                return pattern
+        enrollment = self.target_pattern_enrollment(consumer)
+        if isinstance(enrollment, TargetPatternEnrolledV1):
+            for pattern in self._seated_target_patterns(consumer) or ():
+                if pattern.target_occurrence.ref is target.ref:
+                    return pattern
+        # Not-enrolled and lookup-missed are both refusals HERE by design: this
+        # door promises one exact enrolled pair or nothing.  Telling a foreign
+        # consumer apart from a stranded same-unit one needs the durable
+        # occurrence identity ruled in #7346; the reason string is unchanged
+        # until then so no existing refusal is weakened.
         raise TargetPatternConstructionGapV1(
             "foreign-target-occurrence",
             consumer_occurrence=consumer,
@@ -1969,9 +2202,17 @@ class Node(Typed):
         return cache
 
     @property
-    def target_patterns(self) -> tuple[TargetPatternV1, ...]:
-        """The eager occurrence-owned target products for this consumer."""
-        return self.unit.target_patterns_for(self)
+    def target_pattern_enrollment(self) -> TargetPatternEnrollmentV1:
+        """Is this shape an enrolled target-pattern consumer? (closed answer)"""
+        return self.unit.target_pattern_enrollment(self)
+
+    def require_target_patterns(self) -> tuple[TargetPatternV1, ...]:
+        """The eager occurrence-owned target products for an ENROLLED consumer.
+
+        Refuses rather than returning an empty tuple: absence of enrollment is
+        ``target_pattern_enrollment``, not a smaller product.
+        """
+        return self.unit.require_target_patterns(self)
 
     def __getattr__(self, name: str):
         # Field data is memoized on the unit once per site; this shell exposes it.
@@ -5184,7 +5425,12 @@ class Assign(Statement):
         if not changes:
             return self
         rewritten = rewrite(self, **changes)
-        if self.unit.target_patterns_for(self):
+        # Ask the applicability question, not the relation.  An enrolled Assign
+        # whose row went missing now refuses inside ``retain_target_patterns``
+        # instead of being mistaken for an ordinary/store target.
+        if isinstance(
+            self.unit.target_pattern_enrollment(self), TargetPatternEnrolledV1
+        ):
             self.unit.retain_target_patterns(self, rewritten)
         return rewritten
 
@@ -5310,7 +5556,13 @@ class Assign(Statement):
         target = self.targets[0]
         if not isinstance(target, (Tuple_, List)):
             return None
-        if not self.unit.target_patterns_for(self):
+        enrollment = self.unit.target_pattern_enrollment(self)
+        if not isinstance(
+            enrollment, TargetPatternEnrolledV1
+        ) or not enrollment.covers(target):
+            # Lawful fall-through: mixed / pure-store unpack owns no binding
+            # pattern.  This arm is now reached ONLY for authentic
+            # non-enrollment; a stranded enrolled row goes loud below.
             return None
         pattern = self.unit.require_target_pattern(self, target)
         return pattern.bindings_for(self.value)
@@ -9986,17 +10238,15 @@ class ListComp(Expression):
             target_pattern = None
             target_coordinates = ()
             if target.coordinates is not None:
-                matching_patterns = tuple(
-                    pattern
-                    for pattern in self.unit.target_patterns_for(self)
-                    if pattern.target_occurrence.ref is gen.target.ref
+                # A destructuring generator target IS an enrolled consumer
+                # site.  Zero rows here is a stranded relation, never "this
+                # comprehension is symbolic" -- so read strictly and let the
+                # refusal out instead of degrading to ``target_pattern=None``.
+                target_pattern = self.unit.require_target_pattern(self, gen.target)
+                target_coordinates = target_pattern.target_coordinates
+                self.unit.require_target_pattern_coordinates(
+                    target_pattern, target_coordinates
                 )
-                if len(matching_patterns) == 1:
-                    target_pattern = matching_patterns[0]
-                    target_coordinates = target_pattern.target_coordinates
-                    self.unit.require_target_pattern_coordinates(
-                        target_pattern, target_coordinates
-                    )
             specs.append(
                 ComprehensionGeneratorSugar(
                     target=target,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1155,6 +1155,16 @@ class SourceUnit:
             # silently dropped relation row is the exact defect class this
             # repair exists to end.  The invariant is believed, not proven, so
             # it is stated executably here instead of in a comment.
+            #
+            # The two writes are INDEPENDENTLY reachable and neither is the
+            # other's shadow, which is why both are guarded and both have a
+            # tooth.  A blanket collapse of every occurrence only ever reaches
+            # the consumer write -- it raises before the target loop runs -- so
+            # the target write needs its own lever: collapse ONE grammar kind
+            # (``Tuple``) and the two consumers stay distinct while their
+            # targets claim one key.  Both levers are exercised, and each guard
+            # dies alone under mutation (see
+            # test_the_two_duplicate_key_guards_are_independently_reachable).
             consumer_key = SourceOccurrenceIdentityV1.of(consumer)
             if consumer_key in patterns:
                 raise TargetPatternConstructionGapV1(

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1147,11 +1147,37 @@ class SourceUnit:
             # keeps its kind and unit, so a rewritten consumer denotes the SAME
             # occurrence and joins this row by construction -- for every enrolled
             # consumer at once, with no per-consumer retention to remember.
-            patterns[SourceOccurrenceIdentityV1.of(consumer)] = owned
-            patterns_by_target.update(
-                (SourceOccurrenceIdentityV1.of(pattern.target_occurrence), pattern)
-                for pattern in owned
-            )
+            #
+            # Both writes REFUSE a duplicate key rather than overwriting it.
+            # Ref-keying made a collision structurally impossible: two shells
+            # over one occurrence were two keys.  Occurrence-keying collapses
+            # them into one, so an overwrite becomes expressible -- and a
+            # silently dropped relation row is the exact defect class this
+            # repair exists to end.  The invariant is believed, not proven, so
+            # it is stated executably here instead of in a comment.
+            consumer_key = SourceOccurrenceIdentityV1.of(consumer)
+            if consumer_key in patterns:
+                raise TargetPatternConstructionGapV1(
+                    "duplicate-target-pattern-consumer-occurrence",
+                    consumer_occurrence=consumer,
+                    target_occurrence=None,
+                    target_pattern=(consumer_key, patterns[consumer_key], owned),
+                )
+            patterns[consumer_key] = owned
+            for pattern in owned:
+                target_key = SourceOccurrenceIdentityV1.of(pattern.target_occurrence)
+                if target_key in patterns_by_target:
+                    raise TargetPatternConstructionGapV1(
+                        "duplicate-target-pattern-target-occurrence",
+                        consumer_occurrence=consumer,
+                        target_occurrence=pattern.target_occurrence,
+                        target_pattern=(
+                            target_key,
+                            patterns_by_target[target_key],
+                            pattern,
+                        ),
+                    )
+                patterns_by_target[target_key] = pattern
             constructed_count += len(owned)
         object.__setattr__(self, "_target_patterns_by_consumer", patterns)
         object.__setattr__(self, "_target_patterns_by_target", patterns_by_target)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -328,6 +328,156 @@ class TargetPatternNotEnrolledV1(TargetPatternEnrollmentV1):
 TargetPatternEnrollmentV1._variants_closed = True
 
 
+_LEXICAL_CALL_ENROLLMENT_AUTHORITY = object()
+
+
+def _lexical_enrollment_defect(blame, observed: str, requested: str, fix: str):
+    return BackendDefect(
+        blame=blame,
+        owner="LexicalCallEnrollmentV1",
+        observed=observed,
+        requested=requested,
+        fix=fix,
+    )
+
+
+class LexicalCallEnrollmentV1:
+    """Closed producer-owned applicability outcome for the lexical relation.
+
+    ``Backend.materialize_module`` already decides, during its ONE structural
+    walk, which call occurrences receive a ``_BackendLexicalCallRowV1``: it
+    classifies the callee shape, the enclosing scope, and the binding event the
+    name resolves to.  It published only the positive rows.  A consumer that
+    wanted the applicability answer therefore read the relation and treated an
+    empty tuple as "not enrolled" -- which also swallowed "the enrolled row was
+    stranded by a rewrite" and "this occurrence was never walked at all".
+
+    This type transports the decision the walk ALREADY made; it is never
+    re-derived.  No consumer may repeat the backend's scope/binding walk.
+
+    Exactly two variants exist and only the producer may mint them.  Mirrors
+    ``TargetPatternEnrollmentV1`` deliberately, including the omission of the
+    product: the enrolled row is NOT carried here.  Carrying it would make this
+    table a second copy of the relation, and a stranded row would then be
+    unobservable.  "Is this occurrence enrolled?" is answered here; "did my
+    lookup find the row?" is answered separately and loudly by
+    ``SourceUnit.require_lexical_call_rows``.  The two questions never share a
+    value, and a LOOKUP MISS is a third, typed failure -- it can never
+    masquerade as either outcome.
+    """
+
+    __slots__ = ("call_occurrence",)
+
+    _variants_closed = False
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        if LexicalCallEnrollmentV1._variants_closed:
+            raise _lexical_enrollment_defect(
+                blame=getattr(cls, "__name__", cls),
+                observed="a third lexical-call enrollment variant",
+                requested="exactly two closed variants",
+                fix="extend the closed outcome deliberately, not by subclassing",
+            )
+
+    def __init__(self, *, call_occurrence, _authority=None) -> None:
+        if _authority is not _LEXICAL_CALL_ENROLLMENT_AUTHORITY:
+            raise _lexical_enrollment_defect(
+                blame=getattr(call_occurrence, "fragment", call_occurrence),
+                observed="lexical-call enrollment minted outside the producer",
+                requested="the one authoritative structural walk",
+                fix="publish enrollment from Backend.materialize_module only",
+            )
+        object.__setattr__(self, "call_occurrence", call_occurrence)
+
+    def __setattr__(self, name, value):  # pragma: no cover - immutability guard
+        raise _lexical_enrollment_defect(
+            blame=getattr(self.call_occurrence, "fragment", self.call_occurrence),
+            observed="mutation of a sealed lexical-call enrollment",
+            requested="an immutable producer outcome",
+            fix="mint a new outcome from the producer walk",
+        )
+
+
+class LexicalCallEnrolledV1(LexicalCallEnrollmentV1):
+    """This call occurrence IS in the lexical relation.
+
+    The row is deliberately not carried; read it strictly through
+    ``SourceUnit.require_lexical_call_rows`` so a stranded row refuses instead
+    of degrading into this value.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "LexicalCallEnrolledV1()"
+
+
+_LEXICAL_CALL_NON_ENROLLMENT_REASONS = frozenset(
+    {
+        # The callee is not a bare Name, so no lexical name resolution applies.
+        "non-name-callee",
+        # The call occurs at module scope; the relation covers calls inside a
+        # function scope only.
+        "module-scope-call",
+        # Name resolution found no binding event for this spelling in any
+        # enclosing function scope (external, builtin, or module-level name).
+        "no-lexical-binding-in-scope",
+        # A binding event was found, but it is a parameter, local assignment,
+        # deletion, rebinding, or a later definition -- not a lexical function
+        # definition visible at this call.
+        "binding-not-a-function-definition",
+        # This unit has no typed module root yet, so no lexical relation has
+        # been published for any occurrence in it.
+        "no-typed-module",
+        # A desugarer-synthesized Call shell (``Node._make_call``) over a
+        # borrowed span: it is not a source call occurrence, so it is outside
+        # the relation's DOMAIN.  Only shadow-minted nodes may take this arm;
+        # a source-backed occurrence with no published decision refuses.
+        "synthesized-call-occurrence",
+    }
+)
+
+
+class LexicalCallNotEnrolledV1(LexicalCallEnrollmentV1):
+    """This call occurrence is lawfully outside the lexical relation."""
+
+    __slots__ = ("reason",)
+
+    def __init__(self, *, call_occurrence, reason, _authority=None):
+        super().__init__(call_occurrence=call_occurrence, _authority=_authority)
+        if reason not in _LEXICAL_CALL_NON_ENROLLMENT_REASONS:
+            raise _lexical_enrollment_defect(
+                blame=getattr(call_occurrence, "fragment", call_occurrence),
+                observed=f"undeclared non-enrollment reason {reason!r}",
+                requested="one of the declared closed reasons",
+                fix="declare the reason deliberately in the closed set",
+            )
+        object.__setattr__(self, "reason", reason)
+
+    def __repr__(self) -> str:
+        return f"LexicalCallNotEnrolledV1({self.reason!r})"
+
+
+LexicalCallEnrollmentV1._variants_closed = True
+
+
+def mint_lexical_call_enrollment(
+    call_occurrence, reason: str | None
+) -> LexicalCallEnrollmentV1:
+    """The ONE door the producer walk mints its published decision through."""
+    if reason is None:
+        return LexicalCallEnrolledV1(
+            call_occurrence=call_occurrence,
+            _authority=_LEXICAL_CALL_ENROLLMENT_AUTHORITY,
+        )
+    return LexicalCallNotEnrolledV1(
+        call_occurrence=call_occurrence,
+        reason=reason,
+        _authority=_LEXICAL_CALL_ENROLLMENT_AUTHORITY,
+    )
+
+
 _TARGET_PATTERN_RECEIPT_AUTHORITY = object()
 
 
@@ -634,7 +784,59 @@ class SourceUnit:
         object.__setattr__(self, "_constructed_module", None)
         object.__setattr__(self, "_retained_lexical_call_rows", {})
 
-    def lexical_call_rows_for(self, call: "Call") -> tuple[object, ...]:
+    def lexical_call_enrollment(self, call: "Call") -> LexicalCallEnrollmentV1:
+        """The producer's ONE closed applicability decision for a call.
+
+        Keyed by the durable source occurrence (#7346-A), so a rewritten shell
+        over the same occurrence gets the same answer.  The producer publishes
+        a decision for EVERY call occurrence it walked; therefore a lookup that
+        finds no decision is a failed join and REFUSES.  It is never reported
+        as not-enrolled: absence and lookup-failure do not share a
+        representation here.
+        """
+        if self.typed_module is None:
+            return mint_lexical_call_enrollment(call, "no-typed-module")
+        occurrence = SourceOccurrenceIdentityV1.of(call)
+        matches = tuple(
+            decision
+            for candidate, decision in self.constructed_module.lexical_call_enrollments
+            if candidate == occurrence
+        )
+        if not matches:
+            from .shadow import ShadowNode
+
+            if isinstance(call.ref, ShadowNode):
+                # Out of DOMAIN, not a failed join.  The desugarer mints fresh
+                # Call shells (``Node._make_call``) over a borrowed span of a
+                # node that is not itself a source call; the one structural
+                # walk never saw them and never could.  ``shadow.rewrite``, by
+                # contrast, preserves the origin's span AND kind, so a
+                # rewritten source call still joins its published decision --
+                # that is exactly what occurrence keying buys (#7346-A).
+                #
+                # Stated exactly: this arm requires the node to be
+                # shadow-minted.  A SOURCE-backed call with no published
+                # decision is still a failed join and still refuses below.
+                return mint_lexical_call_enrollment(
+                    call, "synthesized-call-occurrence"
+                )
+        if len(matches) != 1:
+            raise BackendDefect(
+                blame=call.fragment,
+                owner="SourceUnit.lexical_call_enrollment",
+                observed=f"{len(matches)} published enrollment decisions",
+                requested="one decision for this exact call occurrence",
+                fix="publish one lexical enrollment per call in the producer walk",
+            )
+        return matches[0]
+
+    def _seated_lexical_call_rows(self, call: "Call") -> tuple[object, ...]:
+        """Raw relation read.  Empty means exactly one thing: lookup missed.
+
+        Callers never see this; ``require_lexical_call_rows`` turns a miss into
+        a typed refusal.  Non-enrollment is not expressible here -- that
+        question is answered by ``lexical_call_enrollment`` and nothing else.
+        """
         retained = self._retained_lexical_call_rows.get(call.ref)
         if retained is not None:
             return retained
@@ -643,6 +845,38 @@ class SourceUnit:
             for row in self.constructed_module.lexical_call_rows
             if row.call_occurrence_identity is call.ref
         )
+
+    def require_lexical_call_rows(self, call: "Call") -> tuple[object, ...]:
+        """Strict read of an ENROLLED call's producer-owned row.
+
+        Three facts that used to collapse into one empty tuple now have three
+        distinct representations:
+
+        * lawfully not enrolled -> ``LexicalCallNotEnrolledV1`` (a value, from
+          ``lexical_call_enrollment``, never from here);
+        * enrolled but stranded -> ``BackendDefect`` refusal;
+        * never walked / foreign occurrence -> ``BackendDefect`` refusal from
+          ``lexical_call_enrollment``.
+        """
+        enrollment = self.lexical_call_enrollment(call)
+        if not isinstance(enrollment, LexicalCallEnrolledV1):
+            raise BackendDefect(
+                blame=call.fragment,
+                owner="SourceUnit.require_lexical_call_rows",
+                observed=f"not an enrolled lexical call: {enrollment.reason}",
+                requested="an enrolled lexical call occurrence",
+                fix="ask lexical_call_enrollment before reading the relation",
+            )
+        rows = self._seated_lexical_call_rows(call)
+        if len(rows) != 1:
+            raise BackendDefect(
+                blame=call.fragment,
+                owner="SourceUnit.require_lexical_call_rows",
+                observed=f"{len(rows)} lexical rows for one enrolled call occurrence",
+                requested="the one producer-owned row this occurrence is enrolled for",
+                fix="retain the enrolled row through the authenticated rewrite",
+            )
+        return rows
 
     def lexical_class_owner_for(self, function: "Node") -> "ClassDef | None":
         """Project the exact class owner from the backend's one structural walk.
@@ -678,7 +912,7 @@ class SourceUnit:
         return matches[0]
 
     def retain_lexical_call_row(self, source: "Call", rewritten: "Call") -> None:
-        rows = self.lexical_call_rows_for(source)
+        rows = self.require_lexical_call_rows(source)
         if not rows or type(source) is not type(rewritten):
             raise BackendDefect(
                 blame=rewritten.fragment,
@@ -1365,19 +1599,20 @@ class SourceUnit:
         parameter, local, free, nonlocal, ambiguous, or recursive binding is
         not silently treated as this module definition.
         """
-        if not isinstance(call.func, Name) or self.typed_module is None:
-            return None
-        lexical_rows = self.lexical_call_rows_for(call)
-        if len(lexical_rows) > 1:
-            from .panic import backend_defect
-
-            backend_defect(
-                blame=call.fragment,
-                owner="SourceUnit.source_function_definition_for_call",
-                observed=f"{len(lexical_rows)} lexical rows for one call occurrence",
-                requested="zero or one authenticated lexical call row",
-                fix="repair Backend.materialize_module lexical call enrollment",
-            )
+        # Ask the producer's applicability question FIRST; read the relation
+        # only for an enrolled occurrence.  A stranded enrolled row now refuses
+        # instead of entering the fallback and answering with a different
+        # module-level definition (#7348 caller 2).
+        enrollment = self.lexical_call_enrollment(call)
+        if isinstance(enrollment, LexicalCallNotEnrolledV1):
+            if enrollment.reason in ("non-name-callee", "no-typed-module"):
+                return None
+            # module-scope-call / no-lexical-binding-in-scope /
+            # binding-not-a-function-definition: the lawful symtable-classified
+            # path below is this outcome's ONE named continuation.
+            lexical_rows = ()
+        else:
+            lexical_rows = self.require_lexical_call_rows(call)
         if lexical_rows:
             row = lexical_rows[0]
             definition = row.definition_occurrence
@@ -10718,7 +10953,9 @@ class Call(Expression):
         if (
             rewritten is not self
             and isinstance(rewritten, Call)
-            and self.unit.lexical_call_rows_for(self)
+            and isinstance(
+                self.unit.lexical_call_enrollment(self), LexicalCallEnrolledV1
+            )
         ):
             self.unit.retain_lexical_call_row(self, rewritten)
         return rewritten
@@ -10893,18 +11130,16 @@ class Call(Expression):
         elif isinstance(context, TreeConstructionContextV1):
             assert coordinate is not None
             source_call_resolution = context.source_call_resolutions.get(coordinate)
-        lexical_rows = self.unit.lexical_call_rows_for(self)
-        if len(lexical_rows) > 1:
-            from .panic import backend_defect
-
-            backend_defect(
-                blame=self.fragment,
-                owner="Call._construct_sugar",
-                observed=f"{len(lexical_rows)} lexical rows for one call occurrence",
-                requested="zero or one sealed lexical call row",
-                fix="repair lexical call enrollment before constructing the source frame",
+        # Applicability first, relation second.  A non-lexical call is lawfully
+        # not enrolled; a stranded enrolled row refuses instead of quietly
+        # losing the source frame (#7348 caller 4).
+        lexical_row = (
+            self.unit.require_lexical_call_rows(self)[0]
+            if isinstance(
+                self.unit.lexical_call_enrollment(self), LexicalCallEnrolledV1
             )
-        lexical_row = lexical_rows[0] if lexical_rows else None
+            else None
+        )
         if lexical_row is not None:
             function_definition = lexical_row.definition_occurrence
             if (
@@ -11087,18 +11322,17 @@ class Call(Expression):
             formal_function_sugar = None
             formal_coordinates = ()
             formal_coordinate_cids = ()
-            lexical_rows = self.unit.lexical_call_rows_for(self)
-            if len(lexical_rows) > 1:
-                from .panic import backend_defect
-
-                backend_defect(
-                    blame=self.fragment,
-                    owner="Call._construct_sugar",
-                    observed=f"{len(lexical_rows)} lexical rows for one call occurrence",
-                    requested="zero or one sealed lexical call row",
-                    fix="repair lexical call enrollment before constructing the source frame",
+            # Applicability first, relation second (#7348 caller 5): an
+            # external/module/shadowed Name call is lawfully not enrolled, but
+            # a stranded enrolled row must not fall through to a weaker
+            # ordinary CallSiteSugar.
+            lexical_row = (
+                self.unit.require_lexical_call_rows(self)[0]
+                if isinstance(
+                    self.unit.lexical_call_enrollment(self), LexicalCallEnrolledV1
                 )
-            lexical_row = lexical_rows[0] if lexical_rows else None
+                else None
+            )
             if lexical_row is not None:
                 function_definition = lexical_row.definition_occurrence
                 if (

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, ClassVar, Iterator, Optional, Tuple
 if TYPE_CHECKING:  # pragma: no cover
     from .fragment import SourceFragment
 
+from .occurrence import SourceOccurrenceIdentityV1
 from .operators import (
     BinaryOperator,
     BooleanOperator,
@@ -526,11 +527,21 @@ class SourceUnit:
         typed module.  Re-walking class bodies here would create a second answer
         to the same ownership question, so consumers use that producer-owned
         relation directly.
+
+        The join is on the SOURCE OCCURRENCE (#7346-A), not on the Python shell
+        that views it: ``shadow.rewrite`` mints a fresh shell over the borrowed
+        origin span, and a rewritten function denotes the same occurrence the
+        producer walked.  Foreign occurrences still miss, and a miss is still
+        the loud zero-row ``BackendDefect`` -- there is no span-only fallback
+        and no second walk.  Exactly one row per occurrence remains the
+        producer's contract: ``None`` as the owner is authenticated no-owner,
+        zero rows is a failed join, more than one row is a malformed relation.
         """
+        occurrence = SourceOccurrenceIdentityV1.of(function)
         matches = tuple(
             owner
             for candidate, owner in self.constructed_module.function_class_owners
-            if candidate is function
+            if candidate == occurrence
         )
         if len(matches) != 1:
             raise BackendDefect(
@@ -3866,6 +3877,14 @@ class FunctionDef(Statement):
         last same-name initializer is Python's live class binding; overwritten
         definitions and genuinely free functions keep the ordinary formal
         entrance.
+
+        Active membership is decided on the SOURCE OCCURRENCE (#7346-B), not on
+        the shell.  ``owner.body`` holds the producer's shells; a reconstructed
+        ``__init__`` is a different shell denoting the same occurrence, and the
+        shell comparison silently reclassified the live initializer as
+        overwritten -- degrading its receiver entrance to an ordinary formal.
+        A genuinely overwritten initializer denotes a DIFFERENT occurrence and
+        stays inactive.
         """
         if self.name != "__init__":
             return None
@@ -3880,7 +3899,10 @@ class FunctionDef(Statement):
             ),
             None,
         )
-        return owner if active is self else None
+        if active is None:
+            return None
+        occurrence = SourceOccurrenceIdentityV1.of(self)
+        return owner if SourceOccurrenceIdentityV1.of(active) == occurrence else None
 
     def _constructed_receiver_coordinate(self, owner: "ClassDef", parameter: Param):
         """Mint the same receiver coordinate as the class-construction door."""
@@ -4271,8 +4293,16 @@ class ClassDef(Statement):
             or allocation.value.args[0].id != class_param.name
         ):
             return None
+        # Admission is decided on the SOURCE OCCURRENCE (#7346-C).  The name is
+        # bound exactly once at module level AND that one binding must be THIS
+        # occurrence -- a reconstructed shell of the same class is admitted, a
+        # foreign or shadowed class is not.
         bindings = (self.unit.module_direct_bindings or {}).get(self.name, ())
-        if len(bindings) != 1 or bindings[0] is not self:
+        if len(bindings) != 1 or not isinstance(bindings[0], Node):
+            return None
+        if SourceOccurrenceIdentityV1.of(bindings[0]) != (
+            SourceOccurrenceIdentityV1.of(self)
+        ):
             return None
         if (self.unit.module_direct_bindings or {}).get("super"):
             return None

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -258,10 +258,10 @@ class TargetPatternEnrolledV1(TargetPatternEnrollmentV1):
 
     ``enrolled_targets`` are the exact target occurrences the producer minted a
     ``TargetPatternV1`` for.  The row itself is deliberately NOT carried here:
-    binding the product into the outcome requires the durable occurrence
-    identity ruled in #7346, which has not landed.  Until then the row is read
-    strictly and separately, so a stranded row refuses instead of degrading
-    into this value.
+    this value answers *"is this shape enrolled?"* and the relation read answers
+    *"did my lookup find the row?"*.  Merging them would let a stranded row
+    degrade into this value instead of refusing, so they stay separate even
+    though the relation is now keyed by durable source occurrence (#7346-A).
     """
 
     __slots__ = ("enrolled_targets", "_projection_sites")
@@ -1142,9 +1142,15 @@ class SourceUnit:
                 self._construct_target_pattern(consumer, target, prefix)
                 for target, prefix in enrollment._projection_sites
             )
-            patterns[consumer.ref] = owned
+            # Keyed by SourceOccurrenceIdentityV1, never by the producer's Node
+            # shell (#7346-A).  ``shadow.rewrite`` borrows the origin's span and
+            # keeps its kind and unit, so a rewritten consumer denotes the SAME
+            # occurrence and joins this row by construction -- for every enrolled
+            # consumer at once, with no per-consumer retention to remember.
+            patterns[SourceOccurrenceIdentityV1.of(consumer)] = owned
             patterns_by_target.update(
-                (pattern.target_occurrence.ref, pattern) for pattern in owned
+                (SourceOccurrenceIdentityV1.of(pattern.target_occurrence), pattern)
+                for pattern in owned
             )
             constructed_count += len(owned)
         object.__setattr__(self, "_target_patterns_by_consumer", patterns)
@@ -1306,7 +1312,7 @@ class SourceUnit:
                 consumer_occurrence=consumer,
                 target_occurrence=None,
             )
-        return patterns.get(consumer.ref)
+        return patterns.get(SourceOccurrenceIdentityV1.of(consumer))
 
     def require_target_patterns(
         self, consumer: "Node"
@@ -1337,34 +1343,18 @@ class SourceUnit:
             )
         return owned
 
-    def retain_target_patterns(self, source_consumer, rewritten_consumer) -> None:
-        """Seat one rewrite with its exact source consumer's immutable products."""
-        enrollment = self.target_pattern_enrollment(source_consumer)
-        owned = (
-            self._seated_target_patterns(source_consumer)
-            if isinstance(enrollment, TargetPatternEnrolledV1)
-            else None
-        )
-        if not owned or type(rewritten_consumer) is not type(source_consumer):
-            raise TargetPatternConstructionGapV1(
-                "foreign-target-consumer-rewrite",
-                consumer_occurrence=rewritten_consumer,
-                target_occurrence=source_consumer,
-            )
-        patterns = self._target_patterns_by_consumer
-        patterns[rewritten_consumer.ref] = owned
-
     def require_target_pattern(self, consumer, target) -> TargetPatternV1:
         enrollment = self.target_pattern_enrollment(consumer)
+        target_occurrence = SourceOccurrenceIdentityV1.of(target)
         if isinstance(enrollment, TargetPatternEnrolledV1):
             for pattern in self._seated_target_patterns(consumer) or ():
-                if pattern.target_occurrence.ref is target.ref:
+                if (
+                    SourceOccurrenceIdentityV1.of(pattern.target_occurrence)
+                    == target_occurrence
+                ):
                     return pattern
         # Not-enrolled and lookup-missed are both refusals HERE by design: this
-        # door promises one exact enrolled pair or nothing.  Telling a foreign
-        # consumer apart from a stranded same-unit one needs the durable
-        # occurrence identity ruled in #7346; the reason string is unchanged
-        # until then so no existing refusal is weakened.
+        # door promises one exact enrolled pair or nothing.
         raise TargetPatternConstructionGapV1(
             "foreign-target-occurrence",
             consumer_occurrence=consumer,
@@ -1373,7 +1363,11 @@ class SourceUnit:
 
     def require_target_pattern_for_target(self, target) -> TargetPatternV1:
         patterns = self._target_patterns_by_target
-        pattern = None if patterns is None else patterns.get(target.ref)
+        pattern = (
+            None
+            if patterns is None
+            else patterns.get(SourceOccurrenceIdentityV1.of(target))
+        )
         if pattern is None:
             raise TargetPatternConstructionGapV1(
                 "foreign-target-occurrence",
@@ -5690,13 +5684,8 @@ class Assign(Statement):
         if not changes:
             return self
         rewritten = rewrite(self, **changes)
-        # Ask the applicability question, not the relation.  An enrolled Assign
-        # whose row went missing now refuses inside ``retain_target_patterns``
-        # instead of being mistaken for an ordinary/store target.
-        if isinstance(
-            self.unit.target_pattern_enrollment(self), TargetPatternEnrolledV1
-        ):
-            self.unit.retain_target_patterns(self, rewritten)
+        # No retention: the relation is keyed by SOURCE OCCURRENCE, and the
+        # rewrite denotes the same occurrence, so its row joins by construction.
         return rewritten
 
     def _receiver_field_store_state(self, scope, new_value):
@@ -6995,7 +6984,6 @@ class For(Statement):
                 if not changed:
                     return self
                 rewritten = rewrite(self, **changed)
-                self.unit.retain_target_patterns(self, rewritten)
                 return rewritten
 
     @staticmethod
@@ -10302,7 +10290,6 @@ class ListComp(Expression):
         if not changed:
             return self
         rewritten = rewrite(self, **changed)
-        self.unit.retain_target_patterns(self, rewritten)
         return rewritten
 
     def _try_unroll_to_display(self, scope):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/occurrence.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/occurrence.py
@@ -1,0 +1,68 @@
+"""The durable relation key: which SOURCE OCCURRENCE a node denotes.
+
+Sugar carries two non-interchangeable identities over a node, and #7346 rules
+that they may never stand in for each other:
+
+* **construction/shell identity** -- the ``BackendNode`` ref and the typed
+  ``Node`` shell viewing it.  This is a CAPABILITY: it answers accessors, it
+  memoizes field data, it registers on the roll.  Many shells lawfully view
+  one occurrence, and ``materialize`` mints a fresh one every call.
+* **source-occurrence identity** -- this module.  Pinned source CID + exact
+  span + node kind, minted from the already-authenticated source fragment.
+  This is the durable key for every SEMANTIC relation over nodes.
+
+``shadow.rewrite`` deliberately borrows the origin's span ("so its memento
+still addresses the source the rewrite stands for") and then mints a fresh
+ShadowNode and a fresh typed shell.  A relation keyed on shell identity
+therefore loses its rows the instant a substitution rewrites the node, and
+loses them as a plausible EMPTY rather than as a failed join.  A relation
+keyed on the occurrence survives, because the occurrence never moved.
+
+The occurrence key is content-addressed, not text-addressed: the segment CID
+alone is insufficient because identical text occurs at different loci, so the
+key retains the pinned source and the exact span.  A node from another file,
+another pinned revision of the same file, another extent, or another grammar
+kind is a DIFFERENT occurrence and must not join -- there is no fallback,
+no name match, no span-only arm.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .nodes import Node
+
+
+@dataclass(frozen=True, slots=True)
+class SourceOccurrenceIdentityV1:
+    """The one durable key for semantic relations over source nodes.
+
+    Value equality on purpose -- and it is the ONLY equality this type has, so
+    a relation keyed by it cannot be joined with ``is`` by accident.  Minted
+    only by :meth:`of`, from a node that already answers an oracle-pinned unit
+    and an exact span; this type never opens a file, parses, or invents a span.
+    """
+
+    file: str
+    source_cid: str
+    start: int
+    end: int
+    node_kind: str
+
+    @classmethod
+    def of(cls, node: "Node") -> "SourceOccurrenceIdentityV1":
+        """The occurrence this node denotes. Inherited by shadow rewrites."""
+        span = node.span
+        unit = node.unit
+        return cls(
+            file=unit.filename,
+            source_cid=unit.source_cid,
+            start=span.start,
+            end=span.end,
+            node_kind=node.kind,
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"{self.node_kind}@{self.file}[{self.start},{self.end})"

--- a/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
+++ b/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
@@ -299,29 +299,86 @@ def test_producer_walk_and_published_enrollment_are_one_answer(
 # --------------------------------------------------------------------------
 
 
+# --------------------------------------------------------------------------
+# TOOTH 4 -- the LEXICAL arm.  Same law, same defect; unblocked by #7346.
+#
+# FIXTURE ISOLATION (#7364): SourceUnits are memoized by (source_cid,
+# workspace-relative filename).  Byte-identical fixture text SHARES ONE UNIT
+# across tests no matter how distinct the tmp_path is, and two of these teeth
+# deliberately CORRUPT the unit they hold.  Every source below is therefore
+# unique text under a unique filename.
+# --------------------------------------------------------------------------
+
+LEXICAL_NONNAME_SOURCE = """\
+def dispatcher(bag):
+    marker_nonname = 0
+    return bag.handle(marker_nonname)
+"""
+
+LEXICAL_MODULE_SCOPE_SOURCE = """\
+def target_module_scope(item):
+    return item
+
+
+marker_module_scope = target_module_scope(1)
+"""
+
+LEXICAL_NO_BINDING_SOURCE = """\
+def outer_no_binding(value):
+    marker_no_binding = 1
+    return external_no_binding(value, marker_no_binding)
+"""
+
+LEXICAL_PARAMETER_BINDING_SOURCE = """\
+def outer_parameter_binding(handler):
+    marker_parameter_binding = 2
+    return handler(marker_parameter_binding)
+"""
+
+LEXICAL_DOMAIN_SOURCE = """\
+def caller_domain(marker_domain):
+    def helper_domain(item):
+        return item
+
+    return helper_domain(marker_domain)
+"""
+
+LEXICAL_MISS_SOURCE = """\
+def caller_miss(value):
+    def helper_miss(item):
+        return item
+
+    return helper_miss(value)
+"""
+
+
+def _lexical_call(source_file, spelling: str):
+    return next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Call" and getattr(node.func, "id", None) == spelling
+    )
+
+
 def test_stranded_enrolled_lexical_call_refuses_instead_of_shrugging(
     tmp_path: Path,
 ) -> None:
-    """HARD RED, deliberately. Do not xfail, skip, or delete this.
+    """The tooth #7348 was blocked on. It bites the STRAND, not mere failure.
 
-    The #7348 lexical arm is prerequisite-blocked on #7346: the lexical
-    enrollment decision is not a function of the call node -- it needs the
-    backend's scope/binding classification -- so publishing it requires a
-    keyed negative table, and a shell/ref-keyed one would preserve the same
-    defect under a second carrier. Inventing the key here would be a second
-    answer.
+    The producer must still say "this occurrence IS enrolled" after the
+    relation is emptied, and the strict read must REFUSE.  Before the closed
+    outcome landed, the read simply returned ``()`` and every consumer treated
+    a stranded enrolled call as an ordinary non-lexical one.
 
-    So the hole is real and unfixed today. A strict-xfail would render this
-    board green over a known hole, which is the exact failure this project
-    treats as fatal. Merges here are not gated on CI, so a standing red
-    blocks nothing -- it only stays visible. It turns green when, and only
-    when, the closed lexical outcome lands.
+    Note what is asserted: the enrolled verdict SURVIVES the strand.  A tooth
+    that only asserted "something raised" would be satisfied by the enrollment
+    lookup itself failing, which is a different fact.
     """
     source_file = _open(tmp_path, "lexical.py", LEXICAL_SOURCE)
     call = next(node for node in source_file.nodes() if node.kind == "Call")
     unit = source_file.unit
 
-    rows = unit.lexical_call_rows_for(call)
+    rows = unit.require_lexical_call_rows(call)
     assert rows, "fixture must hold an enrolled lexical call"
 
     # Same mutation as the target arm: strand the enrolled row.
@@ -329,25 +386,156 @@ def test_stranded_enrolled_lexical_call_refuses_instead_of_shrugging(
     object.__setattr__(constructed, "lexical_call_rows", ())
     unit._retained_lexical_call_rows.clear()
 
-    # The producer must still say "this occurrence IS enrolled" and the read
-    # must refuse. Today the read simply returns () and every consumer treats
-    # it as an ordinary non-lexical call.
     enrollment = unit.lexical_call_enrollment(call)
-    assert enrollment.__class__.__name__.endswith("EnrolledV1")
-    with pytest.raises(nodes.BackendDefect):
+    assert isinstance(enrollment, nodes.LexicalCallEnrolledV1)
+    with pytest.raises(nodes.BackendDefect) as stranded:
         unit.require_lexical_call_rows(call)
+    assert "0 lexical rows for one enrolled call occurrence" in str(stranded.value)
 
 
-def test_the_defaulting_lexical_reader_is_still_present_and_why() -> None:
-    """Honest instrument: records exactly what is NOT yet repaired.
+def test_lookup_miss_refuses_and_never_reports_not_enrolled(tmp_path: Path) -> None:
+    """Absence and lookup-failure do not share a representation.
 
-    ``lexical_call_rows_for`` still exists and still returns ``()`` for both
-    lawful non-enrollment and a stranded row.  Deleting it before the producer
-    publishes a closed outcome would force its five callers to re-derive the
-    backend's scope walk -- five second answers instead of one side door.
+    The producer publishes a decision for EVERY call occurrence it walked, so
+    finding none is a failed join.  This is the exact masquerade #7348
+    forbids: it must not come back as ``NotEnrolled``.
     """
-    assert hasattr(nodes.SourceUnit, "lexical_call_rows_for"), (
-        "if this reader was deleted, the closed lexical outcome from #7348 "
-        "step 3 must have landed -- delete this test with it"
+    source_file = _open(tmp_path, "lexical_miss.py", LEXICAL_MISS_SOURCE)
+    call = _lexical_call(source_file, "helper_miss")
+    unit = source_file.unit
+
+    assert isinstance(
+        unit.lexical_call_enrollment(call), nodes.LexicalCallEnrolledV1
     )
-    assert not hasattr(nodes.SourceUnit, "lexical_call_enrollment")
+
+    object.__setattr__(unit.constructed_module, "lexical_call_enrollments", ())
+
+    with pytest.raises(nodes.BackendDefect) as missed:
+        unit.lexical_call_enrollment(call)
+    assert "0 published enrollment decisions" in str(missed.value)
+    assert "SourceUnit.lexical_call_enrollment" in str(missed.value)
+
+
+def test_every_declared_non_enrollment_reason_is_produced_by_the_walk(
+    tmp_path: Path,
+) -> None:
+    """BOTH ARMS, per reason: each declared reason has a live producer path.
+
+    A closed reason set nobody mints is decoration.  Each case below is a
+    ``continue`` the backend walk already executed and used to discard.
+    """
+    enrolled = _open(tmp_path, "lex_enrolled.py", LEXICAL_MISS_SOURCE)
+    assert isinstance(
+        enrolled.unit.lexical_call_enrollment(
+            _lexical_call(enrolled, "helper_miss")
+        ),
+        nodes.LexicalCallEnrolledV1,
+    )
+
+    cases = (
+        ("lex_nonname.py", LEXICAL_NONNAME_SOURCE, None, "non-name-callee"),
+        (
+            "lex_module.py",
+            LEXICAL_MODULE_SCOPE_SOURCE,
+            "target_module_scope",
+            "module-scope-call",
+        ),
+        (
+            "lex_nobinding.py",
+            LEXICAL_NO_BINDING_SOURCE,
+            "external_no_binding",
+            "no-lexical-binding-in-scope",
+        ),
+        (
+            "lex_parameter.py",
+            LEXICAL_PARAMETER_BINDING_SOURCE,
+            "handler",
+            "binding-not-a-function-definition",
+        ),
+    )
+    for name, text, spelling, reason in cases:
+        source_file = _open(tmp_path, name, text)
+        call = (
+            _lexical_call(source_file, spelling)
+            if spelling is not None
+            else next(
+                node for node in source_file.nodes() if node.kind == "Call"
+            )
+        )
+        outcome = source_file.unit.lexical_call_enrollment(call)
+        assert isinstance(outcome, nodes.LexicalCallNotEnrolledV1), (
+            f"{name} expected not-enrolled, got {outcome!r}"
+        )
+        assert outcome.reason == reason, f"{name}: {outcome.reason!r} != {reason!r}"
+
+    assert nodes._LEXICAL_CALL_NON_ENROLLMENT_REASONS == frozenset(
+        {reason for *_, reason in cases}
+        | {"no-typed-module", "synthesized-call-occurrence"}
+    ), "a declared reason with no producer path, or a path with no reason"
+
+
+def test_synthesized_call_is_out_of_domain_but_a_source_miss_still_refuses(
+    tmp_path: Path,
+) -> None:
+    """BOTH ARMS of the domain discriminator, on one unit.
+
+    The desugarer mints fresh Call shells over a borrowed span; the one
+    structural walk never saw them, so they are outside the relation's domain
+    rather than a failed join.  That arm is admitted ONLY for a shadow-minted
+    node -- a source-backed occurrence with no published decision is still a
+    refusal.  A tooth that showed only the first arm would certify a
+    masquerade.
+    """
+    source_file = _open(tmp_path, "lex_domain.py", LEXICAL_DOMAIN_SOURCE)
+    unit = source_file.unit
+    real_call = _lexical_call(source_file, "helper_domain")
+    anchor = next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Name" and node.id == "marker_domain"
+    )
+
+    synthesized = anchor._make_call(anchor)
+    assert synthesized.kind == "Call"
+    outcome = unit.lexical_call_enrollment(synthesized)
+    assert isinstance(outcome, nodes.LexicalCallNotEnrolledV1)
+    assert outcome.reason == "synthesized-call-occurrence"
+
+    # Arm two, same table state: the SOURCE call is still decided, and once
+    # its decision is removed it refuses instead of taking the domain arm.
+    assert isinstance(
+        unit.lexical_call_enrollment(real_call), nodes.LexicalCallEnrolledV1
+    )
+    object.__setattr__(unit.constructed_module, "lexical_call_enrollments", ())
+    with pytest.raises(nodes.BackendDefect) as missed:
+        unit.lexical_call_enrollment(real_call)
+    assert "0 published enrollment decisions" in str(missed.value)
+
+
+def test_the_lexical_outcome_is_closed_and_producer_minted() -> None:
+    """The sealed base refuses a third variant, a foreign mint, and mutation."""
+    with pytest.raises(nodes.BackendDefect) as third:
+
+        class _ThirdVariant(nodes.LexicalCallEnrollmentV1):
+            pass
+
+    assert "third lexical-call enrollment variant" in str(third.value)
+
+    with pytest.raises(nodes.BackendDefect) as foreign:
+        nodes.LexicalCallEnrolledV1(call_occurrence=object())
+    assert "minted outside the producer" in str(foreign.value)
+
+    with pytest.raises(nodes.BackendDefect) as undeclared:
+        nodes.mint_lexical_call_enrollment(object(), "invented-reason")
+    assert "undeclared non-enrollment reason" in str(undeclared.value)
+
+    outcome = nodes.mint_lexical_call_enrollment(object(), None)
+    with pytest.raises(nodes.BackendDefect):
+        outcome.call_occurrence = object()
+
+
+def test_the_defaulting_lexical_reader_is_gone() -> None:
+    """#7348 step 5: the ambiguous reader is deleted, the loud one stays."""
+    assert not hasattr(nodes.SourceUnit, "lexical_call_rows_for")
+    assert hasattr(nodes.SourceUnit, "retain_lexical_call_row")
+    assert hasattr(nodes.SourceUnit, "require_lexical_call_rows")

--- a/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
+++ b/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from sugar_source_tree import nodes
+from sugar_source_tree import nodes, occurrence
 from sugar_source_tree.reporter import NULL_REPORTER
 from sugar_source_tree.tree import SourceFile
 
@@ -87,7 +87,9 @@ def _strand(unit, consumer) -> None:
     """
     seated = consumer.require_target_patterns()
     assert seated, "fixture must really own a producer row before stranding"
-    unit._target_patterns_by_consumer.pop(consumer.ref)
+    unit._target_patterns_by_consumer.pop(
+        occurrence.SourceOccurrenceIdentityV1.of(consumer)
+    )
     return seated
 
 
@@ -154,7 +156,10 @@ def test_the_defaulting_target_reader_is_deleted() -> None:
     assert not hasattr(nodes.Node, "target_patterns")
     # The loud readers stay.
     assert hasattr(nodes.SourceUnit, "require_target_pattern")
-    assert hasattr(nodes.SourceUnit, "retain_target_patterns")
+    # Per-consumer retention is gone: the relation is keyed by source
+    # occurrence, so a rewrite joins its row without anyone remembering to
+    # re-seat it.  A retention door would be a second way to seat a row.
+    assert not hasattr(nodes.SourceUnit, "retain_target_patterns")
 
 
 # --------------------------------------------------------------------------
@@ -284,9 +289,11 @@ def test_producer_walk_and_published_enrollment_are_one_answer(
         # Every enrolled shape has a seated row and vice versa: no shape is
         # enrolled-but-unseated at construction time, and no row exists for a
         # shape the published decision calls not-enrolled.
-        assert published == (node.ref in seated), (
+        # The relation is keyed by SOURCE OCCURRENCE, not by the node shell.
+        occurrence_key = occurrence.SourceOccurrenceIdentityV1.of(node)
+        assert published == (occurrence_key in seated), (
             f"{node.kind} disagrees: published={published} "
-            f"seated={node.ref in seated}"
+            f"seated={occurrence_key in seated}"
         )
         if published:
             assert len(unit.require_target_patterns(node)) == len(

--- a/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
+++ b/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
@@ -43,11 +43,10 @@ class Holder:
 """
 
 LEXICAL_SOURCE = """\
-def helper(value):
-    return value
-
-
 def caller(value):
+    def helper(item):
+        return item
+
     return helper(value)
 """
 
@@ -300,21 +299,24 @@ def test_producer_walk_and_published_enrollment_are_one_answer(
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "#7348 lexical arm is prerequisite-blocked on #7346. The lexical "
-        "enrollment decision is not a function of the call node -- it needs "
-        "the backend's scope/binding classification -- so publishing it "
-        "requires a keyed negative table, and a shell/ref-keyed one would "
-        "preserve the same defect under a second carrier. Inventing the key "
-        "here would be a second answer. This tooth XPASSes loudly the moment "
-        "the closed lexical outcome lands."
-    ),
-)
 def test_stranded_enrolled_lexical_call_refuses_instead_of_shrugging(
     tmp_path: Path,
 ) -> None:
+    """HARD RED, deliberately. Do not xfail, skip, or delete this.
+
+    The #7348 lexical arm is prerequisite-blocked on #7346: the lexical
+    enrollment decision is not a function of the call node -- it needs the
+    backend's scope/binding classification -- so publishing it requires a
+    keyed negative table, and a shell/ref-keyed one would preserve the same
+    defect under a second carrier. Inventing the key here would be a second
+    answer.
+
+    So the hole is real and unfixed today. A strict-xfail would render this
+    board green over a known hole, which is the exact failure this project
+    treats as fatal. Merges here are not gated on CI, so a standing red
+    blocks nothing -- it only stays visible. It turns green when, and only
+    when, the closed lexical outcome lands.
+    """
     source_file = _open(tmp_path, "lexical.py", LEXICAL_SOURCE)
     call = next(node for node in source_file.nodes() if node.kind == "Call")
     unit = source_file.unit

--- a/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
+++ b/implementations/python/sugar-source-tree/tests/test_closed_target_pattern_enrollment.py
@@ -1,0 +1,351 @@
+"""Red teeth for #7348: closed producer-owned enrollment, both arms.
+
+The defect: two relations each had a LOUD reader and a DEFAULTING reader over
+the same data.  ``target_patterns_for`` mapped three different facts -- table
+not built, lawfully not enrolled, and an enrolled row stranded by a rewrite --
+onto the same empty tuple, so whether a stale lookup screamed or shrugged
+depended on which function the caller happened to call.
+
+Every test in this file is a tooth.  Each one is written to FAIL at
+``d0ff65fe537cb4a79374a2a1d90c54a13102462f`` (the reader-deletion pin) and to
+pass only once the producer publishes a closed ``Enrolled | NotEnrolled``
+outcome and the defaulting readers are gone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree import nodes
+from sugar_source_tree.reporter import NULL_REPORTER
+from sugar_source_tree.tree import SourceFile
+
+
+ENROLLED_SOURCE = """\
+def fixture(value):
+    root, leaf = split(value)
+    return root[leaf]
+"""
+
+STORE_ONLY_SOURCE = """\
+class Holder:
+    def install(self, left, right):
+        self.left, self.right = left, right
+"""
+
+STORE_LOOP_SOURCE = """\
+class Holder:
+    def drain(self, items):
+        for self.head, self.tail in items:
+            pass
+"""
+
+LEXICAL_SOURCE = """\
+def helper(value):
+    return value
+
+
+def caller(value):
+    return helper(value)
+"""
+
+
+def _open(tmp_path: Path, name: str, text: str) -> SourceFile:
+    path = tmp_path / name
+    path.write_text(text)
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+
+    identity = workspace_path_source(str(path), root=str(tmp_path))
+    return SourceFile(identity, reporter=NULL_REPORTER)
+
+
+def _enrolled(tmp_path: Path, tag: str) -> SourceFile:
+    """One enrolled-Assign fixture per test.
+
+    SourceUnits are memoized by source CONTENT across opens, so two tests that
+    write byte-identical fixtures share one unit -- and a test that strands a
+    row would corrupt its neighbour.  The tag keeps each fixture distinct.
+    """
+    return _open(
+        tmp_path,
+        f"enrolled_{tag}.py",
+        ENROLLED_SOURCE.replace("fixture", f"fixture_{tag}"),
+    )
+
+
+def _sole_assign(source_file: SourceFile):
+    return next(node for node in source_file.nodes() if node.kind == "Assign")
+
+
+def _strand(unit, consumer) -> None:
+    """Bypass the mechanism: drop the enrolled row, keep enrollment true.
+
+    This is the mutation the whole issue is about.  It reproduces exactly what
+    a rewrite without retention does to the relation, without needing a
+    rewrite path that happens to be repaired.
+    """
+    seated = consumer.require_target_patterns()
+    assert seated, "fixture must really own a producer row before stranding"
+    unit._target_patterns_by_consumer.pop(consumer.ref)
+    return seated
+
+
+# --------------------------------------------------------------------------
+# TOOTH 1 -- the producer publishes a closed applicability outcome at all.
+# --------------------------------------------------------------------------
+
+
+def test_producer_publishes_a_closed_enrollment_outcome(tmp_path: Path) -> None:
+    enrolled = _sole_assign(_enrolled(tmp_path, "t1"))
+    not_enrolled = _sole_assign(_open(tmp_path, "store.py", STORE_ONLY_SOURCE))
+
+    yes = enrolled.target_pattern_enrollment
+    no = not_enrolled.target_pattern_enrollment
+
+    assert isinstance(yes, nodes.TargetPatternEnrolledV1)
+    assert isinstance(no, nodes.TargetPatternNotEnrolledV1)
+    # Two variants, and they are not interchangeable values.
+    assert type(yes) is not type(no)
+    assert no.reason == "consumer-shape-not-enrolled"
+    assert yes.covers(enrolled.targets[0])
+
+
+def test_both_declared_non_enrollment_reasons_are_reachable(tmp_path: Path) -> None:
+    """Neither named reason is decorative: each has a real source shape."""
+    shape = _sole_assign(_open(tmp_path, "store.py", STORE_ONLY_SOURCE))
+    loop_file = _open(tmp_path, "store_loop.py", STORE_LOOP_SOURCE)
+    loop = next(node for node in loop_file.nodes() if node.kind == "For")
+
+    assert shape.target_pattern_enrollment.reason == "consumer-shape-not-enrolled"
+    assert loop.target_pattern_enrollment.reason == "no-binding-leaf-target"
+
+
+def test_enrollment_outcome_is_closed_and_producer_minted() -> None:
+    """The wrong state is unrepresentable, not guarded."""
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as unminted:
+        nodes.TargetPatternNotEnrolledV1(
+            consumer_occurrence=None, reason="consumer-shape-not-enrolled"
+        )
+    assert unminted.value.reason == "target-pattern-enrollment-not-producer-minted"
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as third_variant:
+
+        class SmuggledVariant(nodes.TargetPatternEnrollmentV1):
+            pass
+
+    assert third_variant.value.reason == (
+        "target-pattern-enrollment-variant-not-closed"
+    )
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as bad_reason:
+        nodes.TargetPatternNotEnrolledV1(
+            consumer_occurrence=None,
+            reason="made-up",
+            _authority=nodes._TARGET_PATTERN_ENROLLMENT_AUTHORITY,
+        )
+    assert bad_reason.value.reason == (
+        "target-pattern-non-enrollment-reason-not-declared"
+    )
+
+
+def test_the_defaulting_target_reader_is_deleted() -> None:
+    assert not hasattr(nodes.SourceUnit, "target_patterns_for")
+    assert not hasattr(nodes.Node, "target_patterns")
+    # The loud readers stay.
+    assert hasattr(nodes.SourceUnit, "require_target_pattern")
+    assert hasattr(nodes.SourceUnit, "retain_target_patterns")
+
+
+# --------------------------------------------------------------------------
+# TOOTH 2 -- a stranded enrolled row REFUSES; it does not masquerade as
+# "this shape was never enrolled".  This is the law, verbatim.
+# --------------------------------------------------------------------------
+
+
+def test_stranded_enrolled_assign_refuses_instead_of_shrugging(
+    tmp_path: Path,
+) -> None:
+    source_file = _enrolled(tmp_path, "t2")
+    assignment = _sole_assign(source_file)
+    unit = source_file.unit
+
+    # Pre-condition: the row is really there and really read.
+    (pattern,) = assignment.require_target_patterns()
+    assert pattern.consumer_occurrence is assignment
+
+    _strand(unit, assignment)
+
+    # The applicability answer is UNCHANGED by a lost row.  This is the whole
+    # point: enrollment is not read out of the relation.
+    assert isinstance(
+        assignment.target_pattern_enrollment, nodes.TargetPatternEnrolledV1
+    )
+
+    # And the lookup now screams instead of returning a smaller product.
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as stranded:
+        assignment.require_target_patterns()
+    assert stranded.value.reason == "foreign-target-occurrence"
+
+
+def test_stranded_enrolled_assign_does_not_fall_through_to_store_construction(
+    tmp_path: Path,
+) -> None:
+    """Caller #5 (``Assign._destructured_binding``) must stop tolerating.
+
+    Before the repair this returned ``None`` -- indistinguishable from a
+    lawful mixed/store unpack -- and construction silently continued with a
+    weaker answer.
+    """
+    source_file = _enrolled(tmp_path, "t3")
+    assignment = _sole_assign(source_file)
+    _strand(source_file.unit, assignment)
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as refused:
+        assignment.substitution_binding({})
+    assert refused.value.reason == "foreign-target-occurrence"
+
+
+def test_lawful_store_unpack_still_falls_through_silently(tmp_path: Path) -> None:
+    """The other arm of the discriminator: authentic non-enrollment is quiet.
+
+    Run this together with the test above.  If only one of the two passes the
+    mechanism is not discriminating, it is just uniformly loud or uniformly
+    tolerant.
+    """
+    source_file = _open(tmp_path, "store.py", STORE_ONLY_SOURCE)
+    assignment = _sole_assign(source_file)
+    assert isinstance(
+        assignment.target_pattern_enrollment, nodes.TargetPatternNotEnrolledV1
+    )
+    binding = assignment.substitution_binding({})
+    assert binding is None or binding == {}
+
+
+def test_stranded_and_not_enrolled_have_different_representations(
+    tmp_path: Path,
+) -> None:
+    """Absence and lookup-failure never share a representation."""
+    enrolled_file = _enrolled(tmp_path, "t4")
+    assignment = _sole_assign(enrolled_file)
+    _strand(enrolled_file.unit, assignment)
+
+    store_file = _open(tmp_path, "store.py", STORE_ONLY_SOURCE)
+    store_assignment = _sole_assign(store_file)
+
+    # Lawful absence is a VALUE.
+    absence = store_assignment.target_pattern_enrollment
+    assert isinstance(absence, nodes.TargetPatternNotEnrolledV1)
+
+    # Lookup failure is a REFUSAL.  There is no value it could be confused
+    # with, because no reader returns a defaulted product any more.
+    with pytest.raises(nodes.TargetPatternConstructionGapV1):
+        assignment.require_target_patterns()
+
+
+def test_missing_relation_table_is_its_own_refusal(tmp_path: Path) -> None:
+    """The third collapsed fact gets its own name."""
+    source_file = _enrolled(tmp_path, "t5")
+    assignment = _sole_assign(source_file)
+    object.__setattr__(source_file.unit, "_target_patterns_by_consumer", None)
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as unbuilt:
+        assignment.require_target_patterns()
+    assert unbuilt.value.reason == "target-pattern-table-not-built"
+
+
+# --------------------------------------------------------------------------
+# TOOTH 3 -- ONE authority.  The walk and the published predicate cannot
+# disagree, because they are the same function.
+# --------------------------------------------------------------------------
+
+
+def test_producer_walk_and_published_enrollment_are_one_answer(
+    tmp_path: Path,
+) -> None:
+    source_file = _open(
+        tmp_path,
+        "mixed.py",
+        "def fixture(value, items, holder):\n"
+        "    root, leaf = split(value)\n"
+        "    holder.a, holder.b = value\n"
+        "    plain = value\n"
+        "    for a, (b, *c) in items:\n"
+        "        pass\n"
+        "    listed = [a for a, (b, *c) in items]\n"
+        "    return root, leaf, plain, listed\n",
+    )
+    unit = source_file.unit
+    seated = set(unit._target_patterns_by_consumer)
+
+    for node in source_file.nodes():
+        enrollment = unit.target_pattern_enrollment(node)
+        published = isinstance(enrollment, nodes.TargetPatternEnrolledV1)
+        # Every enrolled shape has a seated row and vice versa: no shape is
+        # enrolled-but-unseated at construction time, and no row exists for a
+        # shape the published decision calls not-enrolled.
+        assert published == (node.ref in seated), (
+            f"{node.kind} disagrees: published={published} "
+            f"seated={node.ref in seated}"
+        )
+        if published:
+            assert len(unit.require_target_patterns(node)) == len(
+                enrollment.enrolled_targets
+            )
+
+
+# --------------------------------------------------------------------------
+# TOOTH 4 -- the LEXICAL arm.  Same law, same defect, blocked on #7346.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#7348 lexical arm is prerequisite-blocked on #7346. The lexical "
+        "enrollment decision is not a function of the call node -- it needs "
+        "the backend's scope/binding classification -- so publishing it "
+        "requires a keyed negative table, and a shell/ref-keyed one would "
+        "preserve the same defect under a second carrier. Inventing the key "
+        "here would be a second answer. This tooth XPASSes loudly the moment "
+        "the closed lexical outcome lands."
+    ),
+)
+def test_stranded_enrolled_lexical_call_refuses_instead_of_shrugging(
+    tmp_path: Path,
+) -> None:
+    source_file = _open(tmp_path, "lexical.py", LEXICAL_SOURCE)
+    call = next(node for node in source_file.nodes() if node.kind == "Call")
+    unit = source_file.unit
+
+    rows = unit.lexical_call_rows_for(call)
+    assert rows, "fixture must hold an enrolled lexical call"
+
+    # Same mutation as the target arm: strand the enrolled row.
+    constructed = unit.constructed_module
+    object.__setattr__(constructed, "lexical_call_rows", ())
+    unit._retained_lexical_call_rows.clear()
+
+    # The producer must still say "this occurrence IS enrolled" and the read
+    # must refuse. Today the read simply returns () and every consumer treats
+    # it as an ordinary non-lexical call.
+    enrollment = unit.lexical_call_enrollment(call)
+    assert enrollment.__class__.__name__.endswith("EnrolledV1")
+    with pytest.raises(nodes.BackendDefect):
+        unit.require_lexical_call_rows(call)
+
+
+def test_the_defaulting_lexical_reader_is_still_present_and_why() -> None:
+    """Honest instrument: records exactly what is NOT yet repaired.
+
+    ``lexical_call_rows_for`` still exists and still returns ``()`` for both
+    lawful non-enrollment and a stranded row.  Deleting it before the producer
+    publishes a closed outcome would force its five callers to re-derive the
+    backend's scope walk -- five second answers instead of one side door.
+    """
+    assert hasattr(nodes.SourceUnit, "lexical_call_rows_for"), (
+        "if this reader was deleted, the closed lexical outcome from #7348 "
+        "step 3 must have landed -- delete this test with it"
+    )
+    assert not hasattr(nodes.SourceUnit, "lexical_call_enrollment")

--- a/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_constructed_module_backend_door.py
@@ -672,14 +672,14 @@ def test_rewritten_nested_call_retains_its_exact_lexical_row(
         for node in source_file.nodes()
         if node.kind == "Constant" and node.value == 1
     )
-    (row,) = source_file.unit.lexical_call_rows_for(call)
+    (row,) = source_file.unit.require_lexical_call_rows(call)
 
     rewritten = call.substitute({"value": constant})
 
     assert rewritten is not call
     assert len(rewritten.args) == 1
     assert rewritten.args[0].value == 1
-    assert source_file.unit.lexical_call_rows_for(rewritten) == (row,)
+    assert source_file.unit.require_lexical_call_rows(rewritten) == (row,)
 
 
 def test_rewritten_call_without_lexical_row_stays_unenrolled(
@@ -700,14 +700,20 @@ def test_rewritten_call_without_lexical_row_stays_unenrolled(
         for node in source_file.nodes()
         if node.kind == "Constant" and node.value == 1
     )
-    assert source_file.unit.lexical_call_rows_for(call) == ()
+    assert (
+        source_file.unit.lexical_call_enrollment(call).reason
+        == "no-lexical-binding-in-scope"
+    )
 
     rewritten = call.substitute({"value": constant})
 
     assert rewritten is not call
     assert len(rewritten.args) == 1
     assert rewritten.args[0].value == 1
-    assert source_file.unit.lexical_call_rows_for(rewritten) == ()
+    assert (
+        source_file.unit.lexical_call_enrollment(rewritten).reason
+        == "no-lexical-binding-in-scope"
+    )
 
 
 def test_unchanged_nested_call_keeps_identity_and_lexical_row(
@@ -724,12 +730,12 @@ def test_unchanged_nested_call_keeps_identity_and_lexical_row(
         for node in source_file.nodes()
         if node.kind == "Call" and getattr(node.func, "id", None) == "child"
     )
-    (row,) = source_file.unit.lexical_call_rows_for(call)
+    (row,) = source_file.unit.require_lexical_call_rows(call)
 
     unchanged = call.substitute({})
 
     assert unchanged is call
-    assert source_file.unit.lexical_call_rows_for(unchanged) == (row,)
+    assert source_file.unit.require_lexical_call_rows(unchanged) == (row,)
 
 
 def test_parameter_assignment_delete_and_rebind_do_not_authorize_nested_call(

--- a/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_node_identity.py
+++ b/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_node_identity.py
@@ -1,0 +1,214 @@
+"""Occurrence-keyed node relational identity (#7346 Decisions A, B, C).
+
+A durable semantic relation over source nodes is keyed by the SOURCE
+OCCURRENCE the node denotes -- pinned source CID + exact span + node kind --
+not by the Python shell that happens to view it.  ``shadow.rewrite`` mints a
+fresh ShadowNode and ``materialize`` a fresh typed shell for the SAME source
+occurrence (rewrite explicitly borrows the origin span), so every relation
+keyed on shell identity silently loses its rows across substitution.
+
+Three arms, all of which must move together:
+
+* **A** -- ``SourceUnit.lexical_class_owner_for`` joins the producer-owned
+  ``function_class_owners`` relation.
+* **B** -- ``FunctionDef._active_initializer_owner`` classifies the LIVE
+  ``__init__`` member.  This is a policy comparison downstream of the lookup,
+  so repairing A alone does not reach it.
+* **C** -- ``ClassDef._authenticated_new_constructor_shape`` admits the
+  source-owned ``__new__`` shape against ``module_direct_bindings``.
+
+Each arm carries its negative twin: a genuinely FOREIGN occurrence, a
+genuinely OVERWRITTEN initializer, and a genuinely SHADOWED class must keep
+their existing answers.  Absence and lookup failure never share a
+representation: one row with ``owner=None`` is authenticated no-owner, zero
+rows stays a loud ``BackendDefect``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import (
+    ClassDef,
+    ConstructedReceiverRef,
+    FormalRef,
+    FunctionDef,
+)
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.shadow import rewrite
+from sugar_source_tree.tree import SourceFile
+
+
+def _sf(source: str, name: str) -> SourceFile:
+    return SourceFile((source, name, blake3_512_of(source.encode("utf-8"))))
+
+
+def _fn(tree: SourceFile, name: str) -> FunctionDef:
+    return next(
+        n for n in tree.nodes() if isinstance(n, FunctionDef) and n.name == name
+    )
+
+
+def _cls(tree: SourceFile, name: str) -> ClassDef:
+    return next(n for n in tree.nodes() if isinstance(n, ClassDef) and n.name == name)
+
+
+_BOX = (
+    "class Box:\n"
+    "    def __init__(self, value):\n"
+    "        self.value = value\n"
+    "\n"
+    "    def method(self):\n"
+    "        return self.value\n"
+    "\n"
+    "def free(x):\n"
+    "    return x\n"
+)
+
+
+# --------------------------------------------------------------------------
+# Decision A -- the durable relation key
+# --------------------------------------------------------------------------
+
+
+def test_rewritten_method_joins_the_same_owner_row() -> None:
+    """A rewritten shell over the same occurrence gets the producer's row."""
+    tree = _sf(_BOX, "occ_owner.py")
+    method = _fn(tree, "method")
+    owner = tree.unit.lexical_class_owner_for(method)
+    assert isinstance(owner, ClassDef) and owner.name == "Box"
+
+    rewritten = rewrite(method)
+    assert rewritten is not method
+    assert rewritten.ref is not method.ref
+    assert rewritten.span == method.span
+
+    rewritten_owner = tree.unit.lexical_class_owner_for(rewritten)
+    assert isinstance(rewritten_owner, ClassDef) and rewritten_owner.name == "Box"
+
+
+def test_free_function_keeps_one_authenticated_no_owner_row() -> None:
+    """One row with owner=None is authenticated absence, not a failed join."""
+    tree = _sf(_BOX, "occ_free.py")
+    free = _fn(tree, "free")
+    assert tree.unit.lexical_class_owner_for(free) is None
+    assert tree.unit.lexical_class_owner_for(rewrite(free)) is None
+
+
+def test_foreign_occurrence_stays_a_named_refusal() -> None:
+    """No span fallback: a function from another source refuses loudly."""
+    tree = _sf(_BOX, "occ_home.py")
+    foreign_tree = _sf("def method(self):\n    return 0\n", "occ_foreign.py")
+    foreign = _fn(foreign_tree, "method")
+    with pytest.raises(BackendDefect) as caught:
+        tree.unit.lexical_class_owner_for(foreign)
+    assert "0 backend owner rows" in caught.value.observed
+
+
+# --------------------------------------------------------------------------
+# Decision B -- active-member policy
+# --------------------------------------------------------------------------
+
+
+def test_rewritten_active_initializer_is_still_active() -> None:
+    """`active is self` cannot see a reconstructed shell of the live member."""
+    tree = _sf(_BOX, "occ_active.py")
+    init = _fn(tree, "__init__")
+    owner = init._active_initializer_owner()
+    assert isinstance(owner, ClassDef) and owner.name == "Box"
+
+    rewritten = rewrite(init)
+    rewritten_owner = rewritten._active_initializer_owner()
+    assert isinstance(rewritten_owner, ClassDef), (
+        "the reconstructed active __init__ denotes the same source occurrence "
+        "as the member retained in owner.body"
+    )
+    assert rewritten_owner.name == "Box"
+
+
+def test_rewritten_active_initializer_keeps_the_receiver_entrance() -> None:
+    """The downstream construction delta: receiver, never an ordinary formal."""
+    tree = _sf(_BOX, "occ_receiver.py")
+    init = _fn(tree, "__init__")
+    live = init._make_parameter_entry(init.params[0], 0, {})
+    assert isinstance(live, ConstructedReceiverRef)
+
+    rewritten = rewrite(init)
+    reconstructed = rewritten._make_parameter_entry(rewritten.params[0], 0, {})
+    assert isinstance(reconstructed, ConstructedReceiverRef), (
+        f"reconstructed active __init__ degraded to {type(reconstructed).__name__}"
+    )
+
+
+_OVERWRITTEN = (
+    "class Twice:\n"
+    "    def __init__(self, a):\n"
+    "        self.a = a\n"
+    "\n"
+    "    def __init__(self, b):\n"
+    "        self.b = b\n"
+)
+
+
+def test_overwritten_initializer_stays_inactive_in_both_shells() -> None:
+    """Negative twin: the shadowed __init__ is inactive, rewritten or not."""
+    tree = _sf(_OVERWRITTEN, "occ_overwritten.py")
+    inits = [
+        n for n in tree.nodes() if isinstance(n, FunctionDef) and n.name == "__init__"
+    ]
+    assert len(inits) == 2
+    overwritten, active = inits
+    assert overwritten._active_initializer_owner() is None
+    assert rewrite(overwritten)._active_initializer_owner() is None
+    assert active._active_initializer_owner() is not None
+    # and its ordinary formal entrance is preserved
+    entry = overwritten._make_parameter_entry(overwritten.params[0], 0, {})
+    assert isinstance(entry, FormalRef)
+
+
+_NEW_SHAPE = (
+    "class Cell:\n"
+    "    def __new__(cls, value):\n"
+    "        self = super(Cell, cls).__new__(cls)\n"
+    "        self.value = value\n"
+    "        return self\n"
+)
+
+
+# --------------------------------------------------------------------------
+# Decision C -- authenticated __new__ admission
+# --------------------------------------------------------------------------
+
+
+def test_rewritten_class_keeps_authenticated_new_admission() -> None:
+    """`bindings[0] is self` cannot see a reconstructed shell of the class."""
+    tree = _sf(_NEW_SHAPE, "occ_new.py")
+    cell = _cls(tree, "Cell")
+    assert cell._authenticated_new_constructor_shape() is not None
+
+    rewritten = rewrite(cell)
+    assert rewritten._authenticated_new_constructor_shape() is not None, (
+        "the reconstructed ClassDef denotes the authenticated source occurrence"
+    )
+
+
+def test_shadowed_class_binding_stays_unauthenticated() -> None:
+    """Negative twin: two module bindings for the name -- admission refused."""
+    tree = _sf(_NEW_SHAPE + "\nCell = 1\n", "occ_new_shadowed.py")
+    cell = _cls(tree, "Cell")
+    assert cell._authenticated_new_constructor_shape() is None
+    assert rewrite(cell)._authenticated_new_constructor_shape() is None
+
+
+def test_foreign_class_occurrence_stays_unauthenticated() -> None:
+    """Negative twin: a same-named class from another source is not this one."""
+    foreign_tree = _sf(_NEW_SHAPE, "occ_new_foreign.py")
+    foreign = _cls(foreign_tree, "Cell")
+    home = _sf(_NEW_SHAPE, "occ_new_home.py")
+    bindings = (home.unit.module_direct_bindings or {}).get("Cell", ())
+    assert len(bindings) == 1
+    from sugar_source_tree.occurrence import SourceOccurrenceIdentityV1
+
+    assert SourceOccurrenceIdentityV1.of(bindings[0]) != (
+        SourceOccurrenceIdentityV1.of(foreign)
+    )

--- a/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_target_patterns.py
+++ b/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_target_patterns.py
@@ -177,6 +177,84 @@ def test_the_rewritten_consumer_stays_enrolled_and_a_stranded_row_still_refuses(
     assert stranded.value.reason == "foreign-target-occurrence"
 
 
+_TWO_CONSUMERS = """\
+def fixture_collision(pairs_collision, more_collision):
+    first_collision = [head_collision for (head_collision, tail_collision) in pairs_collision]
+    second_collision = [lead_collision for (lead_collision, rest_collision) in more_collision]
+    return first_collision, second_collision
+"""
+
+
+def _open_text(tmp_path: Path, name: str, text: str) -> SourceFile:
+    path = tmp_path / name
+    path.write_text(text)
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+
+    return SourceFile(
+        workspace_path_source(str(path), root=str(tmp_path)), reporter=NULL_REPORTER
+    )
+
+
+def test_two_enrolled_consumers_seat_two_rows_when_their_occurrences_differ(
+    tmp_path: Path,
+) -> None:
+    """CONTROL for the collision tooth: the ordinary path is untouched.
+
+    Two distinct enrolled consumers in one unit are two distinct occurrences,
+    so both rows seat and neither refuses.  Without this arm the tooth below
+    would pass just as well against a relation that refused everything.
+    """
+    source_file = _open_text(tmp_path, "collision_control.py", _TWO_CONSUMERS)
+    consumers = [node for node in source_file.nodes() if node.kind == "ListComp"]
+    assert len(consumers) == 2
+
+    keys = {
+        occurrence.SourceOccurrenceIdentityV1.of(consumer) for consumer in consumers
+    }
+    assert len(keys) == 2, "fixture's two consumers must be two occurrences"
+    for consumer in consumers:
+        assert len(consumer.require_target_patterns()) == 1
+
+
+def test_a_duplicate_source_occurrence_key_refuses_instead_of_overwriting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TOOTH -- the cost of occurrence-keying, guarded.
+
+    Ref-keying made a collision structurally impossible; occurrence-keying
+    makes it expressible.  An unguarded ``dict`` write would silently DROP the
+    first consumer's producer-minted row -- absence and lookup-failure sharing
+    one representation again, by a different door.
+
+    The collision is planted at the identity function, so the real producer
+    walk runs and the real write path executes: the second enrolled consumer
+    genuinely mints the same key as the first.
+    """
+    collapsed = occurrence.SourceOccurrenceIdentityV1(
+        file="collision.py",
+        source_cid="blake3-512:collapsed",
+        start=0,
+        end=0,
+        node_kind="Collapsed",
+    )
+    monkeypatch.setattr(
+        occurrence.SourceOccurrenceIdentityV1,
+        "of",
+        classmethod(lambda cls, node: collapsed),
+    )
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as collision:
+        _open_text(tmp_path, "collision_planted.py", _TWO_CONSUMERS)
+
+    # The consumer-side write is reached first, so it is the one that names it.
+    assert collision.value.reason == "duplicate-target-pattern-consumer-occurrence"
+    # The refusal carries the colliding key and BOTH claimants, so the report
+    # says which rows collided rather than only that something did.
+    key, seated, proposed = collision.value.target_pattern
+    assert key is collapsed
+    assert seated != proposed
+
+
 @pytest.mark.parametrize("shape", sorted(_SHAPES))
 def test_a_foreign_units_occurrence_never_joins_this_units_relation(
     shape, tmp_path: Path

--- a/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_target_patterns.py
+++ b/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_target_patterns.py
@@ -1,0 +1,218 @@
+"""Red teeth for #7346-A: the target-pattern relation is keyed by OCCURRENCE.
+
+The defect these teeth pin: the relation was keyed by the consumer's ``Node``
+ref.  ``shadow.rewrite`` mints a FRESH ref for the rewritten consumer, so every
+substitution that changed a comprehension stranded its own producer row -- and
+the row went missing as a plausible EMPTY, not as a failed join.
+
+``ListComp`` alone was protected, by a ``retain_target_patterns`` call added
+reactively in 038c435cba when someone hit that case in the wild.  ``SetComp``,
+``DictComp`` and ``GeneratorExp`` are equally enrolled consumers that equally
+mint a new parent ref, and none of them retained.  That asymmetry is the whole
+evidence that a per-consumer obligation nobody can enforce is the wrong shape:
+one consumer was remembered and three were forgotten, and nothing failed loudly
+when the next one was added.
+
+The repair is not a fourth retention call.  ``shadow.rewrite`` deliberately
+borrows the origin's span and keeps its kind and unit, so the rewrite denotes
+the SAME ``SourceOccurrenceIdentityV1`` as its origin while the ref does not.
+Keying the relation on the occurrence makes retention unnecessary for all four
+consumers at once, with no obligation for anyone to remember.
+
+Each test below is one tooth: a rewritten destructuring comprehension of each
+kind must still join its producer-minted pattern.  ``ListComp`` is the control
+-- at the pre-repair pin it passes (it had retention) while the other three
+fail, which is what makes the failure a keying defect rather than a broken
+fixture.
+
+#7364 trap: SourceUnits are memoized by (source_cid, workspace-relative
+filename), so byte-identical fixtures SHARE ONE UNIT and a distinct tmp_path
+buys ZERO isolation.  Every fixture below is given unique source text.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sugar_source_tree import nodes, occurrence
+from sugar_source_tree.reporter import NULL_REPORTER
+from sugar_source_tree.tree import SourceFile
+
+
+# Each fixture destructures ``(left, right)`` out of a FREE name, so the
+# comprehension is an enrolled target-pattern consumer whose ``iter`` really
+# changes under substitution.  The replacement is another free Name, never a
+# concrete display: a concrete iterable would unroll to a display and the
+# rewrite path under test would never be taken.
+_SHAPES = {
+    "listcomp": "[left_{tag} for (left_{tag}, right_{tag}) in seed_{tag}]",
+    "setcomp": "{{left_{tag} for (left_{tag}, right_{tag}) in seed_{tag}}}",
+    "dictcomp": "{{left_{tag}: right_{tag} for (left_{tag}, right_{tag}) in seed_{tag}}}",
+    "generatorexp": "(left_{tag} for (left_{tag}, right_{tag}) in seed_{tag})",
+}
+
+_KINDS = {
+    "listcomp": "ListComp",
+    "setcomp": "SetComp",
+    "dictcomp": "DictComp",
+    "generatorexp": "GeneratorExp",
+}
+
+
+def _source(shape: str) -> str:
+    tag = shape
+    body = _SHAPES[shape].format(tag=tag)
+    # Unique text per shape AND per kind name, so no two fixtures in this file
+    # -- or in any neighbouring file -- can collide on one memoized SourceUnit.
+    return (
+        f"def fixture_{tag}(seed_{tag}, alt_{tag}):\n"
+        # A real load occurrence of ``alt_*``: a parameter is not a Name node,
+        # and the substitution value has to be an actual Node from this unit.
+        f"    keep_{tag} = alt_{tag}\n"
+        f"    return {body}\n"
+    )
+
+
+def _open(tmp_path: Path, shape: str) -> SourceFile:
+    text = _source(shape)
+    path = tmp_path / f"occ_{shape}.py"
+    path.write_text(text)
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+
+    return SourceFile(
+        workspace_path_source(str(path), root=str(tmp_path)), reporter=NULL_REPORTER
+    )
+
+
+def _comprehension(source_file: SourceFile, shape: str):
+    kind = _KINDS[shape]
+    return next(node for node in source_file.nodes() if node.kind == kind)
+
+
+def _free_name(source_file: SourceFile, shape: str):
+    """The ``alt_*`` parameter, used as a non-concrete substitution value."""
+    return next(
+        node
+        for node in source_file.nodes()
+        if node.kind == "Name" and node.id == f"alt_{shape}"
+    )
+
+
+def _rewritten(source_file: SourceFile, shape: str):
+    """Substitute the comprehension's iterable, forcing a real shadow rewrite."""
+    comprehension = _comprehension(source_file, shape)
+    replacement = _free_name(source_file, shape)
+    rewritten = comprehension.substitute({f"seed_{shape}": replacement})
+    assert rewritten is not comprehension, "fixture did not exercise the rewrite path"
+    assert rewritten.kind == _KINDS[shape]
+    # The precondition the whole issue turns on: the rewrite is a NEW ref, so a
+    # ref-keyed relation loses it, while the occurrence is unchanged.
+    assert rewritten.ref is not comprehension.ref
+    assert occurrence.SourceOccurrenceIdentityV1.of(
+        rewritten
+    ) == occurrence.SourceOccurrenceIdentityV1.of(comprehension)
+    return comprehension, rewritten
+
+
+@pytest.mark.parametrize("shape", sorted(_SHAPES))
+def test_a_rewritten_destructuring_comprehension_retains_its_pattern(
+    shape, tmp_path: Path
+) -> None:
+    """TOOTH -- all four consumers, no retention call anywhere."""
+    source_file = _open(tmp_path, shape)
+    origin, rewritten = _rewritten(source_file, shape)
+
+    # Precondition: the origin really owns a producer-minted row.
+    (origin_pattern,) = origin.require_target_patterns()
+
+    # The claim: the rewrite joins the SAME row, with no per-consumer retention.
+    (rewritten_pattern,) = rewritten.require_target_patterns()
+    assert rewritten_pattern is origin_pattern
+
+    # And the pair-exact doors join too, read through the REWRITE as consumer.
+    # (The target child itself is carried through the rewrite unchanged; it is
+    # the CONSUMER's ref that moves, which is exactly what stranded the row.)
+    rewritten_target = rewritten.generators[0].target
+    assert (
+        source_file.unit.require_target_pattern(rewritten, rewritten_target)
+        is origin_pattern
+    )
+    assert (
+        source_file.unit.require_target_pattern_for_target(rewritten_target)
+        is origin_pattern
+    )
+
+
+@pytest.mark.parametrize("shape", sorted(_SHAPES))
+def test_the_rewritten_consumer_stays_enrolled_and_a_stranded_row_still_refuses(
+    shape, tmp_path: Path
+) -> None:
+    """The OTHER arm: keying by occurrence must not soften any refusal.
+
+    Absence and lookup-failure still have separate representations.  Dropping
+    the row keeps the enrollment answer TRUE and makes the lookup scream --
+    exactly as it did when the relation was ref-keyed.
+    """
+    source_file = _open(tmp_path, shape)
+    _origin, rewritten = _rewritten(source_file, shape)
+    unit = source_file.unit
+
+    assert isinstance(
+        rewritten.target_pattern_enrollment, nodes.TargetPatternEnrolledV1
+    )
+
+    # Bypass the mechanism: drop the row the rewrite would have joined.
+    unit._target_patterns_by_consumer.pop(
+        occurrence.SourceOccurrenceIdentityV1.of(rewritten)
+    )
+
+    # Enrollment is UNCHANGED by a lost row: it is not read out of the relation.
+    assert isinstance(
+        rewritten.target_pattern_enrollment, nodes.TargetPatternEnrolledV1
+    )
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as stranded:
+        rewritten.require_target_patterns()
+    assert stranded.value.reason == "foreign-target-occurrence"
+
+
+@pytest.mark.parametrize("shape", sorted(_SHAPES))
+def test_a_foreign_units_occurrence_never_joins_this_units_relation(
+    shape, tmp_path: Path
+) -> None:
+    """Occurrence keying must not become a span-only or name-only match.
+
+    A twin file with the SAME span and the SAME node kind is a DIFFERENT
+    occurrence, because the pinned source differs.  It must refuse, not join.
+    """
+    source_file = _open(tmp_path, shape)
+    origin = _comprehension(source_file, shape)
+
+    # A twin whose text differs only in a trailing comment: the comprehension
+    # keeps its exact span and kind, and only the source CID moves.
+    twin_text = _source(shape) + "# a different authenticated source\n"
+    twin_path = tmp_path / f"occ_{shape}_twin.py"
+    twin_path.write_text(twin_text)
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+
+    twin = SourceFile(
+        workspace_path_source(str(twin_path), root=str(tmp_path)),
+        reporter=NULL_REPORTER,
+    )
+    twin_comprehension = _comprehension(twin, shape)
+
+    origin_occurrence = occurrence.SourceOccurrenceIdentityV1.of(origin)
+    twin_occurrence = occurrence.SourceOccurrenceIdentityV1.of(twin_comprehension)
+    assert (origin_occurrence.start, origin_occurrence.end) == (
+        twin_occurrence.start,
+        twin_occurrence.end,
+    )
+    assert origin_occurrence.node_kind == twin_occurrence.node_kind
+    assert origin_occurrence != twin_occurrence
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as foreign:
+        source_file.unit.require_target_pattern(
+            twin_comprehension, twin_comprehension.generators[0].target
+        )
+    assert foreign.value.reason == "foreign-target-occurrence"

--- a/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_target_patterns.py
+++ b/implementations/python/sugar-source-tree/tests/test_occurrence_keyed_target_patterns.py
@@ -255,6 +255,108 @@ def test_a_duplicate_source_occurrence_key_refuses_instead_of_overwriting(
     assert seated != proposed
 
 
+_TWO_TARGETS = """\
+def fixture_target_collision(value_first, value_second):
+    head_first, tail_first = split_first(value_first)
+    head_second, tail_second = split_second(value_second)
+    return head_first, tail_first, head_second, tail_second
+"""
+
+
+def _collide_only(monkeypatch: pytest.MonkeyPatch, node_kind: str):
+    """Collapse the occurrence of ONE grammar kind, leaving every other real.
+
+    The lever the target-side guard needs.  Collapsing every occurrence makes
+    the CONSUMER keys collide first, and the consumer guard raises before the
+    target loop is ever reached -- which is why a blanket collapse cannot
+    exercise the target write.  Collapsing only ``Tuple`` leaves the two
+    ``Assign`` consumers genuinely distinct and drives two different consumers
+    into one target key.
+    """
+    real = occurrence.SourceOccurrenceIdentityV1.of.__func__
+    collapsed = occurrence.SourceOccurrenceIdentityV1(
+        file="collision.py",
+        source_cid="blake3-512:collapsed-target",
+        start=0,
+        end=0,
+        node_kind=node_kind,
+    )
+
+    def selective(cls, node):
+        # ``node.kind`` is the grammar kind on the NODE; the occurrence spells
+        # the same fact as ``node_kind``.  Reading ``.kind`` off the occurrence
+        # returns nothing -- that attribute does not exist there.
+        return collapsed if node.kind == node_kind else real(cls, node)
+
+    monkeypatch.setattr(
+        occurrence.SourceOccurrenceIdentityV1, "of", classmethod(selective)
+    )
+    return collapsed
+
+
+def test_two_target_patterns_claiming_one_occurrence_refuse_on_the_target_side(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TOOTH -- the target-side write, exercised on its own.
+
+    Two DISTINCT enrolled consumers whose targets collapse to one occurrence.
+    The consumer keys stay distinct, so the consumer guard cannot fire and the
+    target guard is the only thing standing between this and a silently
+    dropped pattern row.
+    """
+    collapsed = _collide_only(monkeypatch, "Tuple")
+
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as collision:
+        _open_text(tmp_path, "target_collision.py", _TWO_TARGETS)
+
+    # The TARGET refusal by name -- not the consumer one, which never ran.
+    assert collision.value.reason == "duplicate-target-pattern-target-occurrence"
+    key, seated, proposed = collision.value.target_pattern
+    assert key is collapsed
+    # Two different patterns, from two different consumers, one target key.
+    assert seated is not proposed
+    assert seated.consumer_occurrence is not proposed.consumer_occurrence
+
+
+def test_the_two_duplicate_key_guards_are_independently_reachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither guard is the other's shadow.
+
+    Collapsing ``Tuple`` reaches the TARGET write with distinct consumer keys;
+    collapsing ``Assign`` collides the CONSUMER keys first.  Two different
+    levers, two different refusals, so deleting either one loses a door that
+    the other does not cover.
+    """
+    _collide_only(monkeypatch, "Tuple")
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as target_side:
+        _open_text(tmp_path, "reach_target.py", _TWO_TARGETS)
+    assert target_side.value.reason == "duplicate-target-pattern-target-occurrence"
+
+    monkeypatch.undo()
+
+    _collide_only(monkeypatch, "Assign")
+    with pytest.raises(nodes.TargetPatternConstructionGapV1) as consumer_side:
+        _open_text(tmp_path, "reach_consumer.py", _TWO_TARGETS)
+    assert consumer_side.value.reason == "duplicate-target-pattern-consumer-occurrence"
+
+
+def test_two_destructuring_assigns_seat_two_rows_when_nothing_is_collapsed(
+    tmp_path: Path,
+) -> None:
+    """CONTROL for both collision teeth: the unpatched fixture is lawful."""
+    source_file = _open_text(tmp_path, "target_collision_control.py", _TWO_TARGETS)
+    assigns = [node for node in source_file.nodes() if node.kind == "Assign"]
+    assert len(assigns) == 2
+    targets = {
+        occurrence.SourceOccurrenceIdentityV1.of(assign.targets[0])
+        for assign in assigns
+    }
+    assert len(targets) == 2, "fixture's two targets must be two occurrences"
+    for assign in assigns:
+        assert len(assign.require_target_patterns()) == 1
+
+
 @pytest.mark.parametrize("shape", sorted(_SHAPES))
 def test_a_foreign_units_occurrence_never_joins_this_units_relation(
     shape, tmp_path: Path

--- a/implementations/python/sugar-source-tree/tests/test_store_unpack_not_foreign_target.py
+++ b/implementations/python/sugar-source-tree/tests/test_store_unpack_not_foreign_target.py
@@ -41,7 +41,10 @@ def test_attribute_only_unpack_substitution_binding_does_not_raise(
         "        self.left, self.right = left, right\n",
     )
     assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
-    assert assignment.target_patterns == ()
+    assert (
+        assignment.target_pattern_enrollment.reason
+        == "consumer-shape-not-enrolled"
+    )
     # The hierarchy door: substitution_binding must not raise.
     binding = assignment.substitution_binding({})
     assert binding is None or binding == {}
@@ -58,7 +61,9 @@ def test_mixed_name_subscript_unpack_does_not_raise_foreign_target(
     )
     assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
     # May or may not enroll depending on _is_binding_target_pattern (mixed = no).
-    assert assignment.target_patterns == ()
+    assert (
+        assignment.target_pattern_enrollment.reason == "consumer-shape-not-enrolled"
+    )
     binding = assignment.substitution_binding({})
     # Must not raise TargetPatternConstructionGapV1
     assert binding is None or isinstance(binding, dict)
@@ -72,7 +77,7 @@ def test_pure_name_unpack_still_has_pattern_and_binds(tmp_path: Path) -> None:
         "def f(key):\n" "    root, leaf = split(key)\n" "    return root\n",
     )
     assignment = next(n for n in sf.nodes() if isinstance(n, Assign))
-    assert len(assignment.target_patterns) == 1
+    assert len(assignment.require_target_patterns()) == 1
     # require still works for enrolled patterns
     pattern = sf.unit.require_target_pattern(assignment, assignment.targets[0])
-    assert pattern is assignment.target_patterns[0]
+    assert pattern is assignment.require_target_patterns()[0]

--- a/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
+++ b/implementations/python/sugar-source-tree/tests/test_target_pattern_law_of_one.py
@@ -102,7 +102,7 @@ def _products(source_file: SourceFile):
     for consumer in function.walk():
         key = (consumer.kind, consumer.line_col_span().start_line)
         if any(expected[:2] == key for expected in EXPECTED):
-            products.extend(consumer.target_patterns)
+            products.extend(consumer.require_target_patterns())
     return tuple(products)
 
 
@@ -155,13 +155,13 @@ def test_ordinary_nested_star_consumers_construct_exact_patterns_once(tmp_path: 
     live_file = _open_source_file(live_path, tmp_path)
     (live_function,) = tuple(live_file.functions())
     live_loop = next(node for node in live_function.walk() if node.kind == "For")
-    (live_pattern,) = live_loop.target_patterns
+    (live_pattern,) = live_loop.require_target_patterns()
     live_function.sugar()
     live_function.sugar()
     repeated_live_loop = next(
         node for node in live_function.walk() if node.kind == "For"
     )
-    (repeated_live_pattern,) = repeated_live_loop.target_patterns
+    (repeated_live_pattern,) = repeated_live_loop.require_target_patterns()
     assert repeated_live_pattern is live_pattern
     assert live_file.unit.target_pattern_construction_count == 1
 
@@ -214,8 +214,8 @@ def test_same_unit_foreign_for_cannot_claim_local_target(tmp_path: Path):
     (function,) = tuple(source_file.functions())
     loops = tuple(node for node in function.walk() if node.kind == "For")
     assert len(loops) == 2
-    (first_pattern,) = loops[0].target_patterns
-    (second_pattern,) = loops[1].target_patterns
+    (first_pattern,) = loops[0].require_target_patterns()
+    (second_pattern,) = loops[1].require_target_patterns()
     before = source_file.unit.target_pattern_construction_count
 
     with pytest.raises(nodes.TargetPatternConstructionGapV1) as rejected:
@@ -227,8 +227,8 @@ def test_same_unit_foreign_for_cannot_claim_local_target(tmp_path: Path):
     assert rejected.value.consumer_occurrence is second_pattern.consumer_occurrence
     assert rejected.value.target_occurrence is first_pattern.target_occurrence
     assert source_file.unit.target_pattern_construction_count == before
-    assert loops[0].target_patterns[0] is first_pattern
-    assert loops[1].target_patterns[0] is second_pattern
+    assert loops[0].require_target_patterns()[0] is first_pattern
+    assert loops[1].require_target_patterns()[0] is second_pattern
 
 
 def test_assign_rhs_rewrite_retains_its_authenticated_target_pattern(
@@ -248,7 +248,7 @@ def test_assign_rhs_rewrite_retains_its_authenticated_target_pattern(
         for node in function.walk()
         if node.kind == "Assign" and node.line_col_span().start_line == 3
     )
-    (original_pattern,) = original.target_patterns
+    (original_pattern,) = original.require_target_patterns()
 
     frame = function.source_visible_call_frame()
 
@@ -285,7 +285,9 @@ def test_mixed_attribute_unpack_is_not_a_lexical_target_pattern(tmp_path: Path):
     source_file = _open_source_file(path, tmp_path)
     assignment = next(node for node in source_file.nodes() if node.kind == "Assign")
 
-    assert assignment.target_patterns == ()
+    assert (
+        assignment.target_pattern_enrollment.reason == "consumer-shape-not-enrolled"
+    )
     assert source_file.unit.target_pattern_construction_count == 0
 
 


### PR DESCRIPTION
Six fixes, each mutation-proved both arms, joined and re-measured at every step.

- occurrence-keyed node identity (#7346 A/B/C) — owner lookup, `active is self`, `bindings[0] is self`
- closed target-pattern enrollment (#7348) — producer publishes `Enrolled | NotEnrolled`; `target_patterns_for` and `Node.target_patterns` DELETED
- closed finite-projection outcome (#7347) — four causes, four names; `AuthenticatedLookupFailed` can never reach `Complete`
- closed lexical-call enrollment (#7348) — `lexical_call_rows_for` DELETED
- occurrence-keyed target patterns — `retain_target_patterns` and all three call sites DELETED; the per-consumer retention obligation is removed, not extended
- duplicate source-occurrence key guards — both independently mutation-proved; refuse instead of silently overwriting a constructed relation row

## Measured blast radius, node ID both directions

`sugar-lift-py-tests`, whole stack vs bare main `d0ff65fe`, identical invocation and collection:

| | base | stack |
|---|---|---|
| failed | 754 | 747 |
| passed | 3353 | 3382 |

**Newly red: 0. Newly green: 7** (`test_producer_emits_authenticated_exceptional_exit` across Attribute/BinOp/BoolOp/Compare/Subscript/UnaryOp, plus renamed contract expressions). Those were failing at main; the identity defect had been breaking them silently.

`sugar-source-tree`: newly red 0, newly green 7 after the comprehension repair.

## Notes

- The 7 tests that went red at the intermediate stage were two causes, not one: 5 comprehension stranding (`SetComp`/`DictComp`/`GeneratorExp` — one-protected-three-forgotten, reproduced as `7 failed / 5 passed` with `listcomp` passing under the same parametrize) and 2 `ConstructedValueCategoryGap` on `TargetPatternEnrolledV1`, a defect the merge itself introduced. Both fixed.
- Four projection tests used a rewrite as the *mechanism* for stranding a row; they encoded the defect and now drop the row explicitly, plus a new test asserting a rewrite keeps its row.
- `_REWRITE_SOURCES` never had a listcomp entry — corroborating the same asymmetry.
- A span-or-kind-changing rewrite would strand LOUDLY as `foreign-target-occurrence`, not as an empty. Degrades safely.
- `grep -c duplicate-target-pattern` over the full suite output is 0: the new guards fire nowhere in the corpus.

Filed along the way: #7364 (SourceUnit memoization gives byte-identical fixtures zero isolation), #7365 (`sugar_lift_py_tests.scripts` untracked, aborts whole default collection).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key semantic node relations by source occurrence identity for target patterns and lexical calls
> - Introduces `SourceOccurrenceIdentityV1` as a stable, hash-equal identity for AST nodes that survives shadow rewrites, replacing node shell identity for joining target-pattern and lexical-call relations.
> - Adds closed enrollment outcome types (`TargetPatternEnrolledV1`, `TargetPatternNotEnrolledV1`, `LexicalCallEnrolledV1`, `LexicalCallNotEnrolledV1`) minted only by the backend producer, replacing opportunistic empty-tuple defaulting with explicit decisions and refusal reasons.
> - Replaces defaulting readers (`target_patterns_for`, `lexical_call_rows_for`) with `require_*` methods that assert enrollment and raise `TargetPatternConstructionGapV1` or `BackendDefect` on stranded rows, missing tables, or foreign occurrences.
> - Rewrites the finite projection fast-path in `ComprehensionSugar._desugar_generators` to return structured `Projected`/`NotProjected` decisions via `FiniteProjectionNonSuccessV1`, raising `FiniteProjectionRefusalV1` for authenticated lookup failures instead of silently falling through.
> - Risk: `Assign`, `For`, and `ListComp` rewrites no longer perform target-pattern retention side effects; `Call` rewrite now requires explicit enrollment rather than checking row presence, which changes behavior for any call or assignment node that was previously silently skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 646e5f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer enrollment outcomes for comprehension targets and lexical calls.
  * Added typed projection results distinguishing successful projections, lawful non-application, unavailable context, lookup failures, and replacement failures.
  * Added durable source-occurrence tracking to preserve relationships across rewrites.
* **Bug Fixes**
  * Prevented invalid, duplicate, foreign, or stranded relationships from being silently accepted.
  * Improved refusal errors with actionable context about the affected construct and location.
  * Preserved valid symbolic fallbacks where projection does not apply.
* **Tests**
  * Expanded coverage for comprehensions, calls, rewrites, enrollment validation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->