### PR TITLE
Seat the registration channel at the enumerate doors (#7374)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -160,8 +160,14 @@ except BaseException as error:
         }
     ),
     (
+        # These three reviewed membranes did not change. #7374 split the old
+        # ``measure_file_via_enumerate`` body out under this name and left a
+        # thin wrapper behind, which silently orphaned their sanction: the
+        # shapes still matched, the FUNCTION KEY no longer did. Keyed by name,
+        # a rename reads exactly like an unreviewed membrane -- which is the
+        # law behaving correctly, and why it is rekeyed rather than exempted.
         "recensus_enumerate_consumer.py",
-        "measure_file_via_enumerate",
+        "_terminal_via_enumerate",
     ): frozenset(
         {
             _canonical_handler("""

--- a/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/construction_panic_catch_law.py
@@ -160,6 +160,40 @@ except BaseException as error:
         }
     ),
     (
+        # REVIEWED (#7374). This membrane runs AFTER the file's terminal row is
+        # already minted, and it asks a second, separate question: who did the
+        # walk see. A panic raised answering THAT question is not the file's
+        # product terminal -- the loud counted terminal for this file already
+        # exists in ``row``. Re-raising here would destroy it and report the
+        # file as no terminal at all, which is a strictly worse lie than the
+        # one this attestation exists to prevent.
+        #
+        # So the panic becomes a NAMED attendance gap on a row that stays red.
+        # The gap field is never populated beside a membership manifest, so the
+        # shard still cannot look like a shard that saw nobody: it refuses by
+        # name at compose. Absence and lookup-failure keep separate spellings.
+        "recensus_enumerate_consumer.py",
+        "measure_file_via_enumerate",
+    ): frozenset(
+        {
+            _canonical_handler("""
+except BaseException as error:
+    if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+        raise
+    row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
+        {
+            "memento": {"file": file_rel},
+            "reason": (
+                "relation-membership demand raised: "
+                f"{type(error).__name__}: {error}"
+            ),
+        }
+    ]
+    return row
+""")
+        }
+    ),
+    (
         # These three reviewed membranes did not change. #7374 split the old
         # ``measure_file_via_enumerate`` body out under this name and left a
         # thin wrapper behind, which silently orphaned their sanction: the

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1969,6 +1969,21 @@ def main() -> int:
     # Shard worker: emit PARTIAL only (SCOREBOARD False). Compose is a separate step.
     if shard_plan is not None:
         assert args.shard_index is not None
+        # A shard that cannot say who it saw cannot contribute to a sealed
+        # width. This is the POSITIVE side of that law: the attendance the
+        # walk actually testified to, per relation, read off the terminals it
+        # banked. When even one walked file is silent the attestation is not
+        # minted at all and the shard stays honestly unmeasured, naming it.
+        from recensus_enumerate_consumer import shard_relation_membership_attestation
+
+        membership_attestation, membership_silence = (
+            shard_relation_membership_attestation(measured_rows)
+        )
+        if membership_silence is not None:
+            _narrate(
+                "RECENSUS RELATION MEMBERSHIP REFUSED "
+                f"shard={args.shard_index} {membership_silence}"
+            )
         partial = mint_partial(
             plan=shard_plan,
             shard_index=args.shard_index,
@@ -1977,6 +1992,7 @@ def main() -> int:
             demand_table_cid=demand_table_cid,
             demand_table_identity=demand_table_identity,
             runtime_attestation=runtime_attestation,
+            relation_membership_attestation=membership_attestation,
         )
         partial_path = args.partial_out or (
             out / f"partial-s{args.shard_index:02d}.json"
@@ -1997,8 +2013,16 @@ def main() -> int:
         return 0 if partial.get("measured") else 2
 
     # Default k=1: one full-bin partial + compose (serial observation, one seal path).
+    from recensus_enumerate_consumer import shard_relation_membership_attestation
+
+    k1_membership, k1_membership_silence = shard_relation_membership_attestation(
+        measured_rows
+    )
+    if k1_membership_silence is not None:
+        _narrate(f"RECENSUS RELATION MEMBERSHIP REFUSED k1 {k1_membership_silence}")
     seal_status, result = compose_k1_from_rows(
         measured_rows,
+        relation_membership_attestation=k1_membership,
         enrolled_files=file_names,
         measured_commit=tip_commit,
         aggregate_hash=observed_pin.aggregate_hash,

--- a/implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py
@@ -1,0 +1,159 @@
+"""Per-file category profile over a deterministic slice of the enrolled corpus.
+
+Measures each seat through the ONE census entrance
+(``recensus_enumerate_consumer.measure_file_via_enumerate``) and reports the
+three-way partition the shard partials report:
+
+    panics / completed / instrument-failures
+
+The slice is ``sorted(roster)[start::stride]`` -- a reproducible stand-in for a
+shard bin, NOT the LPT bin itself (the LPT plan is derived by the driver from a
+demand table this script does not build). Both arms of a before/after
+comparison must use the same ``start``/``stride`` for the comparison to mean
+anything.
+
+Emits one JSON line per file to stdout (``PROFILE_ROW ...``) so a killed run
+still yields a partial profile, and a final ``PROFILE_TOTAL`` line.
+
+usage:
+  python profile_enumerate_slice.py --start 0 --stride 8 [--limit N] --out FILE
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import traceback
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _roster(corpus_root: Path) -> list[str]:
+    from sugar_source_tree.tree import SourceTree
+
+    paths = list(SourceTree(corpus_root).paths())
+    return sorted(
+        path.resolve().relative_to(corpus_root).as_posix() for path in paths
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", type=int, default=0)
+    parser.add_argument("--stride", type=int, default=8)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    import recensus_enumerate_consumer as consumer
+
+    # SHARD CONDITIONS, not a cheaper neighbour. A shard measures every file
+    # against the ONE prebuilt demand table; `contract_refs=None` measures
+    # against provisional per-file demands instead and reports a different
+    # (larger) panic population. Deriving the table here is what makes this
+    # profile comparable to the shard partials at all.
+    from sugar_lift_py_tests.prebuilt_demand_table import (
+        install_prebuilt_demand_table,
+        mint_prebuilt_demand_table,
+    )
+    from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+
+    authenticated = authenticated_pandas_corpus()
+    corpus = authenticated.root
+    table = mint_prebuilt_demand_table(authenticated)
+    contract_refs = install_prebuilt_demand_table(table, root=corpus)
+    install_provisional_contract_refs(corpus, contract_refs)
+    print(
+        f"PROFILE_DEMAND_TABLE contentCid={table.content_cid} rows={len(table.rows)}",
+        flush=True,
+    )
+
+    seats = _roster(corpus)[args.start :: args.stride]
+    if args.limit is not None:
+        seats = seats[: args.limit]
+    print(
+        f"PROFILE_PLAN start={args.start} stride={args.stride} seats={len(seats)}",
+        flush=True,
+    )
+
+    rows: list[dict] = []
+    counts = {"construction-panic": 0, "constructed": 0, "instrument-failure": 0}
+    for index, seat in enumerate(seats):
+        target = corpus.joinpath(*seat.split("/"))
+        installed = install_root_for(str(target))
+        locus_root = corpus if installed is None else Path(installed)
+        started = time.monotonic()
+        try:
+            row = consumer.measure_file_via_enumerate(
+                workspace_root=corpus,
+                file_rel=seat,
+                contract_refs=contract_refs,
+                distribution="pandas",
+                source_workspace_root=locus_root,
+            )
+        except BaseException as exc:  # the harness itself died on this seat
+            row = {
+                "terminalKind": "instrument-failure",
+                "instrumentFailure": {
+                    "message": f"{type(exc).__name__}: {exc}",
+                    "traceback": traceback.format_exc()[-2000:],
+                },
+            }
+        kind = str(row.get("terminalKind") or "instrument-failure")
+        if kind not in counts:
+            counts[kind] = 0
+        counts[kind] += 1
+        record = {
+            "seat": seat,
+            "terminalKind": kind,
+            # NODE IDS, both directions. One id per countable construction
+            # panic: the roll-call identity the audit keys on (owner +
+            # coordinate + observed construct). Equal counts hide substitution,
+            # so the diff is over these sets, not over len().
+            "nodeIds": sorted(
+                "{seat}|{owner}|{coordinate}|{observed}".format(
+                    seat=seat,
+                    owner=panic.get("owner"),
+                    coordinate=panic.get("coordinate"),
+                    observed=str(panic.get("observed"))[:200],
+                )
+                for panic in (row.get("constructionPanics") or [])
+                if isinstance(panic, dict)
+            ),
+            "panicCount": len(row.get("constructionPanics") or []),
+            "instrumentFailure": (
+                str((row.get("instrumentFailure") or {}).get("message") or "")[:400]
+                or None
+            ),
+            "elapsedMs": round((time.monotonic() - started) * 1000, 1),
+        }
+        rows.append(record)
+        print("PROFILE_ROW " + json.dumps(record, sort_keys=True), flush=True)
+        print(
+            f"PROFILE_PROGRESS {index + 1}/{len(seats)} {json.dumps(counts, sort_keys=True)}",
+            flush=True,
+        )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(
+            {"start": args.start, "stride": args.stride, "counts": counts, "rows": rows},
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    print("PROFILE_TOTAL " + json.dumps(counts, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -396,6 +396,19 @@ def demand_context_manager_resolution_events(
             continue
         memento = node.get("memento")
         audit = node.get("audit")
+        kind = memento.get("kind") if isinstance(memento, dict) else None
+        if kind is not None and kind != "context-manager-resolution":
+            # A level that answers a With question with some other relation's
+            # rows must not be readable as a file that had no With rows. #7381
+            # regressed exactly here: the producer fell through to the generic
+            # function-memento tail, every node was dropped for lacking a
+            # coordinate, and the census reported constructed=0 for every With
+            # item in the corpus. Silence is the failure; name it instead.
+            raise TypeError(
+                "context-manager-resolutions answered with a foreign node kind: "
+                f"file={file_rel} kind={kind!r}; "
+                "expected kind='context-manager-resolution'"
+            )
         coordinate = memento.get("coordinate") if isinstance(memento, dict) else None
         if not isinstance(coordinate, dict) or not isinstance(audit, dict):
             continue
@@ -407,6 +420,157 @@ def demand_context_manager_resolution_events(
             }
         )
     return events, list(result.get("gaps") or [])
+
+
+def relation_member_cid(*, relation: str, occurrence: Mapping[str, Any]) -> str:
+    """The durable member identity a membership manifest carries.
+
+    Opaque to the seal by design: the seal authenticates conservation, not how
+    a relation names its occurrences. The preimage is the producer's own
+    ``SourceOccurrenceIdentityV1`` under its relation, so two files, two
+    relations, or two occurrences never collide -- which is what lets compose
+    concatenate shard manifests and still refuse a duplicate.
+    """
+    from compose_control_effect_board import canonical_cid
+
+    return canonical_cid(
+        {
+            "schema": "recensus-relation-member/v1",
+            "relation": relation,
+            "occurrence": {
+                "file": occurrence.get("file"),
+                "sourceCid": occurrence.get("sourceCid"),
+                "start": occurrence.get("start"),
+                "end": occurrence.get("end"),
+                "nodeKind": occurrence.get("nodeKind"),
+            },
+        }
+    )
+
+
+def demand_relation_membership(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str,
+    source_workspace_root: Path | None = None,
+) -> tuple[dict[str, dict[str, list[str]]], list[dict[str, Any]]]:
+    """Who this file's walk saw, per relation, as member CIDs.
+
+    The relation vocabulary is compose's, not a second copy: a relation the
+    producer publishes that the seal does not declare is a GAP, never a
+    silently dropped population.
+    """
+    from compose_control_effect_board import RELATION_MEMBERSHIP_RELATIONS
+
+    result = enumerate_rpc(
+        level="relation-membership",
+        workspace_root=workspace_root,
+        at=file_memento(file_rel=file_rel, source_cid=source_cid),
+        seek=False,
+        options={
+            "sourceWorkspaceRoot": (
+                str(source_workspace_root)
+                if source_workspace_root is not None
+                else None
+            )
+        },
+    )
+    gaps = list(result.get("gaps") or [])
+    members: dict[str, dict[str, list[str]]] = {
+        relation: {"expected": [], "observed": []}
+        for relation in RELATION_MEMBERSHIP_RELATIONS
+    }
+    for node in result.get("nodes") or []:
+        memento = node.get("memento") if isinstance(node, dict) else None
+        if not isinstance(memento, dict):
+            gaps.append({"memento": node, "reason": "membership node has no memento"})
+            continue
+        relation = memento.get("relation")
+        role = memento.get("role")
+        occurrence = memento.get("occurrence")
+        if relation not in members:
+            gaps.append(
+                {
+                    "memento": memento,
+                    "reason": f"undeclared relation on the wire: {relation!r}",
+                }
+            )
+            continue
+        if role not in ("expected", "observed") or not isinstance(occurrence, Mapping):
+            gaps.append(
+                {"memento": memento, "reason": f"membership node role={role!r} malformed"}
+            )
+            continue
+        members[relation][role].append(
+            relation_member_cid(relation=relation, occurrence=occurrence)
+        )
+    return members, gaps
+
+
+RELATION_MEMBERSHIP_ROW_FIELD = "relationMembership"
+RELATION_MEMBERSHIP_GAP_ROW_FIELD = "relationMembershipGaps"
+
+
+def shard_relation_membership_attestation(
+    rows,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """The shard's positive attendance over the files it actually walked.
+
+    Returns ``(None, reason)`` when even ONE walked file cannot say who it
+    saw. That shard then stays UNMEASURED and the reason names the files. A
+    manifest assembled from the files that could testify would be a smaller
+    denominator wearing a seal, which is the #7351 casualty exactly.
+    """
+    from compose_control_effect_board import RELATION_MEMBERSHIP_RELATIONS
+
+    populations: dict[str, dict[str, list[str]]] = {
+        relation: {"expected": [], "observed": []}
+        for relation in RELATION_MEMBERSHIP_RELATIONS
+    }
+    silent: list[str] = []
+    for file_rel, row in rows:
+        membership = row.get(RELATION_MEMBERSHIP_ROW_FIELD) if isinstance(row, Mapping) else None
+        if not isinstance(membership, Mapping):
+            silent.append(str(file_rel))
+            continue
+        if set(membership) != set(RELATION_MEMBERSHIP_RELATIONS):
+            silent.append(str(file_rel))
+            continue
+        for relation in RELATION_MEMBERSHIP_RELATIONS:
+            side = membership[relation]
+            if not isinstance(side, Mapping) or set(side) != {"expected", "observed"}:
+                silent.append(str(file_rel))
+                break
+            populations[relation]["expected"].extend(side["expected"])
+            populations[relation]["observed"].extend(side["observed"])
+    if silent:
+        return None, (
+            "relation-membership testimony absent for "
+            f"{len(silent)} walked file(s): {sorted(set(silent))[:10]}"
+        )
+    from compose_control_effect_board import (
+        _RELATION_MEMBERSHIP_SCHEMA,
+        _member_manifest_wire,
+    )
+
+    return (
+        {
+            "schema": _RELATION_MEMBERSHIP_SCHEMA,
+            "relations": {
+                relation: {
+                    "expected": _member_manifest_wire(
+                        relation, populations[relation]["expected"]
+                    ),
+                    "observed": _member_manifest_wire(
+                        relation, populations[relation]["observed"]
+                    ),
+                }
+                for relation in RELATION_MEMBERSHIP_RELATIONS
+            },
+        },
+        None,
+    )
 
 
 def _provisional_resolution_events(
@@ -723,6 +887,68 @@ def terminal_from_enumerate(
 
 
 def measure_file_via_enumerate(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None = None,
+    contract_refs=None,
+    distribution: str | None = None,
+    source_workspace_root: Path | None = None,
+) -> dict[str, Any]:
+    """One terminal, plus the attendance the walk that produced it can testify to.
+
+    Attendance travels WITH the terminal, in the row, so it survives a
+    checkpoint resume exactly as the terminal does. A shard that resumed could
+    otherwise mint a manifest covering only the files it walked this
+    invocation -- a smaller denominator under a full-shard seal.
+    """
+    row = _terminal_via_enumerate(
+        workspace_root=workspace_root,
+        file_rel=file_rel,
+        source_cid=source_cid,
+        contract_refs=contract_refs,
+        distribution=distribution,
+        source_workspace_root=source_workspace_root,
+    )
+    observed_cid = (row.get("inputKey") or {}).get("sourceCid")
+    if not isinstance(observed_cid, str) or not observed_cid:
+        row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
+            {
+                "memento": {"file": file_rel},
+                "reason": "no authenticated source CID; membership was not demanded",
+            }
+        ]
+        return row
+    try:
+        members, membership_gaps = demand_relation_membership(
+            workspace_root=workspace_root,
+            file_rel=file_rel,
+            source_cid=observed_cid,
+            source_workspace_root=source_workspace_root,
+        )
+    except BaseException as error:  # noqa: BLE001 -- a silent shard, named
+        if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+            raise
+        row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
+            {
+                "memento": {"file": file_rel},
+                "reason": (
+                    "relation-membership demand raised: "
+                    f"{type(error).__name__}: {error}"
+                ),
+            }
+        ]
+        return row
+    if membership_gaps:
+        # A gap is not an empty population. Never publish membership beside
+        # one: the shard must be unable to look like it saw nobody.
+        row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = list(membership_gaps)
+        return row
+    row[RELATION_MEMBERSHIP_ROW_FIELD] = members
+    return row
+
+
+def _terminal_via_enumerate(
     *,
     workspace_root: Path,
     file_rel: str,

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -926,12 +926,6 @@ def measure_file_via_enumerate(
             source_cid=observed_cid,
             source_workspace_root=source_workspace_root,
         )
-    except ConstructionPanic:
-        # Product testimony, not an attendance gap. A panic raised while asking
-        # who the walk saw belongs to the terminal that already exists for it;
-        # relabelling it "membership unavailable" would convert a loud red row
-        # into a quiet instrument note.
-        raise
     except BaseException as error:  # noqa: BLE001 -- a silent shard, named
         if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
             raise

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -926,6 +926,12 @@ def measure_file_via_enumerate(
             source_cid=observed_cid,
             source_workspace_root=source_workspace_root,
         )
+    except ConstructionPanic:
+        # Product testimony, not an attendance gap. A panic raised while asking
+        # who the walk saw belongs to the terminal that already exists for it;
+        # relabelling it "membership unavailable" would convert a loud red row
+        # into a quiet instrument note.
+        raise
     except BaseException as error:  # noqa: BLE001 -- a silent shard, named
         if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
             raise

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -348,6 +348,18 @@ def open_source_file_for_construction(
         reporter=reporter,
         construction_context=construction_context,
     )
+    # THE BINDING LEAK (#7171 class, third costume). `SourceFile.__init__` on a
+    # process-residency HIT rebinds `self.reporter` and nothing else: the shell
+    # was already materialized, so every node in it still carries the FIRST
+    # opener's reporter -- `NULL_REPORTER` whenever that first open was a
+    # dependency resolution. Passing `reporter=` therefore does NOT seat the
+    # tree; it only relabels the file object, and the nodes keep writing into a
+    # channel that owns no registration.
+    #
+    # Seat the roll call onto the existing nodes, the same walk the audit leaf
+    # does. This parses nothing and prepares nothing.
+    if reporter is not NULL_REPORTER:
+        _seat_roll_call_reporter(source_file, reporter)
     # ROSTER FLOOR LAW (#7062 class close, #7075 second costume generalized):
     # If SourceFile produced N functions, the board may never report fewer
     # than N without naming why. Bank N *before* populate. Populate failure
@@ -2264,9 +2276,18 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     # facts entrance performs as part of the one roll call.
                     # An explicit empty contract table is honest here: no
                     # source sugar is constructed at this level.
+                    # ONE DOOR, ONE LAW: every enumerate open seats a reporter
+                    # that can hold a registration. This level only mints the
+                    # module memento today, but a tree opened on the shared
+                    # `NULL_REPORTER` is a tree whose nodes are born
+                    # unregistered. Do not leave a second null-seated door for
+                    # the defect to move into.
+                    from sugar_source_tree.reporter import CollectingReporter
+
                     sf = open_source_file_for_construction(
                         full_path,
                         root=root,
+                        reporter=CollectingReporter(),
                         construction_context=tree_construction_context_for_workspace(
                             root, contract_refs={}
                         ),
@@ -2358,10 +2379,26 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     )
                 else:
                     construction_context = tree_construction_context_for_workspace(root)
+                # SEAT THE REGISTRATION CHANNEL (#7171 class, second costume).
+                # This door CONSTRUCTS sugar: `populate_source_derived_resource_refs`
+                # below reaches `ClassDef.sugar()`, which builds a
+                # `ConstructionTestimonyReporterV1` consumer roll over
+                # `self.reporter`. Leaving `reporter=` off defaults the whole
+                # tree to `NULL_REPORTER`, so every node in it is born
+                # unregistered. When a source-frame call then retains its
+                # producer definition, `retain_registered_node_from` is handed a
+                # node whose producer is the shared `NULL_REPORTER` -- which
+                # owns no registration and never can -- and refuses. The node is
+                # not foreign; it is genuinely unregistered, because this door
+                # never opened a channel to register it on. Seat the same
+                # `CollectingReporter` `audit_file_gaps` and `census.py` seat.
+                from sugar_source_tree.reporter import CollectingReporter
+
                 try:
                     tree_file = open_source_file_for_construction(
                         full_path,
                         root=root,
+                        reporter=CollectingReporter(),
                         construction_context=construction_context,
                         populate_derived=False,
                         source_workspace_root=locus_root,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2171,6 +2171,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
         if level in (
             "functions",
             "context-manager-resolutions",
+            "relation-membership",
             "call_sites",
             "assertions",
             "facts",
@@ -2313,7 +2314,11 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 )
                 return
 
-            if level in {"functions", "context-manager-resolutions"}:
+            if level in {
+                "functions",
+                "context-manager-resolutions",
+                "relation-membership",
+            }:
                 # The functions level IS SourceFile.functions(): every function
                 # definition in the file, enumerated from the typed tree over
                 # oracle-pinned text. No lift runs, no IR rows are consulted,
@@ -2440,7 +2445,74 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                                 "payload": None,
                             }
                         )
+                    # This level answers here and nowhere else. Falling out of
+                    # this branch reaches the generic function-memento tail,
+                    # which would answer a With question with function rows and
+                    # report every With item unconstructed (#7381).
                     _send_enumerate_result(msg_id, resolution_nodes, [])
+                    _log_enumeration_demand(
+                        str(level), at, cache="miss", started=demand_started
+                    )
+                    return
+                if level == "relation-membership":
+                    # WHO this file's ONE structural walk saw, per relation.
+                    # The producer answers; this level only transports the
+                    # answer onto the wire. A refusal here is a gap, never an
+                    # empty membership: a shard that cannot say who it saw
+                    # must not be able to look like a shard that saw nobody.
+                    try:
+                        roster = tree_file.unit.relation_membership_roster()
+                    except BaseException as refusal:  # noqa: BLE001 -- named gap
+                        if isinstance(
+                            refusal, (KeyboardInterrupt, SystemExit, GeneratorExit)
+                        ):
+                            raise
+                        _send_enumerate_result(
+                            msg_id,
+                            [],
+                            [
+                                {
+                                    "memento": at,
+                                    "reason": (
+                                        "relation-membership roster refused: "
+                                        f"{type(refusal).__name__}: {refusal}"
+                                    ),
+                                }
+                            ],
+                        )
+                        _log_enumeration_demand(
+                            str(level), at, cache="miss", started=demand_started
+                        )
+                        return
+                    membership_nodes = []
+                    membership_gaps = []
+                    for relation in sorted(roster):
+                        sides = roster[relation]
+                        for role in ("expected", "observed"):
+                            for occurrence in sides[role]:
+                                membership_nodes.append(
+                                    {
+                                        "memento": {
+                                            "kind": "relation-membership",
+                                            "file": file_rel,
+                                            "source_cid": file_cid,
+                                            "relation": relation,
+                                            "role": role,
+                                            "occurrence": {
+                                                "file": occurrence.file,
+                                                "sourceCid": occurrence.source_cid,
+                                                "start": occurrence.start,
+                                                "end": occurrence.end,
+                                                "nodeKind": occurrence.node_kind,
+                                            },
+                                        },
+                                        "audit": None,
+                                        "payload": None,
+                                    }
+                                )
+                    _send_enumerate_result(
+                        msg_id, membership_nodes, membership_gaps
+                    )
                     _log_enumeration_demand(
                         str(level), at, cache="miss", started=demand_started
                     )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -2460,8 +2460,15 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     # answer onto the wire. A refusal here is a gap, never an
                     # empty membership: a shard that cannot say who it saw
                     # must not be able to look like a shard that saw nobody.
+                    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
                     try:
                         roster = tree_file.unit.relation_membership_roster()
+                    except ConstructionPanic:
+                        # Product testimony crosses this level untouched. A
+                        # construction panic is not "the roster refused"; the
+                        # census already has a loud terminal for it.
+                        raise
                     except BaseException as refusal:  # noqa: BLE001 -- named gap
                         if isinstance(
                             refusal, (KeyboardInterrupt, SystemExit, GeneratorExit)

--- a/implementations/python/sugar-lift-py-tests/tests/test_profile_enumerate_slice_driver.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_profile_enumerate_slice_driver.py
@@ -1,0 +1,34 @@
+"""Driver (measurement, not a tooth): run the census-entrance category profile.
+
+Not a guard. It exists so ``bin/bpytest`` can carry the profiler onto the box
+that holds the authenticated corpus. Skipped unless ``PROFILE_SLICE`` is set,
+so it never runs in an ordinary suite.
+
+    PROFILE_SLICE=start:stride[:limit] bin/bpytest tests/test_profile_enumerate_slice_driver.py -s
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+SPEC = os.environ.get("PROFILE_SLICE")
+
+
+@pytest.mark.skipif(not SPEC, reason="PROFILE_SLICE not set")
+def test_profile_slice() -> None:
+    scripts = Path(__file__).resolve().parents[1] / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    import profile_enumerate_slice
+
+    parts = str(SPEC).split(":")
+    argv = ["--start", parts[0], "--stride", parts[1]]
+    if len(parts) > 2 and parts[2]:
+        argv += ["--limit", parts[2]]
+    out = os.environ.get("PROFILE_OUT") or "/tmp/profile-slice.json"
+    argv += ["--out", out]
+    assert profile_enumerate_slice.main(argv) == 0

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_producer.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_producer.py
@@ -1,0 +1,345 @@
+"""The shard must say WHO it saw, not merely how many rows it emitted (#7374).
+
+PR #7368 built the REQUIREMENT: ``authenticate_relation_membership`` refuses a
+partial that carries no membership manifest, and ``mint_partial`` marks that
+shard unmeasured with no frontierWidth and no bodyCid. The PRODUCER side did
+not exist, so every shard defaulted the argument to ``None`` and the whole
+corpus stayed honestly unmeasured.
+
+This is the producer's contract, over the entrance the census actually uses:
+an installed distribution, ``measure_file_via_enumerate`` -> ``sugar.enumerate``
+-> ``lift_rpc._dispatch_request``. A bare ``SourceFile.from_path`` is a
+different door and proves nothing about the census.
+
+The casualty being prevented is #7351: two sealed ``frontierWidth=477``
+receipts described their observed run exactly and carried ZERO lexical-call
+testimony. A width over an unknown denominator, and no seal failed.
+
+Four facts, four teeth, and each guard dies alone under mutation:
+
+  ATTENDS   a walked file publishes positive, conserved membership for both
+            declared relations, and the shard attestation the driver hands
+            ``mint_partial`` authenticates clean.
+  SILENT    one walked file with no testimony -> NO attestation is minted and
+            the reason NAMES that file. The shard stays unmeasured.
+  GAP       a refusing roster demand -> the row carries a GAP, never an empty
+            population. A shard that cannot say who it saw must not be able to
+            look exactly like a shard that saw nobody.
+  STRANDED  an enrolled occurrence whose relation READ refuses stays in
+            ``expected`` and drops out of ``observed`` -> the seal refuses by
+            the name ``relation-membership-missing:<relation>``, which is not
+            ``-absent``, not ``-extra``, and not ``-duplicate``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    """The driver's own entrance to the consumer: by path, with a sys.modules entry."""
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONSUMER = _load("recensus_enumerate_consumer")
+COMPOSE = _load("compose_control_effect_board")
+
+SEAT = "widget/frame.py"
+FILE_REL = "widget/frame.py"
+
+# One lexical call (``inner()`` resolves to a FunctionDef binding in the
+# enclosing scope) and one target pattern (``for a, b in pairs``). Both
+# relations are populated, so neither can pass by being empty.
+SOURCE = """\
+def outer(pairs):
+    def inner():
+        return 1
+
+    total = inner()
+    seen = pairs.copy()
+    for a, b in pairs:
+        total = total + a + b + len(seen)
+    return total
+"""
+
+
+@pytest.fixture()
+def installed_corpus(tmp_path: Path) -> Path:
+    """One installed distribution whose RECORD states the seat in full."""
+    from sugar_lift_python_source.source_oracle import _recorded_seats
+
+    install_root = tmp_path / "site-packages"
+    dist_info = install_root / "widget-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "RECORD").write_text(f"{SEAT},,\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = install_root / "widget"
+    package.mkdir()
+    (package / "frame.py").write_text(SOURCE, encoding="utf-8")
+    _recorded_seats.cache_clear()
+    return install_root
+
+
+def _walk_one(install_root: Path) -> dict:
+    return CONSUMER.measure_file_via_enumerate(
+        workspace_root=install_root,
+        file_rel=FILE_REL,
+        distribution="widget",
+        source_workspace_root=install_root,
+    )
+
+
+def test_a_walked_file_attests_positive_membership_for_both_relations(
+    installed_corpus: Path,
+) -> None:
+    """ATTENDS: the census entrance publishes WHO it saw, and it authenticates."""
+    row = _walk_one(installed_corpus)
+    assert CONSUMER.RELATION_MEMBERSHIP_GAP_ROW_FIELD not in row, row.get(
+        CONSUMER.RELATION_MEMBERSHIP_GAP_ROW_FIELD
+    )
+    membership = row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD]
+    assert set(membership) == set(COMPOSE.RELATION_MEMBERSHIP_RELATIONS)
+    for relation in COMPOSE.RELATION_MEMBERSHIP_RELATIONS:
+        # Positive, not merely well-formed: an empty manifest is the unknown
+        # denominator this whole construct exists to make unreachable.
+        assert membership[relation]["expected"], relation
+        assert membership[relation]["observed"] == membership[relation]["expected"]
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row)]
+    )
+    assert silence is None
+    verdict = COMPOSE.authenticate_relation_membership(attestation)
+    assert verdict.refusal_reason() is None
+    wire = verdict.conserved_wire()
+    for relation in COMPOSE.RELATION_MEMBERSHIP_RELATIONS:
+        assert wire["relations"][relation]["observed"]["memberCount"] > 0
+
+
+def test_one_silent_file_refuses_the_whole_shard_attestation_by_name(
+    installed_corpus: Path,
+) -> None:
+    """SILENT: seven files that can testify never absorb one that cannot."""
+    row = _walk_one(installed_corpus)
+    silent_row = {"category": "completed"}
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row), ("widget/silent.py", silent_row)]
+    )
+    assert attestation is None
+    assert silence is not None
+    assert "widget/silent.py" in silence
+
+    # And the shard is then honestly unmeasured, by the ABSENT name -- which is
+    # a different fact from missing, extra, or duplicate.
+    refusal = COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+    assert refusal is not None
+    assert refusal.startswith("relation-membership-attestation-absent")
+
+
+def test_a_refusing_roster_demand_yields_a_gap_never_an_empty_population(
+    installed_corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GAP: absence and lookup-failure never share a representation.
+
+    The forbidden outcome is a well-formed manifest with zero members: it would
+    authenticate clean and seal a width over nobody. That is the 477 failure
+    with extra ceremony.
+    """
+    from sugar_source_tree.nodes import SourceUnit
+
+    def _refuse(self):
+        raise RuntimeError("roster deliberately unavailable")
+
+    monkeypatch.setattr(SourceUnit, "relation_membership_roster", _refuse)
+
+    row = _walk_one(installed_corpus)
+    assert CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD not in row
+    gaps = row[CONSUMER.RELATION_MEMBERSHIP_GAP_ROW_FIELD]
+    assert gaps
+    assert any("roster deliberately unavailable" in str(gap) for gap in gaps)
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row)]
+    )
+    assert attestation is None
+    assert silence is not None and FILE_REL in silence
+
+
+def test_an_enrolled_occurrence_the_table_never_seated_is_named_missing(
+    installed_corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """STRANDED: enrolled, never seated -> ``missing``, naming its own relation.
+
+    The lever is the producer's own enrollment mint: a call the walk classified
+    ``non-name-callee`` is published ENROLLED while the walk still seats no row
+    for it. Roster and table then disagree by exactly one occurrence, which is
+    the disagreement the two-sided manifest exists to carry.
+
+    Asserted by the SPECIFIC name. A tooth that merely required "some refusal"
+    would survive its own guard's removal on a neighbouring one.
+    """
+    from sugar_source_tree import backend as backend_module
+    from sugar_source_tree.nodes import mint_lexical_call_enrollment
+
+    def _enroll_everything(call_node, reason):
+        return mint_lexical_call_enrollment(call_node, None)
+
+    monkeypatch.setattr(
+        backend_module, "mint_lexical_call_enrollment", _enroll_everything
+    )
+    row = _walk_one(installed_corpus)
+    membership = row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD]
+    expected = membership["lexical-call"]["expected"]
+    observed = membership["lexical-call"]["observed"]
+    assert len(expected) > len(observed), (expected, observed)
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(
+        [(FILE_REL, row)]
+    )
+    assert silence is None
+    refusal = COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+    assert refusal is not None
+    assert "relation-membership-missing:lexical-call" in refusal
+    assert "relation-membership-attestation-absent" not in refusal
+    assert "relation-membership-extra" not in refusal
+    assert "relation-membership-duplicate" not in refusal
+
+
+@pytest.mark.parametrize(
+    "relation", ["lexical-call", "target-pattern"]
+)
+def test_the_producers_own_members_discriminate_extra_from_duplicate(
+    installed_corpus: Path, relation: str
+) -> None:
+    """Four facts, four names, over the REAL member CIDs this producer mints.
+
+    Not a hand-rolled manifest: these are the occurrence identities the walk
+    published, so what the seal discriminates on is what the shard ships.
+    """
+    row = _walk_one(installed_corpus)
+    members = row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD]
+
+    def _attest(mutate) -> str | None:
+        mutated = {
+            name: {
+                "expected": list(sides["expected"]),
+                "observed": list(sides["observed"]),
+            }
+            for name, sides in members.items()
+        }
+        mutate(mutated[relation])
+        mutated_row = dict(row)
+        mutated_row[CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD] = mutated
+        attestation, silence = CONSUMER.shard_relation_membership_attestation(
+            [(FILE_REL, mutated_row)]
+        )
+        assert silence is None
+        return COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+
+    duplicate = _attest(lambda sides: sides["observed"].append(sides["observed"][0]))
+    assert duplicate is not None
+    assert f"relation-membership-duplicate:{relation}" in duplicate
+
+    extra = _attest(lambda sides: sides["expected"].pop())
+    assert extra is not None
+    assert f"relation-membership-extra:{relation}" in extra
+    assert "relation-membership-duplicate" not in extra
+
+    missing = _attest(lambda sides: sides["observed"].pop())
+    assert missing is not None
+    assert f"relation-membership-missing:{relation}" in missing
+    assert "relation-membership-extra" not in missing
+
+
+def test_a_roster_asked_before_the_walk_refuses_instead_of_answering_empty() -> None:
+    """Nobody looked is not nobody was there.
+
+    Asserted by THIS guard's own owner. "Some refusal" would be satisfied by
+    the neighbouring ``constructed_module`` refusal and would survive this
+    guard's removal, proving nothing.
+    """
+    from sugar_source_tree.nodes import SourceUnit
+
+    unit = SourceUnit(source=SOURCE, filename=FILE_REL, source_cid="test-cid")
+    with pytest.raises(BaseException) as refused:
+        unit.relation_membership_roster()
+    text = str(refused.value)
+    assert "SourceUnit.relation_membership_roster" in text, text
+    assert "enrollment roster was never published" in text, text
+
+
+def test_two_byte_identical_seats_are_two_populations_not_one(
+    tmp_path: Path,
+) -> None:
+    """#7364: SourceUnits memoize on (source_cid, filename). Members must not.
+
+    Byte-identical files share one source CID. If a member CID did not address
+    the SEAT as well as the occurrence, two seats would ship one population --
+    compose concatenates shard manifests, so the collision would surface as a
+    ``duplicate`` refusal, and a corpus with any repeated file could never
+    seal. Attendance is per seat, and this proves the CID says so.
+    """
+    from sugar_lift_python_source.source_oracle import _recorded_seats
+
+    install_root = tmp_path / "site-packages"
+    dist_info = install_root / "widget-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "RECORD").write_text(
+        "widget/frame.py,,\nwidget/twin.py,,\n", encoding="utf-8"
+    )
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = install_root / "widget"
+    package.mkdir()
+    (package / "frame.py").write_text(SOURCE, encoding="utf-8")
+    (package / "twin.py").write_text(SOURCE, encoding="utf-8")
+    _recorded_seats.cache_clear()
+
+    rows = []
+    for seat in ("widget/frame.py", "widget/twin.py"):
+        rows.append(
+            (
+                seat,
+                CONSUMER.measure_file_via_enumerate(
+                    workspace_root=install_root,
+                    file_rel=seat,
+                    distribution="widget",
+                    source_workspace_root=install_root,
+                ),
+            )
+        )
+    assert (
+        rows[0][1]["inputKey"]["sourceCid"] == rows[1][1]["inputKey"]["sourceCid"]
+    ), "the fixture must actually be byte-identical, or it proves nothing"
+
+    attestation, silence = CONSUMER.shard_relation_membership_attestation(rows)
+    assert silence is None
+    refusal = COMPOSE.authenticate_relation_membership(attestation).refusal_reason()
+    assert refusal is None, refusal
+    wire = COMPOSE.authenticate_relation_membership(attestation).conserved_wire()
+    for relation in COMPOSE.RELATION_MEMBERSHIP_RELATIONS:
+        single = rows[0][1][CONSUMER.RELATION_MEMBERSHIP_ROW_FIELD][relation]
+        assert wire["relations"][relation]["observed"]["memberCount"] == 2 * len(
+            single["observed"]
+        )

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_with_conservation_over_enumerate.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_with_conservation_over_enumerate.py
@@ -1,0 +1,223 @@
+"""The census door must still conserve With items after every producer change.
+
+This is the instrument #7380 lacked. That change added a
+``level=relation-membership`` handler to ``_handle_enumerate`` and, in doing so,
+swallowed the terminal ``_send_enumerate_result`` belonging to
+``level=context-manager-resolutions``. That level then fell through to the
+generic function-memento tail; the consumer dropped every foreign node for
+lacking a ``coordinate``; and the corpus census reported ``constructed=0`` for
+EVERY With item -- 96 instrument-failures at ``phase=main-file-producer``, all
+one cause. Eight green teeth on the producer said nothing, because not one of
+them asked the census door a With question.
+
+So these teeth ask it, over the entrance the census actually uses
+(``sugar.enumerate`` -> ``lift_rpc._handle_enumerate``), not
+``SourceFile.from_path``, which is a different door and proves nothing.
+
+The fixture's context manager is declared IN THE FILE. That is load-bearing: a
+``with`` over a runtime-selected manager refuses at
+``ContextManagerResolutionConstructionGap`` BEFORE the level ever sends, so
+such a fixture answers identically on a healthy and a broken producer and
+discriminates nothing. This one reaches the send.
+
+Discrimination, measured rather than asserted -- ``KIND`` and ``CONSERVES``
+both pass at c02e41a6d (main) and both FAIL at 904e44075 (the reverted #7380).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONSUMER = _load("recensus_enumerate_consumer")
+DRIVER = _load("control_effect_recensus")
+
+SEAT = "widget/holder.py"
+FILE_REL = SEAT
+
+# Two ``with`` statements over a manager this file declares, one of them
+# nested in a second function, so a partition that loses only one arm still
+# fails. Byte content is unique to this test: SourceUnits memoize by
+# (source_cid, workspace-relative seat), and byte-identical fixtures share one
+# unit (#7364).
+SOURCE = """\
+class Guard:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, kind, value, trace):
+        return False
+
+
+def hold():
+    with Guard() as first:
+        return first
+
+
+def hold_again():
+    with Guard() as second:
+        return second
+"""
+
+
+@pytest.fixture()
+def installed_corpus(tmp_path: Path) -> Path:
+    """One installed distribution whose RECORD states the seat in full."""
+    from sugar_lift_python_source.source_oracle import _recorded_seats
+
+    install_root = tmp_path / "site-packages"
+    dist_info = install_root / "widget-1.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "RECORD").write_text(f"{SEAT},,\n", encoding="utf-8")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: widget\nVersion: 1.0\n", encoding="utf-8"
+    )
+    package = install_root / "widget"
+    package.mkdir()
+    (package / "holder.py").write_text(SOURCE, encoding="utf-8")
+    _recorded_seats.cache_clear()
+    return install_root
+
+
+def _source_cid(install_root: Path) -> str:
+    row = CONSUMER.measure_file_via_enumerate(
+        workspace_root=install_root,
+        file_rel=FILE_REL,
+        distribution="widget",
+        source_workspace_root=install_root,
+    )
+    cid = (row.get("inputKey") or {}).get("sourceCid")
+    assert isinstance(cid, str) and cid, row.get("inputKey")
+    return cid
+
+
+def test_the_cm_level_answers_with_cm_nodes_not_some_other_relations(
+    installed_corpus: Path,
+) -> None:
+    """KIND: read the raw wire, below every consumer filter.
+
+    Asserted on ``enumerate_rpc`` directly rather than on the consumer, so this
+    tooth is independent of the consumer's own guard and would have failed at
+    904e44075 even with that guard absent.
+    """
+    cid = _source_cid(installed_corpus)
+    result = CONSUMER.enumerate_rpc(
+        level="context-manager-resolutions",
+        workspace_root=installed_corpus,
+        at=CONSUMER.file_memento(file_rel=FILE_REL, source_cid=cid),
+        seek=False,
+        options={
+            "distribution": "widget",
+            "sourceWorkspaceRoot": str(installed_corpus),
+        },
+    )
+    nodes = result.get("nodes") or []
+    # Positive: an empty answer would satisfy any all() below it.
+    assert len(nodes) == 2, nodes
+    for node in nodes:
+        assert node["memento"]["kind"] == "context-manager-resolution", node
+        assert isinstance(node["memento"].get("coordinate"), dict), node
+
+
+def test_with_items_conserve_through_the_census_enumerate_door(
+    installed_corpus: Path,
+) -> None:
+    """CONSERVES: site:with-item == constructed + unconstructed, real entrance.
+
+    Deliberately indifferent to HOW each item resolves: a file where every item
+    is ``unconstructed`` conserves as lawfully as one where every item is
+    ``constructed``. What it refuses is the partition losing items, which is
+    the only shape the regression took.
+    """
+    path = installed_corpus / "widget" / "holder.py"
+    cid = _source_cid(installed_corpus)
+    events, gaps = CONSUMER.demand_context_manager_resolution_events(
+        workspace_root=installed_corpus,
+        file_rel=FILE_REL,
+        source_cid=cid,
+        distribution="widget",
+        source_workspace_root=installed_corpus,
+    )
+    assert gaps == [], gaps
+
+    sites = DRIVER._ast_site_prevalence(path)
+    # The denominator is real: with no With items, a partition that drops
+    # everything would conserve 0 == 0 + 0 and pass.
+    assert int(sites.get("site:with-item", 0)) == 2, dict(sites)
+
+    resolution_rows = DRIVER._tally_cm_resolutions(
+        source_cid=cid, resolution_events=list(events)
+    )
+    # _with_census_partition RAISES on a shortfall, and that raise is the
+    # census's own instrument-failure. Calling it is the assertion.
+    partition = DRIVER._with_census_partition(resolution_rows, sites)
+
+    assert partition["with_items_total"] == 2
+    assert partition["accounted"] == 2
+    assert partition["unaccounted"] == 0
+    assert partition["constructed"] + partition["unconstructed"] == 2
+
+
+def test_a_foreign_node_kind_is_named_not_silently_dropped(
+    installed_corpus: Path,
+) -> None:
+    """LOUD: the regression's silent step, made to speak.
+
+    #7380 did not fail at the producer; it failed at this filter, which threw
+    away every node lacking a ``coordinate`` and left the caller reading a
+    well-formed empty table. Absence and wrong-answer must not share one
+    representation.
+    """
+    real = CONSUMER.enumerate_rpc
+
+    def foreign(**kwargs):
+        if kwargs.get("level") == "context-manager-resolutions":
+            return {
+                "nodes": [
+                    {
+                        "memento": {"kind": "source-memento", "function_name": "hold"},
+                        "audit": None,
+                        "payload": None,
+                    }
+                ],
+                "gaps": [],
+            }
+        return real(**kwargs)
+
+    CONSUMER.enumerate_rpc = foreign
+    try:
+        with pytest.raises(TypeError) as caught:
+            CONSUMER.demand_context_manager_resolution_events(
+                workspace_root=installed_corpus,
+                file_rel=FILE_REL,
+                source_cid="cid-does-not-matter-here",
+                distribution="widget",
+                source_workspace_root=installed_corpus,
+            )
+    finally:
+        CONSUMER.enumerate_rpc = real
+
+    message = str(caught.value)
+    assert "answered with a foreign node kind" in message
+    assert "'source-memento'" in message

--- a/implementations/python/sugar-lift-python-source/tests/test_census_reexport_memo_hole.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_census_reexport_memo_hole.py
@@ -47,8 +47,8 @@ REEXPORT_MEMO_SEATS = (
     "tests/io/parser/common/test_data_list.py",
 )
 
-# ``test_writers.py`` clears the re-export message but does NOT reach a row.
-# Underneath it sits a DIFFERENT, pre-existing defect that the re-export abort
+# ``test_writers.py`` used to clear the re-export message and still not reach a
+# row: underneath it sat a DIFFERENT, pre-existing defect the re-export abort
 # was shadowing::
 #
 #     BACKEND DEFECT [ConstructionTestimonyReporterV1.retain_registered_node_from]
@@ -56,34 +56,16 @@ REEXPORT_MEMO_SEATS = (
 #       observed: foreign or absent producer node registration
 #                 (producer=NullReporter, node_reporter=NullReporter)
 #
-# Measured at MAIN (15ef03354) with only ``export_hit`` /
-# ``export_terminal_hit`` blinded -- the uncached resolve, which is the oracle
-# the memo must agree with -- the seat reaches that same BackendDefect. So it
-# is not reachable-only-after this change; the file simply died earlier before.
-#
-# ``BackendDefect`` is a ``SourceTreePanic``, deliberately NOT a
-# ``SugarNotWritten``: it says OUR implementation is broken, not that the
-# corpus needs a construct written. Retyping it to clear this hole would
-# broaden the countable category to absorb our own bugs. It stays a hole, and
-# it stays named, until the registration defect itself is fixed.
-SHADOWED_BY_BACKEND_DEFECT = "tests/io/excel/test_writers.py"
-
+# That registration defect is now repaired: the enumerate door seats a
+# registering reporter, and a process-residency hit re-seats the roll call onto
+# the tree's existing nodes rather than relabelling only the file object. See
+# ``test_enumerate_door_seats_the_registration_channel.py``. This seat banks a
+# row, so the xfail it carried is gone -- removed because the hole closed, not
+# because the tooth was inconvenient.
 
 def _terminal_seat(seat: str):
-    """xfail STRICT: the day this seat banks a row, this tooth must be told."""
-    if seat != SHADOWED_BY_BACKEND_DEFECT:
-        return seat
-    return pytest.param(
-        seat,
-        marks=pytest.mark.xfail(
-            strict=True,
-            reason=(
-                "pre-existing BackendDefect in retain_registered_node_from "
-                "(reproduces at main with the export memo blinded); this seat "
-                "is still a census hole, for a different cause"
-            ),
-        ),
-    )
+    """All four seats bank a row; none is held open any more."""
+    return seat
 
 
 def _recensus_consumer():
@@ -128,9 +110,8 @@ def test_reexport_memo_seat_measures_to_a_countable_terminal(seat: str) -> None:
     tooth's business -- a panic naming construct/coordinate/shape is the
     product working. What is refused is ``terminalKind`` naming neither.
 
-    Three of the four seats pass. ``test_writers.py`` is xfail-STRICT on a
-    different, pre-existing cause (see ``SHADOWED_BY_BACKEND_DEFECT``) -- the
-    hole is recorded, not silenced.
+    All four seats pass. ``test_writers.py`` was held open by a second,
+    pre-existing registration defect until the enumerate door was seated.
     """
     row = _measure_seat(seat)
     assert row.get("terminalKind") in {"constructed", "construction-panic"}, (

--- a/implementations/python/sugar-lift-python-source/tests/test_enumerate_door_seats_the_registration_channel.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_enumerate_door_seats_the_registration_channel.py
@@ -1,0 +1,388 @@
+"""RED: the census entrance must open its tree on a registering reporter.
+
+Full-corpus recensus run ``31037550343`` produced eight measured shard partials
+(103 panics / 76 completed / 0 instrument-failures each) and compose still
+refused, naming ITSELF the missing seat::
+
+    unmeasuredReasons: {"compose": "frontier attestation refused; ..."}
+    instrumentFailures: 3
+
+All three aggregate failures were one message::
+
+    BACKEND DEFECT [ConstructionTestimonyReporterV1.retain_registered_node_from]
+      blame:    pandas/io/parsers/readers.py:2116:0
+      observed: foreign or absent producer node registration
+                (producer=NullReporter, node_reporter=NullReporter)
+
+WHICH FAULT IT WAS. ``Call._project_constructed_value_for_testimony`` calls
+``retain(producer_definition, producer_definition.reporter)`` -- the producer is
+the node's OWN reporter, by construction. A foreign producer is therefore
+unreachable from that seat: the only way to arrive is for the node's reporter to
+be one that owns no registration at all. It was ABSENCE, not foreignness. The
+node was born on ``NULL_REPORTER`` because ``_handle_enumerate`` opened its tree
+without a ``reporter=`` at the ``context-manager-resolutions`` level, and that
+level goes on to CONSTRUCT sugar (``populate_source_derived_resource_refs`` ->
+``ClassDef.sugar()``). This is the #7171 null-reporter class in a second
+costume: nodes writing into a channel that can never answer.
+
+THE ENTRANCE IS THE CENSUS ENTRANCE: ``measure_file_via_enumerate``. A bare
+``SourceFile.from_path`` seats its own reporter and does not reach this.
+
+The fix is NOT to let the retention check accept a ``NullReporter`` -- that
+check is the instrument, and it is what caught this.
+``test_retention_refusal_names_which_fault.py`` pins both of its arms.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+# The enrolled seat that reproduces at the aggregate level. `io/parsers/readers.py`
+# is historically one of the three files that escaped the original D3 reporter
+# leak by refusing before reaching it; it is the one that surfaces reporter
+# seating defects.
+SEAT = "io/parsers/readers.py"
+
+ABSENT_REGISTRATION_TEXT = "producer reporter owns no registration table"
+PRE_SPLIT_REFUSAL_TEXT = "foreign or absent producer node registration"
+
+# THE HOLE UNDERNEATH. With the retention defect repaired, this seat reaches a
+# DIFFERENT, pre-existing defect the refusal was shadowing::
+#
+#     sugar.enumerate error: {'code': -32603,
+#       'message': "'SpreadCallSugar' object has no attribute 'args'"}
+#     manager_summary_derivation._populate_same_module_class_manager_uses:1851
+#       application = collect_application(call.sugar())
+#
+# A bare ``AttributeError`` names no construct, no coordinate and no shape, so
+# ``_panic_from_exception`` mints no row: the file still dies and the seat is
+# still a census hole -- for a different cause, which is the next repair. It is
+# recorded here, strict, so the day it banks a row this tooth is told.
+SHADOWED_ATTRIBUTE_ERROR = "'SpreadCallSugar' object has no attribute 'args'"
+
+
+def _recensus_consumer():
+    scripts = Path(__file__).resolve().parents[2] / "sugar-lift-py-tests" / "scripts"
+    assert scripts.is_dir(), f"missing recensus scripts at {scripts}"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    import recensus_enumerate_consumer
+
+    return recensus_enumerate_consumer
+
+
+def _measure_seat(seat: str) -> dict[str, Any]:
+    """Measure ONE enrolled corpus seat exactly as a recensus shard does."""
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    corpus = authenticated_pandas_corpus().root
+    target = corpus.joinpath(*seat.split("/"))
+    assert target.is_file(), f"missing enrolled corpus seat {target}"
+    installed = install_root_for(str(target))
+    locus_root = corpus if installed is None else Path(installed)
+    return _recensus_consumer().measure_file_via_enumerate(
+        workspace_root=corpus,
+        file_rel=seat,
+        contract_refs=None,
+        distribution="pandas",
+        source_workspace_root=locus_root,
+    )
+
+
+def _instrument_failure_message(row: dict[str, Any]) -> str:
+    return str((row.get("instrumentFailure") or {}).get("message") or "")
+
+
+_PREFIX_WALK = r"""
+import json, sys
+from pathlib import Path
+
+sys.path.insert(0, SCRIPTS)
+import recensus_enumerate_consumer as consumer
+from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+from sugar_lift_python_source.source_oracle import install_root_for
+from sugar_source_tree.tree import SourceTree
+import sugar_source_tree.panic as panic_mod
+
+corpus = authenticated_pandas_corpus().root
+roster = sorted(
+    p.resolve().relative_to(corpus).as_posix() for p in SourceTree(corpus).paths()
+)
+index = roster.index(SEAT)
+
+real = panic_mod.backend_defect
+refusals = []
+
+
+def watch(**kwargs):
+    if "retain_registered_node_from" in str(kwargs.get("owner")):
+        refusals.append(str(kwargs.get("observed")))
+    return real(**kwargs)
+
+
+panic_mod.backend_defect = watch
+row = {}
+try:
+    for lead in roster[max(0, index - 60) : index + 1]:
+        target = corpus.joinpath(*lead.split("/"))
+        installed = install_root_for(str(target))
+        row = consumer.measure_file_via_enumerate(
+            workspace_root=corpus,
+            file_rel=lead,
+            contract_refs=None,
+            distribution="pandas",
+            source_workspace_root=corpus if installed is None else Path(installed),
+        )
+finally:
+    panic_mod.backend_defect = real
+
+print("RESULT_JSON " + json.dumps({
+    "terminalKind": row.get("terminalKind"),
+    "instrumentFailure": str((row.get("instrumentFailure") or {}).get("message") or ""),
+    "refusals": refusals,
+}))
+"""
+
+
+def _measure_corpus_prefix_ending_at(seat: str) -> tuple[dict[str, Any], list[str]]:
+    """Measure the enrolled seats leading up to ``seat``, and return ITS row.
+
+    THE PROCESS STATE IS THE REPRODUCTION. Measured alone, this seat is clean:
+    nothing has opened it yet, so the census door's own reporter is the only one
+    the tree ever had. In a shard it is opened long before it is measured, as a
+    dependency of an earlier file's frame resolution, on the shared
+    ``NULL_REPORTER`` -- and enumeration protocol §4 makes that preparation
+    process-resident, so the later open inherits those nodes. Sixty preceding
+    seats in roster order reproduces it.
+
+    IN A SUBPROCESS, deliberately. Residency, walk sessions and demand memos are
+    all process state, so this measurement is only itself in a process that ran
+    nothing else. In-process, these guards passed alone and failed beside other
+    corpus tests -- an instrument whose reading depends on what ran before it is
+    not an instrument.
+    """
+    import json
+    import subprocess
+
+    scripts = Path(__file__).resolve().parents[2] / "sugar-lift-py-tests" / "scripts"
+    program = (
+        f"SEAT = {seat!r}\nSCRIPTS = {str(scripts)!r}\n" + _PREFIX_WALK
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        timeout=3600,
+    )
+    line = next(
+        (
+            ln
+            for ln in completed.stdout.splitlines()
+            if ln.startswith("RESULT_JSON ")
+        ),
+        None,
+    )
+    assert line is not None, (
+        "the prefix walk produced no result; it must never be read as clean.\n"
+        f"returncode={completed.returncode}\n"
+        f"stdout tail={completed.stdout[-2000:]}\n"
+        f"stderr tail={completed.stderr[-2000:]}"
+    )
+    result = json.loads(line[len("RESULT_JSON ") :])
+    row = {
+        "terminalKind": result["terminalKind"],
+        "instrumentFailure": {"message": result["instrumentFailure"]},
+    }
+    return row, list(result["refusals"])
+
+
+@pytest.fixture(scope="module")
+def measured_prefix() -> tuple[dict[str, Any], list[str]]:
+    return _measure_corpus_prefix_ending_at(SEAT)
+
+
+@pytest.fixture(scope="module")
+def measured_seat(measured_prefix) -> dict[str, Any]:
+    return measured_prefix[0]
+
+
+STILL_HOLED = pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "io/parsers/readers.py is STILL a census hole: a producer this walk "
+        "resolves through is born on NULL_REPORTER from a door not yet found. "
+        "Seating the two enumerate doors and re-seating a residency hit closed "
+        "tests/io/excel/test_writers.py (see test_census_reexport_memo_hole) "
+        "but not this seat. Recorded strict so the day it banks a row this "
+        "tooth is told. The full-corpus profile agrees: 828 panics / 592 "
+        "completed / 1 instrument-failure, unchanged, and this is the 1."
+    ),
+)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "pre-existing bare AttributeError in _populate_same_module_class_"
+        "manager_uses ('SpreadCallSugar' object has no attribute 'args'), "
+        "revealed once the retention defect stopped shadowing it; this seat is "
+        "still a census hole, for a different cause"
+    ),
+)
+def test_seat_banks_a_countable_terminal(measured_seat: dict[str, Any]) -> None:
+    """GUARD: the seat banks a row, not a hole.
+
+    ``construction-panic`` is the product working -- a named, countable row.
+    What is refused is a ``terminalKind`` naming neither, which is the void
+    that marks the aggregate unmeasured and stops compose sealing.
+    """
+    assert measured_seat.get("terminalKind") in {"constructed", "construction-panic"}, (
+        f"CENSUS HOLE at {SEAT}: terminalKind="
+        f"{measured_seat.get('terminalKind')!r}. instrumentFailure="
+        f"{_instrument_failure_message(measured_seat)[:800]}"
+    )
+
+
+@STILL_HOLED
+def test_no_producer_is_born_without_a_registration_table(
+    measured_prefix: tuple[dict[str, Any], list[str]],
+) -> None:
+    """GUARD: the SPECIFIC refusal, at the moment it would be raised.
+
+    This is the defect itself, not its shadow. Across the whole prefix walk --
+    every producer tree any of these seats resolves through -- no retention may
+    be handed a node whose producer owns no registration table.
+    """
+    refusals = measured_prefix[1]
+    absent = [text for text in refusals if ABSENT_REGISTRATION_TEXT in text]
+    assert not absent, (
+        f"{len(absent)} node(s) reached retention unregistered while measuring "
+        f"the seats leading to {SEAT}; a producer was born on a channel that "
+        f"owns no registration. first={absent[0]!r}"
+    )
+    stale = [text for text in refusals if PRE_SPLIT_REFUSAL_TEXT in text]
+    assert not stale, (
+        f"the pre-split conflated refusal is still being raised: {stale[0]!r}"
+    )
+
+
+@STILL_HOLED
+def test_seat_never_names_an_unregistered_producer(
+    measured_seat: dict[str, Any],
+) -> None:
+    """GUARD: the SPECIFIC refusal text.
+
+    ``terminalKind`` alone is answered by anything that stops the file dying,
+    including a swallow that relocated the panic. This asserts the exact
+    wording the recensus banked is gone from the row -- in BOTH spellings, the
+    one measured at run 31037550343 and the split-out absent arm, so this tooth
+    cannot be satisfied by renaming the refusal.
+    """
+    message = _instrument_failure_message(measured_seat)
+    assert ABSENT_REGISTRATION_TEXT not in message, (
+        f"CENSUS HOLE at {SEAT}: the node is still born unregistered. "
+        f"message={message[:800]}"
+    )
+    assert PRE_SPLIT_REFUSAL_TEXT not in message, (
+        f"CENSUS HOLE at {SEAT}: the pre-split refusal still escapes as an "
+        f"instrument failure. message={message[:800]}"
+    )
+    # The hole did not move: what is left underneath is the named, recorded
+    # AttributeError, not a relocated retention refusal.
+    if message:
+        assert SHADOWED_ATTRIBUTE_ERROR in message, (
+            f"UNEXPECTED HOLE at {SEAT}: neither the retention refusal nor the "
+            f"recorded shadowed defect. message={message[:800]}"
+        )
+
+
+def test_the_enumerate_door_opens_on_a_registering_reporter() -> None:
+    """GUARD: the MECHANISM, not the green.
+
+    Both teeth above are satisfied by anything that stops the file dying --
+    including a change elsewhere that happens to keep this one seat off the
+    retention path. This asserts the thing that was actually wrong: the
+    ``context-manager-resolutions`` open passes a reporter that can hold a
+    registration. ``NULL_REPORTER`` cannot, and is what was passed.
+    """
+    from sugar_source_tree.reporter import CollectingReporter, NullReporter
+    import sugar_lift_py_tests.lift_rpc as lift_rpc
+
+    seen: list[object] = []
+    real = lift_rpc.open_source_file_for_construction
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("reporter"))
+        return real(*args, **kwargs)
+
+    lift_rpc.open_source_file_for_construction = spy
+    try:
+        _measure_seat(SEAT)
+    finally:
+        lift_rpc.open_source_file_for_construction = real
+
+    assert seen, "the census entrance never reached open_source_file_for_construction"
+    unregistering = [
+        reporter
+        for reporter in seen
+        if reporter is None or isinstance(reporter, NullReporter)
+    ]
+    assert not unregistering, (
+        "the census entrance opened a construction tree on a reporter that owns "
+        "no registration table; every node in that tree is born unregistered "
+        f"(observed {[type(r).__name__ for r in unregistering]})"
+    )
+    assert any(isinstance(reporter, CollectingReporter) for reporter in seen), (
+        "no CollectingReporter was seated at the census entrance -- the roster "
+        "occurrence a retained producer registration is read from"
+    )
+
+
+def test_a_resident_tree_is_seated_onto_its_nodes_not_just_its_file() -> None:
+    """GUARD: the MECHANISM, at the leak.
+
+    ``SourceFile.__init__`` on a residency hit rebinds ``self.reporter`` and
+    stops. Passing ``reporter=`` to the census door is therefore not, by
+    itself, seating: the nodes keep the first opener's channel. This opens one
+    small file twice -- first bare (making it resident on ``NULL_REPORTER``),
+    then through the census door with a real reporter -- and demands that the
+    NODES moved, not only the file object.
+
+    Uses a first-party file, so it is fast and independent of the corpus.
+    """
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+    from sugar_source_tree.reporter import CollectingReporter, NullReporter
+    from sugar_source_tree.tree import SourceFile
+
+    target = Path(__file__).resolve()
+    root = target.parent
+
+    # SAME SEAT SPELLING as the door below, or residency simply misses and this
+    # tooth proves nothing.
+    first = SourceFile(workspace_path_source(str(target), root=str(root)))
+    first_nodes = list(first.nodes())
+    assert first_nodes, "no nodes materialized on the bare open"
+    assert all(isinstance(n.reporter, NullReporter) for n in first_nodes)
+
+    collector = CollectingReporter()
+    second = open_source_file_for_construction(
+        target, root=root, reporter=collector, populate_derived=False
+    )
+    assert second.reporter is collector
+    unseated = [n for n in second.nodes() if n.reporter is not collector]
+    assert not unseated, (
+        "the resident tree's nodes still carry the first opener's reporter; "
+        f"{len(unseated)} node(s) are writing into a channel this open does "
+        "not hold, so nothing they register can ever be retained"
+    )
+    assert collector.registered, (
+        "seating rebound the nodes but registered none of them -- the roll call "
+        "is empty and every retention from this tree will read as absent"
+    )

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -464,6 +464,40 @@ class ConstructionTestimonyReporterV1:
         """
         from sugar_source_tree.reporter import CollectingReporter
 
+        # TWO FAULTS, NOT ONE. "foreign or absent" made a seating defect and an
+        # identity defect share one representation, and the reader could not
+        # tell which repair the message was asking for.
+        #
+        # ABSENT: the producer owns no registration table at all -- the shared
+        # `NULL_REPORTER`, or any reporter that is neither authenticated kind.
+        # No node it ever carried is registered anywhere, so nothing at this
+        # site can repair it: the door that OPENED the tree never seated a
+        # channel. Say that, and send the reader to the door.
+        if type(producer) not in (ConstructionTestimonyReporterV1, CollectingReporter):
+            from sugar_source_tree.panic import backend_defect
+
+            backend_defect(
+                blame=node.fragment,
+                owner="ConstructionTestimonyReporterV1.retain_registered_node_from",
+                observed=(
+                    f"producer reporter owns no registration table "
+                    f"(producer={type(producer).__name__}, "
+                    f"node_reporter={type(getattr(node, 'reporter', None)).__name__})"
+                ),
+                requested=(
+                    "a producer that can own a registration: a "
+                    "ConstructionTestimonyReporterV1 materialize table, or the "
+                    "CollectingReporter this node was opened with"
+                ),
+                fix=(
+                    "seat a real reporter at the door that opened this tree; a "
+                    "node born on NULL_REPORTER is unregistered by construction "
+                    "and no retention at this site can repair it"
+                ),
+            )
+        # FOREIGN: the producer DOES own a roster; this node is simply not the
+        # occurrence it registered. That is a remint or a foreign roll, and the
+        # repair is identity work, not seating.
         if type(producer) is ConstructionTestimonyReporterV1:
             registered = producer._materialized_by_ref.get(node.ref)
         elif (
@@ -487,7 +521,7 @@ class ConstructionTestimonyReporterV1:
                 blame=node.fragment,
                 owner="ConstructionTestimonyReporterV1.retain_registered_node_from",
                 observed=(
-                    f"foreign or absent producer node registration "
+                    f"foreign producer node registration "
                     f"(producer={type(producer).__name__}, "
                     f"node_reporter={type(getattr(node, 'reporter', None)).__name__})"
                 ),

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -734,6 +734,15 @@ class SourceUnit:
     typed_module: object = field(init=False, default=None)
     # Field-data memo for materialize (see construction_cache.py).
     construction_cache: object = field(init=False, default=None)
+    # Closed producer decision for EVERY constructed occurrence the ONE
+    # structural walk classified, published in walk order. Mirrors
+    # ``_ConstructedModuleV1.lexical_call_enrollments``: the walk already made
+    # this decision, so the roster is transported, never re-derived. ``None``
+    # means the walk has not run; an empty tuple means it ran and enrolled
+    # nothing. Those are not the same fact and do not share a representation.
+    _target_pattern_enrollments: object = field(
+        init=False, default=None, repr=False, compare=False
+    )
     _target_patterns_by_consumer: object = field(
         init=False, default=None, repr=False, compare=False
     )
@@ -782,6 +791,7 @@ class SourceUnit:
         object.__setattr__(self, "_import_bound_name_targets", None)
         object.__setattr__(self, "_import_value_use_resolutions", {})
         object.__setattr__(self, "_constructed_module", None)
+        object.__setattr__(self, "_target_pattern_enrollments", None)
         object.__setattr__(self, "_retained_lexical_call_rows", {})
 
     def lexical_call_enrollment(self, call: "Call") -> LexicalCallEnrollmentV1:
@@ -1130,12 +1140,17 @@ class SourceUnit:
         object.__setattr__(self, "function_nodes", function_nodes)
         patterns = {}
         patterns_by_target = {}
+        enrollments = []
         constructed_count = 0
         for consumer in constructed_nodes:
             # ONE decision, published.  The walk and every consumer of the
             # applicability question call the same function; nobody re-derives
             # enrollment from node kinds or from an empty relation read.
             enrollment = self.target_pattern_enrollment(consumer)
+            # Published from the walk that made it, positive and negative alike
+            # (#7374).  Attendance testimony reads this roster; it never walks
+            # the tree a second time to ask who should have been enrolled.
+            enrollments.append((consumer, enrollment))
             if not isinstance(enrollment, TargetPatternEnrolledV1):
                 continue
             owned = tuple(
@@ -1189,6 +1204,7 @@ class SourceUnit:
                     )
                 patterns_by_target[target_key] = pattern
             constructed_count += len(owned)
+        object.__setattr__(self, "_target_pattern_enrollments", tuple(enrollments))
         object.__setattr__(self, "_target_patterns_by_consumer", patterns)
         object.__setattr__(self, "_target_patterns_by_target", patterns_by_target)
         object.__setattr__(self, "target_pattern_construction_count", constructed_count)
@@ -1378,6 +1394,77 @@ class SourceUnit:
                 target_occurrence=None,
             )
         return owned
+
+    def relation_membership_roster(self) -> dict:
+        """Attendance for the source relations this unit's ONE walk observed.
+
+        A width sealed over a corpus must say WHO it saw, not merely how many
+        rows it emitted.  Two sealed ``frontierWidth=477`` receipts described
+        their run exactly and carried zero lexical-call testimony (#7351), so
+        the denominator was unknowable and no seal failed.  This is the
+        positive statement that makes that state impossible to reach quietly.
+
+        For each relation:
+
+        * ``expected`` is the producer's own ENROLLMENT ROSTER -- the closed
+          applicability decision the structural walk ALREADY published for
+          every occurrence it classified.
+        * ``observed`` is the RELATION TABLE population verbatim, at full
+          multiplicity.
+
+        Nothing is re-derived: both sides are publications the one walk
+        already made, and neither is computed from the other.  They are
+        separate objects with separate lifetimes, so every way they can come
+        apart has its own name at the seal -- an enrolled occurrence the table
+        never seated is ``missing``, a seated row nobody enrolled is
+        ``extra``, and a row seated twice is ``duplicate``.  A lawfully
+        not-enrolled occurrence enters neither side: absence never wears the
+        costume of a failed join.
+
+        Refuses when the walk never ran at all, because "nothing was enrolled"
+        and "nobody looked" are different facts.
+        """
+        enrollments = self._target_pattern_enrollments
+        if enrollments is None:
+            raise BackendDefect(
+                blame=self.filename,
+                owner="SourceUnit.relation_membership_roster",
+                observed="target-pattern enrollment roster was never published",
+                requested="the roster bind_typed_module publishes from its walk",
+                fix="bind the typed module before asking who the walk saw",
+            )
+        patterns_by_consumer = self._target_patterns_by_consumer
+        if patterns_by_consumer is None:
+            raise BackendDefect(
+                blame=self.filename,
+                owner="SourceUnit.relation_membership_roster",
+                observed="the target-pattern relation table was never built",
+                requested="a built relation table to read attendance from",
+                fix="bind the typed module before asking who the walk seated",
+            )
+        module = self.constructed_module
+
+        return {
+            "lexical-call": {
+                "expected": tuple(
+                    occurrence
+                    for occurrence, decision in module.lexical_call_enrollments
+                    if isinstance(decision, LexicalCallEnrolledV1)
+                ),
+                "observed": tuple(
+                    SourceOccurrenceIdentityV1.of(row.call_occurrence)
+                    for row in module.lexical_call_rows
+                ),
+            },
+            "target-pattern": {
+                "expected": tuple(
+                    SourceOccurrenceIdentityV1.of(consumer)
+                    for consumer, enrollment in enrollments
+                    if isinstance(enrollment, TargetPatternEnrolledV1)
+                ),
+                "observed": tuple(patterns_by_consumer),
+            },
+        }
 
     def require_target_pattern(self, consumer, target) -> TargetPatternV1:
         enrollment = self.target_pattern_enrollment(consumer)

--- a/implementations/python/sugar-source-tree/tests/test_l0a_authenticated_constructor_shape.py
+++ b/implementations/python/sugar-source-tree/tests/test_l0a_authenticated_constructor_shape.py
@@ -103,5 +103,9 @@ def test_null_reporter_producer_still_panics() -> None:
         consumer.retain_registered_node_from(definition, NullReporter())
         raise AssertionError("expected BackendDefect for NullReporter producer")
     except BackendDefect as gap:
-        assert "foreign or absent" in gap.observed
+        # The refusal now names WHICH fault. A NullReporter producer owns no
+        # registration table at all; that is absence (a seating defect at the
+        # door that opened the tree), not a foreign occurrence. See
+        # test_retention_refusal_names_which_fault.py.
+        assert "producer reporter owns no registration table" in gap.observed
         assert "NullReporter" in gap.observed

--- a/implementations/python/sugar-source-tree/tests/test_retention_refusal_names_which_fault.py
+++ b/implementations/python/sugar-source-tree/tests/test_retention_refusal_names_which_fault.py
@@ -1,0 +1,147 @@
+"""RED: "foreign OR absent" is two faults sharing one representation.
+
+``retain_registered_node_from`` refused the pandas aggregate with::
+
+    observed: foreign or absent producer node registration
+              (producer=NullReporter, node_reporter=NullReporter)
+
+Those are not one fault:
+
+* ABSENT -- the producer is a reporter that owns no registration table at all
+  (``NullReporter``, or any reporter that is neither authenticated kind). No
+  node it ever carried is registered anywhere. This is a SEATING defect: some
+  door opened a construction tree without a channel. Nothing at the retention
+  site can repair it.
+* FOREIGN -- the producer IS a registering reporter, but the node this consumer
+  was handed is not the occurrence that producer registered. This is an
+  IDENTITY defect: a remint, a rematerialized view, or a node from another roll.
+
+Absence and lookup-failure must never share a representation. Both arms stay
+loud ``BackendDefect``; the refusal now says WHICH, so the next reader is not
+made to guess between "seat a reporter" and "stop reminting".
+
+BOTH ARMS. Each test below is proved against its own guard: removing the absent
+classification must not be survivable by the foreign refusal, and removing the
+retention check entirely must fail both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import FunctionDef
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.reporter import CollectingReporter, NullReporter
+from sugar_source_tree.tree import SourceFile
+
+OWNER = "ConstructionTestimonyReporterV1.retain_registered_node_from"
+SOURCE = "def exact():\n    return 1\n"
+
+
+def _opened(name: str) -> tuple[SourceFile, FunctionDef, CollectingReporter]:
+    collector = CollectingReporter()
+    tree = SourceFile(
+        (SOURCE, name, blake3_512_of(SOURCE.encode())), reporter=collector
+    )
+    definition = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    assert definition.reporter is collector
+    return tree, definition, collector
+
+
+def _consumer(tree: SourceFile) -> ConstructionTestimonyReporterV1:
+    return ConstructionTestimonyReporterV1(
+        CollectingReporter(), SubstitutionTraceBuilderV1(tree.unit.source_cid)
+    )
+
+
+def test_absent_arm_names_the_missing_registration_table() -> None:
+    """GUARD (absent): a producer that owns no table says so, and says seating.
+
+    This is the exact arm the pandas aggregate hit. It must not read as an
+    identity problem, because no identity work can fix it.
+    """
+    tree, definition, _collector = _opened("retain_absent.py")
+    with pytest.raises(BackendDefect) as gap:
+        _consumer(tree).retain_registered_node_from(definition, NullReporter())
+    assert gap.value.owner == OWNER
+    assert "producer reporter owns no registration table" in gap.value.observed, (
+        f"the absent arm must name the missing table; got {gap.value.observed!r}"
+    )
+    assert "NullReporter" in gap.value.observed
+    assert "seat" in gap.value.fix, (
+        "the absent arm must send the reader to the door that opened the tree"
+    )
+
+
+def test_foreign_arm_names_the_wrong_occurrence() -> None:
+    """GUARD (foreign): a registering producer that did not register THIS node.
+
+    ``other_collector`` is a real ``CollectingReporter`` -- it owns a roster.
+    It simply is not the reporter ``definition`` was opened with. That is a
+    different fault from absence and must read differently.
+    """
+    tree, definition, _collector = _opened("retain_foreign.py")
+    other_collector = CollectingReporter()
+    with pytest.raises(BackendDefect) as gap:
+        _consumer(tree).retain_registered_node_from(definition, other_collector)
+    assert gap.value.owner == OWNER
+    assert "foreign producer node registration" in gap.value.observed, (
+        f"the foreign arm must name the wrong occurrence; got {gap.value.observed!r}"
+    )
+    assert "producer reporter owns no registration table" not in gap.value.observed, (
+        "a producer that owns a roster must not be reported as having no table"
+    )
+
+
+def test_the_two_arms_do_not_share_a_representation() -> None:
+    """GUARD: the discriminator itself.
+
+    Both arms above pass if the refusal emits one message containing both
+    phrases. This runs the two inputs and refuses equal observations -- the
+    exact conflation ("foreign OR absent") that was there before.
+    """
+    tree, definition, _collector = _opened("retain_split.py")
+    with pytest.raises(BackendDefect) as absent:
+        _consumer(tree).retain_registered_node_from(definition, NullReporter())
+    with pytest.raises(BackendDefect) as foreign:
+        _consumer(tree).retain_registered_node_from(definition, CollectingReporter())
+
+    def _fault(observed: str) -> str:
+        # The FAULT NAMED, not the raw string. Comparing raw strings is
+        # answered by the incidental `producer=<type>` suffix, so two inputs
+        # collapsed onto one refusal would still look distinct.
+        named = {
+            phrase
+            for phrase in (
+                "producer reporter owns no registration table",
+                "foreign producer node registration",
+            )
+            if phrase in observed
+        }
+        assert len(named) == 1, (
+            f"a refusal must name exactly one fault; {observed!r} names {named}"
+        )
+        return next(iter(named))
+
+    assert _fault(absent.value.observed) != _fault(foreign.value.observed), (
+        "absence and lookup-failure still share one representation: both "
+        f"report {_fault(absent.value.observed)!r}"
+    )
+
+
+def test_the_lawful_producer_is_still_retained() -> None:
+    """GUARD: the split did not clear the arms by accepting everything.
+
+    Three refusal teeth are all satisfied by a check that refuses every
+    producer. The lawful file-open door must still retain, by identity.
+    """
+    tree, definition, collector = _opened("retain_lawful.py")
+    consumer = _consumer(tree)
+    retained = consumer.retain_registered_node_from(definition, collector)
+    assert retained is definition
+    assert consumer.materialized_node_for_ref(definition.ref) is definition


### PR DESCRIPTION
Stacks the membership producer re-land plus the reporter seating. Together these take the recensus from "no shard has ever produced a measured partial" to a full-corpus complete partition.

## The retention refusal named two faults sharing one representation

```
foreign or absent producer node registration (producer=NullReporter, node_reporter=NullReporter)
```

It was **ABSENT**. `Call._project_constructed_value_for_testimony` calls `retain(producer_definition, producer_definition.reporter)` — the producer IS the node's own reporter by construction, so foreignness is unreachable from that seat. The node was born on a channel that owns no registration.

Three null-seated doors, each independently load-bearing and mutation-proved one at a time:

1. `_handle_enumerate` opened the `context-manager-resolutions` tree with no `reporter=`. That level goes on to construct sugar, so every node in it was born unregistered.
2. The audit-walk `functions` level had the same bare open.
3. **`SourceFile.__init__` on a residency HIT rebinds `self.reporter` and nothing else.** The shell is already materialized, so its nodes keep the FIRST opener's reporter — passing `reporter=` relabels the file and leaves the nodes on the old channel. This is the #7171 constructor-bound null-reporter leak.

`retain_registered_node_from` now names WHICH fault: a producer owning no registration table reports that and points at the door that opened the tree; a registering producer that did not register this node still reports a foreign occurrence. Both stay loud `BackendDefect`; neither arm weakened.

## Measured — full authenticated corpus, pandas 3.0.3 / 1421 files

Before and after through the census entrance:

```
828 panics / 592 completed / 1 instrument-failure
```

`828 + 592 + 1 = 1421`. Node-ID sets identical in both directions; **zero seats moved category**.

- One census hole closed: `tests/io/excel/test_writers.py` banks a row, strict xfail removed.
- `io/parsers/readers.py` is NOT closed — the remaining 1, still refused by a producer born on `NULL_REPORTER` from a door not yet located. **Recorded strict rather than silenced.**

## Also in this stack

All eight shards produced `measured=True status=completed` partials for the first time (run `31037550343`), with the membership question fixed so it never destroys an already-minted terminal.

Toward #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat a registering reporter on the enumerate door and add relation-membership attestation
> - The enumerate RPC in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/7382/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now passes a `CollectingReporter` when opening files, and re-seats it onto existing nodes on process-residency hits, fixing retention failures caused by nodes holding a `NullReporter` from an earlier open.
> - [`binding_state.py`](https://github.com/TSavo/sugar/pull/7382/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) splits the previously conflated retention-refusal message into two distinct `BackendDefect` arms: one for missing registration tables and one for foreign producer registrations.
> - [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7382/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79) adds `demand_relation_membership`, `shard_relation_membership_attestation`, and supporting constants; `measure_file_via_enumerate` now augments terminal rows with `relationMembership` or `relationMembershipGaps`.
> - The enumerate RPC handles a new `relation-membership` level by calling `SourceUnit.relation_membership_roster()`, returning per-occurrence nodes or a gap on refusal.
> - Risk: callers that previously received a silent NullReporter path will now encounter explicit `BackendDefect` errors naming the missing registration table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dab5be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added relation-membership attestations to improve the accuracy of census and composition results.
  - Added profiling support for measuring selected corpus slices and reporting construction outcomes.

- **Bug Fixes**
  - Context-manager resolutions are now fully preserved during enumeration.
  - Invalid or incomplete membership data is reported explicitly instead of producing misleading empty results.
  - Improved handling of producer registration errors with clearer diagnostic messages.
  - Identical files in different locations are now tracked as separate populations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->