### PR TITLE
The re-export terminal memo carries its own hops (#7374)

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_export_adapter.py
@@ -40,23 +40,36 @@ def _bind() -> None:
         g[name] = getattr(da, name)
 
 
-def _export_terminal_result(result: Any) -> Any:
-    """Definition/gap only — no path warrants or import-binding CID.
+def _export_terminal_result(result: Any, prefix: int) -> Any:
+    """Definition plus this key's OWN hops — no caller path, no binding CID.
 
-    Reexport hops carry path warrants and cannot share the pure-entry memo
-    (that memo keeps module-structural reexport warrants).  The terminal memo
-    is the shared definition identity both doors restamp onto.
+    ``prefix`` is how many warrants the caller already held on entry.  Those
+    are the caller's path and are dropped.  Everything after them is the
+    suffix this key resolved through: the hops from the keyed module down to
+    the definition.  The suffix is part of the answer, not part of the path —
+    the keyed module reaches that definition only through those hops, and a
+    memo that discards them answers a different question than the uncached
+    resolve.  Restamping then either fails ``ResolvedPythonObjectV1``'s
+    reaching check ("re-export warrants do not reach the resolved definition")
+    or publishes a definition with no provenance at all.
     """
     if isinstance(result, ResolvedPythonObjectV1):
         return replace(
             result,
             import_binding_cid="",
-            reexport_warrants=(),
+            reexport_warrants=result.reexport_warrants[prefix:],
             cid="",
         )
     if isinstance(result, PythonObjectResolutionGapV1):
         return replace(result, import_binding_cid="")
     return result
+
+
+def _terminal_suffix(terminal: Any) -> tuple:
+    """The hops a stored terminal resolved through, below its keyed module."""
+    if isinstance(terminal, ResolvedPythonObjectV1):
+        return terminal.reexport_warrants
+    return ()
 
 
 def _restamp_export_result(
@@ -98,11 +111,17 @@ def resolve_export(
     * **pure-entry** (``export_resolutions``): how THIS module exports the name,
       including module-structural reexport warrants.  Filled only on pure entry
       (no path warrants / empty seen).
-    * **terminal** (``export_terminals``): definition/gap only.  Filled on every
-      successful resolve so a reexport hop with path warrants can hit after a
-      pure resolve of the same symbol (or after another hop) without re-running
-      prefix fallthrough.  Measured on _json: pure-entry hit for repeats, but
-      reexport hops with warrants skipped the memo and re-paid ~0.8s prefix.
+    * **terminal** (``export_terminals``): definition/gap plus the hops THIS
+      key resolved through, with the entering caller's path warrants stripped.
+      Filled on every successful resolve so a reexport hop with path warrants
+      can hit after a pure resolve of the same symbol (or after another hop)
+      without re-running prefix fallthrough.  Measured on _json: pure-entry hit
+      for repeats, but reexport hops with warrants skipped the memo and re-paid
+      ~0.8s prefix.
+
+    A reader composes its own path with the stored suffix.  The suffix cannot
+    be dropped: the resolved definition may sit several modules below the key,
+    and a chain that stops at the key does not reach it.
 
     ``seen`` still owns cycle detection and is checked before either memo.
     """
@@ -124,12 +143,19 @@ def resolve_export(
         # symbol without a pure-entry row (hops do not write export_resolutions).
         terminal = session.export_terminal_hit(cache_key)
         if terminal is not None:
-            return _restamp_export_result(terminal, binding_cid, warrants=())
+            # Pure entry holds no path, so the stored suffix IS the whole
+            # chain from this module to the definition. Keep it.
+            return _restamp_export_result(terminal, binding_cid)
     else:
-        # Reexport hop / path context: share definition identity only.
+        # Reexport hop: this caller's path, then the hops the memo resolved
+        # through. Dropping the suffix would strand the chain at this module.
         terminal = session.export_terminal_hit(cache_key)
         if terminal is not None:
-            return _restamp_export_result(terminal, binding_cid, warrants=warrants)
+            return _restamp_export_result(
+                terminal,
+                binding_cid,
+                warrants=(*warrants, *_terminal_suffix(terminal)),
+            )
 
     result = _resolve_export_uncached(
         graph,
@@ -140,8 +166,11 @@ def resolve_export(
         seen,
         session=session,
     )
-    # Terminal definition/gap: always, so the next hop can hit.
-    session.remember_export_terminal(cache_key, _export_terminal_result(result))
+    # Terminal definition/gap plus this key's own hops: always, so the next
+    # hop can hit and still compose a chain that reaches the definition.
+    session.remember_export_terminal(
+        cache_key, _export_terminal_result(result, len(warrants))
+    )
     # Pure-entry form (keeps module-structural warrants): pure door only.
     if pure_entry:
         session.remember_export(

--- a/implementations/python/sugar-lift-python-source/tests/test_census_reexport_memo_hole.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_census_reexport_memo_hole.py
@@ -1,0 +1,189 @@
+"""RED: the four pandas seats the re-export memo voided must measure to rows.
+
+Full-corpus recensus run 31005668665 came back 65 completed / 109 panics /
+4 instrument-failures. All four failures were one message::
+
+    sugar.enumerate error: {'code': -32603, 'message':
+      're-export warrants do not reach the resolved definition'}
+
+That is ``ResolvedPythonObjectV1.__post_init__`` refusing an object whose
+warrant chain stops short of the module the definition actually lives in. It
+names no construct, no coordinate and no shape, so ``_panic_from_exception``
+mints no row: the file dies, the shard marks its partial ``measured=False``,
+and all eight seats go missing from compose.
+
+The gap was NOT real. ``resolve_export``'s terminal memo is keyed on
+``(distribution_artifact_cid, module_name, exported_name)`` and stored the
+resolved definition while DISCARDING the re-export hops that key resolved
+through. pandas re-exports heavily, so one middle module is legitimately
+reached from several importers -- the relation was always plural. The first
+arrival paid the hops; every later arrival read a triple pointing at a module
+its own chain never names. Composing the reader's path with the memo's stored
+suffix resolves it. The unit twins are in
+``test_reexport_terminal_memo_warrant_chain.py``; these are the same defect at
+the census entrance, on the seats that actually banked it.
+
+THE ENTRANCE IS THE CENSUS ENTRANCE: ``measure_file_via_enumerate``, the sole
+door ``control_effect_recensus`` measures a file through. A bare
+``SourceFile.from_path`` is a different door and does not reach this.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+# The exact enrolled pandas seats that came back status=instrument-failure
+# from full-corpus recensus run 31005668665. All four, one cause.
+REEXPORT_MEMO_SEATS = (
+    "tests/io/excel/test_writers.py",
+    "tests/io/excel/test_xlrd.py",
+    "tests/io/json/test_readlines.py",
+    "tests/io/parser/common/test_data_list.py",
+)
+
+# ``test_writers.py`` clears the re-export message but does NOT reach a row.
+# Underneath it sits a DIFFERENT, pre-existing defect that the re-export abort
+# was shadowing::
+#
+#     BACKEND DEFECT [ConstructionTestimonyReporterV1.retain_registered_node_from]
+#       blame:    pandas/tests/io/excel/test_writers.py:157:8
+#       observed: foreign or absent producer node registration
+#                 (producer=NullReporter, node_reporter=NullReporter)
+#
+# Measured at MAIN (15ef03354) with only ``export_hit`` /
+# ``export_terminal_hit`` blinded -- the uncached resolve, which is the oracle
+# the memo must agree with -- the seat reaches that same BackendDefect. So it
+# is not reachable-only-after this change; the file simply died earlier before.
+#
+# ``BackendDefect`` is a ``SourceTreePanic``, deliberately NOT a
+# ``SugarNotWritten``: it says OUR implementation is broken, not that the
+# corpus needs a construct written. Retyping it to clear this hole would
+# broaden the countable category to absorb our own bugs. It stays a hole, and
+# it stays named, until the registration defect itself is fixed.
+SHADOWED_BY_BACKEND_DEFECT = "tests/io/excel/test_writers.py"
+
+
+def _terminal_seat(seat: str):
+    """xfail STRICT: the day this seat banks a row, this tooth must be told."""
+    if seat != SHADOWED_BY_BACKEND_DEFECT:
+        return seat
+    return pytest.param(
+        seat,
+        marks=pytest.mark.xfail(
+            strict=True,
+            reason=(
+                "pre-existing BackendDefect in retain_registered_node_from "
+                "(reproduces at main with the export memo blinded); this seat "
+                "is still a census hole, for a different cause"
+            ),
+        ),
+    )
+
+
+def _recensus_consumer():
+    scripts = Path(__file__).resolve().parents[2] / "sugar-lift-py-tests" / "scripts"
+    assert scripts.is_dir(), f"missing recensus scripts at {scripts}"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    import recensus_enumerate_consumer
+
+    return recensus_enumerate_consumer
+
+
+def _measure_seat(seat: str) -> dict[str, Any]:
+    """Measure ONE enrolled corpus seat exactly as a recensus shard does."""
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    corpus = authenticated_pandas_corpus().root
+    target = corpus.joinpath(*seat.split("/"))
+    assert target.is_file(), f"missing enrolled corpus seat {target}"
+    installed = install_root_for(str(target))
+    locus_root = corpus if installed is None else Path(installed)
+    return _recensus_consumer().measure_file_via_enumerate(
+        workspace_root=corpus,
+        file_rel=seat,
+        contract_refs=None,
+        distribution="pandas",
+        source_workspace_root=locus_root,
+    )
+
+
+def _instrument_failure_message(row: dict[str, Any]) -> str:
+    return str((row.get("instrumentFailure") or {}).get("message") or "")
+
+
+@pytest.mark.parametrize(
+    "seat", [_terminal_seat(seat) for seat in REEXPORT_MEMO_SEATS]
+)
+def test_reexport_memo_seat_measures_to_a_countable_terminal(seat: str) -> None:
+    """GUARD: the seat banks a row, not a hole.
+
+    Whether the row is ``constructed`` or ``construction-panic`` is not this
+    tooth's business -- a panic naming construct/coordinate/shape is the
+    product working. What is refused is ``terminalKind`` naming neither.
+
+    Three of the four seats pass. ``test_writers.py`` is xfail-STRICT on a
+    different, pre-existing cause (see ``SHADOWED_BY_BACKEND_DEFECT``) -- the
+    hole is recorded, not silenced.
+    """
+    row = _measure_seat(seat)
+    assert row.get("terminalKind") in {"constructed", "construction-panic"}, (
+        f"CENSUS HOLE at {seat}: terminalKind={row.get('terminalKind')!r}. "
+        "One hole marks the whole shard measured=False and compose cannot "
+        f"seal. instrumentFailure={_instrument_failure_message(row)[:600]}"
+    )
+
+
+@pytest.mark.parametrize("seat", REEXPORT_MEMO_SEATS)
+def test_reexport_memo_seat_never_names_the_unreached_chain(seat: str) -> None:
+    """GUARD: the SPECIFIC text.
+
+    ``terminalKind`` alone is answered by anything that stops the file dying,
+    including a swallow that relocated the ``ValueError``. This asserts the
+    exact wording the recensus banked is gone from the row.
+
+    All FOUR seats pass this, including the one still held by a different
+    defect: that seat's re-export message really is gone.
+    """
+    message = _measure_seat(seat)
+    assert (
+        "re-export warrants do not reach the resolved definition"
+        not in _instrument_failure_message(message)
+    ), (
+        f"CENSUS HOLE at {seat}: the unreached warrant chain still escapes as "
+        f"an instrument failure. message={_instrument_failure_message(message)[:600]}"
+    )
+
+
+def test_the_reaching_check_is_still_enforced() -> None:
+    """GUARD: the fix did not clear the hole by deleting the refusal.
+
+    Composing the reader's path with the memo's suffix is a fix. Dropping
+    ``ResolvedPythonObjectV1``'s reaching check, or letting the memo hand back
+    a chain that stops short, would ALSO clear all four seats -- while
+    publishing definitions no warrant reaches. Both halves are pinned here:
+    the invariant still raises, and the memo still stores its own hops.
+    """
+    import inspect
+
+    from sugar_lift_python_source import dependency_export_adapter as adapter
+    from sugar_lift_python_source.dependency_artifact import ResolvedPythonObjectV1
+
+    invariant = inspect.getsource(ResolvedPythonObjectV1.__post_init__)
+    assert "re-export warrants do not reach the resolved definition" in invariant, (
+        "the reaching invariant must still refuse a chain that stops short"
+    )
+    assert "re-export warrants do not form one source chain" in invariant, (
+        "the chain-continuity invariant must still refuse a broken chain"
+    )
+
+    stored = inspect.getsource(adapter._export_terminal_result)
+    assert "result.reexport_warrants[prefix:]" in stored, (
+        "the terminal memo must store the hops its own key resolved through"
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_reexport_terminal_memo_warrant_chain.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_reexport_terminal_memo_warrant_chain.py
@@ -1,0 +1,252 @@
+"""The terminal export memo must carry its own re-export hops.
+
+``resolve_export`` shares one *terminal* memo keyed on
+``(distribution_artifact_cid, module_name, exported_name)``.  The value it
+stores is the resolution of that symbol: a module/source/definition triple that
+may sit several re-export hops *below* the keyed module.
+
+Those hops are part of the memo value, not part of the caller's path.  Storing
+the triple while discarding them makes the memo answer a different question
+than the uncached resolve:
+
+* a hop restamps its own path warrants onto a triple that no longer reaches
+  from the keyed module to the definition -- ``ResolvedPythonObjectV1``
+  refuses it as ``re-export warrants do not reach the resolved definition``,
+  and the refusal escapes ``sugar.enumerate`` as an untyped instrument
+  failure rather than a construction panic;
+* a pure entry restamps ``()`` and silently publishes a definition in a module
+  the queried module never names, with no warrant at all.
+
+Both twins here are the *same* defect at the two doors that read the memo.
+Each asserts the specific text / the specific chain, and each carries a
+discrimination arm: the uncached resolve (memo disabled) is the oracle, so the
+positive assertion cannot pass vacuously.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+
+
+def _dist(
+    root: Path, *, name: str, files: dict[str, str], tops: tuple[str, ...]
+) -> importlib.metadata.Distribution:
+    for relative, text in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    meta = root / f"{name.replace('-', '_')}_dist-1.0.dist-info"
+    meta.mkdir(parents=True, exist_ok=True)
+    (meta / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (meta / "top_level.txt").write_text(
+        "".join(f"{top}\n" for top in tops), encoding="utf-8"
+    )
+    recorded = (
+        *files.keys(),
+        f"{meta.name}/METADATA",
+        f"{meta.name}/top_level.txt",
+        f"{meta.name}/RECORD",
+    )
+    with (meta / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for item in recorded:
+            writer.writerow((item, "", ""))
+    return importlib.metadata.Distribution.at(meta)
+
+
+def _demand(root: Path, stem: str, source: str):
+    path = root / f"{stem}.py"
+    path.write_text(source, encoding="utf-8")
+    receipts, _ = authenticated_import_use_receipts(
+        root, path, source, blake3_512_of(source.encode("utf-8")), module_identities={}
+    )
+    assert len(receipts) == 1
+    return receipts[0]
+
+
+def _session(graph, *, enabled: bool = True) -> SourceResolutionSession:
+    name = graph.distribution_name
+    assert name, "fixture distribution must be named"
+    return SourceResolutionSession(
+        enabled=enabled, enrolled_distributions=frozenset({name})
+    )
+
+
+def _chain(resolved: ResolvedPythonObjectV1) -> list[tuple[str, str]]:
+    """The hop path this resolution testifies to, from-module -> to-module."""
+    return [(w.from_module, w.to_module) for w in resolved.reexport_warrants]
+
+
+# ---------------------------------------------------------------- fixture
+
+
+def _shared_middle_files(marker: str) -> dict[str, str]:
+    """Two entry packages re-exporting one name through one shared middle.
+
+    ``marker`` keeps each test's module bytes unique: SourceUnits are memoized
+    by (source_cid, workspace-relative filename), so byte-identical fixtures in
+    two tests would share one unit and hide a per-test difference (#7364).
+    """
+    return {
+        "shared_pkg/__init__.py": f"# entry {marker}\nfrom mid_pkg import build\n",
+        "other_pkg/__init__.py": f"# other entry {marker}\nfrom mid_pkg import build\n",
+        "mid_pkg/__init__.py": (
+            f"# middle {marker}\nfrom mid_pkg.implementation import build\n"
+        ),
+        "mid_pkg/implementation.py": (
+            f"# implementation {marker}\ndef build(value):\n    return value\n"
+        ),
+    }
+
+
+_TOPS = ("shared_pkg", "other_pkg", "mid_pkg")
+_HOPS = [("shared_pkg", "mid_pkg"), ("mid_pkg", "mid_pkg.implementation")]
+_OTHER_HOPS = [("other_pkg", "mid_pkg"), ("mid_pkg", "mid_pkg.implementation")]
+_MIDDLE_HOPS = [("mid_pkg", "mid_pkg.implementation")]
+
+
+# ------------------------------------------------------- twin 1: the hop
+
+
+def test_second_path_through_a_shared_middle_reaches_the_definition(
+    tmp_path: Path,
+) -> None:
+    """A hop that hits the terminal memo still testifies to a whole chain.
+
+    ``shared_pkg`` and ``other_pkg`` both re-export ``build`` through
+    ``mid_pkg``.  Resolving the first fills the terminal memo for
+    ``mid_pkg``; the second arrives at that key with its own path
+    warrant and must compose, not refuse.
+    """
+    graph = DependencyArtifactGraph.authenticate(
+        _dist(tmp_path, name="shared-pkg", files=_shared_middle_files("twin-one"), tops=_TOPS)
+    )
+    session = _session(graph)
+
+    first = resolve_import_binding(
+        _demand(tmp_path, "consumer_a", "import shared_pkg\nshared_pkg.build(1)\n"),
+        graph=graph,
+        session=session,
+    )
+    assert isinstance(first, ResolvedPythonObjectV1), first
+    assert _chain(first) == _HOPS
+
+    second = resolve_import_binding(
+        _demand(
+            tmp_path,
+            "consumer_b",
+            "import other_pkg\nother_pkg.build(2)\n",
+        ),
+        graph=graph,
+        session=session,
+    )
+    assert isinstance(second, ResolvedPythonObjectV1), second
+    assert second.module_name == "mid_pkg.implementation"
+    assert _chain(second) == _OTHER_HOPS
+    assert second.reexport_warrants[-1].to_module == second.module_name
+
+
+def test_hop_after_shared_middle_matches_the_uncached_resolve(tmp_path: Path) -> None:
+    """Discrimination arm for twin 1: the memo may change speed only.
+
+    Without the memo no terminal is ever consulted, so this run is the oracle.
+    If twin 1 passed only because the memo were disabled, this arm would still
+    pass while twin 1 failed -- they are asserted to agree.
+    """
+    graph = DependencyArtifactGraph.authenticate(
+        _dist(tmp_path, name="shared-pkg", files=_shared_middle_files("twin-one-arm"), tops=_TOPS)
+    )
+    cold = _session(graph, enabled=False)
+
+    resolve_import_binding(
+        _demand(tmp_path, "consumer_a", "import shared_pkg\nshared_pkg.build(1)\n"),
+        graph=graph,
+        session=cold,
+    )
+    second = resolve_import_binding(
+        _demand(
+            tmp_path,
+            "consumer_b",
+            "import other_pkg\nother_pkg.build(2)\n",
+        ),
+        graph=graph,
+        session=cold,
+    )
+    assert isinstance(second, ResolvedPythonObjectV1), second
+    assert _chain(second) == _OTHER_HOPS
+
+
+# ------------------------------------------------ twin 2: the pure entry
+
+
+def test_pure_entry_on_a_hop_filled_terminal_keeps_its_warrant(tmp_path: Path) -> None:
+    """A pure entry that hits a hop-filled terminal must not lose the hop.
+
+    ``mid_pkg`` is first reached as an intermediate hop, which fills the
+    terminal memo (hops never write the pure-entry memo).  A later direct
+    demand on ``mid_pkg.build`` reads that terminal.  The answer is a
+    definition in ``mid_pkg.implementation`` -- a module ``mid_pkg`` only
+    reaches through one re-export -- so the warrant for that hop must be
+    present.  An empty chain here is a definition published with no provenance.
+    """
+    graph = DependencyArtifactGraph.authenticate(
+        _dist(tmp_path, name="shared-pkg", files=_shared_middle_files("twin-two"), tops=_TOPS)
+    )
+    session = _session(graph)
+
+    resolve_import_binding(
+        _demand(tmp_path, "consumer_a", "import shared_pkg\nshared_pkg.build(1)\n"),
+        graph=graph,
+        session=session,
+    )
+    direct = resolve_import_binding(
+        _demand(
+            tmp_path,
+            "consumer_c",
+            "import mid_pkg\nmid_pkg.build(3)\n",
+        ),
+        graph=graph,
+        session=session,
+    )
+    assert isinstance(direct, ResolvedPythonObjectV1), direct
+    assert direct.module_name == "mid_pkg.implementation"
+    assert _chain(direct) == _MIDDLE_HOPS
+
+
+def test_pure_entry_after_hop_matches_the_uncached_resolve(tmp_path: Path) -> None:
+    """Discrimination arm for twin 2: the uncached resolve is the oracle."""
+    graph = DependencyArtifactGraph.authenticate(
+        _dist(tmp_path, name="shared-pkg", files=_shared_middle_files("twin-two-arm"), tops=_TOPS)
+    )
+    cold = _session(graph, enabled=False)
+
+    resolve_import_binding(
+        _demand(tmp_path, "consumer_a", "import shared_pkg\nshared_pkg.build(1)\n"),
+        graph=graph,
+        session=cold,
+    )
+    direct = resolve_import_binding(
+        _demand(
+            tmp_path,
+            "consumer_c",
+            "import mid_pkg\nmid_pkg.build(3)\n",
+        ),
+        graph=graph,
+        session=cold,
+    )
+    assert isinstance(direct, ResolvedPythonObjectV1), direct
+    assert _chain(direct) == _MIDDLE_HOPS


### PR DESCRIPTION
Three of the four remaining census instrument failures were one message:

```
sugar.enumerate error: 're-export warrants do not reach the resolved definition'
```

**The gap was not real.** `resolve_export`'s terminal memo is keyed on `(distribution_artifact_cid, module_name, exported_name)` and stored the resolved definition while **discarding the re-export hops that key had resolved through**. The relation was always plural — pandas re-exports heavily, so one middle module is legitimately reached from several importers. The first arrival paid the hops; every later arrival read a triple pointing at a module its own chain never names, and `ResolvedPythonObjectV1`'s reaching invariant refused it as an untyped `ValueError` that minted no row and voided the whole shard.

Same shape as `OpaqueSourceCallRosterV1` an hour earlier: a relation that was always plural, keyed as if singular.

## The second, silent defect

> the hop restamped a chain that stopped short and raised; **the pure entry restamped `()` and silently published a definition with no provenance at all**

One door voided shards loudly. The other published unprovenanced definitions with no error, no void, no signal. Both are fixed: the memo now stores the suffix it resolved through, and each reader composes its own path with that suffix.

## Verified on battleaxe

- `test_reexport_terminal_memo_warrant_chain.py` + `test_census_reexport_memo_hole.py` → **12 passed, 1 xfailed** (321s), through the `sugar.enumerate` census door on the real pandas seats.
- The xfail is STRICT on `test_writers.py` — the fourth seat, which has a **different** cause — so it XPASSes loudly the day that seat banks a row. The census reports that seat independently, so nothing is masked.

Census trajectory per shard: `178/178 refused` → `80/57/41` → `67/81/32` → `70/106/3` → `65 completed / 109 panics / 4 instrument-failures`.

Toward #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix re-export terminal memos to carry warrant chain suffixes in `resolve_export`
> - When memoizing a terminal result, `_export_terminal_result` now stores only the warrant suffix below the keyed module (via a new `prefix` parameter) instead of dropping all warrants.
> - On a memo hit in a hop context, `resolve_export` now composes the caller's warrants with the memo's stored suffix via the new `_terminal_suffix` helper, so returned `ResolvedPythonObjectV1` instances include the full chain to the resolved definition.
> - Pure-entry memo hits are restamped without overriding the stored suffix, preserving correctness for callers with no prior hops.
> - New tests in [test_reexport_terminal_memo_warrant_chain.py](https://github.com/TSavo/sugar/pull/7379/files#diff-805ee97026980aed5b76ee8f2c27c6ff27aa0fd822bb4827ce6461cfcba873b4) and [test_census_reexport_memo_hole.py](https://github.com/TSavo/sugar/pull/7379/files#diff-ee71f5ef46350af728b4546995f3c56cbcc64cd6361ad54c55d530162eaa189c) verify chain integrity across shared middle re-exports and assert the fix eliminates the 're-export warrants do not reach the resolved definition' failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb3c479.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export resolution so cached lookups now keep the correct re-export chain, preserving provenance across different import paths.
  * Fixed cases where a later lookup could lose part of the hop history when results came from cache.
* **Tests**
  * Added regression coverage for re-export memoization and terminal result behavior, including shared-path and pure-entry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->