### PR TITLE
Two census holes become countable terminals (#7374)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -3789,9 +3789,35 @@ def _seat_import_value_use_receipts(
                 # for deciding whether that value is usable.
                 seat_receipt()
                 continue
-            raise ImportValueUseSeatingGap(
-                f"resolution-{imported.kind}",
-                "authenticated value-use receipt did not resolve",
+            # A REAL gap, and it stays one: the authenticated target is not
+            # reachable through the binding it claims. What changes is only
+            # that it now names a construct, a coordinate and a shape, so the
+            # census reads a countable terminal at this exact use instead of a
+            # bare ValueError that voids the file. Do NOT seat the receipt
+            # here — the neighbouring `seat_receipt(); continue` arms above are
+            # honest open-world EXPORTS that carry no definition coordinate;
+            # this is a target that does not resolve at all, and silently
+            # seating it would let an unresolved value ride as authenticated.
+            from sugar_source_tree.panic import ImportValueUseResolutionGap
+
+            raise ImportValueUseResolutionGap(
+                blame=coordinate,
+                owner="manager_construction._seat_import_value_use_receipts",
+                observed=(
+                    "authenticated value-use receipt did not resolve: "
+                    f"resolution-{imported.kind} for target "
+                    f"{receipt.target_symbol!r} through module "
+                    f"{dependency_module!r}"
+                ),
+                requested=(
+                    "a resolved Python object for the receipt's authenticated "
+                    "target symbol, reached through its own import binding"
+                ),
+                fix=(
+                    "resolve the target through the binding it names, or keep "
+                    "this value-use coordinate loud; never seat an unresolved "
+                    "target as an authenticated value"
+                ),
             )
         seat_receipt()
         context.source_import_value_resolutions[coordinate] = imported

--- a/implementations/python/sugar-lift-python-source/tests/test_census_instrument_holes_are_terminals.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_census_instrument_holes_are_terminals.py
@@ -1,0 +1,310 @@
+"""RED: the census entrance must never bank a hole nobody can read.
+
+A construction PANIC is a countable frontier row — the product working. An
+INSTRUMENT FAILURE is a hole: an exception that names no construct, no
+coordinate and no shape, so ``_panic_from_exception`` cannot mint a row, the
+shard marks its partial ``measured=False``, and compose cannot seal. Two such
+holes were voiding pandas files in the full-corpus recensus (run 30999353264):
+
+1. ``ImportValueUseSeatingGap("resolution-target-outside-binding", …)`` — a
+   bare ``ValueError`` out of ``_seat_import_value_use_receipts``. The gap is
+   REAL: the authenticated target is not reachable through the binding it
+   claims. It was simply not typed as a terminal. It is now
+   ``ImportValueUseResolutionGap`` (a ``SugarNotWritten``), which the populate
+   membrane cites at the exact use coordinate.
+
+2. ``ConstructedValueCategoryGap`` — a bare ``TypeError`` out of
+   ``live_loop_construction._seal_runtime_state``, which canonicalizes a
+   loop-carried binding state OUTSIDE the reporter membrane that normally
+   wraps that gap. It is now ``ConstructedValueTestimonyNotWritten``.
+
+Neither refusal is weakened and no value category is broadened: an unresolved
+target still refuses, and ``ConstructedValueV2`` still names no arm for
+``cpython_adapter._Handle`` (see
+``sugar-source-tree/tests/test_cpython_call_handle_testimony.py``, which
+requires that the adapter handle stay out). Only the SHAPE of the refusal
+changed, from a hole into a row.
+
+THE ENTRANCE IS THE CENSUS ENTRANCE: ``measure_file_via_enumerate``, the sole
+door ``control_effect_recensus`` measures a file through. ``SourceFile``,
+``SourceFile.from_path`` and a bare ``open_source_file_for_construction`` with
+a provisional context are all DIFFERENT doors and reach none of this — the
+seats below were verified not to reproduce through them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+# The exact enrolled pandas seats that came back
+# ``status=instrument-failure`` from the full-corpus recensus, one per cause,
+# each confirmed to reproduce through this door on the pinned corpus.
+IMPORT_VALUE_USE_SEAT = "io/json/_json.py"
+LIVE_LOOP_SEAL_SEAT = "io/pytables.py"
+
+
+def _recensus_consumer():
+    scripts = (
+        Path(__file__).resolve().parents[2] / "sugar-lift-py-tests" / "scripts"
+    )
+    assert scripts.is_dir(), f"missing recensus scripts at {scripts}"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    import recensus_enumerate_consumer
+
+    return recensus_enumerate_consumer
+
+
+def _measure_seat(seat: str) -> dict[str, Any]:
+    """Measure ONE enrolled corpus seat exactly as a recensus shard does.
+
+    TWO ROOTS, as the driver carries them: ``workspace_root`` is the corpus
+    (WHICH tree is measured) and ``source_workspace_root`` is the install root
+    the distribution recorded its seats against (what the minted address is
+    stated against). Conflating them mints an address no other checkout
+    resolves, and ``require_recorded_seat`` refuses it by name.
+    """
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    corpus = authenticated_pandas_corpus().root
+    target = corpus.joinpath(*seat.split("/"))
+    assert target.is_file(), f"missing enrolled corpus seat {target}"
+    installed = install_root_for(str(target))
+    locus_root = corpus if installed is None else Path(installed)
+    return _recensus_consumer().measure_file_via_enumerate(
+        workspace_root=corpus,
+        file_rel=seat,
+        contract_refs=None,
+        distribution="pandas",
+        source_workspace_root=locus_root,
+    )
+
+
+def _instrument_failure_message(row: dict[str, Any]) -> str:
+    failure = row.get("instrumentFailure") or {}
+    return str(failure.get("message") or "")
+
+
+def _panic_messages(row: dict[str, Any]) -> list[str]:
+    panics = list(row.get("enumerateConstructionPanics") or [])
+    return [str(panic.get("message") or "") for panic in panics] + [
+        str(panic.get("observed") or "") for panic in panics
+    ]
+
+
+def _assert_countable_terminal(row: dict[str, Any], seat: str) -> None:
+    assert row.get("terminalKind") in {"constructed", "construction-panic"}, (
+        f"CENSUS HOLE at {seat}: terminalKind="
+        f"{row.get('terminalKind')!r}. A shard marks its partial "
+        "measured=False if ANY file is an instrument failure, so this one hole "
+        "voids all 178 seats and compose cannot seal. "
+        f"instrumentFailure={_instrument_failure_message(row)[:600]}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Cause 1: the unresolved import value-use is a named terminal, not a hole.
+# --------------------------------------------------------------------------
+
+
+def test_unresolved_import_value_use_seat_measures_to_a_countable_terminal() -> None:
+    """GUARD: the ``ImportValueUseResolutionGap`` raise in
+    ``_seat_import_value_use_receipts``.
+
+    Mutating that one raise back to ``ImportValueUseSeatingGap`` (a bare
+    ``ValueError``) restores exactly the instrument failure the recensus
+    banked for this seat.
+    """
+    row = _measure_seat(IMPORT_VALUE_USE_SEAT)
+    _assert_countable_terminal(row, IMPORT_VALUE_USE_SEAT)
+
+
+def test_unresolved_import_value_use_never_names_the_untyped_seating_gap() -> None:
+    """GUARD: the SPECIFIC text of that same raise.
+
+    ``terminalKind`` alone is answered by anything that stops the file dying,
+    including a swallow. This asserts the retired refusal's own wording is gone
+    from the banked row, so a fix that merely relocated the ``ValueError``
+    cannot pass. ``resolution-`` is deliberately matched WITHOUT the
+    ``ImportValueUseSeatingGap`` prefix it used to carry, because the typed
+    refusal keeps naming the resolution kind.
+    """
+    row = _measure_seat(IMPORT_VALUE_USE_SEAT)
+    message = _instrument_failure_message(row)
+    assert "resolution-target-outside-binding" not in message, (
+        "CENSUS HOLE: the untyped seating gap still escapes as an instrument "
+        f"failure. message={message[:600]}"
+    )
+    assert "authenticated value-use receipt did not resolve" not in message, (
+        "CENSUS HOLE: the value-use refusal is still leaving the entrance as a "
+        f"hole rather than a row. message={message[:600]}"
+    )
+
+
+def test_import_value_use_resolution_gap_is_a_countable_census_row() -> None:
+    """GUARD: the class, not the raise site.
+
+    ``_panic_from_exception`` mints a countable construction-panic row for
+    ``ConstructionPanic`` and ``SugarNotWritten`` ONLY; every other exception
+    becomes an instrument failure. Demoting ``ImportValueUseResolutionGap`` off
+    ``SugarNotWritten`` restores the hole without touching any raise site, so
+    the inheritance gets its own tooth.
+    """
+    from sugar_source_tree.panic import (
+        ImportValueUseResolutionGap,
+        SugarNotWritten,
+    )
+
+    assert issubclass(ImportValueUseResolutionGap, SugarNotWritten)
+    gap = ImportValueUseResolutionGap(
+        blame="pandas/io/json/_json.py:1:0",
+        owner="tooth",
+        observed="authenticated value-use receipt did not resolve",
+        requested="a resolved Python object",
+        fix="resolve the target through the binding it names",
+    )
+    assert "IMPORT VALUE USE RESOLUTION GAP" in str(gap)
+
+
+def test_unresolved_import_value_use_is_still_refused_never_seated() -> None:
+    """GUARD: that the fix did not silence the gap.
+
+    The neighbouring arms in ``_seat_import_value_use_receipts``
+    (``dynamic-export``, ``static-export-absent``, ``reexport-cycle``,
+    ``ambiguous-static-export``) answer with ``seat_receipt(); continue`` —
+    honest open-world exports that carry no definition coordinate. Adding
+    ``target-outside-binding`` to that set would ALSO clear the hole, while
+    seating an unresolved target as an authenticated value. This tooth reads
+    the source of the function and refuses that shape.
+    """
+    import inspect
+
+    from sugar_lift_python_source.manager_construction import (
+        _seat_import_value_use_receipts,
+    )
+
+    source = inspect.getsource(_seat_import_value_use_receipts)
+    assert "ImportValueUseResolutionGap" in source, (
+        "the unresolved-target arm must RAISE a named terminal"
+    )
+    for silently_seated in (
+        '"target-outside-binding"',
+        "'target-outside-binding'",
+        '"artifact-module-absent"',
+        "'artifact-module-absent'",
+    ):
+        assert silently_seated not in source, (
+            f"SILENCED GAP: {silently_seated} was moved into an arm that seats "
+            "the receipt and continues. An unresolved target is not an "
+            "open-world export; seating it lets an unresolved value ride as "
+            "authenticated."
+        )
+
+
+# --------------------------------------------------------------------------
+# Cause 2: the live-loop sealer's constructed value has a typed door.
+# --------------------------------------------------------------------------
+
+
+def test_live_loop_seal_seat_measures_to_a_countable_terminal() -> None:
+    """GUARD: the ``try``/``except`` around ``_constructed_preimage`` in
+    ``live_loop_construction._seal_runtime_state``.
+
+    Removing that door lets ``ConstructedValueCategoryGap`` — a bare
+    ``TypeError`` — leave ``sugar.enumerate``, which is exactly how
+    ``cpython_adapter._Handle`` voided this seat.
+    """
+    row = _measure_seat(LIVE_LOOP_SEAL_SEAT)
+    _assert_countable_terminal(row, LIVE_LOOP_SEAL_SEAT)
+
+
+def test_live_loop_seal_seat_no_longer_leaks_the_raw_category_gap() -> None:
+    """GUARD: the SPECIFIC text, at the banked row.
+
+    The raw gap's wording ("ConstructedValueV2 names its categories") must not
+    appear as an instrument failure. It may still appear inside a construction
+    PANIC — that is the refusal doing its job, and this tooth deliberately does
+    not forbid it.
+    """
+    row = _measure_seat(LIVE_LOOP_SEAL_SEAT)
+    message = _instrument_failure_message(row)
+    assert "unclassified constructed value category" not in message, (
+        "CENSUS HOLE: the raw ConstructedValueCategoryGap still escapes as an "
+        f"instrument failure. message={message[:600]}"
+    )
+    assert "cpython_adapter._Handle" not in message, (
+        f"CENSUS HOLE: the adapter handle still voids this seat. "
+        f"message={message[:600]}"
+    )
+
+
+def test_live_loop_sealer_names_itself_when_a_value_has_no_category() -> None:
+    """GUARD: the ``owner``/``observed`` of that door, at the unit.
+
+    The reporter membrane (``ConstructionTestimonyReporterV1``) raises the SAME
+    exception class from a DIFFERENT owner, so a tooth that only asserted the
+    class would survive this guard's removal. Assert the owner.
+    """
+    from sugar_source_tree import nodes as nodes_module
+    from sugar_source_tree.live_loop_construction import _seal_runtime_state
+    from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
+
+    class _Uncategorized:
+        """No named ConstructedValueV2 arm, exactly like ``_Handle``."""
+
+    class _StandInState:
+        fragment = "tooth-fragment"
+
+        def sugar(self):
+            return _Uncategorized()
+
+    # ``_seal_runtime_state`` dispatches on ``isinstance(state, Node)``, read
+    # off ``sugar_source_tree.nodes`` at call time. Widen that ONE name so the
+    # stand-in reaches the Node arm; the door under test is untouched.
+    real_node = nodes_module.Node
+
+    class _AdmitsStandIn(type):
+        def __instancecheck__(cls, instance) -> bool:
+            return isinstance(instance, (real_node, _StandInState))
+
+    class _NodeOrStandIn(metaclass=_AdmitsStandIn):
+        pass
+
+    nodes_module.Node = _NodeOrStandIn  # type: ignore[assignment]
+    try:
+        with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
+            _seal_runtime_state(_StandInState())
+    finally:
+        nodes_module.Node = real_node  # type: ignore[assignment]
+
+    assert gap.value.owner == "live_loop_construction._seal_runtime_state"
+    assert "loop-carried binding state has no content coordinate" in gap.value.observed
+    assert "_Uncategorized" in gap.value.observed
+
+
+def test_live_loop_sealer_still_refuses_the_adapter_handle_category() -> None:
+    """GUARD: that the fix did not admit ``_Handle`` as a value category.
+
+    The tempting "fix" for cause 2 is a named ``_cv2_entries`` arm for
+    ``cpython_adapter._Handle``. That is a broadened category over a raw parser
+    object with no authenticated content, and
+    ``test_raw_or_reminted_parser_handle_never_becomes_semantic_testimony``
+    already rules the adapter handle out. This tooth keeps the ruling local to
+    the door that was changed.
+    """
+    from sugar_source_tree.binding_state import (
+        ConstructedValueCategoryGap,
+        constructed_value_cid_v2,
+    )
+    from sugar_source_tree.cpython_adapter import _Handle
+
+    handle = _Handle.__new__(_Handle)
+    with pytest.raises(ConstructedValueCategoryGap) as gap:
+        constructed_value_cid_v2(handle)
+    assert "cpython_adapter._Handle" in str(gap.value)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/live_loop_construction.py
@@ -94,6 +94,49 @@ def _formula_cid(formula) -> str:
     return blake3_512_of(encode_jcs(formula_to_value(formula)).encode("utf-8"))
 
 
+def _content_coordinate(constructed, *, blame, owner: str, what: str) -> str:
+    """The ONE typed door for this module's constructed-value canonicalization.
+
+    ``_constructed_preimage`` is the same canonicalization the reporter membrane
+    runs, and it refuses an unnamed value CATEGORY with a bare
+    ``ConstructedValueCategoryGap`` (a ``TypeError``).  On the reporter path
+    ``present_construction`` wraps that into
+    ``ConstructedValueTestimonyNotWritten`` before it leaves.  Live-loop
+    construction is NOT on the reporter path: it canonicalizes directly, so the
+    unwrapped ``TypeError`` escaped all the way out of ``sugar.enumerate``.  An
+    exception that names no construct, no coordinate and no shape is not a
+    terminal any reader can judge — the recensus banks it as an INSTRUMENT
+    FAILURE, which voids the whole file's measurement and, with it, the shard's
+    partial.  ``cpython_adapter._Handle`` reached both call sites below and
+    voided eight pandas files that way.
+
+    Nothing is silenced and no category is broadened here.  The same gap is
+    raised, over the same values, under the name the census already counts
+    (``ConstructedValueTestimonyNotWritten`` is a ``SugarNotWritten``), blamed
+    on this construct's own fragment.  ``_Handle`` still has no
+    ``ConstructedValueV2`` arm and must not get one: it is raw parser
+    machinery with no authenticated content.
+    """
+    try:
+        return cid_of_json(_constructed_preimage(constructed))
+    except (TypeError, ValueError) as cause:
+        from .panic import ConstructedValueTestimonyNotWritten
+
+        raise ConstructedValueTestimonyNotWritten(
+            blame=blame,
+            owner=owner,
+            observed=f"{what} has no content coordinate: {cause}",
+            requested=(
+                "a constructed value whose category ConstructedValueV2 names, "
+                "so this live-loop record addresses its own content"
+            ),
+            fix=(
+                "teach ConstructedValueV2 the value CATEGORY over its "
+                "authenticated content, or keep this coordinate loud"
+            ),
+        ) from cause
+
+
 def _seal_runtime_state(state):
     """Seal ONE live BindingState into its authenticated SealedBindingStateV1.
 
@@ -109,7 +152,13 @@ def _seal_runtime_state(state):
     if isinstance(state, Node):
         constructed = state.sugar()
         testimony = ConstructedValueTestimonyV1.mint(
-            state.fragment, cid_of_json(_constructed_preimage(constructed))
+            state.fragment,
+            _content_coordinate(
+                constructed,
+                blame=state.fragment,
+                owner="live_loop_construction._seal_runtime_state",
+                what="loop-carried binding state",
+            ),
         )
         return BoundBindingStateV1(testimony)
     if isinstance(state, UnboundBinding):
@@ -399,7 +448,12 @@ def construct_live_loop_recurrence(loop, scope: BindingMap) -> LiveLoopProjectio
         guard_cid = _formula_cid(live_guard)
         live_guards[guard_cid] = live_guard
         statement_sugar = statement.sugar()
-        effect_cid = cid_of_json(_constructed_preimage(statement_sugar))
+        effect_cid = _content_coordinate(
+            statement_sugar,
+            blame=statement.fragment,
+            owner="live_loop_construction.construct_live_loop_recurrence",
+            what="loop outward-halted face effect",
+        )
         face = _record(
             {
                 "kind": "loop-outward-halted-face",

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/panic.py
@@ -127,6 +127,31 @@ class OpaqueSourceCallResolutionGap(SugarNotWritten):
     _LABEL = "OPAQUE SOURCE CALL RESOLUTION GAP"
 
 
+class ImportValueUseResolutionGap(SugarNotWritten):
+    """An authenticated import VALUE-use whose target stayed unresolved.
+
+    The value-use sibling of ``OpaqueSourceCallResolutionGap``. A final-checked
+    import receipt named a target symbol, and resolving that target against the
+    authenticated distribution graph produced a resolution GAP rather than a
+    resolved Python object — the target is not reachable through the binding it
+    claims (``target-outside-binding``), or the module it names carries no
+    authenticated source in this artifact (``artifact-module-absent``).
+
+    A *named* subclass of ``SugarNotWritten`` (like
+    ``RuntimeSelectedContextManager``) so the frontier census counts unresolved
+    value-use targets separately, and — decisively — so this refusal travels as
+    a TERMINAL with a construct, a coordinate and a shape. It used to be a bare
+    ``ValueError`` (``ImportValueUseSeatingGap``) that named none of those: it
+    escaped ``sugar.enumerate`` as an instrument failure, voiding the whole
+    file's measurement instead of standing as one readable row at this use.
+
+    Never seat the receipt to make this go away: an unresolved target is not an
+    open-world export that merely carries no definition coordinate.
+    """
+
+    _LABEL = "IMPORT VALUE USE RESOLUTION GAP"
+
+
 class RuntimeSelectedContextManager(SugarNotWritten):
     """A `with` whose manager has no authenticated exit-suppression contract.
 


### PR DESCRIPTION
A construction **panic** is a countable frontier row — the product working. An **instrument failure** is a hole: an exception naming no construct, no coordinate, no shape, so `_panic_from_exception` mints no row, the shard marks its partial `measured=False`, and compose cannot seal. Two such holes voided **39 of 43** instrument-failure files in run `30999353264`.

**1.** `_seat_import_value_use_receipts` raised `ImportValueUseSeatingGap` — a bare `ValueError` — when `resolve_import_binding` returned a resolution gap outside the honest open-world exports. The gap is REAL (`target-outside-binding`, `artifact-module-absent`); it was simply never typed as a terminal. Now `ImportValueUseResolutionGap`, a named `SugarNotWritten` sibling, blamed on the exact use coordinate.

The receipt is deliberately **not seated** — the neighbouring `seat_receipt(); continue` arms are open-world exports carrying no definition coordinate, and seating an unresolved target would let an unresolved value ride as authenticated.

**2.** `live_loop_construction` canonicalized through `_constructed_preimage` at two sites with no typed door, so `ConstructedValueCategoryGap` (a bare `TypeError`) escaped `sugar.enumerate` unwrapped. One `_content_coordinate` door now raises `ConstructedValueTestimonyNotWritten` naming the site.

`_Handle` gets **no** `ConstructedValueV2` arm. It is raw parser machinery with no authenticated content, and `test_raw_or_reminted_parser_handle_never_becomes_semantic_testimony` already rules it out. **A category arm that matches too much is worse than the gap.**

> Neither refusal is weakened and no category is broadened: the same gaps are raised over the same values, under names the census counts.

## Verified on battleaxe

- `test_census_instrument_holes_are_terminals.py` → **8 passed** (274s).
- Teeth go through `measure_file_via_enumerate` — the sole door a recensus shard measures a file through — on enrolled pandas seats that actually reproduce (`io/json/_json.py`, `io/pytables.py`), not a bare `from_path`.
- Five guards mutation-proved **one at a time**; each mutation killed exactly its own teeth and no others.

Census trajectory per shard: `178/178 refused` → `80/57/41` → `67/81/32` → `70 completed / 106 panics / 3 instrument-failures`.

Toward #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for unresolved authenticated import value-use targets, including precise location, resolution details, and remediation guidance.
  * Prevented unresolved import targets from being incorrectly treated as seated or valid.
  * Converted live-loop canonicalization failures into clear, categorized construction errors.
  * Ensured uncategorized constructed values are properly sealed and reported as terminal failures.

* **Tests**
  * Added regression coverage for import-resolution failures, live-loop sealing, terminal reporting, and invalid constructed-value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->