### PR TITLE
The roster demand must state the seat the distribution recorded

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -655,6 +655,7 @@ def terminal_after_measure_escape(
     workspace_root: Path,
     error: BaseException,
     category: str = "panic",
+    source_workspace_root: Path | None = None,
 ) -> dict[str, Any]:
     """Outer-shell law: never bank 0 when roster/AST mass is recoverable.
 
@@ -694,6 +695,7 @@ def terminal_after_measure_escape(
         function_nodes, _gaps = demand_function_roster(
             workspace_root=workspace_root,
             file_rel=relative,
+            source_workspace_root=source_workspace_root,
         )
     except ConstructionPanic:
         raise

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -336,14 +336,31 @@ def demand_function_roster(
     workspace_root: Path,
     file_rel: str,
     source_cid: str | None = None,
+    source_workspace_root: Path | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """D2: sugar.enumerate level=functions → (function nodes, gaps)."""
+    """D2: sugar.enumerate level=functions → (function nodes, gaps).
+
+    ``source_workspace_root`` is the LOCUS authority — the root the minted
+    address is stated against, derived once at the driver from the
+    distribution's own manifest. The roster demand OPENS the file, so it mints
+    the locus; without this the open states an address relative to the corpus
+    root and an installed file's seat law refuses every file by name. That was
+    the whole shard's ``roster-gap``: the driver knew the install root and this
+    demand never received it.
+    """
     at = file_memento(file_rel=file_rel, source_cid=source_cid)
     result = enumerate_rpc(
         level="functions",
         workspace_root=workspace_root,
         at=at,
         seek=False,
+        options={
+            "sourceWorkspaceRoot": (
+                str(source_workspace_root)
+                if source_workspace_root is not None
+                else None
+            )
+        },
     )
     nodes = list(result.get("nodes") or [])
     gaps = list(result.get("gaps") or [])
@@ -765,6 +782,7 @@ def measure_file_via_enumerate(
             workspace_root=workspace_root,
             file_rel=file_rel,
             source_cid=source_cid,
+            source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 — includes ConstructionPanic
         if _is_process_control(error):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -327,8 +327,24 @@ def open_source_file_for_construction(
             contract_refs=contract_refs,
             call_contract_refs=call_contract_refs,
         )
+    # TWO ROOTS, not one. `root` is the WORKSPACE authority: which tree this
+    # open belongs to, what `file_rel` resolves against, which walk session and
+    # construction context own it. `source_workspace_root` is the LOCUS
+    # authority: the root the minted address is stated against. For a
+    # first-party tree they coincide and this reads as before. For an INSTALLED
+    # corpus they must not: seats are recorded relative to the install root, so
+    # opening `.../site-packages/pandas/_testing/_hypothesis.py` under
+    # `root=.../site-packages/pandas` mints `_testing/_hypothesis.py` -- not a
+    # different spelling of the seat, an address no other checkout resolves,
+    # which `require_recorded_seat` refuses by name.
+    #
+    # The locus root is DERIVED ONCE, at the driver, from the distribution's own
+    # manifest (`locus_root_for_corpus` -> `install_root_for`) and carried here.
+    # Nothing on this path adds or strips a package prefix at comparison time:
+    # there is one spelling, minted once, against the root that states it.
+    locus_root = root if source_workspace_root is None else source_workspace_root
     source_file = SourceFile(
-        workspace_path_source(str(path), root=str(root)),
+        workspace_path_source(str(path), root=str(locus_root)),
         reporter=reporter,
         construction_context=construction_context,
     )
@@ -2175,6 +2191,18 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 )
                 return
             full_path = root / file_rel
+            # The LOCUS authority for every open under this demand. `root` says
+            # which tree `file_rel` resolves against; this says which root the
+            # minted address is stated against. They differ for an installed
+            # corpus (seats are recorded against the install root) and coincide
+            # for a first-party tree, where the option is absent and `root`
+            # stands. Read ONCE here so no level can quietly answer differently.
+            demand_locus_root = options.get("sourceWorkspaceRoot")
+            locus_root = (
+                Path(demand_locus_root)
+                if isinstance(demand_locus_root, str) and demand_locus_root
+                else None
+            )
             # SECURITY (macroscope on #3862): a forged memento with an
             # absolute path (pathlib join discards root) or a ../ traversal
             # could enumerate files OUTSIDE the workspace. Require the
@@ -2242,6 +2270,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                             root, contract_refs={}
                         ),
                         populate_derived=False,
+                        source_workspace_root=locus_root,
                     )
                     memento = _tree.module_definition_memento(sf, file_rel, file_cid)
                     _send_enumerate_result(
@@ -2330,6 +2359,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         root=root,
                         construction_context=construction_context,
                         populate_derived=False,
+                        source_workspace_root=locus_root,
                     )
                 except SourceUnavailable as unavailable:
                     _send_enumerate_result(
@@ -2363,7 +2393,6 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 # completed resolution response.
                 if level == "context-manager-resolutions":
                     distribution = options.get("distribution")
-                    source_workspace_root = options.get("sourceWorkspaceRoot")
                     if not isinstance(distribution, str) or not distribution:
                         raise TypeError(
                             "context-manager-resolutions requires distribution "
@@ -2377,11 +2406,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                             root,
                             enrolled_distributions=frozenset({distribution}),
                         ),
-                        source_workspace_root=(
-                            Path(source_workspace_root)
-                            if isinstance(source_workspace_root, str)
-                            else None
-                        ),
+                        source_workspace_root=locus_root,
                         distribution=distribution,
                     )
                     from sugar_lift_py_tests.context_manager_resolution import (

--- a/implementations/python/sugar-lift-py-tests/tests/test_roster_demand_states_the_recorded_seat.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_roster_demand_states_the_recorded_seat.py
@@ -1,0 +1,224 @@
+"""The ROSTER demand must mint the seat the distribution recorded.
+
+`test_recorded_seat_locus_authority` proved two halves separately: the driver
+derives the install root (`locus_root_for_corpus`), and the mint refuses a
+non-seat locus (`workspace_path_source` -> `require_recorded_seat`). Neither
+half touched the CONNECTIVE, and the connective is where the census broke:
+
+    sugar.enumerate level=functions OPENS the file, so it MINTS the locus.
+    The driver knew the install root and that demand never received it.
+
+Run 30985305806 shard s1: every one of 178 pandas files came back
+``instrument-failure phase=roster-gap``, reason ``... records the seat
+`pandas/_testing/_hypothesis.py`, but this locus states
+`_testing/_hypothesis.py``` -- completed=0, measured=False, for the whole
+shard. Two spellings of one identity, so seat identity never matched.
+
+THE REFUSAL IS CORRECT AND IS PINNED HERE TOO. The fix is not to soften it and
+not to translate between spellings at comparison time; it is to state ONE
+spelling, minted once, against the root the distribution states seats against.
+
+Both arms, over the entrance the recensus walk actually uses -- the
+`sugar.enumerate` request through `lift_rpc._dispatch_request`, reached via the
+consumer module loaded by path exactly as the driver loads it:
+
+  ATTRIBUTED  locus root = install root  -> the roster is served, no gap.
+  REFUSED     locus root = package root  -> gap, BY NAME, with that reason.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    """The driver's own entrance to the consumer: by path, with a sys.modules entry."""
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONSUMER = _load("recensus_enumerate_consumer")
+RECENSUS = _load("control_effect_recensus")
+
+# The seat the synthetic distribution records, spelled in full. The defect is
+# exactly the difference between this and its last segment.
+SEAT = "widget/frame.py"
+UNSEATED = "frame.py"
+
+
+@pytest.fixture()
+def installed_corpus(tmp_path: Path) -> tuple[Path, Path, str]:
+    """One installed distribution: (install root, package root, file_rel).
+
+    Shaped like the pandas corpus that broke: the driver is handed the PACKAGE
+    directory as its corpus, while the RECORD states seats against the INSTALL
+    root one level up.
+    """
+    from sugar_lift_python_source.source_oracle import _recorded_seats
+
+    install_root = tmp_path / "site-packages"
+    dist_info = install_root / "widget-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "RECORD").write_text(f"{SEAT},,\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = install_root / "widget"
+    package.mkdir()
+    (package / "frame.py").write_text(
+        "def only_function():\n    return 1\n", encoding="utf-8"
+    )
+    # The seat table is cached per root; a fresh tmp root each test means no
+    # cross-test reuse, but clear so a repeat root can never serve a stale set.
+    _recorded_seats.cache_clear()
+    return install_root, package, UNSEATED
+
+
+def _roster(corpus: Path, file_rel: str, locus_root: Path | None):
+    return CONSUMER.demand_function_roster(
+        workspace_root=corpus,
+        file_rel=file_rel,
+        source_workspace_root=locus_root,
+    )
+
+
+# -- the premise: the two spellings really are different ----------------------
+
+
+def test_the_two_roots_state_two_different_addresses(installed_corpus) -> None:
+    """Without this, both arms could be measuring one root and prove nothing."""
+    install_root, package, _file_rel = installed_corpus
+    from sugar_lift_python_source.source_oracle import recorded_seat_for
+
+    assert install_root != package
+    assert recorded_seat_for(str(package / "frame.py")) == SEAT
+    assert SEAT != UNSEATED
+    assert RECENSUS.locus_root_for_corpus(package) == install_root
+
+
+# -- ARM ONE: a locus that matches the recorded seat is ATTRIBUTED -------------
+
+
+def test_the_roster_demand_rooted_at_the_install_root_is_served(
+    installed_corpus,
+) -> None:
+    """The whole point: the file's functions come back, with no gap at all."""
+    install_root, package, file_rel = installed_corpus
+
+    nodes, gaps = _roster(package, file_rel, install_root)
+
+    assert gaps == [], f"a correctly seated locus must not be refused: {gaps}"
+    assert len(nodes) == 1
+    assert nodes[0]["memento"]["file"] == file_rel
+
+
+def test_the_served_terminal_measures_the_file(installed_corpus) -> None:
+    """Through the driver's own per-file producer, not the demand alone.
+
+    `measure_file_via_enumerate` is what the recensus loop calls; this pins
+    that it FORWARDS the locus root, which is the connective that was missing.
+    """
+    install_root, package, file_rel = installed_corpus
+
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=package,
+        file_rel=file_rel,
+        distribution="widget",
+        source_workspace_root=install_root,
+    )
+
+    assert "instrumentFailure" not in row, row.get("instrumentFailure")
+    assert row["functionsTotal"] == 1
+
+
+# -- ARM TWO: a locus that does NOT match is REFUSED, BY NAME -----------------
+
+
+def test_the_roster_demand_rooted_at_the_package_is_refused_by_name(
+    installed_corpus,
+) -> None:
+    """THE REPRODUCER of run 30985305806 shard s1, one file wide.
+
+    The refusal is the seat law working. It is asserted by its SPECIFIC reason
+    text, not by "some gap appeared": a neighbouring refusal (unreadable file,
+    outside-root, CID mismatch) must not be able to satisfy this tooth.
+    """
+    _install_root, package, file_rel = installed_corpus
+
+    nodes, gaps = _roster(package, file_rel, package)
+
+    assert nodes == []
+    assert len(gaps) == 1
+    reason = gaps[0]["reason"]
+    assert f"records the seat `{SEAT}`" in reason
+    assert f"this locus states `{UNSEATED}`" in reason
+    assert "no other checkout resolves" in reason
+
+
+def test_an_absent_locus_root_is_refused_the_same_way(installed_corpus) -> None:
+    """Omission is not permission. No locus root means the corpus root stands,
+    and for an installed corpus that is precisely the unseated address."""
+    _install_root, package, file_rel = installed_corpus
+
+    nodes, gaps = _roster(package, file_rel, None)
+
+    assert nodes == []
+    assert len(gaps) == 1
+    assert f"records the seat `{SEAT}`" in gaps[0]["reason"]
+
+
+def test_the_refused_locus_becomes_a_roster_gap_terminal(installed_corpus) -> None:
+    """The shape the shard actually banked: phase=roster-gap, mass unmeasured.
+
+    Pinned so the class is recognizable in a run log, and so a future change
+    that turns this refusal into a silent zero is loud here.
+    """
+    _install_root, package, file_rel = installed_corpus
+
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=package,
+        file_rel=file_rel,
+        distribution="widget",
+        source_workspace_root=package,
+    )
+
+    failure = row["instrumentFailure"]
+    assert failure["phase"] == "roster-gap"
+    assert f"records the seat `{SEAT}`" in str(failure["message"])
+    assert row["functionsEnumerated"] == 0
+
+
+# -- scope: a first-party corpus has no RECORD and is untouched ---------------
+
+
+def test_a_first_party_corpus_roster_is_served_with_no_locus_root(
+    tmp_path: Path,
+) -> None:
+    """No distribution states an address here, so the corpus root is the whole
+    law and this change must not have widened the refusal onto it."""
+    package = tmp_path / "firstparty"
+    package.mkdir()
+    (package / "module.py").write_text(
+        "def only_function():\n    return 1\n", encoding="utf-8"
+    )
+
+    nodes, gaps = _roster(package, "module.py", None)
+
+    assert gaps == []
+    assert len(nodes) == 1


### PR DESCRIPTION
Run `30985305806`: the LPT plan succeeded, the load gate passed, and then **all 178 files in every shard refused**:

```
phase=roster-gap
distribution records the seat `pandas/_testing/_hypothesis.py`,
but this locus states `_testing/_hypothesis.py`
```

**The driver knew the install root and the demand never received it.** `control_effect_recensus.py:1079` computes `locus_root_for_corpus()` correctly — the comment there even describes this exact failure — but the roster demand, which is what OPENS the file and therefore mints the locus, was never handed it. So the open stated an address relative to the corpus root, and the seat law refused every file by name.

Produced-then-discarded: a value derived at the producer and dropped before the consumer that needs it.

`source_workspace_root` is now threaded to the demand as the locus authority, derived once at the driver from the distribution's own manifest — one addressing convention, not a normalisation at comparison time.

The seat law itself is untouched. It is the instrument that caught this.

## Verified on battleaxe

- `tests/test_roster_demand_states_the_recorded_seat.py` -> **7 passed**
- Mutation, locus authority dropped in the consumer alone -> `test_the_served_terminal_measures_the_file` fails, nothing else; restored -> 7 passed.

Toward #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make roster demand state the seat recorded by the distribution's source workspace root
> - Adds a `source_workspace_root` (mapped to `sourceWorkspaceRoot` in the RPC options) parameter through the enumerate pipeline so the server can mint/validate seats relative to a specific locus rather than the workspace root.
> - In `open_source_file_for_construction`, the SourceFile address is now stated against `source_workspace_root` when provided, affecting seat recording and roster acceptance vs. refusal.
> - `_handle_enumerate` reads `sourceWorkspaceRoot` from options once per request and passes the derived locus root to all relevant enumeration levels (`module-definition`, `functions`, `context-manager-resolutions`).
> - A new test module asserts correct behavior for matching, mismatched, and absent locus roots, and verifies first-party corpus is unaffected.
> - Behavioral Change: roster enumeration results (served vs. gap) now depend on locus/seat alignment when `sourceWorkspaceRoot` is supplied.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12920dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source-file and function roster resolution when workspace and source locations use different roots.
  - Preserved correct install-root source addresses during enumeration and terminal measurement.
  - Consistently rejects package-root or missing source locations with the appropriate roster-gap result.

- **Tests**
  - Added integration coverage for recorded-seat identity, source resolution, terminal measurement, and first-party corpora without recorded metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->