### PR TITLE
Seat the implementation when a distribution records .py and .pyi

### DIFF
--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/dependency_artifact.py
@@ -629,7 +629,30 @@ class DependencyArtifactGraph:
             _require_parseable_module_source(
                 source, path=diagnostic_path, module_name=module_name
             )
-            if module_name in modules:
+            seated = modules.get(module_name)
+            if seated is not None:
+                # PEP 484: ``x.pyi`` is the STUB FOR ``x.py`` -- ONE module with
+                # two recorded seats, not two rival definitions of one name.
+                # Refusing that pair refused the whole numpy graph (151 such
+                # pairs; the first collision is ``numpy.__config__``), so every
+                # numpy manager cited ``no-derived-contract`` even though the
+                # defining source was recorded, enrolled and parseable.  The
+                # implementation seat IS the module; the stub is derivative and
+                # seats nothing.  Rivalry is unchanged: two seats that do not
+                # share one stem (``pkg.py`` vs ``pkg/__init__.py``,
+                # ``pkg/m.pyi`` vs ``pkg/m/__init__.py``) remain a duplicate
+                # module seat and are still refused.
+                seated_seat = PurePosixPath(seated.source_seat)
+                if seated_seat.with_suffix("") == relative.with_suffix(""):
+                    if seated_seat.suffix != ".py" or relative.suffix != ".pyi":
+                        # The canonical-order door above admits only
+                        # (``.py`` seated, ``.pyi`` arriving) for one stem.
+                        # Refuse rather than choose if that ever changes.
+                        raise DependencyArtifactAuthenticationError(
+                            "stub and implementation seats for "
+                            f"{module_name} are not canonically ordered"
+                        )
+                    continue
                 raise DependencyArtifactAuthenticationError(
                     f"distribution contains duplicate module seat {module_name}"
                 )
@@ -1049,9 +1072,11 @@ def _module_name(path: PurePosixPath) -> str | None:
     # in ``.so`` and the source-visible type definitions in a sibling ``.pyi``
     # (PyArrow's exception hierarchy is one such provider).  Discarding that
     # recorded, content-addressed source turns a reachable class definition
-    # into opacity.  A distribution containing both ``x.py`` and ``x.pyi``
-    # remains a duplicate module seat and is refused by the existing intake
-    # check; this door never chooses whichever file is convenient.
+    # into opacity.  A distribution containing both ``x.py`` and ``x.pyi`` is
+    # ONE module with two seats (PEP 484): the intake check seats the
+    # implementation and drops the stub.  Seats that collide on a module name
+    # WITHOUT sharing a stem stay rivals and are still refused there; this door
+    # never chooses whichever file is convenient.
     if path.suffix not in {".py", ".pyi"}:
         return None
     parts = list(path.with_suffix("").parts)

--- a/implementations/python/sugar-lift-python-source/tests/test_stub_and_implementation_module_seats.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_stub_and_implementation_module_seats.py
@@ -1,0 +1,147 @@
+"""A ``.pyi`` stub beside its ``.py`` is one module seat, not two rivals.
+
+numpy records 151 ``x.py``/``x.pyi`` pairs.  Reading the pair as a duplicate
+module seat refused the ENTIRE numpy dependency graph at the first collision
+(``numpy.__config__``), so every numpy manager in the enrolled corpus cited
+``no-derived-contract`` while its defining source sat recorded and parseable in
+the distribution.  PEP 484 is explicit that a stub declares the module its
+implementation defines; it is not a second definition of that name.
+
+The refusal itself is NOT relaxed.  Two seats that collide on a module name
+without sharing a stem stay rivals and are still refused with the same text.
+Each tooth below asserts the SPECIFIC refusal or the SPECIFIC seated
+implementation, so a neighbouring refusal cannot satisfy it.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactAuthenticationError,
+    DependencyArtifactGraph,
+)
+
+IMPLEMENTATION = "IMPLEMENTATION_MARKER = 1\n"
+STUB = "STUB_MARKER: int\n"
+
+
+def _distribution(root: Path, *, name: str, seats: dict[str, str]):
+    """Record exactly ``seats`` (seat -> source) as one installed distribution."""
+    for seat, source in seats.items():
+        path = root / seat
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    metadata = root / f"{name}-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: 1.0\n", encoding="utf-8"
+    )
+    recorded = [
+        *sorted(seats),
+        f"{name}-1.0.dist-info/METADATA",
+        f"{name}-1.0.dist-info/RECORD",
+    ]
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for seat in recorded:
+            writer.writerow((seat, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def test_stub_beside_implementation_seats_the_implementation(tmp_path: Path) -> None:
+    """The numpy shape: both seats recorded, the ``.py`` is the module.
+
+    RED before the intake change: authentication raised ``distribution contains
+    duplicate module seat stubbed_pkg`` and no module was reachable at all.
+    """
+    distribution = _distribution(
+        tmp_path,
+        name="stubbed_dist",
+        seats={
+            "stubbed_pkg/__init__.py": IMPLEMENTATION,
+            "stubbed_pkg/__init__.pyi": STUB,
+            "stubbed_pkg/inner.py": IMPLEMENTATION,
+            "stubbed_pkg/inner.pyi": STUB,
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+
+    package = graph.modules["stubbed_pkg"]
+    inner = graph.modules["stubbed_pkg.inner"]
+    # SPECIFIC: the seated source is the implementation's bytes, not the stub's.
+    assert package.source_seat == "stubbed_pkg/__init__.py"
+    assert package.source == IMPLEMENTATION
+    assert inner.source_seat == "stubbed_pkg/inner.py"
+    assert inner.source == IMPLEMENTATION
+    # The stub seats no module of its own under any spelling.
+    assert "stubbed_pkg.inner.pyi" not in graph.modules
+    # Both seats stay in the authenticated file record: dropping the stub from
+    # the module map must not silently drop it from the artifact preimage.
+    assert {item.source_seat for item in graph.files} >= {
+        "stubbed_pkg/__init__.py",
+        "stubbed_pkg/__init__.pyi",
+        "stubbed_pkg/inner.py",
+        "stubbed_pkg/inner.pyi",
+    }
+
+
+def test_stub_without_implementation_still_seats_the_stub(tmp_path: Path) -> None:
+    """A lone ``.pyi`` (native extension provider) is unchanged: it IS the seat."""
+    distribution = _distribution(
+        tmp_path,
+        name="lonestub_dist",
+        seats={
+            "lonestub_pkg/__init__.py": IMPLEMENTATION,
+            "lonestub_pkg/native.pyi": STUB,
+        },
+    )
+    graph = DependencyArtifactGraph.authenticate(distribution)
+    assert graph.modules["lonestub_pkg.native"].source == STUB
+    assert graph.modules["lonestub_pkg.native"].source_seat == (
+        "lonestub_pkg/native.pyi"
+    )
+
+
+def test_module_and_package_seats_are_still_duplicate(tmp_path: Path) -> None:
+    """``pkg.py`` beside ``pkg/__init__.py``: different stems, still refused."""
+    distribution = _distribution(
+        tmp_path,
+        name="rival_dist",
+        seats={
+            "rival_pkg/__init__.py": IMPLEMENTATION,
+            "rival_pkg.py": IMPLEMENTATION,
+        },
+    )
+    with pytest.raises(DependencyArtifactAuthenticationError) as caught:
+        DependencyArtifactGraph.authenticate(distribution)
+    assert str(caught.value) == (
+        "distribution contains duplicate module seat rival_pkg"
+    )
+
+
+def test_stub_and_package_seats_are_still_duplicate(tmp_path: Path) -> None:
+    """``pkg/m.pyi`` beside ``pkg/m/__init__.py``: a stub is not a package.
+
+    This is the tooth that a suffix-only rule would fail: both seats end in an
+    admitted suffix and one of them is a ``.pyi``, but they do not share a stem,
+    so nothing here says the stub declares that package.
+    """
+    distribution = _distribution(
+        tmp_path,
+        name="stubrival_dist",
+        seats={
+            "stubrival_pkg/__init__.py": IMPLEMENTATION,
+            "stubrival_pkg/m.pyi": STUB,
+            "stubrival_pkg/m/__init__.py": IMPLEMENTATION,
+        },
+    )
+    with pytest.raises(DependencyArtifactAuthenticationError) as caught:
+        DependencyArtifactGraph.authenticate(distribution)
+    assert str(caught.value) == (
+        "distribution contains duplicate module seat stubrival_pkg.m"
+    )


### PR DESCRIPTION
numpy records **151 `x.py`/`x.pyi` pairs**. The dependency-artifact intake mapped both seats to one module name and refused **the whole numpy graph** at the first collision (`numpy.__config__`) — so every numpy manager in the enrolled corpus cited `no-derived-contract` while its defining source was recorded, enrolled and parseable.

**A wrong entrance, not a missing construct.**

PEP 484: a `.pyi` declares the module its `.py` defines; it is not a rival definition of that name. The implementation seat is the module and the stub seats nothing.

**Rivalry is untouched** — seats that collide on a module name WITHOUT sharing a stem (`pkg.py` vs `pkg/__init__.py`, `pkg/m.pyi` vs `pkg/m/__init__.py`) are still refused with the same text. Both seats stay in the authenticated file record, so the artifact CID is unchanged.

## Verified on battleaxe

`test_stub_and_implementation_module_seats.py` → **4 passed**.

## Context

Sealed baseline: `frontierWidth 779 / filesCompleted 642` at `a60ed9dfb5fa` (#7374). This was dispatched at the 16 `no-derived-contract` / `numpy.errstate` rows, but a whole-distribution intake refusal has wider reach than the manager that happened to surface it — same shape as the `auditFrontier` bare door that produced 772 identical `With.sugar` rows from one defect.

Expect the count to move. Every row is one panic per file, so 779 is a first-terminal lower bound; clearing a masking layer reveals what was behind it. **A rising or more varied count is discovery, not regression.**

Toward the in-population drain behind #7374; the off-population fork is #7384.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat the `.py` implementation when a distribution records both `.py` and `.pyi` for the same module
> - When `DependencyArtifactGraph._construct_from_authenticated_inputs` encounters a `.py`/`.pyi` pair with the same stem, it seats the `.py` file in `graph.modules` and silently ignores the `.pyi` stub, rather than raising a duplicate-module error.
> - If the pair is in non-canonical order (`.pyi` seated before `.py`) or the stems differ, authentication still fails with a descriptive error.
> - New tests in [test_stub_and_implementation_module_seats.py](https://github.com/TSavo/sugar/pull/7385/files#diff-de229caf6f7962e842425d1ee082a4926c78f2028fc5d0b48647f4334f7eea85) cover the seated-implementation case, lone `.pyi`, and two remaining duplicate-seat error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a014b02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Python dependency analysis now correctly treats matching `.py` implementation files and `.pyi` stub files as a single module.
  * Standalone `.pyi` modules continue to be supported.
  * Unrelated module and package name collisions still produce duplicate-module errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->