### PR TITLE
One opaque call has many authenticated owners

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -256,6 +256,92 @@ class OpaqueSourceCallObligationV1:
 
 
 @dataclass(frozen=True)
+class OpaqueSourceCallRosterV1:
+    """Every authenticated owner that parked an obligation at ONE source call.
+
+    One call coordinate has MANY owners. A helper is reached from several
+    exported definitions; one callee is reached through several distinct
+    import bindings. ``OpaqueSourceCallObligationV1.resolved_object_cid`` is
+    not a property of the call — it is the identity of the export whose frame
+    projection walked through it. A coordinate-keyed table holding a single
+    obligation therefore cannot seat the second owner without either dropping
+    its testimony or refusing a duplicate that was never a duplicate. This
+    roster is the plural type the relation always had.
+
+    ``target_name`` and ``resolution_kind`` are the classification EVERY owner
+    states about the call, and they are the sole testimony the consumer reads.
+    Owners are retained whole, ordered by owner CID, so nothing is drained.
+    Owners that disagree about the classification are not a duplicate and are
+    not a keying artefact — that is a construction panic at the coordinate.
+    """
+
+    coordinate: SourceFragmentCoordinateV1
+    target_name: str
+    resolution_kind: str
+    obligations: tuple[OpaqueSourceCallObligationV1, ...]
+
+    def __post_init__(self) -> None:
+        if not self.obligations:
+            raise ValueError("opaque source-call roster names no authenticated owner")
+        owners = [row.resolved_object_cid for row in self.obligations]
+        if len(set(owners)) != len(owners):
+            raise ValueError("opaque source-call roster seats one owner twice")
+        if owners != sorted(owners):
+            raise ValueError("opaque source-call roster is not owner-ordered")
+        for row in self.obligations:
+            if type(row) is not OpaqueSourceCallObligationV1:
+                raise ValueError("opaque source-call roster holds a malformed row")
+            if (row.coordinate, row.target_name, row.resolution_kind) != (
+                self.coordinate,
+                self.target_name,
+                self.resolution_kind,
+            ):
+                raise ValueError("opaque source-call roster testimony is cross-wired")
+
+    def owner(self, resolved_object_cid: str) -> OpaqueSourceCallObligationV1 | None:
+        """The obligation this exact owner parked, or ``None`` if it parked none.
+
+        Absence is ``None``; there is no lookup-failure spelling that shares it.
+        """
+        return next(
+            (
+                row
+                for row in self.obligations
+                if row.resolved_object_cid == resolved_object_cid
+            ),
+            None,
+        )
+
+    def seating(
+        self, obligation: OpaqueSourceCallObligationV1
+    ) -> "OpaqueSourceCallRosterV1":
+        """This roster with one more owner seated, owner-ordered."""
+        return OpaqueSourceCallRosterV1(
+            self.coordinate,
+            self.target_name,
+            self.resolution_kind,
+            tuple(
+                sorted(
+                    self.obligations + (obligation,),
+                    key=lambda row: row.resolved_object_cid,
+                )
+            ),
+        )
+
+
+def opaque_source_call_roster_of(
+    obligation: OpaqueSourceCallObligationV1,
+) -> OpaqueSourceCallRosterV1:
+    """The one-owner roster for a freshly parked obligation."""
+    return OpaqueSourceCallRosterV1(
+        obligation.coordinate,
+        obligation.target_name,
+        obligation.resolution_kind,
+        (obligation,),
+    )
+
+
+@dataclass(frozen=True)
 class ContextManagerContractRefV1:
     resolution_cid: str
     demand_cid: str

--- a/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_context_manager_resolution.py
@@ -12,6 +12,7 @@ from sugar_lift_py_tests.context_manager_resolution import (
     TreeConstructionContextV1,
     _hash_json,
     decode_resolved_contract_refs,
+    opaque_source_call_roster_of,
 )
 
 
@@ -25,13 +26,16 @@ def test_opaque_source_call_obligation_transport_is_frozen_and_inspectable():
     )
     owner_cid = "blake3-512:" + "b" * 128
     obligation = OpaqueSourceCallObligationV1(coordinate, "func", owner_cid)
-    table = {coordinate: obligation}
+    roster = opaque_source_call_roster_of(obligation)
+    table = {coordinate: roster}
     context = TreeConstructionContextV1.for_source_call_construction(
         opaque_source_call_obligations=table
     )
 
     assert context.opaque_source_call_obligations is table
-    assert context.opaque_source_call_obligations[coordinate] == obligation
+    assert context.opaque_source_call_obligations[coordinate] == roster
+    assert roster.obligations == (obligation,)
+    assert roster.owner(owner_cid) is obligation
     assert obligation.coordinate == coordinate
     assert obligation.target_name == "func"
     assert obligation.resolved_object_cid == owner_cid

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -3605,7 +3605,11 @@ def _seat_import_value_use_receipts(
             continue
         receipt.revalidate()
         paired_obligations = []
-        for obligation in context.opaque_source_call_obligations.values():
+        for obligation in (
+            row
+            for roster in context.opaque_source_call_obligations.values()
+            for row in roster.obligations
+        ):
             relation = obligation.import_call_value_subsumption
             if relation is None or relation.value_use_cid != receipt.use["cid"]:
                 continue
@@ -3664,7 +3668,11 @@ def _seat_import_value_use_receipts(
                 )
             paired_obligations.append(obligation)
         paired_obligations = tuple(paired_obligations)
-        if len(paired_obligations) > 1:
+        # The law is one parked CALL per imported value occurrence. Several
+        # authenticated owners may have walked through that one call, and each
+        # parks its own obligation there; counting owners as calls would refuse
+        # a helper reached from two exports. Count coordinates.
+        if len({row.coordinate for row in paired_obligations}) > 1:
             from sugar_source_tree.panic import BackendDefect
 
             raise BackendDefect(
@@ -3676,7 +3684,8 @@ def _seat_import_value_use_receipts(
             )
 
         def exact_parked_callee() -> bool:
-            if len(paired_obligations) != 1:
+            # One coordinate, however many owners parked at it (checked above).
+            if not paired_obligations:
                 return False
             relation = paired_obligations[0].import_call_value_subsumption
             if relation is None:
@@ -3902,16 +3911,55 @@ def _install_opaque_call_obligation(
             requested="one source-call classification at the exact coordinate",
             fix="keep authenticated frames and opaque obligations disjoint",
         )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        opaque_source_call_roster_of,
+    )
+
+    # One coordinate, many authenticated owners. `resolved_object_cid` names
+    # the export whose frame projection walked through this call, not the call
+    # — so a second owner reaching the same helper (or the same callee through
+    # a second import binding) is an ADDITIONAL seat, never a duplicate. The
+    # byte-identity law below is unchanged and applies where it always meant
+    # to: one owner may state its testimony exactly once, exactly the same way.
     existing = context.opaque_source_call_obligations.get(coordinate)
-    if existing is not None and existing != obligation:
-        raise BackendDefect(
-            blame=call.fragment,
-            owner="manager_construction._install_opaque_call_obligation",
-            observed="conflicting opaque-call obligation",
-            requested="byte-identical duplicate testimony",
-            fix="resolve the conflicting target or authenticated owner",
+    if existing is None:
+        context.opaque_source_call_obligations[coordinate] = (
+            opaque_source_call_roster_of(obligation)
         )
-    context.opaque_source_call_obligations[coordinate] = obligation
+        return
+    seated = existing.owner(obligation.resolved_object_cid)
+    if seated is not None:
+        if seated != obligation:
+            raise BackendDefect(
+                blame=call.fragment,
+                owner="manager_construction._install_opaque_call_obligation",
+                observed="conflicting opaque-call obligation",
+                requested="byte-identical duplicate testimony",
+                fix="resolve the conflicting target or authenticated owner",
+            )
+        return
+    if (existing.target_name, existing.resolution_kind) != (
+        obligation.target_name,
+        obligation.resolution_kind,
+    ):
+        # Not a keying artefact: two authenticated owners state DIFFERENT
+        # unresolved-callee classifications for one call, and the consumer
+        # holds no owner with which to choose. A construction panic is a
+        # countable frontier row; a BackendDefect here would void the file.
+        from sugar_lift_py_tests.gap import construction_panic_gap
+
+        construction_panic_gap(
+            owner="manager_construction._install_opaque_call_obligation",
+            blame=call.fragment,
+            observed=(
+                "authenticated owners disagree about one opaque call: "
+                f"{existing.resolution_kind}:{existing.target_name} vs "
+                f"{obligation.resolution_kind}:{obligation.target_name}"
+            ),
+            requested="one opaque-call classification at the exact coordinate",
+            fix="resolve the callee for every owner, or name why they differ",
+        )
+    context.opaque_source_call_obligations[coordinate] = existing.seating(obligation)
 
 
 def _install_source_call_frame(

--- a/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_regex_search_dependency_authority.py
@@ -105,7 +105,11 @@ def test_exact_re_search_receipt_resolves_and_seats_cpython_definition_body(
     assert frame.definition_site.source_cid == module.source_cid
     assert frame.definition_site.source_cid == resolved.definition.source_cid
     obligations = tuple(
-        frame.owner.unit.construction_context.opaque_source_call_obligations.values()
+        row
+        for roster in (
+            frame.owner.unit.construction_context.opaque_source_call_obligations.values()
+        )
+        for row in roster.obligations
     )
     warnings = tuple(
         item for item in obligations if item.target_name == "python:warnings.warn"
@@ -273,7 +277,10 @@ def test_reversed_receipt_iteration_preserves_relation_cid(
         _, target = projected
         rows = tuple(
             row
-            for row in target.unit.construction_context.opaque_source_call_obligations.values()
+            for roster in (
+                target.unit.construction_context.opaque_source_call_obligations.values()
+            )
+            for row in roster.obligations
             if row.target_name == "python:warnings.warn"
         )
         assert len(rows) == 1

--- a/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_sole_path_manager_construction.py
@@ -233,7 +233,12 @@ def test_unresolved_source_call_is_parked_at_its_exact_coordinate(tmp_path):
         and node.func.id == "missing_helper"
     )
     coordinate = _call_coordinate(missing_call)
-    obligation = context.opaque_source_call_obligations[coordinate]
+    roster = context.opaque_source_call_obligations[coordinate]
+    assert roster.coordinate == coordinate
+    assert roster.target_name == "missing_helper"
+    assert roster.resolution_kind == "call-target-source-absent"
+    obligation = roster.owner(resolved.cid)
+    assert obligation is not None
     assert obligation.coordinate == coordinate
     assert obligation.target_name == "missing_helper"
     assert obligation.resolved_object_cid == resolved.cid
@@ -285,6 +290,8 @@ def test_source_call_coordinate_rejects_conflicting_testimony():
     _install_opaque_call_obligation(context, call, obligation)
     _install_opaque_call_obligation(context, call, obligation)
 
+    # SAME authenticated owner, different testimony: still byte-identity or
+    # nothing. This is the arm the law was always about.
     with pytest.raises(BackendDefect, match="conflicting opaque-call obligation"):
         _install_opaque_call_obligation(
             context,
@@ -292,7 +299,7 @@ def test_source_call_coordinate_rejects_conflicting_testimony():
             OpaqueSourceCallObligationV1(
                 coordinate,
                 "other_helper",
-                "blake3-512:" + "2" * 128,
+                "blake3-512:" + "1" * 128,
             ),
         )
     with pytest.raises(BackendDefect, match="frame/obligation collision"):
@@ -306,6 +313,237 @@ def test_source_call_coordinate_rejects_conflicting_testimony():
         _install_opaque_call_obligation(context, call, obligation)
     with pytest.raises(BackendDefect, match="conflicting source-call frame"):
         _install_source_call_frame(context, call, object())
+
+
+def _opaque_probe_call(source: str = "missing_helper(1)\n"):
+    """A construction context plus one Call node to park obligations against."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+
+    context = TreeConstructionContextV1.for_source_call_construction()
+    tree = SourceFile(
+        (source, "owners.py", blake3_512_of(source.encode("utf-8"))),
+        construction_context=context,
+    )
+    call = next(node for node in tree.nodes() if isinstance(node, Call))
+    return context, call, _call_coordinate(call)
+
+
+def test_second_authenticated_owner_seats_beside_the_first():
+    """One call coordinate, two owners: an ADDITIONAL seat, never a duplicate.
+
+    A helper reached from two exported definitions is parked twice, once per
+    owner. Before the roster this refused as `conflicting opaque-call
+    obligation` and voided the whole file at
+    `phase=context-manager-resolutions` — a BackendDefect where the callee
+    testimony did not differ at all.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+    )
+
+    context, call, coordinate = _opaque_probe_call()
+    first = OpaqueSourceCallObligationV1(
+        coordinate,
+        "missing_helper",
+        "blake3-512:" + "1" * 128,
+        resolution_kind="call-target-source-absent",
+    )
+    second = OpaqueSourceCallObligationV1(
+        coordinate,
+        "missing_helper",
+        "blake3-512:" + "2" * 128,
+        resolution_kind="call-target-source-absent",
+    )
+    _install_opaque_call_obligation(context, call, first)
+    _install_opaque_call_obligation(context, call, second)
+
+    roster = context.opaque_source_call_obligations[coordinate]
+    assert roster.obligations == (first, second)
+    assert roster.owner(first.resolved_object_cid) is first
+    assert roster.owner(second.resolved_object_cid) is second
+    # Absence is None and nothing else.
+    assert roster.owner("blake3-512:" + "9" * 128) is None
+    # The consumed classification is unchanged by the extra seat.
+    assert roster.target_name == "missing_helper"
+    assert roster.resolution_kind == "call-target-source-absent"
+
+
+def test_owners_are_seated_in_owner_order_whatever_the_install_order():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+    )
+
+    context, call, coordinate = _opaque_probe_call()
+    low = OpaqueSourceCallObligationV1(
+        coordinate, "missing_helper", "blake3-512:" + "1" * 128
+    )
+    high = OpaqueSourceCallObligationV1(
+        coordinate, "missing_helper", "blake3-512:" + "2" * 128
+    )
+    _install_opaque_call_obligation(context, call, high)
+    _install_opaque_call_obligation(context, call, low)
+    assert context.opaque_source_call_obligations[coordinate].obligations == (
+        low,
+        high,
+    )
+
+
+def test_disagreeing_owners_panic_rather_than_void_the_file():
+    """Two owners, two classifications: a countable panic, NOT a BackendDefect.
+
+    A BackendDefect at this coordinate is an instrument failure — the file
+    produces no terminal a reader can judge. A genuine disagreement about what
+    the callee is must land as a construction panic, which the census counts.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+    )
+    from sugar_lift_py_tests.gap import ConstructionPanic
+    from sugar_source_tree.panic import BackendDefect
+
+    context, call, coordinate = _opaque_probe_call()
+    _install_opaque_call_obligation(
+        context,
+        call,
+        OpaqueSourceCallObligationV1(
+            coordinate,
+            "missing_helper",
+            "blake3-512:" + "1" * 128,
+            resolution_kind="call-target-source-absent",
+        ),
+    )
+    with pytest.raises(ConstructionPanic) as caught:
+        _install_opaque_call_obligation(
+            context,
+            call,
+            OpaqueSourceCallObligationV1(
+                coordinate,
+                "missing_helper",
+                "blake3-512:" + "2" * 128,
+                resolution_kind="call-graph-cycle",
+            ),
+        )
+    assert not isinstance(caught.value, BackendDefect)
+    message = str(caught.value)
+    assert "authenticated owners disagree about one opaque call" in message
+    assert "call-target-source-absent:missing_helper" in message
+    assert "call-graph-cycle:missing_helper" in message
+    # The panic is refusal, not mutation: the first owner's seat is intact and
+    # no half-written roster is left behind.
+    roster = context.opaque_source_call_obligations[coordinate]
+    assert roster.resolution_kind == "call-target-source-absent"
+    assert len(roster.obligations) == 1
+
+
+def test_roster_refuses_a_repeated_owner():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+        OpaqueSourceCallRosterV1,
+    )
+
+    _context, _call, coordinate = _opaque_probe_call()
+    row = OpaqueSourceCallObligationV1(
+        coordinate, "missing_helper", "blake3-512:" + "1" * 128
+    )
+    with pytest.raises(ValueError, match="seats one owner twice"):
+        OpaqueSourceCallRosterV1(
+            coordinate, "missing_helper", "opaque-call-target", (row, row)
+        )
+
+
+def test_roster_refuses_unordered_owners():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+        OpaqueSourceCallRosterV1,
+    )
+
+    _context, _call, coordinate = _opaque_probe_call()
+    low = OpaqueSourceCallObligationV1(
+        coordinate, "missing_helper", "blake3-512:" + "1" * 128
+    )
+    high = OpaqueSourceCallObligationV1(
+        coordinate, "missing_helper", "blake3-512:" + "2" * 128
+    )
+    with pytest.raises(ValueError, match="not owner-ordered"):
+        OpaqueSourceCallRosterV1(
+            coordinate, "missing_helper", "opaque-call-target", (high, low)
+        )
+
+
+def test_roster_refuses_cross_wired_testimony():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+        OpaqueSourceCallRosterV1,
+    )
+
+    _context, _call, coordinate = _opaque_probe_call()
+    row = OpaqueSourceCallObligationV1(
+        coordinate, "missing_helper", "blake3-512:" + "1" * 128
+    )
+    with pytest.raises(ValueError, match="testimony is cross-wired"):
+        OpaqueSourceCallRosterV1(
+            coordinate, "other_helper", "opaque-call-target", (row,)
+        )
+
+
+def test_roster_refuses_to_name_no_owner():
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallRosterV1,
+    )
+
+    _context, _call, coordinate = _opaque_probe_call()
+    with pytest.raises(ValueError, match="names no authenticated owner"):
+        OpaqueSourceCallRosterV1(
+            coordinate, "missing_helper", "opaque-call-target", ()
+        )
+
+
+def test_second_owner_does_not_change_what_the_call_constructs():
+    """The consumer entrance: CallSiteSugar still reads one kind:name.
+
+    ``Call._construct_sugar`` looks the coordinate up and projects
+    ``contract_resolution_gap``. Seating a second owner must not change that
+    projection, and must not make the lookup ambiguous.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+    )
+
+    context, call, coordinate = _opaque_probe_call()
+    _install_opaque_call_obligation(
+        context,
+        call,
+        OpaqueSourceCallObligationV1(
+            coordinate,
+            "missing_helper",
+            "blake3-512:" + "1" * 128,
+            resolution_kind="call-target-source-absent",
+        ),
+    )
+    before = call.sugar()
+    assert before.target_name == "python:unresolved-source-call"
+    assert (
+        before.contract_resolution_gap
+        == "call-target-source-absent:missing_helper"
+    )
+
+    _install_opaque_call_obligation(
+        context,
+        call,
+        OpaqueSourceCallObligationV1(
+            coordinate,
+            "missing_helper",
+            "blake3-512:" + "2" * 128,
+            resolution_kind="call-target-source-absent",
+        ),
+    )
+    after = call.sugar()
+    assert after.target_name == "python:unresolved-source-call"
+    assert (
+        after.contract_resolution_gap == "call-target-source-absent:missing_helper"
+    )
 
 
 def test_builtin_named_call_is_not_false_opaque_call_target(tmp_path):

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -11073,6 +11073,9 @@ class Call(Expression):
                 span.end_line,
                 span.end_col,
             )
+            # The roster states the ONE classification every authenticated
+            # owner gave this call; owners that disagreed panicked at install,
+            # so there is nothing here to choose between.
             obligation = context.opaque_source_call_obligations.get(coordinate)
             if obligation is not None:
                 from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar

--- a/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
+++ b/implementations/python/sugar-source-tree/tests/test_formal_substitution_coordinate.py
@@ -127,7 +127,12 @@ def test_opaque_source_call_obligation_precedes_spread_selection() -> None:
         "func",
         "blake3-512:" + "c" * 128,
     )
-    context.opaque_source_call_obligations[coordinate] = obligation
+    from sugar_lift_py_tests.context_manager_resolution import (
+        opaque_source_call_roster_of,
+    )
+
+    roster = opaque_source_call_roster_of(obligation)
+    context.opaque_source_call_obligations[coordinate] = roster
 
     opaque = opaque_call.sugar()
 
@@ -143,7 +148,7 @@ def test_opaque_source_call_obligation_precedes_spread_selection() -> None:
     with pytest.raises(SugarNotWritten) as raised:
         opaque.desugar()
     assert raised.value.observed == "opaque-call-target:func"
-    assert context.opaque_source_call_obligations[coordinate] is obligation
+    assert context.opaque_source_call_obligations[coordinate] is roster
 
     ordinary = ordinary_call.sugar()
     assert isinstance(ordinary, CallSiteSugar)


### PR DESCRIPTION
`_install_opaque_call_obligation` keyed ONE obligation per source-call coordinate and refused the second install as `conflicting opaque-call obligation`. But the obligation carries `resolved_object_cid` — the identity of the **export whose frame projection walked through the call**, not a property of the call. A helper reached from two exports produced two non-identical testimonies at one coordinate and voided the whole file as a BackendDefect instrument failure.

**Measured, not argued.** On pandas 3.0.3 through the census door (`sugar.enumerate level=context-manager-resolutions`, `tests/computation/test_eval.py`): **11 conflicts, every one same coordinate, same `target_name`, same `resolution_kind`**, differing only in `resolved_object_cid`. Nothing disagreed about the call.

`OpaqueSourceCallRosterV1` is the plural type the relation always had.

## Three outcomes, three treatments

| condition | result |
|---|---|
| same owner, non-identical testimony | `BackendDefect` — byte-identity law **unchanged**, now applied per owner where it meant to |
| different owners, disagreeing `target_name`/`resolution_kind` | **construction panic** — a countable frontier row (`NoReturn`, so nothing is seated) |
| different owners, agreeing | seated into the roster |

An instrument failure is a hole in the denominator; a panic is a row in it. This converts a class of voids into either valid multi-owner testimony or countable data.

## Verified on battleaxe

- `tests/test_sole_path_manager_construction.py`: 72 failed / 34 passed. Diffed by node ID against main `44086a42e2f3`: **zero newly red, zero newly green** — the 72 are pre-existing (that file is red at main; `+8` passes are the new teeth).
- `construction_panic_gap` confirmed `-> NoReturn`, so the disagreement arm cannot fall through to seating.

Blocker on the census: run `30991724635` showed 32 instrument failures per shard at `phase=context-manager-resolutions`, all from this one site.

Toward #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple authenticated owners sharing the same opaque source-call coordinate.
  * Added roster lookup and owner-specific seating operations.
  * Preserved deterministic owner ordering and shared call classification.

* **Bug Fixes**
  * Conflicting classifications are now rejected without mutating construction state.
  * Improved validation for duplicate owners, invalid ordering, and malformed roster entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple authenticated owners for a single opaque source call coordinate
> - Introduces `OpaqueSourceCallRosterV1`, a frozen dataclass that aggregates one or more `OpaqueSourceCallObligationV1` rows per source call coordinate, with validation for non-empty obligations, unique owners, sorted owner order, and matching coordinate metadata.
> - Adds `opaque_source_call_roster_of` as a constructor helper for creating a single-owner roster when first installing an obligation.
> - Updates `_install_opaque_call_obligation` in [manager_construction.py](https://github.com/TSavo/sugar/pull/7377/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) to seat additional owners into rosters; same-owner conflicting testimony raises `BackendDefect`, while cross-owner disagreements raise a `ConstructionPanic` leaving the existing roster intact.
> - Updates `_seat_import_value_use_receipts` to flatten rosters and allow multiple owners at the same call coordinate during import value use seating.
> - Behavioral Change: `context.opaque_source_call_obligations` now stores `OpaqueSourceCallRosterV1` objects per coordinate instead of individual `OpaqueSourceCallObligationV1` objects; all consumers must flatten rosters to access individual obligations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abe13f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->