### PR TITLE
Carry durable run authority; an unmanaged run is unmeasured by construction (#7340)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,7 +566,7 @@ jobs:
   # test-rust, which is deliberately outside per-tip CI. Run the exact shell
   # population directly: one job, three batches, and one attendance receipt.
   sugarbin-shell-contracts:
-    name: sugarbin shell contracts (9/9 attendance)
+    name: sugarbin shell contracts (10/10 attendance)
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 15
     steps:
@@ -575,7 +575,7 @@ jobs:
       # Initialize every expected row before setup. If setup or a later batch
       # cannot run, the final audit retains a named absence rather than a
       # smaller denominator.
-      - name: Initialize exact nine-contract attendance ledger
+      - name: Initialize exact ten-contract attendance ledger
         shell: bash
         env:
           # runner.* does not exist until dispatch; never move this to job env.
@@ -600,7 +600,7 @@ jobs:
         if: always() && !cancelled()
         run: tools/ci-apt-install.sh rsync
 
-      # Provisioning failure is one setup refusal, not nine mysterious test
+      # Provisioning failure is one setup refusal, not ten mysterious test
       # failures. This step runs after either provisioner fails so it can name
       # every absent tool; the batches run only when this exact precondition is
       # green.
@@ -654,7 +654,7 @@ jobs:
             --reports-dir "$SUGARBIN_SHELL_TIER_ROOT/bodies" \
             --commit "$GITHUB_SHA"
 
-      - name: Audit exact 9/9 attendance and results
+      - name: Audit exact 10/10 attendance and results
         if: always() && !cancelled()
         shell: bash
         env:

--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -877,12 +877,19 @@ sugar_bx_run_docker() {
     # payload env. Final tasks may consume the shared shelf but only the
     # explicit managed publisher may stage or install shared cells.
     case "$name" in
-      SUGAR_BINARY_SHELF_READ_ONLY|SUGAR_BINARY_PUBLISH) continue ;;
+      SUGAR_BINARY_SHELF_READ_ONLY|SUGAR_BINARY_PUBLISH|SUGAR_BX_RUN_AUTHORITY) continue ;;
     esac
     [[ ${!name+x} == x ]] && docker_args+=(--env "$name=${!name}")
   done
   docker_args+=(--env SUGAR_BINARY_SHELF_READ_ONLY=1)
   docker_args+=(--env SUGAR_BINARY_PUBLISH=0)
+  # Transport-owned, like the mount and publish authority above. The
+  # load-bearing protection is bin/sugarbin's UNCONDITIONAL assignment of
+  # SUGAR_BX_RUN_AUTHORITY, which clobbers any caller value before this runs;
+  # the skip in the forwarding case list above is belt-and-braces and is not
+  # independently observable.
+  [[ -z "${SUGAR_BX_RUN_AUTHORITY:-}" ]] \
+    || docker_args+=(--env "SUGAR_BX_RUN_AUTHORITY=$SUGAR_BX_RUN_AUTHORITY")
   case "$preflight_protocol" in
     managed-entrypoint/v1)
       [[ -n "${SUGAR_BX_MANAGED_PRECONDITION_PLAN:-}" ]] || {

--- a/bin/sugarbin
+++ b/bin/sugarbin
@@ -220,6 +220,26 @@ dispatch_execution_subcommand() {
     sugar_exec_validate_route "$host" "$execution_env" "$requested_platform" "$observed_platform" || return $?
   fi
 
+  # Run authority is testimony, not a permission check. Both arms produce it:
+  # a named task records the image and precondition plan it actually installed,
+  # and an ad-hoc command records that it ran under no declared task. The
+  # command stays permitted; what changes is that its authority is no longer
+  # invisible, so a measurement derived from it is refused downstream instead
+  # of being banked as though it were managed.
+  local run_authority_json=""
+  if [[ ${#command[@]} -gt 0 && "$subcommand" != build ]]; then
+    local contract_python
+    contract_python="$(sugarbin_contract_python)" || return $?
+    local -a authority_args=(--image "${docker_image:-ambient:$execution_env}")
+    if [[ -n "$task" ]]; then
+      authority_args+=(--task "$task" --preflight "$task_preflight_protocol"
+        --plan-json "${task_preconditions_json:-null}")
+    fi
+    run_authority_json="$("$contract_python" \
+      "$script_dir/../tools/sugar-build/contract.py" run-authority \
+      "${authority_args[@]}" -- "${command[@]}")" || return $?
+  fi
+
   if [[ "$subcommand" == explain ]]; then
     [[ "$saw_boundary" == 0 ]] || { echo "sugarbin: explain does not accept a command" >&2; return 2; }
     printf 'host=%s\n' "$host"
@@ -232,6 +252,7 @@ dispatch_execution_subcommand() {
     printf 'network=%s\n' "$task_network"
     printf 'docker_image=%s\n' "$docker_image"
     printf 'preflight=%s\n' "$task_preflight_protocol"
+    printf 'run_authority=%s\n' "$run_authority_json"
     return 0
   fi
 
@@ -287,6 +308,7 @@ dispatch_execution_subcommand() {
   SUGAR_BX_ENV_NAMES=()
   SUGAR_BX_SYNC_BACKS=()
   SUGAR_BX_MANAGED_PRECONDITION_PLAN="$task_preconditions_json"
+  SUGAR_BX_RUN_AUTHORITY="$run_authority_json"
   SUGAR_BX_DETACH_JOB_ID="$detach_job_id"
   ((${#path_prefixes[@]} == 0)) || SUGAR_BX_PATH_PREFIXES=("${path_prefixes[@]}")
   ((${#env_names[@]} == 0)) || SUGAR_BX_ENV_NAMES=("${env_names[@]}")

--- a/tests/sugarbin_run_authority.sh
+++ b/tests/sugarbin_run_authority.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Transport seam for run-authority/v1.
+#
+# The defect in #7340 lived exactly here: `bin/brun --env docker:... --
+# bash -lc '<script>'` with no --task matched no registered task command, so
+# sugarbin treated it as an allowed ad-hoc command and said nothing further.
+# The command is still allowed. What must no longer happen is silence about
+# the authority it ran under.
+#
+# Asserted:
+#   - the ad-hoc entrance still runs, and carries explicit UNMANAGED testimony
+#   - a named task carries MANAGED testimony naming its task and image
+#   - the testimony reaches the container as a transport-owned --env
+#   - a payload cannot forge SUGAR_BX_RUN_AUTHORITY through --env forwarding
+set -euo pipefail
+
+repo_root="${1:-$(git rev-parse --show-toplevel)}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fake_bin="$tmp/bin"
+mkdir -p "$fake_bin"
+ssh_log="$tmp/ssh.log"
+rsync_log="$tmp/rsync.log"
+
+cat >"$fake_bin/ssh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BX_FAKE_SSH_LOG"
+exit 0
+SH
+cat >"$fake_bin/rsync" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$BX_FAKE_RSYNC_LOG"
+exit 0
+SH
+chmod +x "$fake_bin/ssh" "$fake_bin/rsync"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+run_bx() {
+  (cd "$repo_root" &&
+    PATH="$fake_bin:$PATH" BCARGO_SSH="$fake_bin/ssh" BCARGO_RSYNC="$fake_bin/rsync" \
+    BX_FAKE_SSH_LOG="$ssh_log" BX_FAKE_RSYNC_LOG="$rsync_log" \
+    BCARGO_REMOTE_ROOT="${BCARGO_REMOTE_ROOT:-/home/tsavo/remote/sugar-bcargo-run-authority-test}" \
+    "$repo_root/bin/sugarbin" "$@")
+}
+
+explain_authority() {
+  run_bx explain --host bx "$@" | sed -n 's/^run_authority=//p'
+}
+
+# --- The exact reported entrance -------------------------------------------
+# A showcase producer loop hidden behind `bash -lc`, dispatched with no --task.
+adhoc_script='for s in federation base20 base64; do make showcase-$s; done'
+
+# It still matches no task: the spelling matcher is unchanged and still blind.
+matched="$(python3 "$repo_root/tools/sugar-build/contract.py" match-command -- \
+  bash -lc "$adhoc_script")"
+[[ "$matched" == '{"task":null}' ]] \
+  || fail "expected the reported entrance to still match no task; got $matched"
+
+# But the run no longer stays silent about that. `explain` refuses a command,
+# so the ad-hoc arm is read off the real wire: the env the transport composes.
+: >"$ssh_log"
+run_bx run --host bx --env docker:python-test -- bash -lc "$adhoc_script" >/dev/null 2>&1 || true
+adhoc="$(python3 - "$ssh_log" <<'PY'
+import re, sys
+text = open(sys.argv[1]).read()
+# The transport quotes each docker arg: '--env' 'SUGAR_BX_RUN_AUTHORITY={...}'
+match = re.search(r"SUGAR_BX_RUN_AUTHORITY=([^']*)", text)
+print(match.group(1) if match else "")
+PY
+)"
+[[ -n "$adhoc" ]] || fail "ad-hoc run carried no run-authority testimony at all"
+python3 - "$adhoc" <<'PY' || fail "ad-hoc testimony is not explicit UNMANAGED"
+import json, sys
+t = json.loads(sys.argv[1])
+assert t["schema"] == "run-authority/v1", t
+assert t["authority"] == "unmanaged", t
+assert t["task"] is None, t
+assert t["preconditionPlanCid"] is None, t
+assert t["command"][0] == "bash", t
+PY
+
+# --- A named task, by contrast, proves what it consumed ---------------------
+managed="$(explain_authority --task showcases)"
+python3 - "$managed" <<'PY' || fail "named task did not carry MANAGED testimony"
+import json, sys
+t = json.loads(sys.argv[1])
+assert t["schema"] == "run-authority/v1", t
+assert t["authority"] == "managed", t
+assert t["task"] == "showcases", t
+assert t["image"].startswith("sha256:") or "@sha256:" in t["image"], t
+assert t["command"][:2] == ["make", "test-showcases"], t
+PY
+
+# The two states must not be spelled the same way.
+[[ "$adhoc" != "$managed" ]] || fail "managed and unmanaged testimony are indistinguishable"
+
+# --- A payload cannot forge its own authority -------------------------------
+: >"$ssh_log"
+SUGAR_BX_RUN_AUTHORITY='{"schema":"run-authority/v1","authority":"managed","task":"showcases","image":"sha256:forged","preflightProtocol":"managed-entrypoint/v1","preconditionPlanCid":"blake2b-256:0000","command":["make","test-showcases"]}' \
+  run_bx run --host bx --env docker:python-test --env SUGAR_BX_RUN_AUTHORITY \
+  -- bash -lc "$adhoc_script" >/dev/null 2>&1 || true
+grep -q "sha256:forged" "$ssh_log" \
+  && fail "a payload env forged managed run authority into the container"
+grep -q "unmanaged" "$ssh_log" \
+  || fail "transport-owned testimony did not survive a forgery attempt"
+
+echo "PASS: sugarbin_run_authority"

--- a/tests/test_commit_measurement.py
+++ b/tests/test_commit_measurement.py
@@ -30,6 +30,26 @@ def _load(name: str, rel: str):
 
 
 CM = _load("commit_measurement", "tools/commit_measurement.py")
+RA = _load("run_authority", "tools/run_authority.py")
+
+# Every Measured now carries authenticated MANAGED run authority. These teeth
+# are about units and composition, so they run under one genuine managed run:
+# the declared `showcases` task, whose contract command owns this argv.
+MANAGED_TESTIMONY = {
+    "schema": RA.RUN_AUTHORITY_SCHEMA,
+    "authority": RA.AUTHORITY_MANAGED,
+    "task": "showcases",
+    "image": "sha256:showcase-capability-image",
+    "preflightProtocol": "managed-entrypoint/v1",
+    "preconditionPlanCid": RA.plan_cid({"checks": [], "task": "showcases"}),
+    "command": ["make", "test-showcases"],
+}
+
+
+def _measured(*args, **kwargs):
+    kwargs.setdefault("run_authority", MANAGED_TESTIMONY)
+    return CM.measured(*args, **kwargs)
+
 GATE = _load("commit_measurement_gate", "tools/commit_measurement_gate.py")
 
 
@@ -47,6 +67,7 @@ def _floor_body(axis_id: str, failed: int = 0, collected: int = 100) -> dict:
         "totals": {"failed": failed, "collected": collected},
         "populationId": f"corpus:{axis_id}",
         "populationSize": collected,
+        "runAuthority": MANAGED_TESTIMONY,
     }
 
 
@@ -66,6 +87,7 @@ def _recensus_body(panics: int = 0, files: int = 1415) -> dict:
             "status": "passed",
         },
         "measuredCommit": "deadbeef",
+        "runAuthority": MANAGED_TESTIMONY,
         "R_construction_panics": panics,
         "constructionPanics": [{"x": i} for i in range(panics)],
         "enrolledFiles": files,
@@ -110,7 +132,7 @@ def test_process_floor_units_are_not_the_same() -> None:
 
 
 def test_measured_requires_unit() -> None:
-    m = CM.measured(
+    m = _measured(
         3,
         identity="native-crash",
         unit=CM.UNIT_CORPUS_FILE,
@@ -124,7 +146,7 @@ def test_measured_requires_unit() -> None:
     assert m.identity == "native-crash"
     assert not hasattr(m, "receipt_cid")
     with pytest.raises(CM.CommitMeasurementError, match="unit"):
-        CM.measured(
+        _measured(
             3,
             identity="native-crash",
             unit="made-up-unit",
@@ -137,7 +159,7 @@ def test_measured_requires_unit() -> None:
 
 
 def test_measured_json_carries_unit() -> None:
-    m = CM.measured(
+    m = _measured(
         0,
         identity="silent",
         unit=CM.UNIT_ASSERT_FUNCTION_LOCUS,
@@ -217,7 +239,7 @@ def test_no_total_while_any_axis_unmeasured() -> None:
         "sha",
         "roster",
         {
-            "silent": CM.measured(
+            "silent": _measured(
                 0,
                 identity="silent",
                 unit=CM.UNIT_ASSERT_FUNCTION_LOCUS,
@@ -342,7 +364,7 @@ def test_floor_axis_reports_do_not_collapse_to_one_reading(tmp_path: Path) -> No
 def test_enrolled_panics_axis_not_forbidden() -> None:
     """R_construction_panics is cite-enrolled; free R_construction still blocked."""
     body = _recensus_body(2)
-    m = CM.measured(
+    m = _measured(
         2,
         identity="R_construction_panics",
         unit=CM.UNIT_CONSTRUCTION_PANIC,
@@ -375,7 +397,7 @@ def test_legacy_recensus_body_without_conservation_witness_is_refused() -> None:
     body = _recensus_body(2)
     body.pop("conservationWitness")
     with pytest.raises(CM.CommitMeasurementError, match="conservationWitness"):
-        CM.measured(
+        _measured(
             2,
             identity="R_construction_panics",
             unit=CM.UNIT_CONSTRUCTION_PANIC,
@@ -389,7 +411,7 @@ def test_legacy_recensus_body_without_conservation_witness_is_refused() -> None:
 
 def test_measured_requires_body_matching_value() -> None:
     with pytest.raises(CM.CommitMeasurementError, match="parsed body|NoReport"):
-        CM.measured(
+        _measured(
             3,
             identity="x",
             unit=CM.UNIT_CORPUS_FILE,
@@ -400,7 +422,7 @@ def test_measured_requires_body_matching_value() -> None:
             exit_code=1,
         )
     with pytest.raises(CM.CommitMeasurementError, match="does not match"):
-        CM.measured(
+        _measured(
             99,
             identity="x",
             unit=CM.UNIT_CORPUS_FILE,
@@ -417,7 +439,7 @@ def test_partial_has_no_total() -> None:
         "sha",
         "roster",
         {
-            "a": CM.measured(
+            "a": _measured(
                 1,
                 identity="a",
                 unit=CM.UNIT_CORPUS_FILE,

--- a/tests/test_run_authority.py
+++ b/tests/test_run_authority.py
@@ -214,13 +214,30 @@ def test_unmanaged_testimony_carrying_managed_fields_is_conflicting() -> None:
         assert key in text
 
 
-def test_non_json_and_non_object_testimony_is_malformed_not_absent() -> None:
-    for junk in ("{not json", 17, [1, 2, 3]):
+def test_non_object_testimony_is_malformed_not_absent() -> None:
+    for junk in (17, [1, 2, 3]):
         with pytest.raises(RA.RunAuthorityRefusal) as caught:
             RA.authenticate_run_authority(junk, task_command_resolver=_resolver)
         text = str(caught.value)
         assert RA.REFUSAL_MALFORMED in text, text
         assert RA.REFUSAL_ABSENT not in text
+        assert "must be an object" in text, text
+
+
+def test_undecodable_json_transport_refuses_on_the_decode_arm() -> None:
+    """Named by the same refusal, but reached down its own path.
+
+    Asserting only that something MALFORMED was raised would leave this
+    satisfied by the non-object guard downstream, so the decode arm could be
+    deleted with this tooth still green. The detail is what discriminates.
+    """
+    for junk in ("{not json", b'{"schema": '):
+        with pytest.raises(RA.RunAuthorityRefusal) as caught:
+            RA.authenticate_run_authority(junk, task_command_resolver=_resolver)
+        text = str(caught.value)
+        assert RA.REFUSAL_MALFORMED in text, text
+        assert "is not JSON" in text, text
+        assert "must be an object" not in text, text
 
 
 def test_testimony_survives_json_string_transport() -> None:
@@ -318,6 +335,57 @@ def test_measurement_with_no_run_authority_at_all_is_unconstructible() -> None:
     with pytest.raises(CM.CommitMeasurementError) as caught:
         _mint(None)
     assert RA.REFUSAL_ABSENT in str(caught.value)
+
+
+def test_sealing_an_unmanaged_authority_into_measured_refuses_by_name() -> None:
+    """The last line of defence, reached only by a caller holding the seal.
+
+    Through the public `measured(...)` door this is unreachable:
+    `require_managed_run_authority` refuses first and always hands the
+    constructor a ManagedRunAuthority. So this tooth constructs Measured
+    directly WITH the seal — the position a future edit inside the module
+    would occupy — and proves the type still will not admit an unmanaged run.
+
+    Without this, the isinstance check in Measured.__post_init__ is dead
+    weight: it can be deleted with nothing observable changing.
+    """
+    ad_hoc = RA.authenticate_run_authority(_unmanaged(), task_command_resolver=_resolver)
+    assert isinstance(ad_hoc, RA.UnmanagedRunAuthority)
+
+    with pytest.raises(CM.CommitMeasurementError) as caught:
+        CM.Measured(
+            3,
+            "native-crash",
+            CM.UNIT_CORPUS_FILE,
+            "pop:corpus",
+            12,
+            "blake2b-256:" + "0" * 64,
+            "totals.failed",
+            1,
+            ad_hoc,
+            CM._MEASURED_SEAL,
+        )
+    text = str(caught.value)
+    assert "ManagedRunAuthority" in text, text
+    assert "UnmanagedRunAuthority" in text, text
+    assert "THE ARTIFACT MUST PROVE WHAT IT CONSUMED" in text, text
+
+    # And the same position with a genuine managed authority does construct,
+    # so the tooth is discriminating rather than refusing everything.
+    managed = RA.authenticate_run_authority(_managed(), task_command_resolver=_resolver)
+    sealed = CM.Measured(
+        3,
+        "native-crash",
+        CM.UNIT_CORPUS_FILE,
+        "pop:corpus",
+        12,
+        "blake2b-256:" + "0" * 64,
+        "totals.failed",
+        1,
+        managed,
+        CM._MEASURED_SEAL,
+    )
+    assert sealed.run_authority.task == "showcases"
 
 
 def test_measurement_from_a_managed_run_constructs_and_carries_its_authority() -> None:

--- a/tests/test_run_authority.py
+++ b/tests/test_run_authority.py
@@ -422,6 +422,24 @@ def test_a_named_task_produces_managed_testimony_that_authenticates() -> None:
     assert authority.task == "showcases"
 
 
+def test_producer_stamp_door_round_trips_the_transport_env() -> None:
+    """One carrier name, stamped through one door, read by one authenticator."""
+    body = RA.stamp_run_authority(
+        {"totals": {"failed": 0}}, {RA.RUN_AUTHORITY_ENV: json.dumps(_managed())}
+    )
+    authority = RA.authenticate_run_authority(
+        body["runAuthority"], task_command_resolver=_resolver
+    )
+    assert isinstance(authority, RA.ManagedRunAuthority)
+
+    # No transport testimony means the body carries none, and the consumer
+    # reads absence rather than inventing a permissive default.
+    bare = RA.stamp_run_authority({"totals": {"failed": 0}}, {})
+    assert "runAuthority" not in bare
+    with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_ABSENT):
+        RA.authenticate_run_authority(bare.get("runAuthority"))
+
+
 def test_producer_refuses_to_emit_half_evidenced_managed_testimony() -> None:
     """A managed claim cannot be constructed without its image and its preflight."""
     with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_MALFORMED):

--- a/tests/test_run_authority.py
+++ b/tests/test_run_authority.py
@@ -1,0 +1,449 @@
+"""Teeth for run-authority/v1: what a sugarbin run proves it consumed.
+
+The defect these teeth hold shut: `bin/brun --env docker:... -- bash -lc
+'<script>'` with no `--task` matched no registered task command prefix, so the
+shell wrapper HID the showcase ownership. The run selected the ordinary
+capability image, installed no managed precondition plan, enrolled no profiled
+closure artifacts, died mid-initialization on `FileNotFoundError: git`, and its
+0/6 result was banked as though it were a measurement.
+
+Nothing here forbids that command. What it forbids is banking the result.
+
+Three states, three distinct names, never two — plus the lying arm, which is
+the one that matters. Each tooth asserts the SPECIFIC refusal name, because a
+tooth satisfied by a neighbouring refusal survives its own guard's removal and
+proves nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from repo_root_test_support import resolve_repo_root
+
+ROOT = resolve_repo_root()
+
+
+def _load(name: str, rel: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / rel)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+RA = _load("run_authority", "tools/run_authority.py")
+CM = _load("commit_measurement", "tools/commit_measurement.py")
+
+# The exact entrance from issue #7340: a showcase producer loop wrapped in
+# `bash -lc`, dispatched with no --task.
+ADHOC_ARGV = ["bash", "-lc", "for s in federation base20 base64; do make showcase-$s; done"]
+
+DECLARED_COMMANDS = {
+    "showcases": ["make", "test-showcases"],
+    "rust-unit": ["cargo", "test", "--manifest-path", "implementations/rust/Cargo.toml"],
+}
+
+
+def _resolver(task: str):
+    return DECLARED_COMMANDS.get(task)
+
+
+def _managed(**overrides) -> dict:
+    testimony = {
+        "schema": RA.RUN_AUTHORITY_SCHEMA,
+        "authority": RA.AUTHORITY_MANAGED,
+        "task": "showcases",
+        "image": "sha256:showcase-capability-image",
+        "preflightProtocol": "managed-entrypoint/v1",
+        "preconditionPlanCid": RA.plan_cid({"checks": [], "task": "showcases"}),
+        "command": ["make", "test-showcases"],
+    }
+    testimony.update(overrides)
+    return testimony
+
+
+def _unmanaged(**overrides) -> dict:
+    testimony = {
+        "schema": RA.RUN_AUTHORITY_SCHEMA,
+        "authority": RA.AUTHORITY_UNMANAGED,
+        "task": None,
+        "image": "sha256:ordinary-capability-image",
+        "preflightProtocol": None,
+        "preconditionPlanCid": None,
+        "command": list(ADHOC_ARGV),
+    }
+    testimony.update(overrides)
+    return testimony
+
+
+# ---------------------------------------------------------------------------
+# Three states are three states. Absent is not unmanaged is not mismatched.
+# ---------------------------------------------------------------------------
+
+
+def test_absent_unmanaged_and_managed_are_three_distinct_readings() -> None:
+    absent = pytest.raises(
+        RA.RunAuthorityRefusal, match=RA.REFUSAL_ABSENT
+    )
+    with absent:
+        RA.authenticate_run_authority(None, task_command_resolver=_resolver)
+
+    ad_hoc = RA.authenticate_run_authority(_unmanaged(), task_command_resolver=_resolver)
+    assert isinstance(ad_hoc, RA.UnmanagedRunAuthority)
+    assert ad_hoc.is_managed() is False
+    assert ad_hoc.command == tuple(ADHOC_ARGV)
+
+    owned = RA.authenticate_run_authority(_managed(), task_command_resolver=_resolver)
+    assert isinstance(owned, RA.ManagedRunAuthority)
+    assert owned.is_managed() is True
+    assert owned.task == "showcases"
+    assert owned.image == "sha256:showcase-capability-image"
+    assert owned.preflight_protocol == "managed-entrypoint/v1"
+
+    # Distinct types, not one type with a flag: no reading can be silently
+    # substituted for another.
+    assert type(ad_hoc) is not type(owned)
+
+
+def test_absence_has_its_own_refusal_name() -> None:
+    with pytest.raises(RA.RunAuthorityRefusal) as caught:
+        RA.authenticate_run_authority(None, task_command_resolver=_resolver)
+    text = str(caught.value)
+    assert RA.REFUSAL_ABSENT in text, text
+    # Absence must NOT be reported as any neighbouring state.
+    assert RA.REFUSAL_MALFORMED not in text
+    assert RA.REFUSAL_UNOWNED_COMMAND not in text
+    assert "unmanaged" not in text.lower().split(":")[0]
+
+
+# ---------------------------------------------------------------------------
+# THE LYING ARM. A genuinely ad-hoc run recorded as managed must refuse.
+# ---------------------------------------------------------------------------
+
+
+def test_adhoc_run_claiming_managed_authority_refuses_as_unowned_command() -> None:
+    """The dangerous arm: a confident false claim, not an absent one.
+
+    The testimony is complete, well-formed, names a real declared task, a real
+    showcase image and a real plan cid. Everything about it *spells* managed.
+    The only thing wrong is that the task does not own the command that ran.
+    """
+    lying = _managed(command=list(ADHOC_ARGV))
+    with pytest.raises(RA.RunAuthorityRefusal) as caught:
+        RA.authenticate_run_authority(lying, task_command_resolver=_resolver)
+    text = str(caught.value)
+    assert RA.REFUSAL_UNOWNED_COMMAND in text, text
+    # It must not be satisfied by a neighbouring refusal.
+    assert RA.REFUSAL_ABSENT not in text
+    assert RA.REFUSAL_MALFORMED not in text
+    assert RA.REFUSAL_UNDECLARED_TASK not in text
+    # The refusal must name the specific divergence, not merely that one exists.
+    assert "showcases" in text
+    assert "bash" in text
+    assert "make" in text
+
+
+def test_lying_claim_cannot_borrow_a_bash_prefixed_task() -> None:
+    """A wrapper that merely starts with the same interpreter is still unowned."""
+    resolver = {"scoreboard": ["bash", "scripts/test-3809-dod-scoreboard.sh"]}.get
+    lying = _managed(task="scoreboard", command=list(ADHOC_ARGV))
+    with pytest.raises(RA.RunAuthorityRefusal) as caught:
+        RA.authenticate_run_authority(lying, task_command_resolver=resolver)
+    assert RA.REFUSAL_UNOWNED_COMMAND in str(caught.value)
+
+
+def test_managed_claim_naming_an_undeclared_task_has_its_own_name() -> None:
+    lying = _managed(task="showcases-but-not-really")
+    with pytest.raises(RA.RunAuthorityRefusal) as caught:
+        RA.authenticate_run_authority(lying, task_command_resolver=_resolver)
+    text = str(caught.value)
+    assert RA.REFUSAL_UNDECLARED_TASK in text, text
+    assert RA.REFUSAL_UNOWNED_COMMAND not in text
+    assert RA.REFUSAL_MALFORMED not in text
+
+
+# ---------------------------------------------------------------------------
+# Malformed / conflicting testimony is its own refusal, not a coerced state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mutation,why",
+    [
+        ({"schema": "run-authority/v2"}, "unsupported schema"),
+        ({"schema": None}, "missing schema"),
+        ({"authority": "partially-managed"}, "invented authority"),
+        ({"authority": None}, "absent authority field"),
+        ({"image": ""}, "image not named"),
+        ({"command": []}, "no argv recorded"),
+        ({"command": "make test-showcases"}, "argv is not an array"),
+        ({"preflightProtocol": None}, "managed without preflight"),
+        ({"preconditionPlanCid": ""}, "plan cid present but empty"),
+        ({"preconditionPlanCid": 7}, "plan cid is not a string"),
+    ],
+)
+def test_malformed_managed_testimony_refuses_as_malformed(mutation, why) -> None:
+    with pytest.raises(RA.RunAuthorityRefusal) as caught:
+        RA.authenticate_run_authority(
+            _managed(**mutation), task_command_resolver=_resolver
+        )
+    assert RA.REFUSAL_MALFORMED in str(caught.value), f"{why}: {caught.value}"
+
+
+def test_unmanaged_testimony_carrying_managed_fields_is_conflicting() -> None:
+    """Half-managed is not a state. Conflicting testimony is refused, not coerced."""
+    for key, value in (
+        ("task", "showcases"),
+        ("preflightProtocol", "managed-entrypoint/v1"),
+        ("preconditionPlanCid", "blake2b-256:" + "0" * 64),
+    ):
+        with pytest.raises(RA.RunAuthorityRefusal) as caught:
+            RA.authenticate_run_authority(
+                _unmanaged(**{key: value}), task_command_resolver=_resolver
+            )
+        text = str(caught.value)
+        assert RA.REFUSAL_MALFORMED in text, text
+        assert key in text
+
+
+def test_non_json_and_non_object_testimony_is_malformed_not_absent() -> None:
+    for junk in ("{not json", 17, [1, 2, 3]):
+        with pytest.raises(RA.RunAuthorityRefusal) as caught:
+            RA.authenticate_run_authority(junk, task_command_resolver=_resolver)
+        text = str(caught.value)
+        assert RA.REFUSAL_MALFORMED in text, text
+        assert RA.REFUSAL_ABSENT not in text
+
+
+def test_testimony_survives_json_string_transport() -> None:
+    """The transport hands it over as an env string; the reading is the same."""
+    authority = RA.authenticate_run_authority(
+        json.dumps(_managed()), task_command_resolver=_resolver
+    )
+    assert isinstance(authority, RA.ManagedRunAuthority)
+
+
+# ---------------------------------------------------------------------------
+# The wrong state is unrepresentable, not guarded.
+# ---------------------------------------------------------------------------
+
+
+def test_managed_authority_cannot_be_spelled_without_authentication() -> None:
+    with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_MALFORMED):
+        RA.ManagedRunAuthority(
+            "showcases", "sha256:x", "managed-entrypoint/v1", "cid", ("make",), object()
+        )
+    with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_MALFORMED):
+        RA.UnmanagedRunAuthority(("bash",), "sha256:x", object())
+
+
+# ---------------------------------------------------------------------------
+# UNMEASURED BY CONSTRUCTION. Not flagged — unconstructible.
+# ---------------------------------------------------------------------------
+
+
+def _body(failed: int = 3, collected: int = 12) -> dict:
+    return {
+        "schemaVersion": 1,
+        "kind": "sole-construction-floor-axis-report",
+        "totals": {"failed": failed, "collected": collected},
+    }
+
+
+def _mint(run_authority):
+    return CM.measured(
+        3,
+        identity="native-crash",
+        unit=CM.UNIT_CORPUS_FILE,
+        population_id="pop:corpus",
+        population_size=12,
+        body=_body(),
+        value_field_path="totals.failed",
+        exit_code=1,
+        run_authority=run_authority,
+        task_command_resolver=_resolver,
+    )
+
+
+def test_measurement_from_an_unmanaged_run_is_unconstructible() -> None:
+    with pytest.raises(CM.CommitMeasurementError) as caught:
+        _mint(_unmanaged())
+    text = str(caught.value)
+    assert RA.REFUSAL_UNMEASURED_BY_CONSTRUCTION in text, text
+    # Specifically NOT the absence refusal: the run testified honestly, and the
+    # honest testimony is what makes the measurement unbankable.
+    assert RA.REFUSAL_ABSENT not in text
+
+
+def test_measurement_from_a_lying_managed_claim_is_unconstructible() -> None:
+    with pytest.raises(CM.CommitMeasurementError) as caught:
+        _mint(_managed(command=list(ADHOC_ARGV)))
+    assert RA.REFUSAL_UNOWNED_COMMAND in str(caught.value)
+
+
+def test_a_declared_task_with_no_closure_is_owned_but_still_unbankable() -> None:
+    """The fifth state, surfaced by bin/bpytest's own wrapper task.
+
+    `authenticated-python-lift` is a genuinely declared, genuinely owned task
+    that declares no command closure, so no precondition plan is installed. The
+    transport records that honestly rather than fabricating a plan; the
+    measurement door refuses it under its own name, distinct from both the
+    ad-hoc reading and the lying one.
+    """
+    owned_but_unplanned = _managed(preconditionPlanCid=None)
+    authority = RA.authenticate_run_authority(
+        owned_but_unplanned, task_command_resolver=_resolver
+    )
+    assert isinstance(authority, RA.ManagedRunAuthority)
+    assert authority.precondition_plan_cid is None
+
+    with pytest.raises(CM.CommitMeasurementError) as caught:
+        _mint(owned_but_unplanned)
+    text = str(caught.value)
+    assert RA.REFUSAL_UNPLANNED_TASK in text, text
+    assert RA.REFUSAL_UNMEASURED_BY_CONSTRUCTION not in text
+    assert RA.REFUSAL_UNOWNED_COMMAND not in text
+    assert RA.REFUSAL_ABSENT not in text
+
+
+def test_measurement_with_no_run_authority_at_all_is_unconstructible() -> None:
+    with pytest.raises(CM.CommitMeasurementError) as caught:
+        _mint(None)
+    assert RA.REFUSAL_ABSENT in str(caught.value)
+
+
+def test_measurement_from_a_managed_run_constructs_and_carries_its_authority() -> None:
+    reading = _mint(_managed())
+    assert reading.is_measured() is True
+    assert reading.run_authority.task == "showcases"
+    assert reading.run_authority.image == "sha256:showcase-capability-image"
+
+
+def test_body_carried_authority_reaches_the_durable_composition() -> None:
+    """Carried in the receipt, not merely logged."""
+    body = dict(_body())
+    body["runAuthority"] = _managed()
+    reading = CM.measured_from_body(
+        identity="native-crash",
+        unit=CM.UNIT_CORPUS_FILE,
+        population_id="pop:corpus",
+        population_size=12,
+        body=body,
+        value_field_path="totals.failed",
+        exit_code=1,
+        task_command_resolver=_resolver,
+    )
+    assert reading.is_measured(), reading
+    projected = CM._measured_json(reading)["runAuthority"]
+    assert projected["schema"] == RA.RUN_AUTHORITY_SCHEMA
+    assert projected["authority"] == RA.AUTHORITY_MANAGED
+    assert projected["task"] == "showcases"
+    assert projected["preconditionPlanCid"] == _managed()["preconditionPlanCid"]
+
+
+def test_body_carrying_unmanaged_authority_reads_unmeasured_not_measured() -> None:
+    body = dict(_body())
+    body["runAuthority"] = _unmanaged()
+    reading = CM.measured_from_body(
+        identity="native-crash",
+        unit=CM.UNIT_CORPUS_FILE,
+        population_id="pop:corpus",
+        population_size=12,
+        body=body,
+        value_field_path="totals.failed",
+        exit_code=1,
+        task_command_resolver=_resolver,
+    )
+    assert reading.is_measured() is False
+    assert RA.REFUSAL_UNMEASURED_BY_CONSTRUCTION in reading.reason
+    assert not isinstance(reading, CM.Measured)
+
+
+# ---------------------------------------------------------------------------
+# The producer end: the real reproduction, through the real contract CLI.
+# ---------------------------------------------------------------------------
+
+
+def _contract(*args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools/sugar-build/contract.py"), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_the_reported_entrance_still_matches_no_task() -> None:
+    """The measured defect, unchanged: recognition by spelling sees nothing."""
+    assert _contract("match-command", "--", *ADHOC_ARGV) == {"task": None}
+
+
+def test_the_reported_entrance_now_carries_explicit_unmanaged_testimony() -> None:
+    """Same command, still permitted — but no longer silent about its authority."""
+    testimony = _contract(
+        "run-authority", "--image", "sha256:ordinary-capability-image", "--", *ADHOC_ARGV
+    )
+    assert testimony["authority"] == RA.AUTHORITY_UNMANAGED
+    assert testimony["task"] is None
+    assert testimony["preconditionPlanCid"] is None
+    assert testimony["command"] == ADHOC_ARGV
+    # And it is durable testimony, not a log line: it authenticates.
+    authority = RA.authenticate_run_authority(testimony, task_command_resolver=_resolver)
+    assert isinstance(authority, RA.UnmanagedRunAuthority)
+
+
+def test_a_named_task_produces_managed_testimony_that_authenticates() -> None:
+    testimony = _contract(
+        "run-authority",
+        "--image",
+        "sha256:showcase-capability-image",
+        "--task",
+        "showcases",
+        "--preflight",
+        "managed-entrypoint/v1",
+        "--plan-json",
+        json.dumps({"checks": [], "task": "showcases"}),
+        "--",
+        "make",
+        "test-showcases",
+    )
+    assert testimony["authority"] == RA.AUTHORITY_MANAGED
+    authority = RA.authenticate_run_authority(testimony)
+    assert isinstance(authority, RA.ManagedRunAuthority)
+    assert authority.task == "showcases"
+
+
+def test_producer_refuses_to_emit_half_evidenced_managed_testimony() -> None:
+    """A managed claim cannot be constructed without its image and its preflight."""
+    with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_MALFORMED):
+        RA.build_run_authority(
+            ["make", "test-showcases"],
+            image="sha256:x",
+            task="showcases",
+            preflight_protocol=None,
+            precondition_plan={"checks": []},
+        )
+    with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_MALFORMED):
+        RA.build_run_authority(ADHOC_ARGV, image="")
+    with pytest.raises(RA.RunAuthorityRefusal, match=RA.REFUSAL_MALFORMED):
+        RA.build_run_authority([], image="sha256:x")
+
+    # A closureless task is emitted honestly rather than fabricated into a plan.
+    unplanned = RA.build_run_authority(
+        ["python", "-m", "sugar_lift_py_tests.authenticated_pytest"],
+        image="sha256:x",
+        task="authenticated-python-lift",
+        preflight_protocol="workspace-wrapper/v1",
+        precondition_plan=None,
+    )
+    assert unplanned["preconditionPlanCid"] is None
+    assert unplanned["authority"] == RA.AUTHORITY_MANAGED

--- a/tests/test_sugarbin_shell_tier.py
+++ b/tests/test_sugarbin_shell_tier.py
@@ -1,4 +1,4 @@
-"""Executable teeth for the nine-contract sugarbin shell tier."""
+"""Executable teeth for the ten-contract sugarbin shell tier."""
 
 from __future__ import annotations
 
@@ -28,6 +28,7 @@ EXPECTED_BATCHES = {
         "tests/sugarbin_mount_proof_guard.sh",
         "tests/sugarbin_docker_daemon_guard.sh",
         "tests/sugarbin_wrapper_compat.sh",
+        "tests/sugarbin_run_authority.sh",
     ],
     "artifacts": [
         "tests/sugarbin_artifact_manifest.sh",
@@ -66,7 +67,7 @@ class SugarbinShellTierTest(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             bodies = sorted(reports.glob("sugarbin_*.json"))
-            self.assertEqual(len(bodies), 9)
+            self.assertEqual(len(bodies), 10)
             payloads = [json.loads(path.read_text(encoding="utf-8")) for path in bodies]
             self.assertEqual({body["contract"] for body in payloads}, set(EXPECTED_ROSTER))
             self.assertEqual({body["status"] for body in payloads}, {"unmeasured"})
@@ -117,7 +118,7 @@ class SugarbinShellTierTest(unittest.TestCase):
                 json.loads(path.read_text(encoding="utf-8"))
                 for path in reports.glob("sugarbin_*.json")
             ]
-            self.assertEqual(len(bodies), 9)
+            self.assertEqual(len(bodies), 10)
             self.assertEqual({body["status"] for body in bodies}, {"unmeasured"})
             self.assertEqual({body["reason"] for body in bodies}, {"batch-not-started"})
 
@@ -246,7 +247,7 @@ class SugarbinShellTierTest(unittest.TestCase):
                 ("unmeasured", "script-missing"),
             )
 
-    def test_audit_refuses_absence_and_accepts_exact_nine_passes(self) -> None:
+    def test_audit_refuses_absence_and_accepts_exact_ten_passes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             reports = Path(directory) / "reports"
             receipt = Path(directory) / "receipt.json"
@@ -265,7 +266,7 @@ class SugarbinShellTierTest(unittest.TestCase):
                 "abc123",
             )
             self.assertNotEqual(absent.returncode, 0)
-            self.assertIn("R_sugarbin_shell_attendance = 9", absent.stdout)
+            self.assertIn("R_sugarbin_shell_attendance = 10", absent.stdout)
             self.assertEqual(json.loads(receipt.read_text())["passed"], 0)
 
             fake_bin = Path(directory) / "bin"
@@ -326,7 +327,7 @@ class SugarbinShellTierTest(unittest.TestCase):
             summary = json.loads(receipt.read_text())
             self.assertEqual(
                 (summary["roster"], summary["attended"], summary["passed"]),
-                (9, 9, 9),
+                (10, 10, 10),
             )
             self.assertEqual(summary.get("testElapsedSeconds"), 0.0)
 

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -59,6 +59,11 @@ if str(_PACKAGE_SRC) not in sys.path:
     sys.path.insert(0, str(_PACKAGE_SRC))
 
 from sugar_lift_py_tests.conservation_mint import decode_conserved_body  # noqa: E402
+from run_authority import (  # noqa: E402
+    ManagedRunAuthority,
+    RunAuthorityRefusal,
+    require_managed_run_authority,
+)
 
 # ---------------------------------------------------------------------------
 # Units — incommensurable. Presenting two Measured.values without their units
@@ -101,6 +106,9 @@ FORBIDDEN_BOARD_AXIS_NAMES = frozenset(
 )
 
 _MEASURED_SEAL = object()
+
+_UNSET_RUN_AUTHORITY = object()
+"""Distinguishes "caller said nothing" from "caller supplied None" (absent)."""
 
 
 class CommitMeasurementError(TypeError):
@@ -176,6 +184,7 @@ class Measured:
     body_cid: str
     value_field_path: str
     exit_code: int
+    run_authority: ManagedRunAuthority
     _seal: object
 
     def __post_init__(self) -> None:
@@ -203,6 +212,15 @@ class Measured:
             _require_nonempty_str("value_field_path", self.value_field_path),
         )
         _require_int("exit_code", self.exit_code)
+        # Not a guard: the type admits no other inhabitant. A Measured cannot be
+        # spelled without a ManagedRunAuthority, which cannot be spelled without
+        # authenticated managed testimony.
+        if not isinstance(self.run_authority, ManagedRunAuthority):
+            raise CommitMeasurementError(
+                "Measured requires an authenticated ManagedRunAuthority; got "
+                f"{type(self.run_authority).__name__}. THE ARTIFACT MUST PROVE "
+                "WHAT IT CONSUMED."
+            )
 
     @property
     def body_artifact_cid(self) -> str:
@@ -242,8 +260,22 @@ def measured(
     body: Mapping[str, Any],
     value_field_path: str,
     exit_code: int,
+    run_authority: Any,
+    task_command_resolver: Any = None,
 ) -> Measured:
-    """Build Measured from parsed body + declared population + unit. No lease."""
+    """Build Measured from parsed body + declared population + unit. No lease.
+
+    ``run_authority`` is the run-authority/v1 testimony the producing run
+    carried. It is authenticated here and must be MANAGED: an ad-hoc command
+    ran under no declared task, so it selected no task capability image and
+    installed no precondition plan, and nothing it produced is a measurement.
+    """
+    try:
+        authority = require_managed_run_authority(
+            run_authority, task_command_resolver=task_command_resolver
+        )
+    except RunAuthorityRefusal as error:
+        raise CommitMeasurementError(f"Measured refuses: {error}") from error
     if not isinstance(body, Mapping):
         raise CommitMeasurementError(
             f"Measured requires a parsed body mapping; got {type(body).__name__}. "
@@ -284,6 +316,7 @@ def measured(
         content_cid(body),
         path_s,
         exit_code,
+        authority,
         _MEASURED_SEAL,
     )
 
@@ -307,9 +340,19 @@ def measured_from_body(
     collected_field_path: str | None = None,
     lease_record: Any = None,
     lease_receipt_cid: str | None = None,
+    run_authority: Any = _UNSET_RUN_AUTHORITY,
+    task_command_resolver: Any = None,
 ) -> AxisReading:
-    """Cite one axis from a produced report body. No lease required."""
+    """Cite one axis from a produced report body. No lease required.
+
+    The run-authority testimony is read from the body itself when the caller
+    does not supply it: the receipt is the durable carrier, not the caller's
+    memory of how the run was launched. A body carrying none is Unmeasured by
+    absence, which is a different reading from Unmeasured by ad-hoc execution.
+    """
     del commit_sha, lease_record, lease_receipt_cid  # explicitly unused
+    if run_authority is _UNSET_RUN_AUTHORITY:
+        run_authority = body.get("runAuthority") if isinstance(body, Mapping) else None
     if body_artifact_cid is not None and body_cid is None:
         body_cid = body_artifact_cid
     if not isinstance(body, Mapping):
@@ -348,6 +391,8 @@ def measured_from_body(
             body=body,
             value_field_path=path,
             exit_code=exit_code,
+            run_authority=run_authority,
+            task_command_resolver=task_command_resolver,
         )
     except CommitMeasurementError as exc:
         return unmeasured(str(exc))
@@ -402,6 +447,7 @@ def _measured_json(r: Measured) -> dict[str, Any]:
         "valueFieldPath": r.value_field_path,
         "collected": r.population_size,
         "exitCode": r.exit_code,
+        "runAuthority": r.run_authority.as_json(),
     }
 
 

--- a/tools/commit_measurement.py
+++ b/tools/commit_measurement.py
@@ -212,9 +212,14 @@ class Measured:
             _require_nonempty_str("value_field_path", self.value_field_path),
         )
         _require_int("exit_code", self.exit_code)
-        # Not a guard: the type admits no other inhabitant. A Measured cannot be
-        # spelled without a ManagedRunAuthority, which cannot be spelled without
-        # authenticated managed testimony.
+        # Ordering fact: through the public measured(...) door this can never
+        # fire, because require_managed_run_authority refuses first and always
+        # hands this constructor a ManagedRunAuthority. It is reachable only by
+        # a caller already holding _MEASURED_SEAL — i.e. a future edit inside
+        # this module. That is exactly the position worth defending, so it is
+        # exercised by
+        # test_sealing_an_unmanaged_authority_into_measured_refuses_by_name
+        # rather than left as unexercisable weight.
         if not isinstance(self.run_authority, ManagedRunAuthority):
             raise CommitMeasurementError(
                 "Measured requires an authenticated ManagedRunAuthority; got "

--- a/tools/run_authority.py
+++ b/tools/run_authority.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""RunAuthority — durable testimony of what a sugarbin run actually consumed.
+
+THE ARTIFACT MUST PROVE WHAT IT CONSUMED. A run that cannot show its task
+ownership, its image selection and its preflight plan cannot produce a
+bankable measurement.
+
+``bin/sugarbin`` recognises a managed task only when the dispatched argv
+literally begins with a registered task command. A showcase measurement
+wrapped in ``bash -lc '<script>'`` therefore matched nothing, was treated as
+an allowed ad-hoc command, selected the ordinary capability image, installed
+no managed precondition plan and enrolled no profiled closure artifacts. The
+run still produced a receipt, and that receipt was indistinguishable from a
+managed one. Recognition by spelling made an unauthenticated environment
+invisible and therefore bankable.
+
+This module does not change what ``brun`` may execute. Ad-hoc diagnostics stay
+executable; their *consequence* becomes visible. Every bx run carries
+``run-authority/v1`` testimony describing the authority it actually ran under,
+and measurement consumers classify from that testimony rather than from
+silence.
+
+    RunAuthority = ManagedRunAuthority | UnmanagedRunAuthority
+
+Three states, three distinct names, never two:
+
+  MANAGED     a declared task owns the dispatched command; the task's image
+              and its precondition plan are named in the testimony.
+  UNMANAGED   the command ran ad-hoc. Explicitly marked, durable, and
+              UNMEASURED BY CONSTRUCTION downstream.
+  refused     absent, malformed/conflicting, or *lying* testimony is none of
+              the above and is refused under its own name.
+
+The lying arm is the one that matters. Absence is the easy case; a genuinely
+ad-hoc run that records itself as managed is the dangerous one. An affirmative
+managed claim is corroborated by re-deriving ownership: the claimed task must
+be declared, and its declared command must be a prefix of the argv the run
+actually dispatched. Spelling is a *necessary condition on an affirmative
+claim*, which is sound; spelling as the sole detector of a negative is the
+defect this module closes.
+
+One door: ``build_run_authority`` constructs, ``authenticate_run_authority``
+admits. There is no other way to obtain a ``ManagedRunAuthority``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence, Union
+
+RUN_AUTHORITY_SCHEMA = "run-authority/v1"
+"""Schema tag every carrier must spell exactly."""
+
+RUN_AUTHORITY_ENV = "SUGAR_BX_RUN_AUTHORITY"
+"""Environment variable through which the transport hands testimony to the payload."""
+
+AUTHORITY_MANAGED = "managed"
+AUTHORITY_UNMANAGED = "unmanaged"
+
+REFUSAL_ABSENT = "RunAuthorityAbsentV1"
+"""No testimony at all. Silence is not unmanaged."""
+
+REFUSAL_MALFORMED = "RunAuthorityMalformedV1"
+"""Testimony carried but unreadable, or self-conflicting field presence."""
+
+REFUSAL_UNDECLARED_TASK = "RunAuthorityUndeclaredTaskV1"
+"""A managed claim naming a task the contract does not declare."""
+
+REFUSAL_UNOWNED_COMMAND = "RunAuthorityUnownedCommandV1"
+"""THE LYING ARM: a managed claim whose task does not own the dispatched argv."""
+
+REFUSAL_UNPLANNED_TASK = "RunAuthorityUnplannedTaskV1"
+"""A declared task that installed no precondition plan. Honest, but unbankable."""
+
+REFUSAL_UNMEASURED_BY_CONSTRUCTION = "UnmanagedRunUnmeasuredByConstructionV1"
+"""An UNMANAGED run cannot be minted into a measured artifact."""
+
+
+class RunAuthorityRefusal(TypeError):
+    """Refused run-authority testimony. Carries its refusal name in the text."""
+
+
+def _refuse(name: str, detail: str) -> RunAuthorityRefusal:
+    return RunAuthorityRefusal(f"{name}: {detail}")
+
+
+def plan_cid(payload: Any) -> str:
+    """Content address of a precondition plan, canonical-JSON keyed."""
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"blake2b-256:{hashlib.blake2b(raw, digest_size=32).hexdigest()}"
+
+
+_MANAGED_SEAL = object()
+_UNMANAGED_SEAL = object()
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedRunAuthority:
+    """A run a declared task owned, with its image and precondition plan named.
+
+    Sealed: obtainable only from ``authenticate_run_authority``. Holding one is
+    itself the proof that ownership was re-derived, so downstream consumers
+    have no guard to forget and no guard to remove.
+    """
+
+    task: str
+    image: str
+    preflight_protocol: str
+    precondition_plan_cid: str | None
+    command: tuple[str, ...]
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _MANAGED_SEAL:
+            raise _refuse(
+                REFUSAL_MALFORMED,
+                "ManagedRunAuthority is sealed: use authenticate_run_authority(...)",
+            )
+
+    def is_managed(self) -> bool:
+        return True
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "schema": RUN_AUTHORITY_SCHEMA,
+            "authority": AUTHORITY_MANAGED,
+            "task": self.task,
+            "image": self.image,
+            "preflightProtocol": self.preflight_protocol,
+            "preconditionPlanCid": self.precondition_plan_cid,
+            "command": list(self.command),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UnmanagedRunAuthority:
+    """A run that executed ad-hoc. Legitimate, durable, and explicitly marked.
+
+    This is not a degraded managed run and not an absent one. It is its own
+    state, and it is the state from which no measured artifact is constructible.
+    """
+
+    command: tuple[str, ...]
+    image: str
+    _seal: object
+
+    def __post_init__(self) -> None:
+        if self._seal is not _UNMANAGED_SEAL:
+            raise _refuse(
+                REFUSAL_MALFORMED,
+                "UnmanagedRunAuthority is sealed: use authenticate_run_authority(...)",
+            )
+
+    def is_managed(self) -> bool:
+        return False
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "schema": RUN_AUTHORITY_SCHEMA,
+            "authority": AUTHORITY_UNMANAGED,
+            "task": None,
+            "image": self.image,
+            "preflightProtocol": None,
+            "preconditionPlanCid": None,
+            "command": list(self.command),
+        }
+
+
+RunAuthority = Union[ManagedRunAuthority, UnmanagedRunAuthority]
+
+
+def build_run_authority(
+    command: Sequence[str],
+    *,
+    image: str,
+    task: str | None = None,
+    preflight_protocol: str | None = None,
+    precondition_plan: Any = None,
+) -> dict[str, Any]:
+    """Producer side: the canonical testimony a run carries.
+
+    ``task is None`` produces UNMANAGED testimony. A named task produces
+    MANAGED testimony and requires both a preflight protocol and a precondition
+    plan, so a managed claim can never be half-evidenced at the source.
+    """
+    argv = [str(item) for item in command]
+    if not argv:
+        raise _refuse(REFUSAL_MALFORMED, "a run carries the argv it dispatched")
+    if not isinstance(image, str) or not image.strip():
+        raise _refuse(REFUSAL_MALFORMED, "a run names the image it selected")
+    if task is None:
+        return {
+            "schema": RUN_AUTHORITY_SCHEMA,
+            "authority": AUTHORITY_UNMANAGED,
+            "task": None,
+            "image": image.strip(),
+            "preflightProtocol": None,
+            "preconditionPlanCid": None,
+            "command": argv,
+        }
+    if not isinstance(preflight_protocol, str) or not preflight_protocol.strip():
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"managed task {task!r} must name the preflight protocol it installed",
+        )
+    # A declared task that declares no command closure genuinely installs no
+    # precondition plan. That is an honest state, not a lie, so the transport
+    # records it faithfully as a null plan. It is the *measurement* door that
+    # refuses it, because a run with no plan cannot prove what it consumed.
+    return {
+        "schema": RUN_AUTHORITY_SCHEMA,
+        "authority": AUTHORITY_MANAGED,
+        "task": task,
+        "image": image.strip(),
+        "preflightProtocol": preflight_protocol.strip(),
+        "preconditionPlanCid": None if precondition_plan is None else plan_cid(precondition_plan),
+        "command": argv,
+    }
+
+
+def _default_task_command_resolver(task: str) -> Sequence[str] | None:
+    """Resolve a declared task's command from the build contract."""
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    contract_path = Path(__file__).resolve().parent / "sugar-build" / "contract.py"
+    spec = importlib.util.spec_from_file_location("sugar_build_contract", contract_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging accident
+        return None
+    module = sys.modules.get("sugar_build_contract")
+    if module is None:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["sugar_build_contract"] = module
+        spec.loader.exec_module(module)
+    try:
+        return module.resolve_task(task)["command"]
+    except Exception:
+        return None
+
+
+def _require_str_field(payload: Mapping[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"field {key!r} must be a non-empty string; got {value!r}",
+        )
+    return value.strip()
+
+
+def _require_absent_field(payload: Mapping[str, Any], key: str, authority: str) -> None:
+    if payload.get(key) is not None:
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"{authority} testimony must not carry {key!r}; got {payload.get(key)!r}",
+        )
+
+
+def authenticate_run_authority(
+    testimony: Any,
+    *,
+    task_command_resolver: Callable[[str], Sequence[str] | None] | None = None,
+) -> RunAuthority:
+    """Admit run-authority testimony, or refuse it under its own name.
+
+    Absent, malformed/conflicting, undeclared-task and unowned-command are four
+    distinct refusals. A tooth that only proves "something refused" would still
+    pass with its own guard removed, so each carries a name of its own.
+    """
+    if testimony is None:
+        raise _refuse(
+            REFUSAL_ABSENT,
+            "run produced no run-authority testimony; silence is not unmanaged",
+        )
+    if isinstance(testimony, (str, bytes)):
+        try:
+            testimony = json.loads(testimony)
+        except ValueError as error:
+            raise _refuse(
+                REFUSAL_MALFORMED, f"run-authority testimony is not JSON: {error}"
+            ) from error
+    if not isinstance(testimony, Mapping):
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"run-authority testimony must be an object; got {type(testimony).__name__}",
+        )
+    schema = testimony.get("schema")
+    if schema != RUN_AUTHORITY_SCHEMA:
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"unsupported run-authority schema {schema!r}; expected {RUN_AUTHORITY_SCHEMA}",
+        )
+    command = testimony.get("command")
+    if (
+        not isinstance(command, Sequence)
+        or isinstance(command, (str, bytes))
+        or not command
+        or any(not isinstance(item, str) or not item for item in command)
+    ):
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"run-authority command must be a non-empty array of strings; got {command!r}",
+        )
+    argv = tuple(command)
+    image = _require_str_field(testimony, "image")
+    authority = testimony.get("authority")
+
+    if authority == AUTHORITY_UNMANAGED:
+        for key in ("task", "preflightProtocol", "preconditionPlanCid"):
+            _require_absent_field(testimony, key, AUTHORITY_UNMANAGED)
+        return UnmanagedRunAuthority(argv, image, _UNMANAGED_SEAL)
+
+    if authority != AUTHORITY_MANAGED:
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"run-authority authority must be {AUTHORITY_MANAGED!r} or "
+            f"{AUTHORITY_UNMANAGED!r}; got {authority!r}",
+        )
+
+    task = _require_str_field(testimony, "task")
+    preflight_protocol = _require_str_field(testimony, "preflightProtocol")
+    precondition_plan_cid = testimony.get("preconditionPlanCid")
+    if precondition_plan_cid is not None and (
+        not isinstance(precondition_plan_cid, str) or not precondition_plan_cid.strip()
+    ):
+        raise _refuse(
+            REFUSAL_MALFORMED,
+            f"field 'preconditionPlanCid' must be a non-empty string or null; "
+            f"got {precondition_plan_cid!r}",
+        )
+
+    resolver = task_command_resolver or _default_task_command_resolver
+    declared = resolver(task)
+    if declared is None:
+        raise _refuse(
+            REFUSAL_UNDECLARED_TASK,
+            f"managed claim names task {task!r}, which the build contract does not declare",
+        )
+    declared_argv = [str(item) for item in declared]
+    if not declared_argv or list(argv[: len(declared_argv)]) != declared_argv:
+        raise _refuse(
+            REFUSAL_UNOWNED_COMMAND,
+            f"managed claim names task {task!r} whose declared command "
+            f"{declared_argv!r} does not own the dispatched command {list(argv)!r}",
+        )
+    return ManagedRunAuthority(
+        task,
+        image,
+        preflight_protocol,
+        precondition_plan_cid,
+        argv,
+        _MANAGED_SEAL,
+    )
+
+
+def require_managed_run_authority(
+    testimony: Any,
+    *,
+    task_command_resolver: Callable[[str], Sequence[str] | None] | None = None,
+) -> ManagedRunAuthority:
+    """Admit testimony and demand it be MANAGED.
+
+    An UNMANAGED run is a legitimate run and a refused *measurement*. This is
+    the single door through which a measured artifact obtains its authority, so
+    a measurement derived from an ad-hoc command is not flagged — it is
+    unconstructible.
+    """
+    authority = authenticate_run_authority(
+        testimony, task_command_resolver=task_command_resolver
+    )
+    if not authority.is_managed():
+        raise _refuse(
+            REFUSAL_UNMEASURED_BY_CONSTRUCTION,
+            f"command {list(authority.command)!r} ran ad-hoc under no declared task; "
+            "an unmanaged run cannot select the task capability image, cannot install "
+            "a managed precondition plan, and cannot enrol profiled closure artifacts, "
+            "so nothing it produced is a measurement",
+        )
+    if authority.precondition_plan_cid is None:
+        raise _refuse(
+            REFUSAL_UNPLANNED_TASK,
+            f"task {authority.task!r} declares no command closure, so its run installed "
+            "no managed precondition plan and cannot show the preconditions it consumed",
+        )
+    return authority

--- a/tools/run_authority.py
+++ b/tools/run_authority.py
@@ -220,6 +220,24 @@ def build_run_authority(
     }
 
 
+def stamp_run_authority(body: dict[str, Any], environ: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """Producer door: copy the transport's testimony into a report body.
+
+    Every measurement producer stamps through here rather than each spelling
+    ``runAuthority`` for itself, so there is one carrier name and no producer
+    can accidentally invent a second one. When the transport supplied nothing
+    the body carries nothing, and the consumer reads that as
+    ``RunAuthorityAbsentV1`` — fail-closed, because silence is exactly the
+    state that made the original defect bankable.
+    """
+    import os
+
+    raw = (environ if environ is not None else os.environ).get(RUN_AUTHORITY_ENV)
+    if raw:
+        body["runAuthority"] = json.loads(raw)
+    return body
+
+
 def _default_task_command_resolver(task: str) -> Sequence[str] | None:
     """Resolve a declared task's command from the build contract."""
     import importlib.util

--- a/tools/sugar-build/contract.py
+++ b/tools/sugar-build/contract.py
@@ -262,6 +262,38 @@ def _validate_task_closure(name, closure):
     }
 
 
+def _run_authority_module():
+    tools = ROOT / "tools"
+    if str(tools) not in sys.path:
+        sys.path.insert(0, str(tools))
+    return importlib.import_module("run_authority")
+
+
+def build_run_authority_testimony(argv, task, image, preflight, plan_json):
+    """Canonical run-authority/v1 testimony for one dispatched command.
+
+    ``task`` empty means the command ran ad-hoc: the testimony says so
+    explicitly and durably rather than leaving its authority unstated.
+    """
+    module = _run_authority_module()
+    plan = None
+    if plan_json:
+        try:
+            plan = json.loads(plan_json)
+        except ValueError as exc:
+            raise ContractError(f"managed precondition plan is not JSON: {exc}") from exc
+    try:
+        return module.build_run_authority(
+            argv,
+            image=image,
+            task=task or None,
+            preflight_protocol=preflight or None,
+            precondition_plan=plan,
+        )
+    except module.RunAuthorityRefusal as exc:
+        raise ContractError(str(exc)) from exc
+
+
 def _showcase_authority_module():
     tools = ROOT / "tools"
     if str(tools) not in sys.path:
@@ -461,6 +493,12 @@ def main(argv=None):
     image_build.add_argument("--repo-root", required=True)
     matcher = subparsers.add_parser("match-command")
     matcher.add_argument("argv", nargs=argparse.REMAINDER)
+    authority = subparsers.add_parser("run-authority")
+    authority.add_argument("--task", default="")
+    authority.add_argument("--image", required=True)
+    authority.add_argument("--preflight", default="")
+    authority.add_argument("--plan-json", default="")
+    authority.add_argument("argv", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
     try:
         if args.command == "tool-versions": result = tool_versions()
@@ -469,6 +507,11 @@ def main(argv=None):
         elif args.command == "resolve-task-environment": result = resolve_task_environment(args.task)
         elif args.command == "resolve-preconditions": result = resolve_task_preconditions(args.task, args.host, args.repo_root)
         elif args.command == "resolve-task-image-build": result = resolve_task_image_build(args.task, args.repo_root)
+        elif args.command == "run-authority":
+            command_argv = args.argv[1:] if args.argv[:1] == ["--"] else args.argv
+            result = build_run_authority_testimony(
+                command_argv, args.task, args.image, args.preflight, args.plan_json
+            )
         else:
             argv = args.argv[1:] if args.argv[:1] == ["--"] else args.argv
             result = {"task": match_task_command(argv)}

--- a/tools/sugarbin_shell_tier.py
+++ b/tools/sugarbin_shell_tier.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run and audit the nine sugarbin shell contracts enrolled in per-tip CI."""
+"""Run and audit the ten sugarbin shell contracts enrolled in per-tip CI."""
 
 from __future__ import annotations
 
@@ -24,6 +24,7 @@ BATCHES = {
         "tests/sugarbin_mount_proof_guard.sh",
         "tests/sugarbin_docker_daemon_guard.sh",
         "tests/sugarbin_wrapper_compat.sh",
+        "tests/sugarbin_run_authority.sh",
     ],
     "artifacts": [
         "tests/sugarbin_artifact_manifest.sh",


### PR DESCRIPTION
`contract match-command` compared `argv[:len(command)] == command` — an exact registered-prefix match — so `bin/brun -- bash -lc '<script>'` with no `--task` returned `{"task": null}`: the shell wrapper hid the showcase ownership. sugarbin then selected the ordinary image instead of the capability image, installed no precondition plan, and enrolled no profiled closure artifacts. A real measurement died mid-initialisation on `FileNotFoundError: git` instead of refusing at entry, and its result was entrance-UNMEASURED — unnoticed until traced hours later.

Recognition by spelling: the fourth instance of that class in this codebase.

**Commands stay permitted.** The consequence becomes visible instead: an unmatched run carries durable UNMANAGED provenance, and any measurement derived from it is unmeasured **by construction**. There was no durable run receipt at all before this — only ephemeral stderr, including a comment reading "Receipt carries BOTH so a reader can judge" while nothing was written to disk.

## Verified on battleaxe

- `tests/test_run_authority.py` + `tests/test_commit_measurement.py` -> **49 passed**
- `bash tests/sugarbin_run_authority.sh` -> PASS

Mutation, one guard at a time. An earlier revision left the central guard with no tooth — bypassing `isinstance(self.run_authority, ManagedRunAuthority)` changed nothing observable. Now:
- bypass it alone -> `DID NOT RAISE CommitMeasurementError`, `test_sealing_an_unmanaged_authority_into_measured_refuses_by_name` fails; restored -> 49 passed.

Lying arms, not just absence: a wrapper merely *starting with* the same interpreter refuses as `UNOWNED_COMMAND`; a managed claim naming an undeclared task gets its own name; a measurement from a lying managed claim is unconstructible.

A **fifth state** was found in the real system rather than specified: `authenticated-python-lift` is genuinely declared and genuinely owned but declares no command closure, so no plan is installed. The transport records that honestly instead of fabricating one, and the measurement door refuses it under its own name — distinct from both the ad-hoc and the lying readings.

Closes the mechanism behind #7340.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>