### PR TITLE
Remove the CI measurement load ceiling; keep the testimony

### DIFF
--- a/tools/bx_host_measure_gates.sh
+++ b/tools/bx_host_measure_gates.sh
@@ -117,10 +117,19 @@ else
   max="$(awk -v n="$n" 'BEGIN{ m=n/4.0; if (m < 2.0) m=2.0; printf "%.2f", m }')"
 fi
 echo "sugarbin: bx-load-gate phase=before load1=$l1 nproc=$n max=$max lease=held mode=$mode" >&2
-if awk -v l="$l1" -v m="$max" 'BEGIN{ exit !(l+0 > m+0) }'; then
-  echo "sugarbin: crime=host-not-quiet load1=$l1 nproc=$n max=$max lease=held replacement=wait for load1<=$max. Exit 76. A measurement that cannot testify to its own conditions is not a measurement." >&2
-  exit 76
-fi
+# NO LOAD CEILING (owner ruling, 2026-08-05).
+#
+# The ceiling was set for the single-process era and never revisited for the
+# shared-runner topology this workflow is built around: k=8 shards are
+# containers on ONE box, so the fan-out trips a ceiling of nproc/4 by simply
+# existing -- eight seats refused at load1=8.45 on a 32-core host, which is
+# ~26% utilisation. A gate that refuses the very concurrency it was written to
+# permit measures nothing.
+#
+# The condition is still TESTIFIED -- load1 before and after are recorded on
+# every run and travel in the receipt. What is removed is the REFUSAL, not the
+# observation: a measurement still says what its conditions were, and a reader
+# can judge them. Serialisation against human brun remains the lease's job.
 
 set +e
 "$@"


### PR DESCRIPTION
In run `30982613415` the LPT plan succeeded and **all eight shards refused**:

```
crime=host-not-quiet load1=8.45 nproc=32 max=8.00 lease=held
replacement=wait for load1<=8.00. Exit 76.
```

The k=8 shards are containers on one box, so the fan-out trips a ceiling of `nproc/4` by simply existing — and 8.45 on 32 cores is ~26% utilisation. A gate that refuses the concurrency it was written to permit measures nothing.

**The refusal is removed; the observation is not.** `load1` before and after are still recorded on every run and travel in the receipt, so a measurement still testifies to its conditions and a reader can judge them. Serialisation against human `brun` remains the lease's job.

The separate `cpu_idle` quiet gate on the human `brun` path (`bin/lib/sugar-bx.sh`) is a different metric and is deliberately untouched.

Owner ruling.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove load ceiling exit from `bx_host_measure_gates.sh`
> The script previously exited with code 76 and logged a `crime=host-not-quiet` message when `load1` exceeded a computed max. That check is removed and replaced with comments documenting the decision. The script now always proceeds to execute the passed command regardless of host load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2a4d06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a pre-check that could stop a measurement run when system load was temporarily high.
  * Measurement runs now continue more reliably while still recording load conditions before and after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->