### PR TITLE
Open the auditFrontier facts leaf through the construction door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -607,15 +607,33 @@ def demand_construction_residual(
     workspace_root: Path,
     file_rel: str,
     source_cid: str | None = None,
+    distribution: str | None = None,
+    source_workspace_root: Path | None = None,
 ) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
-    """D3: sugar.enumerate level=facts + auditFrontier → construction residual."""
+    """D3: sugar.enumerate level=facts + auditFrontier → construction residual.
+
+    ``distribution`` and ``source_workspace_root`` travel with the demand for
+    the same reason D2 carries them: D3 CONSTRUCTS, so its open needs the same
+    preconstruction authority and the same locus authority D2 used. Sending D3
+    with less than D2 had is what let the frontier report a manufactured
+    ``RuntimeSelectedContextManager`` at every ``With``.
+    """
     at = file_memento(file_rel=file_rel, source_cid=source_cid)
     result = enumerate_rpc(
         level="facts",
         workspace_root=workspace_root,
         at=at,
         seek=True,
-        options={"auditFrontier": True, "allowedBrokenComponents": ["python"]},
+        options={
+            "auditFrontier": True,
+            "allowedBrokenComponents": ["python"],
+            "distribution": distribution,
+            "sourceWorkspaceRoot": (
+                str(source_workspace_root)
+                if source_workspace_root is not None
+                else None
+            ),
+        },
     )
     gaps = list(result.get("gaps") or [])
     nodes = list(result.get("nodes") or [])
@@ -1143,6 +1161,8 @@ def _terminal_via_enumerate(
             workspace_root=workspace_root,
             file_rel=file_rel,
             source_cid=source_cid,
+            distribution=distribution,
+            source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 — residual failed; roster stands
         if _is_process_control(error):

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1860,10 +1860,43 @@ def _seat_roll_call_reporter(source_file, reporter) -> None:
         reporter.register(node)
 
 
+def audit_frontier_construction_context(root: Path):
+    """The ONE preconstruction authority every ``auditFrontier`` level opens with.
+
+    Bound authenticated refs when the Rust prebind installed them; otherwise the
+    provisional demand table for this workspace root. Never ``None`` and never an
+    empty stand-in: a tree opened without this authority makes every ``With``
+    report ``RuntimeSelectedContextManager`` regardless of resolvability, which
+    is a manufactured frontier, not a measurement.
+
+    This does NOT manufacture a contract ref. It supplies the table the use-site
+    is looked up in; a use-site with no row still resolves to a typed
+    ``ContextManagerResolutionGapV1`` and stays a countable construction panic.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+    )
+
+    if _BOUND_CONTRACT_REFS is not None or _BOUND_CALL_CONTRACT_REFS is not None:
+        return TreeConstructionContextV1(
+            (
+                _BOUND_CONTRACT_REFS
+                if _BOUND_CONTRACT_REFS is not None
+                else provisional_contract_refs_from_demands(root)
+            ),
+            call_contract_refs=_BOUND_CALL_CONTRACT_REFS,
+            workspace_root=str(root),
+        )
+    return tree_construction_context_for_workspace(root)
+
+
 def _roll_call_audit_leaf(
     full_path: Path,
     file_rel: str,
     *,
+    root: Path,
+    locus_root: Path | None = None,
+    distribution: str | None = None,
     expected_source_cid: str | None = None,
 ) -> dict:
     from sugar_lift_py_tests.kit_rpc import AuditLeafEnvelopeDto
@@ -1876,7 +1909,6 @@ def _roll_call_audit_leaf(
     """
     from sugar_source_tree.reporter import CollectingReporter
     from sugar_source_tree.roll_call import discharge
-    from sugar_source_tree.tree import SourceFile
 
     from sugar_lift_py_tests.tree_enumerate import source_audit_from_report
 
@@ -1888,8 +1920,29 @@ def _roll_call_audit_leaf(
     )
     source_file = None
     try:
-        source_file = SourceFile.from_path(str(full_path), reporter=reporter)
-        _seat_roll_call_reporter(source_file, reporter)
+        # THE CONSTRUCTION DOOR, never the bare one. `discharge` drives
+        # `.sugar()` over the whole tree, so this scope CONSTRUCTS. Opening
+        # through the bare path door gave the tree no construction context,
+        # and a context-less tree paints every `With`
+        # `RuntimeSelectedContextManager` regardless of resolvability -- one
+        # panic per file, at the file's FIRST `with`, masking everything behind
+        # it. See scripts/construction_context_door_law.py; the production
+        # `functions` level and `audit_file_gaps` already open this way.
+        source_file = open_source_file_for_construction(
+            full_path,
+            root=root,
+            reporter=reporter,
+            construction_context=audit_frontier_construction_context(root),
+            source_workspace_root=locus_root,
+            # Source-derived manager refs are frozen at exact use-sites only
+            # when the demand names its enrolled distribution -- the same
+            # condition D2's `context-manager-resolutions` level requires. A
+            # demand without one is NOT quietly derived against a guessed
+            # roster: it constructs against the contract table alone, and any
+            # manager that would have derived stays a countable panic.
+            populate_derived=bool(distribution),
+            distribution=distribution,
+        )
         report = discharge(source_file)
     finally:
         if expected_source_cid is not None:
@@ -2312,6 +2365,14 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                     leaf = _roll_call_audit_leaf(
                         full_path,
                         file_rel,
+                        root=root,
+                        locus_root=locus_root,
+                        distribution=(
+                            options.get("distribution")
+                            if isinstance(options.get("distribution"), str)
+                            and options.get("distribution")
+                            else None
+                        ),
                         expected_source_cid=(
                             str(expected_source_cid)
                             if isinstance(expected_source_cid, str)

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_frontier_construction_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_frontier_construction_door.py
@@ -137,31 +137,34 @@ def test_facts_leaf_keeps_the_unresolvable_with_a_countable_panic(
     ), with_gaps
 
 
-def test_facts_leaf_unmasks_what_sits_behind_the_first_with(tmp_path: Path) -> None:
-    """ARM THREE. The point of unmasking: a later function is now measured too.
+def test_facts_leaf_terminal_names_the_resolution_that_actually_ran(
+    tmp_path: Path,
+) -> None:
+    """ARM THREE. The terminal carries testimony only a real resolution can carry.
 
-    The masked board reported ONE panic per file because the file's first
-    ``with`` terminated the roll. ``second`` here holds an unrelated, differently
-    owned gap. It is only observable once the ``with`` in ``first`` stops being a
-    manufactured terminal -- which is why a RISING panic count is discovery.
+    A missing authority has nothing to say about the manager: it reports the
+    same sentence at every use-site. A resolution that RAN reports what it
+    found -- here the demand row's own ``runtime-selected`` kind, at this exact
+    use-site. That suffix is unforgeable by the absent-authority arm, which is
+    what makes this a discriminator rather than a restatement of arm two.
+
+    NOT asserted here: that a later function in the same file now gets
+    measured. An unresolvable ``with`` still terminates the module root, so a
+    file whose only ``with`` cannot resolve reports the same one terminal as
+    before -- with a different, honest name. Unmasking shows up on files whose
+    ``with``es DO resolve, which needs an enrolled distribution and is measured
+    on the corpus, not here.
     """
-    (tmp_path / "behind.py").write_text(
-        "def first(manager):\n"
-        "    with manager:\n"
-        "        pass\n"
-        "\n"
-        "\n"
-        "def second():\n"
-        "    return undefined_name\n",
-        encoding="utf-8",
-    )
+    (tmp_path / "consumer.py").write_text(UNRESOLVABLE_WITH, encoding="utf-8")
 
-    core = _facts_leaf(tmp_path, "behind.py")
-    owners = {str(gap.get("owner")) for gap in _panic_gaps(core)}
-    assert "With._construct_sugar" in owners, owners
-    assert owners - {"With._construct_sugar"}, (
-        "nothing behind the first `with` was measured -- the file is still "
-        f"terminating at it: {core['panics']}"
+    core = _facts_leaf(tmp_path, "consumer.py")
+    observed = [str(gap.get("observed")) for gap in _panic_gaps(core)]
+    assert any(
+        text.startswith(LOOKUP_FAILURE) and text != LOOKUP_FAILURE
+        for text in observed
+    ), (
+        "the terminal names no resolution outcome -- nothing resolved, the "
+        f"entrance only reported its own absence: {observed}"
     )
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_frontier_construction_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_frontier_construction_door.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""The ``auditFrontier`` facts leaf opens through the CONSTRUCTION door.
+
+``_roll_call_audit_leaf`` is the census entrance: the Rust driver walks
+``source_files -> functions -> facts`` and every countable construction panic on
+the board comes out of it. It opened the file with ``SourceFile.from_path`` --
+the bare door. A tree opened there has **no construction context**, and
+``With._prebound_manager_resolution`` reads a missing context as
+``RuntimeSelectedContextManager`` unconditionally. So every file containing a
+``with`` halted at its first one with
+
+    owner:    With.sugar
+    observed: With manager has no injected authenticated preconstruction authority
+
+regardless of whether that manager was resolvable. That is not a frontier, it is
+a mask: the width it reports is a first-terminal lower bound and everything
+behind the file's first ``with`` is invisible.
+
+**Absence and lookup-failure must never share a representation.** These are two
+different facts:
+
+* the entrance gave construction no authority to resolve against -- an
+  *instrument* defect, and the panic above is its correct name;
+* the authority was supplied and this exact use-site has no authenticated
+  contract in it -- a *product* gap, whose correct name is
+  ``ContextManagerResolutionConstructionGap`` at ``With._construct_sugar``.
+
+Supplying the authority does not weaken the ``With`` demand and never
+manufactures a contract ref. The second arm below proves the demand still bites:
+an unresolvable manager is still a countable construction panic afterwards. Only
+its NAME changes -- from the instrument's absence to the product's lookup
+failure.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests import lift_rpc
+
+# The exact text the masked board reported 772 times, one per file.
+ABSENT_AUTHORITY = "With manager has no injected authenticated preconstruction authority"
+# The exact text a supplied-but-empty authority must report instead.
+LOOKUP_FAILURE = "authenticated preconstruction resolution has no contract ref"
+
+
+def _facts_leaf(workspace: Path, file_rel: str) -> dict:
+    """One ``sugar.enumerate level=facts auditFrontier`` demand, the census entrance."""
+    captured: dict = {}
+    original = lift_rpc._send_enumerate_result
+    lift_rpc._send_enumerate_result = (
+        lambda _mid, nodes, gaps, **_kw: captured.update(nodes=nodes, gaps=gaps)
+    )
+    try:
+        lift_rpc._handle_enumerate(
+            1,
+            {
+                "level": "facts",
+                "workspace_root": str(workspace),
+                "at": {"file": file_rel},
+                "seek": True,
+                "options": {"auditFrontier": True},
+            },
+        )
+    finally:
+        lift_rpc._send_enumerate_result = original
+    assert not captured["gaps"], captured["gaps"]
+    assert len(captured["nodes"]) == 1, captured["nodes"]
+    leaf = captured["nodes"][0]["audit"]
+    return leaf["semanticCore"] if "semanticCore" in leaf else leaf
+
+
+def _panic_gaps(core: dict) -> list[dict]:
+    return [p.get("gap") or {} for p in core["panics"]]
+
+
+UNRESOLVABLE_WITH = "def use_resource(manager):\n    with manager:\n        pass\n"
+
+
+def test_facts_leaf_does_not_report_absent_construction_authority(
+    tmp_path: Path,
+) -> None:
+    """ARM ONE. The entrance supplies the authority, so the mask is gone.
+
+    RED against the bare door: with no construction context every ``with`` --
+    resolvable or not -- reports ``RuntimeSelectedContextManager`` naming a
+    MISSING AUTHORITY. The authority is the entrance's job, and the entrance
+    now does it.
+    """
+    (tmp_path / "consumer.py").write_text(UNRESOLVABLE_WITH, encoding="utf-8")
+
+    core = _facts_leaf(tmp_path, "consumer.py")
+    offenders = [
+        gap for gap in _panic_gaps(core) if ABSENT_AUTHORITY in str(gap.get("observed"))
+    ]
+    assert offenders == [], (
+        "the census entrance still constructs without preconstruction authority: "
+        f"{offenders}"
+    )
+
+
+def test_facts_leaf_keeps_the_unresolvable_with_a_countable_panic(
+    tmp_path: Path,
+) -> None:
+    """ARM TWO. Supplying the authority must not buy a single ``with`` its way in.
+
+    This manager is a bare formal parameter: nothing authenticates it, so the
+    provisional table holds a typed gap row at its use-site and no contract ref
+    is manufactured for it. It stays a countable construction panic -- named as
+    the product's own lookup failure at ``With._construct_sugar``, not as the
+    instrument's missing authority.
+
+    Without this arm, arm one is satisfiable by deleting the demand.
+    """
+    (tmp_path / "consumer.py").write_text(UNRESOLVABLE_WITH, encoding="utf-8")
+
+    core = _facts_leaf(tmp_path, "consumer.py")
+    assert core["status"] == "failed"
+    with_gaps = [
+        gap
+        for gap in _panic_gaps(core)
+        if str(gap.get("owner")) == "With._construct_sugar"
+    ]
+    assert with_gaps, f"the With demand stopped biting: {core['panics']}"
+    assert any(LOOKUP_FAILURE in str(gap.get("observed")) for gap in with_gaps), (
+        "an unresolvable manager must name the lookup failure, never a missing "
+        f"authority: {with_gaps}"
+    )
+    assert all(
+        str(gap.get("observedEventType", "")).endswith(
+            ".ContextManagerResolutionConstructionGap"
+        )
+        for gap in with_gaps
+    ), with_gaps
+
+
+def test_facts_leaf_unmasks_what_sits_behind_the_first_with(tmp_path: Path) -> None:
+    """ARM THREE. The point of unmasking: a later function is now measured too.
+
+    The masked board reported ONE panic per file because the file's first
+    ``with`` terminated the roll. ``second`` here holds an unrelated, differently
+    owned gap. It is only observable once the ``with`` in ``first`` stops being a
+    manufactured terminal -- which is why a RISING panic count is discovery.
+    """
+    (tmp_path / "behind.py").write_text(
+        "def first(manager):\n"
+        "    with manager:\n"
+        "        pass\n"
+        "\n"
+        "\n"
+        "def second():\n"
+        "    return undefined_name\n",
+        encoding="utf-8",
+    )
+
+    core = _facts_leaf(tmp_path, "behind.py")
+    owners = {str(gap.get("owner")) for gap in _panic_gaps(core)}
+    assert "With._construct_sugar" in owners, owners
+    assert owners - {"With._construct_sugar"}, (
+        "nothing behind the first `with` was measured -- the file is still "
+        f"terminating at it: {core['panics']}"
+    )
+
+
+def test_frontier_leaf_never_reaches_the_bare_door(tmp_path: Path) -> None:
+    """Enforcement ladder above prose: the leaf's own scope may not name it.
+
+    ``scripts/construction_context_door_law.py`` catches
+    ``SourceFile.from_path`` + ``.sugar()`` in one scope. This leaf drives
+    construction through ``roll_call.discharge``, which the law's syntactic
+    pattern does not see -- so the door law was silent here for as long as the
+    defect existed. This tooth closes that blind spot at the one scope that had
+    it.
+    """
+    body = inspect.getsource(lift_rpc._roll_call_audit_leaf)
+    assert "SourceFile.from_path" not in body, (
+        "the census entrance is back on the bare door; a context-less tree "
+        "paints every With RuntimeSelectedContextManager"
+    )
+    assert "open_source_file_for_construction" in body
+
+
+@pytest.mark.parametrize("source", [UNRESOLVABLE_WITH, "x = 1\n"])
+def test_facts_leaf_never_manufactures_a_contract_ref(
+    tmp_path: Path, source: str
+) -> None:
+    """No use-site is silently promoted: the authority is a table, not a grant."""
+    (tmp_path / "t.py").write_text(source, encoding="utf-8")
+
+    context = lift_rpc.audit_frontier_construction_context(tmp_path)
+    from sugar_lift_py_tests.context_manager_resolution import (
+        ContextManagerResolutionGapV1,
+    )
+
+    rows = (getattr(context.contract_refs, "by_use_site", None) or {}).values()
+    assert all(isinstance(row, ContextManagerResolutionGapV1) for row in rows), (
+        "the entrance minted a resolution it was never handed: "
+        f"{[type(row).__name__ for row in rows]}"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_frontier_construction_door.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_frontier_construction_door.py
@@ -203,3 +203,58 @@ def test_facts_leaf_never_manufactures_a_contract_ref(
         "the entrance minted a resolution it was never handed: "
         f"{[type(row).__name__ for row in rows]}"
     )
+
+
+def test_facts_leaf_opens_with_the_BOUND_refs_when_the_prebind_installed_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The authority is the AUTHENTICATED table when one exists, not a stand-in.
+
+    ``open_source_file_for_construction`` defaults a context when none is
+    passed, and that default is built from the PROVISIONAL demand table. On a
+    production shard the Rust prebind has installed authenticated resolutions;
+    constructing the frontier against provisional gap rows instead would report
+    every authenticated manager as unresolved -- a second manufactured frontier
+    wearing the first one's clothes.
+
+    So the leaf must pass the bound table explicitly. Nothing else in this file
+    can see that: with no prebind installed, the door's own default and this
+    leaf's choice coincide, and every other arm here stays green either way.
+    """
+    class _BoundRefs:
+        catalog_cid = "blake3-512:catalog-sentinel"
+        table_cid = "blake3-512:table-sentinel"
+        by_use_site: dict = {}
+
+        def require(self, _coordinate):
+            raise AssertionError("no use-site should be required in this fixture")
+
+    bound = _BoundRefs()
+    monkeypatch.setattr(lift_rpc, "_BOUND_CONTRACT_REFS", bound)
+
+    class _Stop(Exception):
+        """Halt the leaf at its open; this tooth reads the argument, not the tree."""
+
+    seen: dict = {}
+
+    def _spy(*args, **kwargs):
+        seen["construction_context"] = kwargs.get("construction_context")
+        raise _Stop
+
+    monkeypatch.setattr(lift_rpc, "open_source_file_for_construction", _spy)
+    (tmp_path / "consumer.py").write_text(UNRESOLVABLE_WITH, encoding="utf-8")
+
+    with pytest.raises(_Stop):
+        lift_rpc._roll_call_audit_leaf(
+            tmp_path / "consumer.py", "consumer.py", root=tmp_path
+        )
+
+    context = seen["construction_context"]
+    assert context is not None, (
+        "the leaf opened with no authority of its own -- it inherits the door's "
+        "provisional default and silently discards the authenticated prebind"
+    )
+    assert context.contract_refs is bound, (
+        "the leaf constructed the frontier against a table that is not the "
+        f"authenticated one: {context.contract_refs!r}"
+    )

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -321,9 +321,11 @@ def test_rpc_entry_preserves_tree_panic_role(
     requests = iter([request])
     sent = []
     monkeypatch.setattr(lift_rpc, "_recv", lambda: next(requests, None))
+    # The facts leaf opens through the CONSTRUCTION door, never the bare one.
     monkeypatch.setattr(
-        "sugar_source_tree.tree.SourceFile.from_path",
-        classmethod(lambda _cls, *_args, **_kwargs: (_ for _ in ()).throw(panic)),
+        lift_rpc,
+        "open_source_file_for_construction",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(panic),
     )
     monkeypatch.setattr(lift_rpc, "_send", sent.append)
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc_frontier_honest.py
@@ -139,7 +139,7 @@ def test_shared_cid_at_distinct_loci_stays_distinct_without_fake_panics():
     with tempfile.TemporaryDirectory() as root:
         path = Path(root, "t.py")
         path.write_text("import os\nimport os\n")
-        leaf = lift_rpc._roll_call_audit_leaf(path, "t.py")
+        leaf = lift_rpc._roll_call_audit_leaf(path, "t.py", root=Path(root))
 
     panics = leaf["semanticCore"]["panics"]
     owners = [(p["demandedSource"], p["terminalGapLocus"]) for p in panics]
@@ -175,6 +175,7 @@ def test_d3_residency_observer_distinguishes_real_miss_and_hit(tmp_path):
     lift_rpc._roll_call_audit_leaf(
         path,
         "t.py",
+        root=tmp_path,
         expected_source_cid=source_cid,
     )
     miss = lift_rpc.take_d3_residency_observation(source_cid)
@@ -193,6 +194,7 @@ def test_d3_residency_observer_distinguishes_real_miss_and_hit(tmp_path):
     lift_rpc._roll_call_audit_leaf(
         path,
         "t.py",
+        root=tmp_path,
         expected_source_cid=source_cid,
     )
     hit = lift_rpc.take_d3_residency_observation(source_cid)

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_audit_presence_tuple.py
@@ -149,7 +149,6 @@ def test_lying_twin_lift_rpc_roll_call_uses_the_one_door(
 ) -> None:
     """lift_rpc must not re-derive presence by CID; it uses the one door."""
     from sugar_lift_py_tests import lift_rpc
-    from sugar_source_tree.tree import SourceFile
     import sugar_source_tree.roll_call as roll_call
 
     report = _split_presence_report()
@@ -168,15 +167,18 @@ def test_lying_twin_lift_rpc_roll_call_uses_the_one_door(
             self.gaps: list = []
             self.present = list(report.reporter.present)
 
+    # The leaf opens through the CONSTRUCTION door, never `SourceFile.from_path`
+    # (a context-less tree paints every With RuntimeSelectedContextManager).
+    # Stub that door, so this test still exercises the real projection.
     monkeypatch.setattr(
-        SourceFile, "from_path", classmethod(lambda cls, *a, **k: _SF())
+        lift_rpc, "open_source_file_for_construction", lambda *a, **k: _SF()
     )
     monkeypatch.setattr(roll_call, "discharge", lambda sf: report)
     monkeypatch.setattr("sugar_source_tree.reporter.CollectingReporter", _Reporter)
 
     path = tmp_path / "t.py"
     path.write_text("# seat file\n", encoding="utf-8")
-    leaf = lift_rpc._roll_call_audit_leaf(path, "t.py")
+    leaf = lift_rpc._roll_call_audit_leaf(path, "t.py", root=tmp_path)
     audit = leaf["auxiliaryRows"]["sourceAudit"]
 
     assert _status_by_line(audit) == {

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -86,6 +86,12 @@ binaries = ["sugar"]
 command = ["python", "-m", "sugar_lift_py_tests.authenticated_pytest"]
 network = "none"
 
+[tasks.frontier-profile]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py"]
+network = "none"
+
 [tasks.authenticated-no-call-body-attribution]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]


### PR DESCRIPTION
`_roll_call_audit_leaf` is the census entrance — the Rust driver walks `source_files -> functions -> facts`, and every countable construction panic on the board comes out of it. It opened the file with `SourceFile.from_path`, **the bare door**, then drove construction through `roll_call.discharge`.

A tree opened there has no construction context, and `With._prebound_manager_resolution` reads a missing context as `RuntimeSelectedContextManager` **unconditionally**. So every file containing a `with` terminated at its first one:

```
owner:    With.sugar
observed: With manager has no injected authenticated preconstruction authority
```

regardless of whether that manager was resolvable — **772 of the 829 sealed frontier terminals, 93%, exactly one per file across 772 distinct files.**

> That is not a frontier, it is a mask.

The entrance now supplies the same preconstruction authority D2 already used (bound authenticated refs when the Rust prebind installed them, otherwise the provisional demand table for the workspace root) and the same locus root.

**No contract ref is manufactured.** A use-site with no authenticated row still resolves to a typed `ContextManagerResolutionGapV1` and stays a countable `ContextManagerResolutionConstructionGap` at `With._construct_sugar`.

## A tooth that passed for the wrong reason

Mutation-proving one guard at a time exposed a hole: replacing `construction_context=audit_frontier_construction_context(root)` with `None` left all six teeth green — `open_source_file_for_construction` **defaults** a context when none is passed, so with no prebind installed the door's default and the leaf's choice coincide and nothing could tell them apart.

They do **not** coincide on a production shard: the default is built from the PROVISIONAL demand table, so with authenticated resolutions installed, constructing against provisional gap rows would report every authenticated manager as unresolved — *a second manufactured frontier wearing the first one's clothes.*

The added tooth installs a bound table, spies the leaf's open, and requires the context it passes to carry that exact table. It is the only test in the file that dies to that mutation: **1 failed, 6 passed.**

Baseline to compare against: sealed `frontierWidth=829 / filesCompleted=592` at `e44e4a11249b` (#7374). Expect the `With.sugar` count to fall sharply and other owners to appear — **a rising or more varied panic count is DISCOVERY, not regression.**

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved construction-frontier enumeration by preserving workspace and distribution context.
  - Kept authority, lookup, and unresolved-resource outcomes distinct in diagnostics.
  - Ensured terminal messages accurately reflect the resolution path taken.
  - Preserved original panic details across RPC boundaries.
  - Prevented invalid contract references from being generated.

- **Developer Tools**
  - Added a frontier profiling task for performance analysis without network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open the audit frontier facts leaf through the construction door
> - `_roll_call_audit_leaf` in [`lift_rpc.py`](https://github.com/TSavo/sugar/pull/7383/files#diff-ae9ef9552d092f7b88255bb5b999856f8ae03f439f4afbaa391586534eefd335) now opens source files via `open_source_file_for_construction` instead of `SourceFile.from_path`, passing an explicit construction context, locus root, and optional distribution.
> - A new `audit_frontier_construction_context` helper builds a `TreeConstructionContextV1` that honors bound contract refs when present, falling back to provisional or workspace-default refs.
> - The `_handle_enumerate` facts-level branch forwards `root`, `locus_root`, and an optional `distribution` from options to the leaf, making construction distribution- and locus-aware.
> - `demand_construction_residual` in the recensus script accepts new `distribution` and `source_workspace_root` kwargs, passing them through to the enumerate RPC options.
> - Behavioral Change: unresolvable `With` references now surface as concrete lookup failures rather than missing-authority panics, since construction now uses bound/prebound contract refs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4315c58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->