### PR TITLE
Reset the process-resident file cache between tests (#7364)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/conftest.py
+++ b/implementations/python/sugar-lift-py-tests/tests/conftest.py
@@ -92,6 +92,34 @@ def sugar_binary_handoff() -> str:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_process_resident_files():
+    """One test, one residency (#7364). Cross-test sharing is unrepresentable.
+
+    The process-resident file cache in ``sugar_source_tree`` is keyed by
+    (content CID, workspace-RELATIVE filename), so byte-identical fixture source
+    under the same relative name collides across tests and distinct ``tmp_path``
+    gives ZERO isolation. ``_prepare_uncached`` -- MaterializeModule plus the
+    unit's relation tables -- runs only on a MISS, so a later test can inherit a
+    unit an earlier test already mutated.
+
+    False red is merely expensive. False GREEN is the reason this is autouse: a
+    test expecting a refusal, handed an already-refusing unit, passes without
+    exercising its own mechanism, and that green cannot be told from a real one.
+
+    Unconditional by design -- an opt-out marker would reinstate the silent
+    default this closes. Residency is a within-test property; the prepare-count
+    tests measure it inside one body and clear at entry already.
+
+    Production behaviour is untouched: this resets only at the test boundary.
+    """
+    from sugar_source_tree.process_resident_file import clear_process_resident_files
+
+    clear_process_resident_files()
+    yield
+    clear_process_resident_files()
+
+
+@pytest.fixture(autouse=True)
 def refuse_non_hermetic_sugar_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     """Fail loud if any test shells out to sugar mint/prove/lift/verify without SUGAR_HOME.
 

--- a/implementations/python/sugar-source-tree/tests/conftest.py
+++ b/implementations/python/sugar-source-tree/tests/conftest.py
@@ -10,6 +10,8 @@ import os
 import sys
 import tempfile
 
+import pytest
+
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _ROOT = _HERE
 while _ROOT != os.path.dirname(_ROOT) and not (
@@ -23,6 +25,40 @@ if os.path.join(_ROOT, "tests") not in sys.path:
 from checkout_resolution import pin_checkout  # noqa: E402
 
 pin_checkout(__file__, siblings=("sugar-lift-python-source",))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_process_resident_files():
+    """One test, one residency (#7364). Cross-test sharing is unrepresentable.
+
+    The process-resident file cache is keyed by (content CID, workspace-RELATIVE
+    filename). Byte-identical fixture source written under the same relative
+    name therefore collides across tests, and distinct ``tmp_path`` gives ZERO
+    isolation. ``_prepare_uncached`` -- which runs MaterializeModule and builds
+    the unit's relation tables -- is reached only on a residency MISS, so a
+    second test inherits whatever unit state the first left behind.
+
+    Both polarities of false signal follow, and the worse one is silent:
+
+      false red   -- a neighbour is blamed for state an earlier test mutated;
+      false GREEN -- a test that expects a refusal is handed a unit some earlier
+                     test already put into the refusing state, and passes
+                     without ever exercising its own mechanism. That green is
+                     indistinguishable from a real one.
+
+    The reset is autouse and unconditional: an opt-out marker would restore
+    exactly the silent default this closes. Residency is a WITHIN-test property
+    (prepare-count tests measure it inside one test body and already clear at
+    entry), so nothing legitimately needs it to span the test boundary.
+
+    Production behaviour is untouched. This is a test-boundary reset only; the
+    protocol §4 cache remains the amortisation door for census/demand.
+    """
+    from sugar_source_tree.process_resident_file import clear_process_resident_files
+
+    clear_process_resident_files()
+    yield
+    clear_process_resident_files()
 
 
 def oracle_source_file(source: str, backend=None, suffix: str = ".py"):

--- a/implementations/python/sugar-source-tree/tests/test_process_resident_cross_test_isolation.py
+++ b/implementations/python/sugar-source-tree/tests/test_process_resident_cross_test_isolation.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""Teeth for the test-boundary residency reset (#7364).
+
+The process-resident file cache is keyed by (content CID, workspace-RELATIVE
+filename). Two tests writing byte-identical source under the same relative name
+collide, and ``_prepare_uncached`` -- MaterializeModule plus the unit's relation
+tables -- runs only on a MISS. So without a reset at the test boundary, the
+second test inherits the first test's mutated unit and can pass without ever
+exercising its own mechanism.
+
+These teeth are deliberately ORDER-INDEPENDENT: each one asserts a clean unit on
+entry and then mutates it. Whichever runs second bites when isolation is absent,
+so ``pytest-randomly`` cannot shuffle the trap out of the run.
+
+Discrimination: ``test_residency_still_shares_within_one_test`` runs the OTHER
+arm -- residency must still amortise inside a single test body. A reset that
+also broke within-test sharing would satisfy the isolation teeth while silently
+repealing protocol §4, and this arm refuses that.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.process_resident_file import prepare_count_for, resident_size
+from sugar_source_tree.tree import SourceFile
+
+# ONE body, ONE relative name, shared by both isolation teeth on purpose: this
+# is exactly the colliding key. Do not make these unique -- uniqueness is the
+# local workaround the autouse reset exists to make unnecessary.
+_SHARED_BODY = "def collide(value):\n    return value\n"
+_SHARED_SEAT = "shared/collide.py"
+_SENTINEL = "_cross_test_residency_sentinel_7364"
+
+
+def _identity() -> tuple[str, str, str]:
+    return (_SHARED_BODY, _SHARED_SEAT, blake3_512_of(_SHARED_BODY.encode("utf-8")))
+
+
+def _open_shared() -> object:
+    return SourceFile(_identity())
+
+
+def _assert_unit_is_not_inherited(source_file: object, *, arm: str) -> None:
+    """Refuse a unit another test already touched. Names the coordinate.
+
+    Absence and lookup-failure do not share a representation: a unit this test
+    prepared has no sentinel ATTRIBUTE at all, while an inherited unit carries
+    the sentinel naming the arm that stranded it.
+    """
+    stranded = getattr(source_file.unit, _SENTINEL, None)
+    assert stranded is None, (
+        f"construct=SourceUnit coordinate=(source_cid={source_file.unit.source_cid}, "
+        f"seat={_SHARED_SEAT!r}) shape=inherited-residency: arm {arm!r} was handed a "
+        f"unit already mutated by arm {stranded!r}. The process-resident cache "
+        f"survived the test boundary, so this arm never ran _prepare_uncached and "
+        f"its mechanism was never exercised (#7364)."
+    )
+
+
+def _strand(source_file: object, *, arm: str) -> None:
+    object.__setattr__(source_file.unit, _SENTINEL, arm)
+
+
+def test_resident_unit_is_not_inherited_arm_a() -> None:
+    """Arm A: clean unit on entry, then strand it for whoever comes next."""
+    source_file = _open_shared()
+    _assert_unit_is_not_inherited(source_file, arm="arm_a")
+    _strand(source_file, arm="arm_a")
+
+
+def test_resident_unit_is_not_inherited_arm_b() -> None:
+    """Arm B: byte-identical body, same seat, same key. Must still be clean."""
+    source_file = _open_shared()
+    _assert_unit_is_not_inherited(source_file, arm="arm_b")
+    _strand(source_file, arm="arm_b")
+
+
+def test_residency_still_shares_within_one_test() -> None:
+    """Other arm: protocol §4 amortisation inside one test body is intact.
+
+    The reset is a test-BOUNDARY reset. Within one body, the same CID and seat
+    must still hit residency and pay MaterializeModule exactly once.
+    """
+    cid = blake3_512_of(_SHARED_BODY.encode("utf-8"))
+    first = _open_shared()
+    second = _open_shared()
+    assert second is first, (
+        "construct=SourceUnit coordinate=(source_cid=%s, seat=%r) shape=residency-repealed: "
+        "two opens of the same content and seat inside ONE test body produced "
+        "distinct SourceFiles. The test-boundary reset must not break within-test "
+        "amortisation (protocol §4)." % (cid, _SHARED_SEAT)
+    )
+    assert prepare_count_for(cid, _SHARED_SEAT) == 1
+    assert resident_size() == 1


### PR DESCRIPTION
`process_resident_file.py` keys its cache by `(source_cid, workspace-relative filename)`. Because the filename component is workspace-**relative**, `tmp_path_a/enrolled.py` and `tmp_path_b/enrolled.py` with identical bytes collide — so **distinct `tmp_path` gives zero isolation**, which is what makes it a trap. `_prepare_uncached` (which runs `MaterializeModule` and builds the relation tables) is reached only on a miss, so a test can inherit an already-refusing unit and pass without ever exercising its own mechanism.

`clear_process_resident_files()` already existed, documented in-source as a test door, and was called from no conftest.

The reset is **autouse and unconditional** — an opt-out marker would restore exactly the hazard.

## Measured on battleaxe, node ID both directions

Full `sugar-source-tree` suite, current main vs this branch, identical collection:

| | main | with reset |
|---|---|---|
| failed | 291 | 290 |
| passed | 840 | 844 |

**Newly red: 0. Newly green: 1** — `test_classdef_chained_assignment_adapter_testimony.py::test_removing_class_chained_assign_arm_restores_exact_re_failure`, which was failing at main *because it inherited a poisoned unit*. That is the false-red polarity of the defect, demonstrated. `+4` passes = 3 new teeth + 1 recovered.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>