### PR TITLE
One serialization: the demand-table key must address the bytes on disk

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/prebuilt_demand_table.py
@@ -26,7 +26,11 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Mapping
 
-from sugar_lift_python_source.canonical import cid_of_json
+from sugar_lift_python_source.canonical import (
+    blake3_512_of,
+    canonical_json_bytes,
+    cid_of_json,
+)
 from sugar_lift_py_tests.authenticated_pytest import AuthenticatedPandasCorpus
 from sugar_lift_py_tests.demand_table_identity import (
     DemandTableIdentityV1,
@@ -137,7 +141,7 @@ class PrebuiltDemandTableV1:
     schema: str = SCHEMA
 
     def preimage(self) -> dict[str, Any]:
-        """Bytes that content_cid addresses (no contentCid field)."""
+        """The value the artifact bytes encode. content_cid addresses it."""
         return {
             "schema": self.schema,
             "corpusPin": self.corpus_pin.as_dict(),
@@ -145,15 +149,26 @@ class PrebuiltDemandTableV1:
             "semanticIdentity": self.semantic_identity.as_dict(),
         }
 
-    def to_json_dict(self) -> dict[str, Any]:
-        body = self.preimage()
-        body["contentCid"] = self.content_cid
-        body["semanticIdentity"] = self.semantic_identity.as_dict()
-        return body
+    def artifact_bytes(self) -> bytes:
+        """THE bytes. Stored, hashed, and published are one spelling."""
+        return serialize_prebuilt_demand_table(self.preimage())
+
+
+def serialize_prebuilt_demand_table(preimage: Mapping[str, Any]) -> bytes:
+    """The single artifact byte producer.
+
+    A content address is h(content). There is exactly one serialization of a
+    demand table: these bytes. Storage writes them, the content key hashes
+    them, and CAS publication publishes them. A second spelling — a pretty
+    dump, or a body carrying its own ``contentCid`` — makes the key address
+    bytes that are not the bytes on disk, which is the publish-time CAS lie
+    (``cas-publish-key-payload-mismatch``).
+    """
+    return canonical_json_bytes(dict(preimage))
 
 
 def content_cid_for_preimage(preimage: Mapping[str, Any]) -> str:
-    return cid_of_json(dict(preimage))
+    return blake3_512_of(serialize_prebuilt_demand_table(preimage))
 
 
 def validate_prebuilt_demand_table(
@@ -223,12 +238,19 @@ def mint_prebuilt_demand_table(
 
 
 def write_prebuilt_demand_table(table: PrebuiltDemandTableV1, path: Path) -> Path:
+    """Write the artifact bytes the content key addresses — and only those."""
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(table.to_json_dict(), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    payload = table.artifact_bytes()
+    written = blake3_512_of(payload)
+    if written != table.content_cid:
+        raise DemandTableArtifactRefusal(
+            f"demand table storage key/payload mismatch: "
+            f"claimed={table.content_cid!r} payload={written!r} "
+            f"replacement=derive content_cid from serialize_prebuilt_demand_table "
+            f"(a content address is h(content); one serialization, one place)"
+        )
+    path.write_bytes(payload)
     return path
 
 
@@ -276,9 +298,10 @@ def load_prebuilt_demand_table(
 ) -> PrebuiltDemandTableV1:
     """Load and authenticate a prebuilt table.
 
-    Refuses:
+    The content CID is h(artifact bytes) — read, never presented. Refuses:
       - missing / malformed artifact
-      - contentCid that does not recompute from preimage
+      - bytes that are not the one serialization (a re-dump is a different
+        artifact, and its address is not the plan's address)
       - corpus pin mismatch (wrong pandas / fileCount / aggregate)
       - expected_content_cid mismatch when the plan pin requires a specific CID
     """
@@ -289,8 +312,9 @@ def load_prebuilt_demand_table(
             f"replacement=mint at plan time and pass the path to every shard"
         )
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        data = path.read_bytes()
+        raw = json.loads(data.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise DemandTableArtifactRefusal(
             f"prebuilt demand table unreadable path={path} detail={exc}"
         ) from exc
@@ -324,25 +348,34 @@ def load_prebuilt_demand_table(
             f"replacement=rebuild the table against the authenticated pin "
             f"(blonde law: wrong corpus is not a measurement)"
         )
-    presented = raw.get("contentCid")
-    # Reconstruct the authenticated value first; its preimage() is the only
-    # serialization door shared with minting and validation.
+    if "contentCid" in raw:
+        raise DemandTableArtifactRefusal(
+            "prebuilt demand table body carries its own contentCid: "
+            "the address is h(artifact bytes), so a self-describing key would "
+            "address bytes that are not these bytes "
+            "replacement=rebuild the table; the artifact is the preimage only"
+        )
+    # The address is h(bytes) — read from the file, never taken on the file's
+    # word. Reconstruct through the one serialization door and require the
+    # bytes on disk to BE that serialization.
     table = PrebuiltDemandTableV1(
-        content_cid=str(presented),
+        content_cid=blake3_512_of(data),
         corpus_pin=pin,
         rows=tuple(raw["rows"]),
         semantic_identity=semantic_identity,
     )
-    recomputed = content_cid_for_preimage(table.preimage())
-    if presented != recomputed:
+    if table.artifact_bytes() != data:
         raise DemandTableArtifactRefusal(
-            f"prebuilt demand table contentCid mismatch: "
-            f"presented={presented!r} recomputed={recomputed!r}"
+            f"prebuilt demand table bytes are not the canonical serialization: "
+            f"path={path} storedCid={table.content_cid!r} "
+            f"canonicalCid={content_cid_for_preimage(table.preimage())!r} "
+            f"replacement=write through write_prebuilt_demand_table "
+            f"(one serialization, one place)"
         )
-    if expected_content_cid is not None and presented != expected_content_cid:
+    if expected_content_cid is not None and table.content_cid != expected_content_cid:
         raise DemandTableArtifactRefusal(
             f"prebuilt demand table contentCid != plan demandTableCid: "
-            f"artifact={presented!r} plan={expected_content_cid!r}"
+            f"artifact={table.content_cid!r} plan={expected_content_cid!r}"
         )
     return table
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_prebuilt_demand_table.py
@@ -5,12 +5,17 @@ Counting walks is a unit test, not a measurement. No stopwatch.
 
 from __future__ import annotations
 
+import os
+import shutil
 import sys
 import json
 from pathlib import Path
 
 import pytest
 
+from dataclasses import replace
+
+from sugar_lift_python_source.canonical import blake3_512_of
 from sugar_lift_py_tests import lift_rpc as lr
 from sugar_lift_py_tests.prebuilt_demand_table import (
     DemandTableArtifactRefusal,
@@ -20,6 +25,7 @@ from sugar_lift_py_tests.prebuilt_demand_table import (
     load_plan_bound_demand_table,
     load_prebuilt_demand_table,
     mint_prebuilt_demand_table,
+    publish_prebuilt_demand_table,
     validate_prebuilt_demand_table,
     DemandTableSemanticIdentityMismatch,
     write_prebuilt_demand_table,
@@ -108,7 +114,7 @@ def test_mint_carries_distinct_storage_and_semantic_identities(tmp_path: Path) -
     second = mint_prebuilt_demand_table(_authenticated(second_corpus))
     assert first.semantic_identity.content_key != second.semantic_identity.content_key
     assert first.content_cid != second.content_cid
-    assert first.content_cid == first.to_json_dict()["contentCid"]
+    assert first.content_cid == blake3_512_of(first.artifact_bytes())
     assert first.semantic_identity.as_dict()["contentKey"] != first.content_cid
 
 
@@ -167,10 +173,7 @@ def test_plan_bound_load_cid_mismatch_never_derives_replacement(tmp_path: Path) 
         )
 
     assert caught.value.observed_content_cid == table.content_cid
-    assert (
-        caught.value.observed_semantic_identity
-        == table.semantic_identity.as_dict()
-    )
+    assert caught.value.observed_semantic_identity == table.semantic_identity.as_dict()
     assert lr.preconstruction_walk_count() == walks_before
 
 
@@ -240,18 +243,57 @@ def test_load_refuses_corpus_pin_mismatch(tmp_path: Path) -> None:
         load_prebuilt_demand_table(artifact, expected_corpus_pin=wrong)
 
 
-def test_load_refuses_tampered_content_cid(tmp_path: Path) -> None:
+def test_load_refuses_tampered_bytes_by_plan_address(tmp_path: Path) -> None:
     corpus = _tiny_corpus(tmp_path / "c")
     artifact = tmp_path / "table.json"
     lr.clear_provisional_contract_refs_memo()
     table = mint_prebuilt_demand_table(_authenticated(corpus))
     write_prebuilt_demand_table(table, artifact)
-    raw = artifact.read_text(encoding="utf-8")
-    # Flip one hex nibble in the presented contentCid.
-    bad = raw.replace(table.content_cid[-4:], "ffff", 1)
-    artifact.write_text(bad, encoding="utf-8")
-    with pytest.raises(DemandTableArtifactRefusal, match="contentCid mismatch"):
+    raw = artifact.read_bytes()
+    # Tamper one row payload. The address is h(bytes), so the tampered file
+    # simply is not the plan's artifact.
+    bad = raw.replace(b'"rows":[', b'"rows":[  ', 1)
+    assert bad != raw
+    artifact.write_bytes(bad)
+    with pytest.raises(
+        DemandTableArtifactRefusal, match="not the canonical serialization"
+    ):
         load_prebuilt_demand_table(artifact, expected_corpus_pin=_expected_pin(corpus))
+
+
+def test_load_refuses_body_carrying_its_own_content_cid(tmp_path: Path) -> None:
+    """The old self-describing spelling is the CAS lie; refuse it by shape."""
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "table.json"
+    lr.clear_provisional_contract_refs_memo()
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
+    write_prebuilt_demand_table(table, artifact)
+    body = json.loads(artifact.read_text(encoding="utf-8"))
+    body["contentCid"] = table.content_cid
+    artifact.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n", "utf-8")
+    with pytest.raises(DemandTableArtifactRefusal, match="carries its own contentCid"):
+        load_prebuilt_demand_table(artifact, expected_corpus_pin=_expected_pin(corpus))
+
+
+def test_written_bytes_hash_to_the_published_content_key(tmp_path: Path) -> None:
+    """The storage bytes ARE the CAS preimage: h(file) == the claimed key."""
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "table.json"
+    lr.clear_provisional_contract_refs_memo()
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
+    write_prebuilt_demand_table(table, artifact)
+    assert blake3_512_of(artifact.read_bytes()) == table.content_cid
+
+
+def test_write_refuses_a_key_that_is_not_h_of_the_payload(tmp_path: Path) -> None:
+    corpus = _tiny_corpus(tmp_path / "c")
+    lr.clear_provisional_contract_refs_memo()
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
+    lying = replace(table, content_cid="blake3-512:" + ("0" * 128))
+    with pytest.raises(
+        DemandTableArtifactRefusal, match="storage key/payload mismatch"
+    ):
+        write_prebuilt_demand_table(lying, tmp_path / "lying.json")
 
 
 def test_load_refuses_plan_cid_mismatch(tmp_path: Path) -> None:
@@ -282,3 +324,60 @@ def test_install_without_walk_seeds_memo(tmp_path: Path) -> None:
     lr.provisional_contract_refs_from_demands(corpus)
     assert lr.preconstruction_walk_count() == 0
     assert walks == 1
+
+
+def _sugarbin_shelf_env(shelf: Path) -> dict[str, str]:
+    """Isolate CAS publication to a throwaway shelf; never the real one."""
+    env = dict(os.environ)
+    env["SUGAR_BINARY_SHELF_ROOT"] = str(shelf)
+    env["SUGAR_BINARY_PUBLISH"] = "1"
+    return env
+
+
+@pytest.mark.skipif(
+    shutil.which("b3sum") is None, reason="b3sum required for CAS content keys"
+)
+def test_publish_door_accepts_the_minted_table(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The entrance plan_control_effect_recensus_shards.py uses, end to end.
+
+    mint -> write -> publish through the real bin/sugarbin. This is the call
+    that refused in Actions run 30979536949 with
+    crime=cas-publish-key-payload-mismatch.
+    """
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "python-demand-table.json"
+    shelf = tmp_path / "shelf"
+    lr.clear_provisional_contract_refs_memo()
+    for key, value in _sugarbin_shelf_env(shelf).items():
+        monkeypatch.setenv(key, value)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
+    write_prebuilt_demand_table(table, artifact)
+    publish_prebuilt_demand_table(table, artifact)
+    # A green publish that filed nothing is a no-op wearing success. Require
+    # the cell, and require it to be addressed by h(payload).
+    cells = sorted(shelf.rglob("*.metadata.json"))
+    assert len(cells) == 1, cells
+    key_path_form = table.content_cid.replace("blake3-512:", "blake3-512_")
+    assert key_path_form in str(cells[0]), cells[0]
+
+
+@pytest.mark.skipif(
+    shutil.which("b3sum") is None, reason="b3sum required for CAS content keys"
+)
+def test_publish_door_refuses_a_key_that_is_not_h_of_the_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mismatched claim refuses BY NAME at the CAS door. Do not weaken this."""
+    corpus = _tiny_corpus(tmp_path / "c")
+    artifact = tmp_path / "python-demand-table.json"
+    lr.clear_provisional_contract_refs_memo()
+    for key, value in _sugarbin_shelf_env(tmp_path / "shelf").items():
+        monkeypatch.setenv(key, value)
+    table = mint_prebuilt_demand_table(_authenticated(corpus))
+    write_prebuilt_demand_table(table, artifact)
+    lying = replace(table, content_cid="blake3-512:" + ("0" * 128))
+    with pytest.raises(DemandTableArtifactRefusal) as caught:
+        publish_prebuilt_demand_table(lying, artifact)
+    assert "crime=cas-publish-key-payload-mismatch" in str(caught.value)


### PR DESCRIPTION
The full-corpus recensus (run `30979536949`) refused at the LPT plan job:

```
crime=cas-publish-key-payload-mismatch owner=bin/sugarbin
  claimed=blake3-512_7e03424c...
  payload=blake3-512_c787ad05...
  illegal shape=artifact publish trusted a caller content key that is not h(payload)
  replacement=pass the blake3-512 of the payload bytes
```

**The CAS was right.** The key was `cid_of_json(preimage)`, but the file written was `to_json_dict()` — which *adds* `contentCid` and `semanticIdentity` — serialized with `json.dumps(indent=2)`. The key addressed one value; the bytes on disk were another. A body carrying its own `contentCid` can never be addressed by that CID.

Now there is exactly one spelling: `serialize_prebuilt_demand_table()` produces THE bytes, the content key is `blake3_512_of` those bytes, storage writes those bytes, and the writer re-hashes and refuses on disagreement.

## Verified on battleaxe

- `tests/test_prebuilt_demand_table.py` -> **18 passed**
- Mutation, write-time key guard bypassed alone -> `test_write_refuses_a_key_that_is_not_h_of_the_payload` fails, nothing else; restored -> 18 passed.

The refusal itself is untouched — it is the instrument that caught this, and it worked.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce canonical byte serialization as the demand-table storage key
> - Introduces `serialize_prebuilt_demand_table()` as the single byte producer for demand table artifacts, replacing ad-hoc `to_json_dict()` calls.
> - The content CID is now computed as `blake3_512_of(artifact_bytes())` instead of hashing a JSON dict, so the key addresses the exact bytes on disk.
> - `write_prebuilt_demand_table` verifies that `blake3_512_of(payload) == table.content_cid` before writing and raises `DemandTableArtifactRefusal` on mismatch.
> - `load_prebuilt_demand_table` reads raw bytes, rejects files that carry a `contentCid` field, and rejects any non-canonical serialization (e.g. different whitespace) even if JSON-equivalent.
> - Behavioral Change: files written or loaded must now be the exact canonical serialization; previously valid but non-canonical JSON files will be refused on load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b52bf19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->