### PR TITLE
A sealed body must carry positive membership attestation (#7351)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -240,6 +240,314 @@ def _validate_demand_table_agreement(
     }
 
 
+_RELATION_MEMBERSHIP_SCHEMA = "recensus-relation-membership-attestation/v1"
+_RELATION_MEMBER_MANIFEST_SCHEMA = "recensus-relation-member-manifest/v1"
+# The relations whose population a sealed width is taken to describe. Both
+# receipts at frontierWidth=477 carried ZERO testimony for either of them.
+RELATION_MEMBERSHIP_RELATIONS = ("lexical-call", "target-pattern")
+_RELATION_MEMBERSHIP_FIELDS = frozenset({"schema", "relations"})
+_RELATION_MEMBER_MANIFEST_FIELDS = frozenset(
+    {"schema", "relation", "memberCids", "memberCount", "manifestCid"}
+)
+
+# Closed refusal vocabulary. Absent is not missing is not extra is not
+# duplicate: four different facts about attendance, four different names, and
+# none of them is "no errors were seen".
+_RELATION_MEMBERSHIP_ABSENT = "relation-membership-attestation-absent"
+_RELATION_MEMBERSHIP_MALFORMED = "relation-membership-attestation-malformed"
+_RELATION_MEMBERSHIP_MISSING = "relation-membership-missing"
+_RELATION_MEMBERSHIP_EXTRA = "relation-membership-extra"
+_RELATION_MEMBERSHIP_DUPLICATE = "relation-membership-duplicate"
+_RELATION_MEMBERSHIP_REFUSAL_CODES = frozenset(
+    {
+        _RELATION_MEMBERSHIP_ABSENT,
+        _RELATION_MEMBERSHIP_MALFORMED,
+        _RELATION_MEMBERSHIP_MISSING,
+        _RELATION_MEMBERSHIP_EXTRA,
+        _RELATION_MEMBERSHIP_DUPLICATE,
+    }
+)
+
+# Only this module may mint an attendance verdict. A new callsite can write a
+# guard; it cannot write this object.
+_RELATION_MEMBERSHIP_AUTHORITY = object()
+
+
+class RelationMembershipAttestationV1:
+    """Closed attendance verdict for the relations a sealed width describes.
+
+    A sealed board must carry POSITIVE ATTENDANCE for every population it
+    claims to have observed. Before this type existed the mint's only inputs
+    were things it could refuse for being *wrong*; nothing forced a claim to
+    exist at all, so a run that never observed the lexical-call relation sealed
+    a width over an unknown denominator and no cryptographic seal failed.
+
+    Exactly two variants exist -- conserved and refused -- and only the mint may
+    make either. ``conserved_wire`` is the sole source of the body's
+    ``relationMembershipAttestation`` field, so the sealed body literal cannot
+    be evaluated without a conserved verdict in hand. That is a missing
+    constructor rather than a bypassable guard.
+    """
+
+    __slots__ = ()
+
+    _variants_closed = False
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        if RelationMembershipAttestationV1._variants_closed:
+            raise TypeError(
+                "relation-membership-attestation-variant-not-closed: "
+                f"{cls.__name__} is a third variant"
+            )
+
+    def __init__(self, *, _authority: object = None) -> None:
+        if _authority is not _RELATION_MEMBERSHIP_AUTHORITY:
+            raise TypeError(
+                "relation-membership-attestation-not-mint-minted: "
+                f"{type(self).__name__} may only be minted by the seal door"
+            )
+
+    def refusal_reason(self) -> str | None:
+        """The refusal name, or None when attendance was conserved."""
+        raise NotImplementedError
+
+    def conserved_wire(self) -> dict[str, Any]:
+        """The attested membership. Refused verdicts have no wire form."""
+        raise TypeError(
+            "relation-membership-attestation-refused: "
+            f"{type(self).__name__} carries no conserved membership"
+        )
+
+
+class RelationMembershipConservedV1(RelationMembershipAttestationV1):
+    """Expected and observed agreed exactly, for every declared relation."""
+
+    __slots__ = ("_wire",)
+
+    def __init__(self, *, wire: Mapping[str, Any], _authority: object = None) -> None:
+        super().__init__(_authority=_authority)
+        object.__setattr__(self, "_wire", dict(wire))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise TypeError("relation-membership-attestation-is-immutable")
+
+    def refusal_reason(self) -> str | None:
+        return None
+
+    def conserved_wire(self) -> dict[str, Any]:
+        return dict(self._wire)
+
+
+class RelationMembershipRefusedV1(RelationMembershipAttestationV1):
+    """Attendance was not conserved, named by which fact failed."""
+
+    __slots__ = ("_findings", "_detail")
+
+    def __init__(
+        self,
+        *,
+        findings: Sequence[tuple[str, str | None]],
+        detail: str,
+        _authority: object = None,
+    ) -> None:
+        super().__init__(_authority=_authority)
+        if not findings:
+            raise TypeError("relation-membership-refusal-without-a-named-fact")
+        for code, _relation in findings:
+            if code not in _RELATION_MEMBERSHIP_REFUSAL_CODES:
+                raise TypeError(
+                    f"relation-membership-refusal-reason-not-declared: {code}"
+                )
+        object.__setattr__(self, "_findings", tuple(findings))
+        object.__setattr__(self, "_detail", detail)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise TypeError("relation-membership-attestation-is-immutable")
+
+    def refusal_reason(self) -> str:
+        names = [
+            code if relation is None else f"{code}:{relation}"
+            for code, relation in self._findings
+        ]
+        return f"{' '.join(names)}: {self._detail}"
+
+
+RelationMembershipAttestationV1._variants_closed = True
+
+
+def _relation_member_manifest(
+    raw: object, *, relation: str, role: str
+) -> tuple[str, ...]:
+    """Authenticate one recomputable member manifest, or name its defect."""
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"{role} manifest for {relation} is not an object")
+    fields = set(raw)
+    if fields != _RELATION_MEMBER_MANIFEST_FIELDS:
+        raise ValueError(
+            f"{role} manifest for {relation} closed fields differ "
+            f"missing={sorted(_RELATION_MEMBER_MANIFEST_FIELDS - fields)} "
+            f"extra={sorted(fields - _RELATION_MEMBER_MANIFEST_FIELDS)}"
+        )
+    if raw["schema"] != _RELATION_MEMBER_MANIFEST_SCHEMA:
+        raise ValueError(
+            f"{role} manifest for {relation} schema must be "
+            f"{_RELATION_MEMBER_MANIFEST_SCHEMA}"
+        )
+    if raw["relation"] != relation:
+        raise ValueError(
+            f"{role} manifest is labelled {raw['relation']!r} under {relation!r}"
+        )
+    members = raw["memberCids"]
+    if not isinstance(members, list) or any(
+        not isinstance(member, str) or not member for member in members
+    ):
+        raise ValueError(
+            f"{role} manifest for {relation} memberCids must be non-empty strings"
+        )
+    if type(raw["memberCount"]) is not int or raw["memberCount"] != len(members):
+        raise ValueError(
+            f"{role} manifest for {relation} memberCount={raw['memberCount']!r} "
+            f"disagrees with {len(members)} member CIDs"
+        )
+    recomputed = canonical_cid(
+        {
+            "schema": _RELATION_MEMBER_MANIFEST_SCHEMA,
+            "relation": relation,
+            "memberCids": list(members),
+            "memberCount": len(members),
+        }
+    )
+    if raw["manifestCid"] != recomputed:
+        raise ValueError(
+            f"{role} manifest for {relation} manifestCid is not recomputable: "
+            f"presented={raw['manifestCid']!r} recomputed={recomputed!r}"
+        )
+    return tuple(members)
+
+
+def _member_manifest_wire(relation: str, members: Sequence[str]) -> dict[str, Any]:
+    preimage = {
+        "schema": _RELATION_MEMBER_MANIFEST_SCHEMA,
+        "relation": relation,
+        "memberCids": list(members),
+        "memberCount": len(members),
+    }
+    return {**preimage, "manifestCid": canonical_cid(preimage)}
+
+
+def authenticate_relation_membership(
+    attestation: Mapping[str, Any] | None,
+) -> RelationMembershipAttestationV1:
+    """Sole mint of the attendance verdict a sealed width requires.
+
+    Mirrors ``_validate_demand_table_agreement``: a closed field set, a pinned
+    schema, and one distinctly named refusal per fact. The difference is what
+    absence means here -- an absent agreement is a missing cross-check, an
+    absent membership manifest is an unknown denominator.
+    """
+    if attestation is None:
+        return RelationMembershipRefusedV1(
+            findings=[(_RELATION_MEMBERSHIP_ABSENT, None)],
+            detail=(
+                "sealed mint requires positive expected/observed member "
+                "manifests for "
+                f"{', '.join(RELATION_MEMBERSHIP_RELATIONS)}; a width sealed "
+                "without them attests an unknown denominator"
+            ),
+            _authority=_RELATION_MEMBERSHIP_AUTHORITY,
+        )
+
+    def malformed(detail: str) -> RelationMembershipRefusedV1:
+        return RelationMembershipRefusedV1(
+            findings=[(_RELATION_MEMBERSHIP_MALFORMED, None)],
+            detail=detail,
+            _authority=_RELATION_MEMBERSHIP_AUTHORITY,
+        )
+
+    if not isinstance(attestation, Mapping):
+        return malformed(f"attestation is {type(attestation).__name__}, not an object")
+    fields = set(attestation)
+    if fields != _RELATION_MEMBERSHIP_FIELDS:
+        return malformed(
+            "closed fields differ "
+            f"missing={sorted(_RELATION_MEMBERSHIP_FIELDS - fields)} "
+            f"extra={sorted(fields - _RELATION_MEMBERSHIP_FIELDS)}"
+        )
+    if attestation.get("schema") != _RELATION_MEMBERSHIP_SCHEMA:
+        return malformed(f"schema must be {_RELATION_MEMBERSHIP_SCHEMA}")
+    relations = attestation.get("relations")
+    if not isinstance(relations, Mapping):
+        return malformed("relations must be an object")
+    if set(relations) != set(RELATION_MEMBERSHIP_RELATIONS):
+        return malformed(
+            "declared relations differ "
+            f"missing={sorted(set(RELATION_MEMBERSHIP_RELATIONS) - set(relations))} "
+            f"extra={sorted(set(relations) - set(RELATION_MEMBERSHIP_RELATIONS))}"
+        )
+
+    findings: list[tuple[str, str | None]] = []
+    details: list[str] = []
+    wire_relations: dict[str, Any] = {}
+    for relation in RELATION_MEMBERSHIP_RELATIONS:
+        pair = relations[relation]
+        if not isinstance(pair, Mapping) or set(pair) != {"expected", "observed"}:
+            return malformed(
+                f"{relation} must carry exactly expected and observed manifests"
+            )
+        try:
+            expected = _relation_member_manifest(
+                pair["expected"], relation=relation, role="expected"
+            )
+            observed = _relation_member_manifest(
+                pair["observed"], relation=relation, role="observed"
+            )
+        except ValueError as error:
+            return malformed(str(error))
+        if len(set(expected)) != len(expected):
+            return malformed(
+                f"expected manifest for {relation} repeats a member CID; the "
+                "manifest is not a population"
+            )
+
+        expected_set = set(expected)
+        observed_set = set(observed)
+
+        duplicates = sorted(
+            {member for member in observed if observed.count(member) > 1}
+        )
+        if duplicates:
+            findings.append((_RELATION_MEMBERSHIP_DUPLICATE, relation))
+            details.append(f"{relation} observed twice: {duplicates}")
+
+        absent_members = sorted(expected_set - observed_set)
+        if absent_members:
+            findings.append((_RELATION_MEMBERSHIP_MISSING, relation))
+            details.append(f"{relation} manifest members never observed: "
+                           f"{absent_members}")
+
+        unexpected = sorted(observed_set - expected_set)
+        if unexpected:
+            findings.append((_RELATION_MEMBERSHIP_EXTRA, relation))
+            details.append(f"{relation} observed outside the manifest: {unexpected}")
+
+        wire_relations[relation] = {
+            "expected": _member_manifest_wire(relation, expected),
+            "observed": _member_manifest_wire(relation, observed),
+        }
+
+    if findings:
+        return RelationMembershipRefusedV1(
+            findings=findings,
+            detail="; ".join(details),
+            _authority=_RELATION_MEMBERSHIP_AUTHORITY,
+        )
+    return RelationMembershipConservedV1(
+        wire={"schema": _RELATION_MEMBERSHIP_SCHEMA, "relations": wire_relations},
+        _authority=_RELATION_MEMBERSHIP_AUTHORITY,
+    )
+
+
 def _runtime_attestation_fields(
     runtime_attestation: Mapping[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -988,6 +1296,7 @@ def mint_partial(
     unmeasured_reason: str | None = None,
     demand_table_cid: str | None = None,
     demand_table_identity: Mapping[str, Any] | None = None,
+    relation_membership_attestation: Mapping[str, Any] | None = None,
     runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> dict[str, Any]:
     """Mint a shard partial. Never includes R_construction_panics top-level."""
@@ -1085,6 +1394,14 @@ def mint_partial(
     if demand_reason is not None and unmeasured_reason is None:
         status = "unmeasured"
         unmeasured_reason = demand_reason
+    # A shard that cannot say who it saw cannot contribute to a sealed width.
+    shard_membership = authenticate_relation_membership(
+        relation_membership_attestation
+    )
+    membership_reason = shard_membership.refusal_reason()
+    if membership_reason is not None and unmeasured_reason is None:
+        status = "unmeasured"
+        unmeasured_reason = membership_reason
     measured = status == "completed" and files_complete and unmeasured_reason is None
     if not measured and unmeasured_reason is None:
         unmeasured_reason = (
@@ -1147,6 +1464,8 @@ def mint_partial(
     if demand_claim is not None:
         body["demandTableCid"] = demand_claim[0]
         body["demandTableIdentity"] = demand_claim[1]
+    if membership_reason is None:
+        body["relationMembershipAttestation"] = shard_membership.conserved_wire()
     if runtime is not None:
         body.update(runtime)
     else:
@@ -1417,6 +1736,7 @@ def seal_board_from_aggregate(
     with_census: Mapping[str, Any] | None = None,
     frontier_attestation: Mapping[str, Any] | None = None,
     demand_table_agreement: Mapping[str, Any] | None = None,
+    relation_membership_attestation: Mapping[str, Any] | None = None,
     runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> dict[str, Any]:
     """Mint the sealed authoritative board body. Sole mint of the class."""
@@ -1458,6 +1778,18 @@ def seal_board_from_aggregate(
             plan=plan,
             missing_shards=["plan"],
             unmeasured_reasons={"plan": str(error)},
+            measured_commit=measured_commit,
+            runtime_attestation=runtime,
+        )
+    relation_membership = authenticate_relation_membership(
+        relation_membership_attestation
+    )
+    membership_refusal = relation_membership.refusal_reason()
+    if membership_refusal is not None:
+        return unmeasured_envelope(
+            plan=plan,
+            missing_shards=["plan"],
+            unmeasured_reasons={"plan": membership_refusal},
             measured_commit=measured_commit,
             runtime_attestation=runtime,
         )
@@ -1627,6 +1959,10 @@ def seal_board_from_aggregate(
         "planCid": (plan or {}).get("planCid"),
         "perShardCids": dict(sorted((per_shard_cids or {}).items())),
         "composeSchema": COMPOSE_SCHEMA,
+        # Positive attendance for every population this width describes. Only
+        # a RelationMembershipConservedV1 answers conserved_wire(), so this
+        # literal cannot be evaluated without one.
+        "relationMembershipAttestation": relation_membership.conserved_wire(),
         **runtime,
     }
     plan_claim = authenticated_demand_table_agreement["plan"]
@@ -1773,6 +2109,10 @@ def compose_from_partials(
 
     first_partial_runtime_cid: str | None = None
     shard_demand_claims: dict[str, dict[str, object]] = {}
+    shard_membership_members: dict[str, dict[str, list[str]]] = {
+        relation: {"expected": [], "observed": []}
+        for relation in RELATION_MEMBERSHIP_RELATIONS
+    }
     for i in range(k):
         seat = f"s{i:02d}"
         p = by_index.get(i)
@@ -1862,6 +2202,25 @@ def compose_from_partials(
             continue
         if first_partial_runtime_cid is None:
             first_partial_runtime_cid = partial_runtime_cid
+        # Attendance is conserved shard by shard, then unioned. A seat that
+        # names no population cannot be silently absorbed by seven that do.
+        shard_membership = authenticate_relation_membership(
+            p.get("relationMembershipAttestation")
+        )
+        shard_membership_reason = shard_membership.refusal_reason()
+        if shard_membership_reason is not None:
+            missing.append(seat)
+            reasons[seat] = shard_membership_reason
+            continue
+        shard_wire = shard_membership.conserved_wire()
+        for relation in RELATION_MEMBERSHIP_RELATIONS:
+            pair = shard_wire["relations"][relation]
+            shard_membership_members[relation]["expected"].extend(
+                pair["expected"]["memberCids"]
+            )
+            shard_membership_members[relation]["observed"].extend(
+                pair["observed"]["memberCids"]
+            )
 
     if missing:
         return "unmeasured", unmeasured_envelope(
@@ -1953,6 +2312,20 @@ def compose_from_partials(
         "expectedShardCount": k,
         "allAgree": len(shard_demand_claims) == k,
     }
+    composed_relation_membership = {
+        "schema": _RELATION_MEMBERSHIP_SCHEMA,
+        "relations": {
+            relation: {
+                "expected": _member_manifest_wire(
+                    relation, shard_membership_members[relation]["expected"]
+                ),
+                "observed": _member_manifest_wire(
+                    relation, shard_membership_members[relation]["observed"]
+                ),
+            }
+            for relation in RELATION_MEMBERSHIP_RELATIONS
+        },
+    }
     board = seal_board_from_aggregate(
         agg,
         plan=plan,
@@ -1970,6 +2343,7 @@ def compose_from_partials(
         with_census=with_census,
         frontier_attestation=frontier_attestation,
         demand_table_agreement=demand_table_agreement,
+        relation_membership_attestation=composed_relation_membership,
         runtime_attestation=runtime,
     )
     if board.get("measurement") != "measured":
@@ -2009,6 +2383,7 @@ def compose_k1_from_rows(
     manifest_cid: str | None = None,
     demand_table_cid: str | None = None,
     demand_table_identity: Mapping[str, Any] | None = None,
+    relation_membership_attestation: Mapping[str, Any] | None = None,
     runtime_attestation: Mapping[str, Any] | None | object = _RUNTIME_AUTO,
 ) -> tuple[str, dict[str, Any]]:
     """k=1 path: one full-bin partial + compose (serial observation, one seal door)."""
@@ -2049,6 +2424,7 @@ def compose_k1_from_rows(
         measured_commit=measured_commit,
         demand_table_cid=demand_table_cid,
         demand_table_identity=demand_table_identity,
+        relation_membership_attestation=relation_membership_attestation,
         runtime_attestation=runtime,
     )
     return compose_from_partials(

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -228,6 +228,9 @@ def test_seal_board_splits_file_and_residual_meanings() -> None:
         aggregate_hash="pin-hash",
         manifest_shape_cid="manifest",
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(
+            mod, [file for file, _ in rows]
+        ),
     )
     assert status == "sealed", body.get("instrumentFailures")
     assert body["filesEnrolled"] == 4
@@ -302,9 +305,38 @@ def test_direct_board_mint_without_frontier_witness_is_unmeasured() -> None:
         measured_commit="abc123",
         aggregate_hash="pin-hash",
         demand_table_agreement=agreement,
+        relation_membership_attestation=_relation_membership(
+            mod, agg["enrolled_files"]
+        ),
     )
     assert body["measurement"] == "unmeasured"
     assert body["kind"] == "measurement-conservation-failure-v1"
     assert "conservationWitness" not in body
     assert "R_construction_panics" not in body
     assert "functionsPopulation" not in body
+
+
+def _relation_membership(module, files):
+    """Positive attendance for both relations over the given files.
+
+    Built by hand rather than through the module so the wire shape the mint
+    demands is pinned here independently of the code that checks it.
+    """
+    relations = {}
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        members = [
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        ]
+        preimage = {
+            "schema": "recensus-relation-member-manifest/v1",
+            "relation": relation,
+            "memberCids": members,
+            "memberCount": len(members),
+        }
+        manifest = {**preimage, "manifestCid": module.canonical_cid(preimage)}
+        relations[relation] = {"expected": manifest, "observed": dict(manifest)}
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -192,6 +192,9 @@ def _compose(module, row, *, runtime_attestation=None):
         aggregate_hash="agg",
         manifest_shape_cid="manifest",
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(
+            module, ["pandas/a.py"]
+        ),
         runtime_attestation=(
             _runtime_attestation()
             if runtime_attestation is None
@@ -293,6 +296,9 @@ def test_partial_without_runtime_identity_refuses_at_compose() -> None:
         shard_index=0,
         terminal_rows=[("pandas/a.py", _row(module))],
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(
+            module, ["pandas/a.py"]
+        ),
         runtime_attestation=attestation,
     )
     for field in ("requiredRuntime", "runtimeIdentity", "runtimeCid"):
@@ -331,6 +337,9 @@ def test_non_recomputable_partial_runtime_cid_refuses() -> None:
         shard_index=0,
         terminal_rows=[("pandas/a.py", _row(module))],
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(
+            module, ["pandas/a.py"]
+        ),
         runtime_attestation=attestation,
     )
     partial["runtimeCid"] = "blake3-512:" + ("0" * 128)
@@ -370,6 +379,9 @@ def test_valid_but_disagreeing_shard_runtime_cids_refuse() -> None:
             shard_index=0,
             terminal_rows=[("pandas/a.py", _row(module))],
             **_demand_table_kwargs(),
+            relation_membership_attestation=_relation_membership(
+                module, ["pandas/a.py"]
+            ),
             runtime_attestation=left,
         ),
         module.mint_partial(
@@ -377,6 +389,9 @@ def test_valid_but_disagreeing_shard_runtime_cids_refuse() -> None:
             shard_index=1,
             terminal_rows=[("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))],
             **_demand_table_kwargs(),
+            relation_membership_attestation=_relation_membership(
+                module, ["pandas/b.py"]
+            ),
             runtime_attestation=right,
         ),
     ]
@@ -412,6 +427,9 @@ def test_well_formed_shard_runtime_wrong_for_compose_authority_refuses() -> None
         shard_index=0,
         terminal_rows=[("pandas/a.py", _row(module))],
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(
+            module, ["pandas/a.py"]
+        ),
         runtime_attestation=forged,
     )
 
@@ -454,6 +472,9 @@ def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
             shard_index=0,
             terminal_rows=[("pandas/a.py", _row(module))],
             **_demand_table_kwargs(),
+            relation_membership_attestation=_relation_membership(
+                module, ["pandas/a.py"]
+            ),
             runtime_attestation=mutually_agreeing_wrong_runtime,
         ),
         module.mint_partial(
@@ -461,6 +482,9 @@ def test_shards_agree_with_each_other_but_not_required_runtime_refuse() -> None:
             shard_index=1,
             terminal_rows=[("pandas/b.py", _row(module, key=_key("pandas/b.py", "g")))],
             **_demand_table_kwargs(),
+            relation_membership_attestation=_relation_membership(
+                module, ["pandas/b.py"]
+            ),
             runtime_attestation=mutually_agreeing_wrong_runtime,
         ),
     ]
@@ -754,9 +778,38 @@ def test_aggregate_panic_magnitude_cannot_disagree_with_attested_keys() -> None:
         manifest_shape_cid="manifest",
         frontier_attestation=attestation,
         demand_table_agreement=agreement,
+        relation_membership_attestation=_relation_membership(
+            module, ["pandas/a.py"]
+        ),
         runtime_attestation=_runtime_attestation(),
     )
     assert body["measurement"] == "unmeasured"
     assert "frontierWidth" not in body
     assert "R_construction_panics" not in body
     assert "conservationWitness" not in body
+
+
+def _relation_membership(module, files):
+    """Positive attendance for both relations over the given files.
+
+    Built by hand rather than through the module so the wire shape the mint
+    demands is pinned here independently of the code that checks it.
+    """
+    relations = {}
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        members = [
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        ]
+        preimage = {
+            "schema": "recensus-relation-member-manifest/v1",
+            "relation": relation,
+            "memberCids": members,
+            "memberCount": len(members),
+        }
+        manifest = {**preimage, "manifestCid": module.canonical_cid(preimage)}
+        relations[relation] = {"expected": manifest, "observed": dict(manifest)}
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
@@ -153,6 +153,9 @@ def _partials(
                 terminal_rows=[(file, _row(module, file))],
                 demand_table_cid=observed_cid,
                 demand_table_identity=observed_identity,
+                relation_membership_attestation=_relation_membership(
+                    module, [file]
+                ),
                 runtime_attestation=runtime,
             )
         )
@@ -193,6 +196,9 @@ def _direct_seal(
         measured_commit="dc41472e64",
         frontier_attestation=frontier,
         demand_table_agreement=demand_table_agreement,
+        relation_membership_attestation=_relation_membership(
+            module, plan["enrolledFiles"]
+        ),
         runtime_attestation=_runtime_attestation(),
     )
 
@@ -364,3 +370,29 @@ def test_plan_refuses_semantic_identity_with_unrecomputable_content_key() -> Non
         assert "demand-table-identity-content-key-mismatch" in str(error)
     else:
         raise AssertionError("plan accepted an unrecomputable semantic identity")
+
+
+def _relation_membership(module, files):
+    """Positive attendance for both relations over the given files.
+
+    Built by hand rather than through the module so the wire shape the mint
+    demands is pinned here independently of the code that checks it.
+    """
+    relations = {}
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        members = [
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        ]
+        preimage = {
+            "schema": "recensus-relation-member-manifest/v1",
+            "relation": relation,
+            "memberCids": members,
+            "memberCount": len(members),
+        }
+        manifest = {**preimage, "manifestCid": module.canonical_cid(preimage)}
+        relations[relation] = {"expected": manifest, "observed": dict(manifest)}
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_seal.py
@@ -1,0 +1,314 @@
+"""A sealed width requires conserved relation-membership testimony.
+
+This contract deliberately precedes the producer manifests governed by #7346
+and #7348.  The seal sees opaque member CIDs: it does not choose how lexical
+calls or target patterns mint durable source-occurrence identities.  It does
+require positive, recomputable expected/observed manifests for both relations.
+
+These teeth remain red until that producer-owned construct exists.  In
+particular, the absent arm reproduces the historical casualty: a direct call to
+the sole mint currently seals with no relation-membership testimony at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Mapping, Sequence
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import runtime_cid_for_identity
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+from sugar_lift_python_source.canonical import cid_of_json
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+_SCRIPT = _SCRIPTS / "compose_control_effect_board.py"
+_RELATIONS = ("lexical-call", "target-pattern")
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        "compose_control_effect_board_relation_membership", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runtime_attestation() -> dict[str, object]:
+    identity = {
+        "schema": "runtimeIdentity/v1",
+        "implementation": "cpython",
+        "version": "3.12.13",
+        "sysVersion": "3.12.13 relation-membership-seal-test",
+        "cacheTag": "cpython-312",
+        "SOABI": "cpython-312-x86_64-linux-gnu",
+        "hexVersion": "0x30c0df0",
+        "platformTag": "Linux-test-x86_64-with-glibc2.39",
+        "invokedExecutable": "/venv/bin/python",
+        "resolvedBaseExecutable": "/runtime/bin/python3.12",
+        "executableSha256": "a" * 64,
+    }
+    return {
+        "requiredRuntime": "cpython-3.12.13",
+        "runtimeIdentity": identity,
+        "runtimeCid": runtime_cid_for_identity(identity),
+    }
+
+
+def _demand_identity() -> dict[str, object]:
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:corpus-a",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:producer-a",
+        resolution_config_cid="blake3-512:config-a",
+        parser_identity="cpython-3.12",
+        file_count=8,
+    )
+    return DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    ).as_dict()
+
+
+def _row(module, file: str) -> dict[str, object]:
+    input_key = {
+        "file": file,
+        "sourceCid": module.canonical_cid({"file": file}),
+        "function": {"qualname": "f", "coordinate": "1:0"},
+    }
+    return {
+        "category": "completed",
+        "functionsTotal": 1,
+        "functionsEnumerated": 1,
+        "functionsClean": 1,
+        "cleanRatioRefused": False,
+        "families": {},
+        "inputKey": input_key,
+        "rowId": module.canonical_cid({"inputKey": input_key}),
+        "stageId": module.STAGE_ENUMERATE_FILE_TERMINAL,
+        "observedEventType": "sugar_lift_py_tests.outcome.Complete",
+        "terminalKind": "constructed",
+        "observed_chain_length": 1,
+        "blocking_terminal_count": 0,
+        "final_terminal": "constructed",
+        "edgeWitnesses": {
+            module.EDGE_ENUMERATE_FILE: module.key_edge_witness(
+                stage_id=module.STAGE_ENUMERATE_FILE_TERMINAL,
+                input_keys=[input_key],
+                output_keys=[input_key],
+            ),
+            module.EDGE_WITH_PARTITION: module.key_edge_witness(
+                stage_id=module.STAGE_WITH_TALLY_PARTITION,
+                input_keys=[],
+                output_keys=[],
+            ),
+        },
+    }
+
+
+def _plan(module, *, demand_cid: str, demand_identity: Mapping[str, object]):
+    files = [f"pandas/f{i}.py" for i in range(8)]
+    return module.build_plan(
+        enrolled_files=files,
+        shard_count=8,
+        measured_commit="cd866d512d",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[[file] for file in files],
+        split_mode="fixture",
+        prior_hits=0,
+        prior_misses=8,
+        estimated_loads=[1.0] * 8,
+        demand_table_cid=demand_cid,
+        demand_table_identity=demand_identity,
+    )
+
+
+def _demand_table_agreement(
+    *, demand_cid: str, demand_identity: Mapping[str, object]
+) -> dict[str, object]:
+    claim = {
+        "demandTableCid": demand_cid,
+        "demandTableIdentity": demand_identity,
+    }
+    return {
+        "schema": "demand-table-shard-agreement/v1",
+        "plan": claim,
+        "shards": {f"s{i:02d}": claim for i in range(8)},
+        "authenticatedShardCount": 8,
+        "expectedShardCount": 8,
+        "allAgree": True,
+    }
+
+
+def _manifest(module, relation: str, member_cids: Sequence[str]) -> dict[str, object]:
+    preimage = {
+        "schema": "recensus-relation-member-manifest/v1",
+        "relation": relation,
+        "memberCids": list(member_cids),
+        "memberCount": len(member_cids),
+    }
+    return {**preimage, "manifestCid": module.canonical_cid(preimage)}
+
+
+def _membership_attestation(
+    module,
+    *,
+    changed_relation: str | None = None,
+    mutation: str | None = None,
+) -> dict[str, object]:
+    relations: dict[str, object] = {}
+    for relation in _RELATIONS:
+        expected = [
+            module.canonical_cid({"relation": relation, "occurrence": index})
+            for index in range(2)
+        ]
+        observed = list(expected)
+        if relation == changed_relation:
+            if mutation == "missing":
+                observed.pop()
+            elif mutation == "extra":
+                observed.append(
+                    module.canonical_cid({"relation": relation, "occurrence": 2})
+                )
+            elif mutation == "duplicate":
+                observed.append(observed[0])
+            else:
+                raise AssertionError(f"unknown mutation: {mutation}")
+        relations[relation] = {
+            "expected": _manifest(module, relation, expected),
+            "observed": _manifest(module, relation, observed),
+        }
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }
+
+
+def _direct_seal(
+    module,
+    *,
+    relation_membership_attestation: Mapping[str, object] | None,
+    omit_membership_argument: bool = False,
+) -> dict[str, object]:
+    demand_cid = "blake3-512:table-a"
+    demand_identity = _demand_identity()
+    plan = _plan(module, demand_cid=demand_cid, demand_identity=demand_identity)
+    measured_rows = [(file, _row(module, file)) for file in plan["enrolledFiles"]]
+    aggregate = module.aggregate_terminal_rows(
+        measured_rows,
+        enrolled_files=plan["enrolledFiles"],
+        manifest_cid="manifest",
+    )
+    frontier, failures = module.attest_frontier_rows(measured_rows)
+    assert failures == []
+    kwargs = {
+        "plan": plan,
+        "per_shard_cids": {f"s{i:02d}": f"partial-{i}" for i in range(8)},
+        "compose_cid": "blake3-512:compose",
+        "measured_commit": "cd866d512d",
+        "frontier_attestation": frontier,
+        "demand_table_agreement": _demand_table_agreement(
+            demand_cid=demand_cid, demand_identity=demand_identity
+        ),
+        "runtime_attestation": _runtime_attestation(),
+    }
+    if not omit_membership_argument:
+        kwargs["relation_membership_attestation"] = relation_membership_attestation
+    return module.seal_board_from_aggregate(aggregate, **kwargs)
+
+
+def _assert_unmeasured_without_width(body: Mapping[str, object]) -> None:
+    assert body["kind"] == "control-effect-recensus-unmeasured/v1"
+    assert body["status"] == "unmeasured"
+    assert body["measured"] is False
+    assert "frontierWidth" not in body
+    assert "bodyCid" not in body
+
+
+def test_direct_seal_refuses_no_relation_membership_manifest() -> None:
+    """Historical casualty: zero relation testimony must never seal again."""
+    module = _load()
+
+    body = _direct_seal(
+        module,
+        relation_membership_attestation=None,
+        omit_membership_argument=True,
+    )
+
+    _assert_unmeasured_without_width(body)
+    assert "relation-membership-attestation-absent" in body["unmeasuredReasons"]["plan"]
+
+
+@pytest.mark.parametrize("relation", _RELATIONS)
+def test_direct_seal_refuses_missing_relation_member(relation: str) -> None:
+    module = _load()
+
+    body = _direct_seal(
+        module,
+        relation_membership_attestation=_membership_attestation(
+            module, changed_relation=relation, mutation="missing"
+        ),
+    )
+
+    _assert_unmeasured_without_width(body)
+    assert (
+        f"relation-membership-missing:{relation}" in body["unmeasuredReasons"]["plan"]
+    )
+
+
+@pytest.mark.parametrize("relation", _RELATIONS)
+def test_direct_seal_refuses_extra_relation_member(relation: str) -> None:
+    module = _load()
+
+    body = _direct_seal(
+        module,
+        relation_membership_attestation=_membership_attestation(
+            module, changed_relation=relation, mutation="extra"
+        ),
+    )
+
+    _assert_unmeasured_without_width(body)
+    assert f"relation-membership-extra:{relation}" in body["unmeasuredReasons"]["plan"]
+
+
+@pytest.mark.parametrize("relation", _RELATIONS)
+def test_direct_seal_refuses_duplicate_relation_member(relation: str) -> None:
+    module = _load()
+
+    body = _direct_seal(
+        module,
+        relation_membership_attestation=_membership_attestation(
+            module, changed_relation=relation, mutation="duplicate"
+        ),
+    )
+
+    _assert_unmeasured_without_width(body)
+    assert (
+        f"relation-membership-duplicate:{relation}" in body["unmeasuredReasons"]["plan"]
+    )
+
+
+def test_exact_relation_membership_agreement_still_seals() -> None:
+    module = _load()
+    attestation = _membership_attestation(module)
+
+    body = _direct_seal(module, relation_membership_attestation=attestation)
+
+    assert body["status"] == "sealed"
+    assert body["measured"] is True
+    assert body["frontierWidth"] == 0
+    assert body["relationMembershipAttestation"] == attestation
+    assert body["bodyCid"]

--- a/implementations/python/sugar-lift-py-tests/tests/test_relation_membership_construct.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_relation_membership_construct.py
@@ -258,6 +258,16 @@ def test_one_shard_with_no_membership_refuses_the_whole_compose() -> None:
         for index, file in enumerate(files)
     ]
 
+    # The shard refuses itself first, in its own testimony -- pinned here so
+    # this tooth is not satisfied by compose's separate re-read downstream.
+    assert partials[0]["measured"] is True
+    assert partials[1]["measured"] is False
+    assert (
+        "relation-membership-attestation-absent"
+        in partials[1]["unmeasuredReason"]
+    )
+    assert "relationMembershipAttestation" not in partials[1]
+
     status, body = module.compose_from_partials(
         plan, partials, runtime_attestation=runtime
     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_relation_membership_construct.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_relation_membership_construct.py
@@ -1,0 +1,369 @@
+"""The attendance verdict is a missing constructor, not a guard.
+
+The eight contract teeth in ``test_recensus_relation_membership_seal`` pin what
+the mint refuses. They would all stay green if the refusal were an ordinary
+``if`` that a new callsite could route around -- which is exactly how the two
+sealed frontierWidth=477 receipts were minted with zero lexical-call testimony.
+
+These teeth pin the other half: only the mint can make an attendance verdict,
+there are exactly two of them, and the sealed body's membership field has no
+source other than a conserved one.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from collections.abc import Mapping
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import runtime_cid_for_identity
+from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+from sugar_lift_python_source.canonical import cid_of_json
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+_SCRIPT = _SCRIPTS / "compose_control_effect_board.py"
+
+
+def _load():
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        "compose_control_effect_board_membership_construct", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runtime_attestation() -> dict[str, object]:
+    identity = {
+        "schema": "runtimeIdentity/v1",
+        "implementation": "cpython",
+        "version": "3.12.13",
+        "sysVersion": "3.12.13 relation-membership-construct-test",
+        "cacheTag": "cpython-312",
+        "SOABI": "cpython-312-x86_64-linux-gnu",
+        "hexVersion": "0x30c0df0",
+        "platformTag": "Linux-test-x86_64-with-glibc2.39",
+        "invokedExecutable": "/venv/bin/python",
+        "resolvedBaseExecutable": "/runtime/bin/python3.12",
+        "executableSha256": "b" * 64,
+    }
+    return {
+        "requiredRuntime": "cpython-3.12.13",
+        "runtimeIdentity": identity,
+        "runtimeCid": runtime_cid_for_identity(identity),
+    }
+
+
+def _demand_identity() -> dict[str, object]:
+    identity = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:corpus-construct",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:producer-construct",
+        resolution_config_cid="blake3-512:config-construct",
+        parser_identity="cpython-3.12",
+        file_count=2,
+    )
+    return DemandTableIdentityV1(
+        content_key=cid_of_json(dict(identity.preimage())),
+        corpus_manifest_cid=identity.corpus_manifest_cid,
+        schema_version=identity.schema_version,
+        producer_source_cid=identity.producer_source_cid,
+        resolution_config_cid=identity.resolution_config_cid,
+        parser_identity=identity.parser_identity,
+        file_count=identity.file_count,
+    ).as_dict()
+
+
+def _membership(module, files) -> dict[str, object]:
+    """Positive attendance for both relations over the given files."""
+    relations: dict[str, object] = {}
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        members = [
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        ]
+        preimage = {
+            "schema": "recensus-relation-member-manifest/v1",
+            "relation": relation,
+            "memberCids": members,
+            "memberCount": len(members),
+        }
+        manifest = {**preimage, "manifestCid": module.canonical_cid(preimage)}
+        relations[relation] = {"expected": manifest, "observed": dict(manifest)}
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }
+
+
+def _row(module, file: str) -> dict[str, object]:
+    input_key = {
+        "file": file,
+        "sourceCid": module.canonical_cid({"file": file}),
+        "function": {"qualname": "f", "coordinate": "1:0"},
+    }
+    return {
+        "category": "completed",
+        "functionsTotal": 1,
+        "functionsEnumerated": 1,
+        "functionsClean": 1,
+        "cleanRatioRefused": False,
+        "families": {},
+        "inputKey": input_key,
+        "rowId": module.canonical_cid({"inputKey": input_key}),
+        "stageId": module.STAGE_ENUMERATE_FILE_TERMINAL,
+        "observedEventType": "sugar_lift_py_tests.outcome.Complete",
+        "terminalKind": "constructed",
+        "observed_chain_length": 1,
+        "blocking_terminal_count": 0,
+        "final_terminal": "constructed",
+        "edgeWitnesses": {
+            module.EDGE_ENUMERATE_FILE: module.key_edge_witness(
+                stage_id=module.STAGE_ENUMERATE_FILE_TERMINAL,
+                input_keys=[input_key],
+                output_keys=[input_key],
+            ),
+            module.EDGE_WITH_PARTITION: module.key_edge_witness(
+                stage_id=module.STAGE_WITH_TALLY_PARTITION,
+                input_keys=[],
+                output_keys=[],
+            ),
+        },
+    }
+
+
+def test_a_third_attendance_variant_cannot_be_declared() -> None:
+    """Absent / conserved / refused is not an open set a consumer may extend."""
+    module = _load()
+
+    with pytest.raises(TypeError) as error:
+
+        class MostlyConserved(module.RelationMembershipAttestationV1):
+            pass
+
+    assert "relation-membership-attestation-variant-not-closed" in str(error.value)
+
+
+@pytest.mark.parametrize("variant", ("RelationMembershipConservedV1",
+                                     "RelationMembershipRefusedV1"))
+def test_only_the_mint_may_make_an_attendance_verdict(variant: str) -> None:
+    """A new callsite can write a guard; it cannot write this object."""
+    module = _load()
+    cls = getattr(module, variant)
+    kwargs: dict[str, object] = (
+        {"wire": {"schema": "x", "relations": {}}}
+        if variant == "RelationMembershipConservedV1"
+        else {"findings": [("relation-membership-missing", "lexical-call")],
+              "detail": "forged"}
+    )
+
+    with pytest.raises(TypeError) as error:
+        cls(**kwargs)
+
+    assert "relation-membership-attestation-not-mint-minted" in str(error.value)
+
+
+def test_a_refused_verdict_has_no_conserved_wire() -> None:
+    """Absence and lookup-failure never share a representation."""
+    module = _load()
+    refused = module.authenticate_relation_membership(None)
+
+    assert refused.refusal_reason() is not None
+    with pytest.raises(TypeError) as error:
+        refused.conserved_wire()
+    assert "relation-membership-attestation-refused" in str(error.value)
+
+
+def test_a_refusal_reason_outside_the_closed_set_is_refused() -> None:
+    module = _load()
+
+    with pytest.raises(TypeError) as error:
+        module.RelationMembershipRefusedV1(
+            findings=[("relation-membership-probably-fine", None)],
+            detail="invented",
+            _authority=module._RELATION_MEMBERSHIP_AUTHORITY,
+        )
+
+    assert "relation-membership-refusal-reason-not-declared" in str(error.value)
+
+
+def test_sealed_body_membership_field_has_exactly_one_source() -> None:
+    """Static tooth: the field is minted from a conserved verdict and nowhere else.
+
+    A second assignment -- a literal, a passthrough of the caller's mapping, a
+    ``or {}`` default -- would restore the bypass without failing any behaviour
+    tooth, so the source is read directly.
+    """
+    module = _load()
+    tree = ast.parse(_SCRIPT.read_text(encoding="utf-8"))
+    seal = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "seal_board_from_aggregate"
+    )
+    sources = [
+        ast.unparse(value)
+        for node in ast.walk(seal)
+        if isinstance(node, ast.Dict)
+        for key, value in zip(node.keys, node.values)
+        if isinstance(key, ast.Constant)
+        and key.value == "relationMembershipAttestation"
+    ]
+    assert sources == ["relation_membership.conserved_wire()"], sources
+    assert module.RelationMembershipAttestationV1._variants_closed is True
+
+
+def test_one_shard_with_no_membership_refuses_the_whole_compose() -> None:
+    """The historical case at the real door: seven attesting seats cannot cover one silent seat."""
+    module = _load()
+    files = ["pandas/f0.py", "pandas/f1.py"]
+    demand_cid = "blake3-512:table-construct"
+    demand_identity = _demand_identity()
+    plan = module.build_plan(
+        enrolled_files=files,
+        shard_count=2,
+        measured_commit="098bf65aa",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[[file] for file in files],
+        split_mode="fixture",
+        prior_hits=0,
+        prior_misses=2,
+        estimated_loads=[1.0, 1.0],
+        demand_table_cid=demand_cid,
+        demand_table_identity=demand_identity,
+    )
+    runtime = _runtime_attestation()
+    partials = [
+        module.mint_partial(
+            plan=plan,
+            shard_index=index,
+            terminal_rows=[(file, _row(module, file))],
+            demand_table_cid=demand_cid,
+            demand_table_identity=demand_identity,
+            relation_membership_attestation=(
+                None if index == 1 else _membership(module, [file])
+            ),
+            runtime_attestation=runtime,
+        )
+        for index, file in enumerate(files)
+    ]
+
+    status, body = module.compose_from_partials(
+        plan, partials, runtime_attestation=runtime
+    )
+
+    assert status == "unmeasured"
+    assert "frontierWidth" not in body
+    assert "bodyCid" not in body
+    assert "relation-membership-attestation-absent" in body["unmeasuredReasons"]["s01"]
+    assert "s00" not in body["unmeasuredReasons"]
+
+
+def test_compose_reauthenticates_membership_it_reads_from_a_partial() -> None:
+    """A measured partial whose membership was stripped is caught at compose.
+
+    Distinct from the seat above: that one is refused by ``mint_partial``, so
+    its reason arrives on the partial's own status. Here the partial is
+    ``measured`` and complete, and only compose's own read of the shard's
+    membership stands between it and a sealed width.
+    """
+    module = _load()
+    files = ["pandas/f0.py"]
+    demand_cid = "blake3-512:table-construct"
+    demand_identity = _demand_identity()
+    plan = module.build_plan(
+        enrolled_files=files,
+        shard_count=1,
+        measured_commit="098bf65aa",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[files],
+        split_mode="fixture",
+        prior_hits=0,
+        prior_misses=1,
+        estimated_loads=[1.0],
+        demand_table_cid=demand_cid,
+        demand_table_identity=demand_identity,
+    )
+    runtime = _runtime_attestation()
+    partial = module.mint_partial(
+        plan=plan,
+        shard_index=0,
+        terminal_rows=[(files[0], _row(module, files[0]))],
+        demand_table_cid=demand_cid,
+        demand_table_identity=demand_identity,
+        relation_membership_attestation=_membership(module, files),
+        runtime_attestation=runtime,
+    )
+    assert partial["measured"] is True
+    del partial["relationMembershipAttestation"]
+
+    status, body = module.compose_from_partials(
+        plan, [partial], runtime_attestation=runtime
+    )
+
+    assert status == "unmeasured"
+    assert "frontierWidth" not in body
+    assert "bodyCid" not in body
+    assert "relation-membership-attestation-absent" in body["unmeasuredReasons"]["s00"]
+
+
+def test_two_attesting_shards_seal_the_unioned_population() -> None:
+    """Attendance composes: the sealed width names every member both shards saw."""
+    module = _load()
+    files = ["pandas/f0.py", "pandas/f1.py"]
+    demand_cid = "blake3-512:table-construct"
+    demand_identity = _demand_identity()
+    plan = module.build_plan(
+        enrolled_files=files,
+        shard_count=2,
+        measured_commit="098bf65aa",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[[file] for file in files],
+        split_mode="fixture",
+        prior_hits=0,
+        prior_misses=2,
+        estimated_loads=[1.0, 1.0],
+        demand_table_cid=demand_cid,
+        demand_table_identity=demand_identity,
+    )
+    runtime = _runtime_attestation()
+    partials = [
+        module.mint_partial(
+            plan=plan,
+            shard_index=index,
+            terminal_rows=[(file, _row(module, file))],
+            demand_table_cid=demand_cid,
+            demand_table_identity=demand_identity,
+            relation_membership_attestation=_membership(module, [file]),
+            runtime_attestation=runtime,
+        )
+        for index, file in enumerate(files)
+    ]
+
+    status, body = module.compose_from_partials(
+        plan, partials, runtime_attestation=runtime
+    )
+
+    assert status == "sealed", body.get("unmeasuredReasons")
+    sealed = body["relationMembershipAttestation"]
+    assert isinstance(sealed, Mapping)
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        observed = sealed["relations"][relation]["observed"]
+        assert observed["memberCount"] == 2
+        assert sorted(observed["memberCids"]) == sorted(
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        )
+    assert body["bodyCid"]

--- a/tests/test_board_function_facts_c4.py
+++ b/tests/test_board_function_facts_c4.py
@@ -354,6 +354,7 @@ def test_compose_seal_uses_three_sealed_meanings() -> None:
         aggregate_hash="agg",
         manifest_shape_cid="cid",
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(compose, files),
     )
     assert status == "sealed"
     assert body["functionsTotal"] == 5
@@ -430,3 +431,29 @@ def test_population_and_enumerated_cannot_be_the_same_informal_int() -> None:
         "sealedFunctionFactCids": dict(fields["sealedFactCids"]),
     }
     BFF.require_sealed_board_function_fields(body)  # does not panic
+
+
+def _relation_membership(module, files):
+    """Positive attendance for both relations over the given files.
+
+    Built by hand rather than through the module so the wire shape the mint
+    demands is pinned here independently of the code that checks it.
+    """
+    relations = {}
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        members = [
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        ]
+        preimage = {
+            "schema": "recensus-relation-member-manifest/v1",
+            "relation": relation,
+            "memberCids": members,
+            "memberCount": len(members),
+        }
+        manifest = {**preimage, "manifestCid": module.canonical_cid(preimage)}
+        relations[relation] = {"expected": manifest, "observed": dict(manifest)}
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }

--- a/tests/test_recensus_enumerate_mass_and_clean.py
+++ b/tests/test_recensus_enumerate_mass_and_clean.py
@@ -465,6 +465,9 @@ def test_compose_refuses_unattested_clean_board() -> None:
         aggregate_hash="agg",
         manifest_shape_cid="cid",
         **_demand_table_kwargs(),
+        relation_membership_attestation=_relation_membership(
+            COMPOSE, ["good.py", "blind.py"]
+        ),
     )
     assert status == "unmeasured"
     assert body["status"] == "unmeasured"
@@ -635,3 +638,29 @@ def test_outer_shell_escape_banks_ast_when_roster_demand_also_fails(
     assert row["functionsTotal"] == 2  # AST FunctionDef count
     assert row["functionsEnumerated"] == 0
     assert row.get("cleanRatioRefused") is True
+
+
+def _relation_membership(module, files):
+    """Positive attendance for both relations over the given files.
+
+    Built by hand rather than through the module so the wire shape the mint
+    demands is pinned here independently of the code that checks it.
+    """
+    relations = {}
+    for relation in module.RELATION_MEMBERSHIP_RELATIONS:
+        members = [
+            module.canonical_cid({"relation": relation, "file": file})
+            for file in files
+        ]
+        preimage = {
+            "schema": "recensus-relation-member-manifest/v1",
+            "relation": relation,
+            "memberCids": members,
+            "memberCount": len(members),
+        }
+        manifest = {**preimage, "manifestCid": module.canonical_cid(preimage)}
+        relations[relation] = {"expected": manifest, "observed": dict(manifest)}
+    return {
+        "schema": "recensus-relation-membership-attestation/v1",
+        "relations": relations,
+    }


### PR DESCRIPTION
Both sealed census receipts in the repo — sha256 `cedb4303...` at `1b3ac2dd9` and `6c4cd7f4...` at `b57827f36`, both `frontierWidth=477` — contain **zero** lexical-call testimony. They seal a run that never observed the population they were taken to describe. No cryptographic seal failed; the seals are valid and attest an unknown denominator.

The bypass was still live at main: calling the sole mint `seal_board_from_aggregate` with no membership attestation produced a sealed body.

Now `authenticate_relation_membership` refuses and the mint returns an unmeasured envelope **before** constructing the measured body — structurally closed, not flagged. Four facts, four distinct names: missing, extra, duplicate, and no-manifest-at-all, plus the exact-agreement happy path.

## Verified on battleaxe

- `test_recensus_relation_membership_seal.py` + `test_relation_membership_construct.py` -> **17 passed**
- Mutation, mint membership guard bypassed alone (`if False and membership_refusal is not None`) -> **7 failed**; restored -> 17 passed. The teeth bite on that specific guard.

Does not unseal, edit, or relabel any existing receipt — that is a provenance decision and is not made here.

Closes the mechanism behind #7351.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>