### PR TITLE
The shard attests WHO it saw, per relation (#7374)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1969,6 +1969,21 @@ def main() -> int:
     # Shard worker: emit PARTIAL only (SCOREBOARD False). Compose is a separate step.
     if shard_plan is not None:
         assert args.shard_index is not None
+        # A shard that cannot say who it saw cannot contribute to a sealed
+        # width. This is the POSITIVE side of that law: the attendance the
+        # walk actually testified to, per relation, read off the terminals it
+        # banked. When even one walked file is silent the attestation is not
+        # minted at all and the shard stays honestly unmeasured, naming it.
+        from recensus_enumerate_consumer import shard_relation_membership_attestation
+
+        membership_attestation, membership_silence = (
+            shard_relation_membership_attestation(measured_rows)
+        )
+        if membership_silence is not None:
+            _narrate(
+                "RECENSUS RELATION MEMBERSHIP REFUSED "
+                f"shard={args.shard_index} {membership_silence}"
+            )
         partial = mint_partial(
             plan=shard_plan,
             shard_index=args.shard_index,
@@ -1977,6 +1992,7 @@ def main() -> int:
             demand_table_cid=demand_table_cid,
             demand_table_identity=demand_table_identity,
             runtime_attestation=runtime_attestation,
+            relation_membership_attestation=membership_attestation,
         )
         partial_path = args.partial_out or (
             out / f"partial-s{args.shard_index:02d}.json"
@@ -1997,8 +2013,16 @@ def main() -> int:
         return 0 if partial.get("measured") else 2
 
     # Default k=1: one full-bin partial + compose (serial observation, one seal path).
+    from recensus_enumerate_consumer import shard_relation_membership_attestation
+
+    k1_membership, k1_membership_silence = shard_relation_membership_attestation(
+        measured_rows
+    )
+    if k1_membership_silence is not None:
+        _narrate(f"RECENSUS RELATION MEMBERSHIP REFUSED k1 {k1_membership_silence}")
     seal_status, result = compose_k1_from_rows(
         measured_rows,
+        relation_membership_attestation=k1_membership,
         enrolled_files=file_names,
         measured_commit=tip_commit,
         aggregate_hash=observed_pin.aggregate_hash,

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -409,6 +409,157 @@ def demand_context_manager_resolution_events(
     return events, list(result.get("gaps") or [])
 
 
+def relation_member_cid(*, relation: str, occurrence: Mapping[str, Any]) -> str:
+    """The durable member identity a membership manifest carries.
+
+    Opaque to the seal by design: the seal authenticates conservation, not how
+    a relation names its occurrences. The preimage is the producer's own
+    ``SourceOccurrenceIdentityV1`` under its relation, so two files, two
+    relations, or two occurrences never collide -- which is what lets compose
+    concatenate shard manifests and still refuse a duplicate.
+    """
+    from compose_control_effect_board import canonical_cid
+
+    return canonical_cid(
+        {
+            "schema": "recensus-relation-member/v1",
+            "relation": relation,
+            "occurrence": {
+                "file": occurrence.get("file"),
+                "sourceCid": occurrence.get("sourceCid"),
+                "start": occurrence.get("start"),
+                "end": occurrence.get("end"),
+                "nodeKind": occurrence.get("nodeKind"),
+            },
+        }
+    )
+
+
+def demand_relation_membership(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str,
+    source_workspace_root: Path | None = None,
+) -> tuple[dict[str, dict[str, list[str]]], list[dict[str, Any]]]:
+    """Who this file's walk saw, per relation, as member CIDs.
+
+    The relation vocabulary is compose's, not a second copy: a relation the
+    producer publishes that the seal does not declare is a GAP, never a
+    silently dropped population.
+    """
+    from compose_control_effect_board import RELATION_MEMBERSHIP_RELATIONS
+
+    result = enumerate_rpc(
+        level="relation-membership",
+        workspace_root=workspace_root,
+        at=file_memento(file_rel=file_rel, source_cid=source_cid),
+        seek=False,
+        options={
+            "sourceWorkspaceRoot": (
+                str(source_workspace_root)
+                if source_workspace_root is not None
+                else None
+            )
+        },
+    )
+    gaps = list(result.get("gaps") or [])
+    members: dict[str, dict[str, list[str]]] = {
+        relation: {"expected": [], "observed": []}
+        for relation in RELATION_MEMBERSHIP_RELATIONS
+    }
+    for node in result.get("nodes") or []:
+        memento = node.get("memento") if isinstance(node, dict) else None
+        if not isinstance(memento, dict):
+            gaps.append({"memento": node, "reason": "membership node has no memento"})
+            continue
+        relation = memento.get("relation")
+        role = memento.get("role")
+        occurrence = memento.get("occurrence")
+        if relation not in members:
+            gaps.append(
+                {
+                    "memento": memento,
+                    "reason": f"undeclared relation on the wire: {relation!r}",
+                }
+            )
+            continue
+        if role not in ("expected", "observed") or not isinstance(occurrence, Mapping):
+            gaps.append(
+                {"memento": memento, "reason": f"membership node role={role!r} malformed"}
+            )
+            continue
+        members[relation][role].append(
+            relation_member_cid(relation=relation, occurrence=occurrence)
+        )
+    return members, gaps
+
+
+RELATION_MEMBERSHIP_ROW_FIELD = "relationMembership"
+RELATION_MEMBERSHIP_GAP_ROW_FIELD = "relationMembershipGaps"
+
+
+def shard_relation_membership_attestation(
+    rows,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """The shard's positive attendance over the files it actually walked.
+
+    Returns ``(None, reason)`` when even ONE walked file cannot say who it
+    saw. That shard then stays UNMEASURED and the reason names the files. A
+    manifest assembled from the files that could testify would be a smaller
+    denominator wearing a seal, which is the #7351 casualty exactly.
+    """
+    from compose_control_effect_board import RELATION_MEMBERSHIP_RELATIONS
+
+    populations: dict[str, dict[str, list[str]]] = {
+        relation: {"expected": [], "observed": []}
+        for relation in RELATION_MEMBERSHIP_RELATIONS
+    }
+    silent: list[str] = []
+    for file_rel, row in rows:
+        membership = row.get(RELATION_MEMBERSHIP_ROW_FIELD) if isinstance(row, Mapping) else None
+        if not isinstance(membership, Mapping):
+            silent.append(str(file_rel))
+            continue
+        if set(membership) != set(RELATION_MEMBERSHIP_RELATIONS):
+            silent.append(str(file_rel))
+            continue
+        for relation in RELATION_MEMBERSHIP_RELATIONS:
+            side = membership[relation]
+            if not isinstance(side, Mapping) or set(side) != {"expected", "observed"}:
+                silent.append(str(file_rel))
+                break
+            populations[relation]["expected"].extend(side["expected"])
+            populations[relation]["observed"].extend(side["observed"])
+    if silent:
+        return None, (
+            "relation-membership testimony absent for "
+            f"{len(silent)} walked file(s): {sorted(set(silent))[:10]}"
+        )
+    from compose_control_effect_board import (
+        _RELATION_MEMBERSHIP_SCHEMA,
+        _member_manifest_wire,
+    )
+
+    return (
+        {
+            "schema": _RELATION_MEMBERSHIP_SCHEMA,
+            "relations": {
+                relation: {
+                    "expected": _member_manifest_wire(
+                        relation, populations[relation]["expected"]
+                    ),
+                    "observed": _member_manifest_wire(
+                        relation, populations[relation]["observed"]
+                    ),
+                }
+                for relation in RELATION_MEMBERSHIP_RELATIONS
+            },
+        },
+        None,
+    )
+
+
 def _provisional_resolution_events(
     *, contract_refs: object, source_cid: str
 ) -> list[dict[str, Any]]:
@@ -723,6 +874,68 @@ def terminal_from_enumerate(
 
 
 def measure_file_via_enumerate(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None = None,
+    contract_refs=None,
+    distribution: str | None = None,
+    source_workspace_root: Path | None = None,
+) -> dict[str, Any]:
+    """One terminal, plus the attendance the walk that produced it can testify to.
+
+    Attendance travels WITH the terminal, in the row, so it survives a
+    checkpoint resume exactly as the terminal does. A shard that resumed could
+    otherwise mint a manifest covering only the files it walked this
+    invocation -- a smaller denominator under a full-shard seal.
+    """
+    row = _terminal_via_enumerate(
+        workspace_root=workspace_root,
+        file_rel=file_rel,
+        source_cid=source_cid,
+        contract_refs=contract_refs,
+        distribution=distribution,
+        source_workspace_root=source_workspace_root,
+    )
+    observed_cid = (row.get("inputKey") or {}).get("sourceCid")
+    if not isinstance(observed_cid, str) or not observed_cid:
+        row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
+            {
+                "memento": {"file": file_rel},
+                "reason": "no authenticated source CID; membership was not demanded",
+            }
+        ]
+        return row
+    try:
+        members, membership_gaps = demand_relation_membership(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=observed_cid,
+            source_workspace_root=source_workspace_root,
+        )
+    except BaseException as error:  # noqa: BLE001 -- a silent shard, named
+        if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+            raise
+        row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
+            {
+                "memento": {"file": file_rel},
+                "reason": (
+                    "relation-membership demand raised: "
+                    f"{type(error).__name__}: {error}"
+                ),
+            }
+        ]
+        return row
+    if membership_gaps:
+        # A gap is not an empty population. Never publish membership beside
+        # one: the shard must be unable to look like it saw nobody.
+        row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = list(membership_gaps)
+        return row
+    row[RELATION_MEMBERSHIP_ROW_FIELD] = members
+    return row
+
+
+def _terminal_via_enumerate(
     *,
     workspace_root: Path,
     file_rel: str,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2171,6 +2171,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
         if level in (
             "functions",
             "context-manager-resolutions",
+            "relation-membership",
             "call_sites",
             "assertions",
             "facts",
@@ -2313,7 +2314,11 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 )
                 return
 
-            if level in {"functions", "context-manager-resolutions"}:
+            if level in {
+                "functions",
+                "context-manager-resolutions",
+                "relation-membership",
+            }:
                 # The functions level IS SourceFile.functions(): every function
                 # definition in the file, enumerated from the typed tree over
                 # oracle-pinned text. No lift runs, no IR rows are consulted,
@@ -2440,7 +2445,65 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                                 "payload": None,
                             }
                         )
-                    _send_enumerate_result(msg_id, resolution_nodes, [])
+                if level == "relation-membership":
+                    # WHO this file's ONE structural walk saw, per relation.
+                    # The producer answers; this level only transports the
+                    # answer onto the wire. A refusal here is a gap, never an
+                    # empty membership: a shard that cannot say who it saw
+                    # must not be able to look like a shard that saw nobody.
+                    try:
+                        roster = tree_file.unit.relation_membership_roster()
+                    except BaseException as refusal:  # noqa: BLE001 -- named gap
+                        if isinstance(
+                            refusal, (KeyboardInterrupt, SystemExit, GeneratorExit)
+                        ):
+                            raise
+                        _send_enumerate_result(
+                            msg_id,
+                            [],
+                            [
+                                {
+                                    "memento": at,
+                                    "reason": (
+                                        "relation-membership roster refused: "
+                                        f"{type(refusal).__name__}: {refusal}"
+                                    ),
+                                }
+                            ],
+                        )
+                        _log_enumeration_demand(
+                            str(level), at, cache="miss", started=demand_started
+                        )
+                        return
+                    membership_nodes = []
+                    membership_gaps = []
+                    for relation in sorted(roster):
+                        sides = roster[relation]
+                        for role in ("expected", "observed"):
+                            for occurrence in sides[role]:
+                                membership_nodes.append(
+                                    {
+                                        "memento": {
+                                            "kind": "relation-membership",
+                                            "file": file_rel,
+                                            "source_cid": file_cid,
+                                            "relation": relation,
+                                            "role": role,
+                                            "occurrence": {
+                                                "file": occurrence.file,
+                                                "sourceCid": occurrence.source_cid,
+                                                "start": occurrence.start,
+                                                "end": occurrence.end,
+                                                "nodeKind": occurrence.node_kind,
+                                            },
+                                        },
+                                        "audit": None,
+                                        "payload": None,
+                                    }
+                                )
+                    _send_enumerate_result(
+                        msg_id, membership_nodes, membership_gaps
+                    )
                     _log_enumeration_demand(
                         str(level), at, cache="miss", started=demand_started
                     )

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_producer.py
@@ -1,0 +1,345 @@
+"""The shard must say WHO it saw, not merely how many rows it emitted (#7374).
+
+PR #7368 built the REQUIREMENT: ``authenticate_relation_membership`` refuses a
+partial that carries no membership manifest, and ``mint_partial`` marks that
+shard unmeasured with no frontierWidth and no bodyCid. The PRODUCER side did
+not exist, so every shard defaulted the argument to ``None`` and the whole
+corpus stayed honestly unmeasured.
+
+This is the producer's contract, over the entrance the census actually uses:
+an installed distribution, ``measure_file_via_enumerate`` -> ``sugar.enumerate``
+-> ``lift_rpc._dispatch_request``. A bare ``SourceFile.from_path`` is a
+different door and proves nothing about the census.
+
+The casualty being prevented is #7351: two sealed ``frontierWidth=477``
+receipts described their observed run exactly and carried ZERO lexical-call
+testimony. A width over an unknown denominator, and no seal failed.
+
+Four facts, four teeth, and each guard dies alone under mutation:
+
+  ATTENDS   a walked file publishes positive, conserved membership for both
+            declared relations, and the shard attestation the driver hands
+            ``mint_partial`` authenticates clean.
+  SILENT    one walked file with no testimony -> NO attestation is minted and
+            the reason NAMES that file. The shard stays unmeasured.
+  GAP       a refusing roster demand -> the row carries a GAP, never an empty
+            population. A shard that cannot say who it saw must not be able to
+            look exactly like a shard that saw nobody.
+  STRANDED  an enrolled occurrence whose relation READ refuses stays in
+            ``expected`` and drops out of ``observed`` -> the seal refuses by
+            the name ``relation-membership-missing:<relation>``, which is not
+            ``-absent``, not ``-extra``, and not ``-duplicate``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    """The driver's own entrance to the consumer: by path, with a sys.modules entry."""
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONSUMER = _load("recensus_enumerate_consumer")
+COMPOSE = _load("compose_control_effect_board")
+
+SEAT = "widget/frame.py"
+FILE_REL = "widget/frame.py"
+
+# One lexical call (``inner()`` resolves to a FunctionDef binding in the
+# enclosing scope) and one target pattern (``for a, b in pairs``). Both
+# relations are populated, so neither can pass by being empty.
+SOURCE = """\
+def outer(pairs):
+    def inner():
+        return 1
+
+    total = inner()
+    seen = pairs.copy()
+    for a, b in pairs:
+        total = total + a + b + len(seen)
+    return total
+"""
+
+
+@pytest.fixture()
+def installed_corpus(tmp_path: Path) -> Path:
+    """One installed distribution whose RECORD states the seat in full."""
+    from sugar_lift_python_source.source_oracle import _recorded_seats
+
+    install_root = tmp_path / "site-packages"
+    dist_info = install_root / "widget-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "RECORD").write_text(f"{SEAT},,\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = install_root / "widget"
+    package.mkdir()
+    (package / "frame.py").write_text(SOURCE, encoding="utf-8")
+    _recorded_seats.cache_clear()
+    return install_root
+
+
+def _walk_one(install_root: Path) -> dict:
+    return CONSUMER.measure_file_via_enumerate(
+        workspace_root=install_root,
+        file_rel=FILE_REL,
+        distribution="widget",
+        source_workspace_root=install_root,
+    )
+
+
+def test_a_walked_file_attests_positive_membership_for_both_relations(
+    installed_corpus: Path,
+) -> None:
+    """ATTENDS: the census entrance publishes WHO it saw, and it authenticates."""
+    row = _walk_one(installed_corpus)
+    assert CONSUMER.RELATION_MEMBERSHIP_GAP_ROW_FIELD not in row, row.get(
+        CONSUMER.RELATION_MEMBERSHIP_GAP_ROW_FIELD
+    )
+    membership = row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD]
+    assert set(membership) == set(COMPOSE.RELATION_MEMBERSHIP_RELATIONS)
+    for relation in COMPOSE.RELATION_MEMBERSHIP_RELATIONS:
+        # Positive, not merely well-formed: an empty manifest is the unknown
+        # denominator this whole construct exists to make unreachable.
+        assert membership[relation]["expected"], relation
+        assert membership[relation]["observed"] == membership[relation]["expected"]
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row)]
+    )
+    assert silence is None
+    verdict = COMPOSE.authenticate_relation_membership(attestation)
+    assert verdict.refusal_reason() is None
+    wire = verdict.conserved_wire()
+    for relation in COMPOSE.RELATION_MEMBERSHIP_RELATIONS:
+        assert wire["relations"][relation]["observed"]["memberCount"] > 0
+
+
+def test_one_silent_file_refuses_the_whole_shard_attestation_by_name(
+    installed_corpus: Path,
+) -> None:
+    """SILENT: seven files that can testify never absorb one that cannot."""
+    row = _walk_one(installed_corpus)
+    silent_row = {"category": "completed"}
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row), ("widget/silent.py", silent_row)]
+    )
+    assert attestation is None
+    assert silence is not None
+    assert "widget/silent.py" in silence
+
+    # And the shard is then honestly unmeasured, by the ABSENT name -- which is
+    # a different fact from missing, extra, or duplicate.
+    refusal = COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+    assert refusal is not None
+    assert refusal.startswith("relation-membership-attestation-absent")
+
+
+def test_a_refusing_roster_demand_yields_a_gap_never_an_empty_population(
+    installed_corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GAP: absence and lookup-failure never share a representation.
+
+    The forbidden outcome is a well-formed manifest with zero members: it would
+    authenticate clean and seal a width over nobody. That is the 477 failure
+    with extra ceremony.
+    """
+    from sugar_source_tree.nodes import SourceUnit
+
+    def _refuse(self):
+        raise RuntimeError("roster deliberately unavailable")
+
+    monkeypatch.setattr(SourceUnit, "relation_membership_roster", _refuse)
+
+    row = _walk_one(installed_corpus)
+    assert CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD not in row
+    gaps = row[CONSUMER.RELATION_MEMBERSHIP_GAP_ROW_FIELD]
+    assert gaps
+    assert any("roster deliberately unavailable" in str(gap) for gap in gaps)
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row)]
+    )
+    assert attestation is None
+    assert silence is not None and FILE_REL in silence
+
+
+def test_an_enrolled_occurrence_the_table_never_seated_is_named_missing(
+    installed_corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """STRANDED: enrolled, never seated -> ``missing``, naming its own relation.
+
+    The lever is the producer's own enrollment mint: a call the walk classified
+    ``non-name-callee`` is published ENROLLED while the walk still seats no row
+    for it. Roster and table then disagree by exactly one occurrence, which is
+    the disagreement the two-sided manifest exists to carry.
+
+    Asserted by the SPECIFIC name. A tooth that merely required "some refusal"
+    would survive its own guard's removal on a neighbouring one.
+    """
+    from sugar_source_tree import backend as backend_module
+    from sugar_source_tree.nodes import mint_lexical_call_enrollment
+
+    def _enroll_everything(call_node, reason):
+        return mint_lexical_call_enrollment(call_node, None)
+
+    monkeypatch.setattr(
+        backend_module, "mint_lexical_call_enrollment", _enroll_everything
+    )
+    row = _walk_one(installed_corpus)
+    membership = row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD]
+    expected = membership["lexical-call"]["expected"]
+    observed = membership["lexical-call"]["observed"]
+    assert len(expected) > len(observed), (expected, observed)
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row)]
+    )
+    assert silence is None
+    refusal = COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+    assert refusal is not None
+    assert "relation-membership-missing:lexical-call" in refusal
+    assert "relation-membership-attestation-absent" not in refusal
+    assert "relation-membership-extra" not in refusal
+    assert "relation-membership-duplicate" not in refusal
+
+
+@pytest.mark.parametrize(
+    "relation", ["lexical-call", "target-pattern"]
+)
+def test_the_producers_own_members_discriminate_extra_from_duplicate(
+    installed_corpus: Path, relation: str
+) -> None:
+    """Four facts, four names, over the REAL member CIDs this producer mints.
+
+    Not a hand-rolled manifest: these are the occurrence identities the walk
+    published, so what the seal discriminates on is what the shard ships.
+    """
+    row = _walk_one(installed_corpus)
+    members = row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD]
+
+    def _attest(mutate) -> str | None:
+        mutated = {
+            name: {
+                "expected": list(sides["expected"]),
+                "observed": list(sides["observed"]),
+            }
+            for name, sides in members.items()
+        }
+        mutate(mutated[relation])
+        mutated_row = dict(row)
+        mutated_row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD] = mutated
+        attestation, silence = CONSUMER.shard_relation_membership_attestation(
+            [(FILE_REL, mutated_row)]
+        )
+        assert silence is None
+        return COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+
+    duplicate = _attest(lambda sides: sides["observed"].append(sides["observed"][0]))
+    assert duplicate is not None
+    assert f"relation-membership-duplicate:{relation}" in duplicate
+
+    extra = _attest(lambda sides: sides["expected"].pop())
+    assert extra is not None
+    assert f"relation-membership-extra:{relation}" in extra
+    assert "relation-membership-duplicate" not in extra
+
+    missing = _attest(lambda sides: sides["observed"].pop())
+    assert missing is not None
+    assert f"relation-membership-missing:{relation}" in missing
+    assert "relation-membership-extra" not in missing
+
+
+def test_a_roster_asked_before_the_walk_refuses_instead_of_answering_empty() -> None:
+    """Nobody looked is not nobody was there.
+
+    Asserted by THIS guard's own owner. "Some refusal" would be satisfied by
+    the neighbouring ``constructed_module`` refusal and would survive this
+    guard's removal, proving nothing.
+    """
+    from sugar_source_tree.nodes import SourceUnit
+
+    unit = SourceUnit(source=SOURCE, filename=FILE_REL, source_cid="test-cid")
+    with pytest.raises(BaseException) as refused:
+        unit.relation_membership_roster()
+    text = str(refused.value)
+    assert "SourceUnit.relation_membership_roster" in text, text
+    assert "enrollment roster was never published" in text, text
+
+
+def test_two_byte_identical_seats_are_two_populations_not_one(
+    tmp_path: Path,
+) -> None:
+    """#7364: SourceUnits memoize on (source_cid, filename). Members must not.
+
+    Byte-identical files share one source CID. If a member CID did not address
+    the SEAT as well as the occurrence, two seats would ship one population --
+    compose concatenates shard manifests, so the collision would surface as a
+    ``duplicate`` refusal, and a corpus with any repeated file could never
+    seal. Attendance is per seat, and this proves the CID says so.
+    """
+    from sugar_lift_python_source.source_oracle import _recorded_seats
+
+    install_root = tmp_path / "site-packages"
+    dist_info = install_root / "widget-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "RECORD").write_text(
+        "widget/frame.py,,\nwidget/twin.py,,\n", encoding="utf-8"
+    )
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = install_root / "widget"
+    package.mkdir()
+    (package / "frame.py").write_text(SOURCE, encoding="utf-8")
+    (package / "twin.py").write_text(SOURCE, encoding="utf-8")
+    _recorded_seats.cache_clear()
+
+    rows = []
+    for seat in ("widget/frame.py", "widget/twin.py"):
+        rows.append(
+            (
+                seat,
+                CONSUMER.measure_file_via_enumerate(
+                    workspace_root=install_root,
+                    file_rel=seat,
+                    distribution="widget",
+                    source_workspace_root=install_root,
+                ),
+            )
+        )
+    assert (
+        rows[0][1]["inputKey"]["sourceCid"] == rows[1][1]["inputKey"]["sourceCid"]
+    ), "the fixture must actually be byte-identical, or it proves nothing"
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(rows)
+    assert silence is None
+    refusal = COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+    assert refusal is None, refusal
+    wire = COMPOSE.authenticate_relation_membership(attestation).conserved_wire()
+    for relation in COMPOSE.RELATION_MEMBERSHIP_RELATIONS:
+        single = rows[0][1][CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD][relation]
+        assert wire["relations"][relation]["observed"]["memberCount"] == 2 * len(
+            single["observed"]
+        )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -734,6 +734,15 @@ class SourceUnit:
     typed_module: object = field(init=False, default=None)
     # Field-data memo for materialize (see construction_cache.py).
     construction_cache: object = field(init=False, default=None)
+    # Closed producer decision for EVERY constructed occurrence the ONE
+    # structural walk classified, published in walk order. Mirrors
+    # ``_ConstructedModuleV1.lexical_call_enrollments``: the walk already made
+    # this decision, so the roster is transported, never re-derived. ``None``
+    # means the walk has not run; an empty tuple means it ran and enrolled
+    # nothing. Those are not the same fact and do not share a representation.
+    _target_pattern_enrollments: object = field(
+        init=False, default=None, repr=False, compare=False
+    )
     _target_patterns_by_consumer: object = field(
         init=False, default=None, repr=False, compare=False
     )
@@ -782,6 +791,7 @@ class SourceUnit:
         object.__setattr__(self, "_import_bound_name_targets", None)
         object.__setattr__(self, "_import_value_use_resolutions", {})
         object.__setattr__(self, "_constructed_module", None)
+        object.__setattr__(self, "_target_pattern_enrollments", None)
         object.__setattr__(self, "_retained_lexical_call_rows", {})
 
     def lexical_call_enrollment(self, call: "Call") -> LexicalCallEnrollmentV1:
@@ -1130,12 +1140,17 @@ class SourceUnit:
         object.__setattr__(self, "function_nodes", function_nodes)
         patterns = {}
         patterns_by_target = {}
+        enrollments = []
         constructed_count = 0
         for consumer in constructed_nodes:
             # ONE decision, published.  The walk and every consumer of the
             # applicability question call the same function; nobody re-derives
             # enrollment from node kinds or from an empty relation read.
             enrollment = self.target_pattern_enrollment(consumer)
+            # Published from the walk that made it, positive and negative alike
+            # (#7374).  Attendance testimony reads this roster; it never walks
+            # the tree a second time to ask who should have been enrolled.
+            enrollments.append((consumer, enrollment))
             if not isinstance(enrollment, TargetPatternEnrolledV1):
                 continue
             owned = tuple(
@@ -1189,6 +1204,7 @@ class SourceUnit:
                     )
                 patterns_by_target[target_key] = pattern
             constructed_count += len(owned)
+        object.__setattr__(self, "_target_pattern_enrollments", tuple(enrollments))
         object.__setattr__(self, "_target_patterns_by_consumer", patterns)
         object.__setattr__(self, "_target_patterns_by_target", patterns_by_target)
         object.__setattr__(self, "target_pattern_construction_count", constructed_count)
@@ -1378,6 +1394,77 @@ class SourceUnit:
                 target_occurrence=None,
             )
         return owned
+
+    def relation_membership_roster(self) -> dict:
+        """Attendance for the source relations this unit's ONE walk observed.
+
+        A width sealed over a corpus must say WHO it saw, not merely how many
+        rows it emitted.  Two sealed ``frontierWidth=477`` receipts described
+        their run exactly and carried zero lexical-call testimony (#7351), so
+        the denominator was unknowable and no seal failed.  This is the
+        positive statement that makes that state impossible to reach quietly.
+
+        For each relation:
+
+        * ``expected`` is the producer's own ENROLLMENT ROSTER -- the closed
+          applicability decision the structural walk ALREADY published for
+          every occurrence it classified.
+        * ``observed`` is the RELATION TABLE population verbatim, at full
+          multiplicity.
+
+        Nothing is re-derived: both sides are publications the one walk
+        already made, and neither is computed from the other.  They are
+        separate objects with separate lifetimes, so every way they can come
+        apart has its own name at the seal -- an enrolled occurrence the table
+        never seated is ``missing``, a seated row nobody enrolled is
+        ``extra``, and a row seated twice is ``duplicate``.  A lawfully
+        not-enrolled occurrence enters neither side: absence never wears the
+        costume of a failed join.
+
+        Refuses when the walk never ran at all, because "nothing was enrolled"
+        and "nobody looked" are different facts.
+        """
+        enrollments = self._target_pattern_enrollments
+        if enrollments is None:
+            raise BackendDefect(
+                blame=self.filename,
+                owner="SourceUnit.relation_membership_roster",
+                observed="target-pattern enrollment roster was never published",
+                requested="the roster bind_typed_module publishes from its walk",
+                fix="bind the typed module before asking who the walk saw",
+            )
+        patterns_by_consumer = self._target_patterns_by_consumer
+        if patterns_by_consumer is None:
+            raise BackendDefect(
+                blame=self.filename,
+                owner="SourceUnit.relation_membership_roster",
+                observed="the target-pattern relation table was never built",
+                requested="a built relation table to read attendance from",
+                fix="bind the typed module before asking who the walk seated",
+            )
+        module = self.constructed_module
+
+        return {
+            "lexical-call": {
+                "expected": tuple(
+                    occurrence
+                    for occurrence, decision in module.lexical_call_enrollments
+                    if isinstance(decision, LexicalCallEnrolledV1)
+                ),
+                "observed": tuple(
+                    SourceOccurrenceIdentityV1.of(row.call_occurrence)
+                    for row in module.lexical_call_rows
+                ),
+            },
+            "target-pattern": {
+                "expected": tuple(
+                    SourceOccurrenceIdentityV1.of(consumer)
+                    for consumer, enrollment in enrollments
+                    if isinstance(enrollment, TargetPatternEnrolledV1)
+                ),
+                "observed": tuple(patterns_by_consumer),
+            },
+        }
 
     def require_target_pattern(self, consumer, target) -> TargetPatternV1:
         enrollment = self.target_pattern_enrollment(consumer)


### PR DESCRIPTION
#7368 built the REQUIREMENT that a sealed width carry positive relation membership. The **producer was never built**, so `mint_partial` defaulted the argument to `None`, `authenticate_relation_membership` refused, and every shard was honestly marked `measured=False`. This is the producer.

For `lexical-call` and `target-pattern` the walk publishes the two sides it already has: the **enrollment roster** the one structural walk decided, and the **relation table population verbatim**. Neither is computed from the other and neither is re-derived — so missing / extra / duplicate each keep their own name at the seal, and a lawfully not-enrolled occurrence enters neither side.

Two independent statements that must conserve. If both came from one computation, agreement would prove the computation ran, not that the populations match.

> A file whose roster demand gaps publishes a GAP and never an empty population; **one silent file refuses the whole shard attestation by name rather than shrinking the denominator.**

That is the #7351 casualty, prevented: two sealed `frontierWidth=477` receipts carrying zero lexical-call testimony.

Transport is `sugar.enumerate level=relation-membership` — the same door the census walks — and attendance travels in the terminal row, so it survives a checkpoint resume exactly as the terminal does.

## Verified on battleaxe

`test_recensus_relation_membership_producer.py` → **8 passed**.

## Census state entering this change

Run `31011125421`, per shard: **111 panics / 68 completed / 0 instrument-failures** — 179 files, complete partition, no holes. Trajectory: `178/178 refused` → `41 voids` → `32` → `4` → `0`.

Toward #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add relation-membership attestation to shard partials per observed relation
> - Adds `SourceUnit.relation_membership_roster()` in [nodes.py](https://github.com/TSavo/sugar/pull/7380/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) returning expected/observed attendance for `lexical-call` and `target-pattern` relations; raises `BackendDefect` if called before the walk.
> - Extends the enumerate RPC handler in [lift_rpc.py](https://github.com/TSavo/sugar/pull/7380/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) to support `level='relation-membership'`, returning per-occurrence membership mementos or a named gap on roster refusal.
> - Adds `demand_relation_membership` and `shard_relation_membership_attestation` to [recensus_enumerate_consumer.py](https://github.com/TSavo/sugar/pull/7380/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79); the shard-level aggregator returns `(None, reason)` if any file lacks testimony.
> - Updates [control_effect_recensus.py](https://github.com/TSavo/sugar/pull/7380/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d) to compute and pass `relation_membership_attestation` into `mint_partial` (shard path) and `compose_k1_from_rows` (k=1 path), logging a refusal if any file is silent.
> - Risk: shard partials omit the attestation entirely when any walked file fails to produce testimony, which may silently reduce attestation coverage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 847633e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relation-membership attestations to generated and composed artifacts.
  * Added support for querying expected and observed relation members.
  * Added detailed membership data, including roles, locations, node types, and detected gaps.
  * Added safeguards that reject incomplete, malformed, missing, extra, or duplicate relation memberships.
  * Added separate membership tracking for identical files used in different locations.

* **Bug Fixes**
  * Prevented incomplete or unavailable membership rosters from being published as valid attestations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->