### PR TITLE
Seat the bind-time roster, not only the walk the seating creates

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -1853,11 +1853,53 @@ def _seat_roll_call_reporter(source_file, reporter) -> None:
     each existing node with this consumer's reporter.  Parent-first order also
     ensures any lazily materialized child is born on the same channel.  This
     does not parse, populate, or prepare the SourceFile again.
+
+    THE LIVE WALK IS NOT THE WHOLE TREE.  ``Node.__getattr__`` memoizes child
+    slots under a key that includes ``self.reporter``, so seating a parent does
+    not move its children -- it makes the next read mint FRESH child shells on
+    the new reporter.  ``source_file.nodes()`` is exactly that read.  It
+    therefore seats a tree the walk itself is creating, and never visits the
+    shells materialized at ``Backend.materialize_module`` time and handed to
+    ``SourceUnit.bind_typed_module``.
+
+    That bind-time roster is not inert.  ``SourceUnit`` reads a call's owning
+    definition out of ``unit.function_nodes``, and that FunctionDef becomes
+    ``SourceVisibleCallFrameV1.owner`` -- the exact producer
+    ``Call._project_constructed_value_for_testimony`` hands to
+    ``retain_registered_node_from``.  Left on the first opener's
+    ``NULL_REPORTER`` it owns no registration table, and retention refuses it as
+    ABSENT.  That refusal is right; the stale roster is what is wrong.
+
+    So seat the bind-time roster FIRST, then the live walk.  Both, and in that
+    order: the roster is what the frame owner is read from, and the walk is what
+    ordinary construction traverses.
     """
     source_file.reporter = reporter
-    for node in source_file.nodes():
+    # id -> node, never a bare set of ids. The live walk mints shells nothing
+    # else holds, so a set would let one be collected and its address reused by
+    # the next shell, which would then be skipped as already seated -- silent
+    # under-seating, the exact failure this function exists to end. The mapping
+    # keeps every seated node alive for the duration of the walk.
+    seated: dict[int, object] = {}
+
+    def seat(node) -> None:
+        if id(node) in seated:
+            return
+        seated[id(node)] = node
         object.__setattr__(node, "reporter", reporter)
+        # Rebinding alone is not seating: it moves the label and registers
+        # nothing, which turns the ABSENT refusal into the FOREIGN one -- the
+        # same hole, renamed.  The two must stay one operation.
         reporter.register(node)
+
+    unit = source_file.unit
+    for node in getattr(unit, "function_nodes", ()) or ():
+        seat(node)
+    for statements in (getattr(unit, "module_direct_bindings", None) or {}).values():
+        for statement in statements:
+            seat(statement)
+    for node in source_file.nodes():
+        seat(node)
 
 
 def audit_frontier_construction_context(root: Path):

--- a/implementations/python/sugar-lift-python-source/tests/test_bind_time_roster_is_seated_too.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_bind_time_roster_is_seated_too.py
@@ -1,0 +1,190 @@
+"""RED: seating must reach the BIND-TIME roster, not only the live walk.
+
+Full-corpus recensus run ``31076183814`` at ``cbdd870fe1ed`` measured all eight
+shards clean (90 panics / 88 completed / 0 instrument-failures each) and compose
+still refused, with three instrument failures that were one message::
+
+    BACKEND DEFECT [ConstructionTestimonyReporterV1.retain_registered_node_from]
+      blame:    pandas/io/parsers/readers.py:2116:0
+      observed: producer reporter owns no registration table
+                (producer=NullReporter, node_reporter=NullReporter)
+
+WHICH DOOR. Instrumenting ``Call._project_constructed_value_for_testimony`` over
+the sixty enrolled seats leading to that one showed the producer and the consumer
+share ONE ``SourceUnit`` object (``same_unit_object: true``) while carrying
+DIFFERENT reporters: consumer ``ConstructionTestimonyReporterV1``, producer
+``NullReporter``. So this is not a second tree, not a second seat spelling, and
+not a foreign roll -- it is two VIEWS of one tree, one of them stale.
+
+THE MECHANISM. ``Node.__getattr__`` memoizes child slots in
+``ConstructionCache.fields`` under a key that includes ``self.reporter``. So
+re-seating a parent does not move its children; it makes the next read mint
+FRESH child shells on the new reporter. ``_seat_roll_call_reporter`` walks
+``source_file.nodes()`` (``root.walk()``), which is exactly that read: it seats
+the root, then descends into newly minted shells and seats those. The shells the
+walk actually needed to reach -- the ones materialized at
+``Backend.materialize_module`` time and handed to
+``SourceUnit.bind_typed_module`` as ``function_nodes`` /
+``module_direct_bindings`` -- are never visited. They keep the first opener's
+``NULL_REPORTER`` forever.
+
+That bind-time roster is not inert. ``SourceUnit`` resolves a call's owning
+definition out of ``self.function_nodes``, and that FunctionDef becomes
+``SourceVisibleCallFrameV1.owner`` -- which is precisely the producer
+``_project_constructed_value_for_testimony`` hands to
+``retain_registered_node_from``. A node born on ``NULL_REPORTER`` owns no
+registration table, so retention refuses. Correctly: the refusal is the
+instrument and it is not what needs changing.
+
+WHY #7382 AND #7383 MISSED IT. #7382 seated the two bare enumerate opens and
+added ``_seat_roll_call_reporter`` for the residency-hit leak; #7383 routed the
+``auditFrontier`` facts leaf through the construction door. Both fixed WHICH
+reporter is passed to the door. Neither could fix WHICH NODES the seating walk
+reaches, and the roster the frame owner is read from is not on that walk.
+
+ORDER DEPENDENCE, explained by the same mechanism. Measured alone, the census
+door is the first opener: the bind-time roster is minted under the real reporter
+and there is nothing stale to reach. Only when an earlier seat has already made
+the file resident under ``NULL_REPORTER`` does the roster go stale -- which is
+why this seat is clean in isolation, why it resolved itself as a countable panic
+in run ``31061976549``, and why #7385 letting numpy construct further brought it
+back.
+
+These teeth use FIRST-PARTY files: the defect is in the seating walk, not in
+pandas, so it needs no corpus and runs in milliseconds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _resident_bare_then_seated(target: Path, root: Path):
+    """Open ``target`` bare (resident, NULL_REPORTER), then through the door.
+
+    Returns ``(source_file, collector)``. SAME SEAT SPELLING for both opens or
+    residency simply misses and the teeth prove nothing: residency is keyed by
+    (content CID, source seat).
+    """
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_lift_python_source.source_oracle import workspace_path_source
+    from sugar_source_tree.reporter import CollectingReporter, NullReporter
+    from sugar_source_tree.tree import SourceFile
+
+    first = SourceFile(workspace_path_source(str(target), root=str(root)))
+    # Force the bind-time roster to exist and be read at least once, exactly as
+    # a dependency resolution would.
+    assert list(first.functions()), "no functions materialized on the bare open"
+    assert isinstance(first.reporter, NullReporter)
+
+    collector = CollectingReporter()
+    seated = open_source_file_for_construction(
+        target, root=root, reporter=collector, populate_derived=False
+    )
+    assert seated.unit is first.unit, (
+        "the two opens did not share one resident unit; the seat spellings "
+        "differ and this measurement is about something else"
+    )
+    return seated, collector
+
+
+@pytest.fixture(scope="module")
+def seated_first_party():
+    """A first-party module with NESTED definitions, deliberately.
+
+    ``module_direct_bindings`` only holds module-level statements, so a flat
+    file is seated by that roster alone and the ``function_nodes`` guard cannot
+    die on its own.  ``lift_rpc`` has definitions nested inside functions and
+    classes, which live in ``function_nodes`` and nowhere else -- that is what
+    makes the two levers independently reachable (measured: dropping the
+    function-roster loop leaves 8 stale nodes here and 0 in a flat file).
+    """
+    import sugar_lift_py_tests.lift_rpc as lift_rpc
+
+    target = Path(lift_rpc.__file__).resolve()
+    return _resident_bare_then_seated(target, target.parent)
+
+
+def test_the_bind_time_function_roster_is_seated(seated_first_party) -> None:
+    """GUARD (the defect itself): ``unit.function_nodes`` must move.
+
+    This is the roster ``SourceUnit`` reads a call's owning definition out of,
+    and that definition becomes ``SourceVisibleCallFrameV1.owner`` -- the exact
+    producer handed to ``retain_registered_node_from``. If it keeps the first
+    opener's channel, every retention through it reads as ABSENT.
+    """
+    seated, collector = seated_first_party
+    stale = [
+        node
+        for node in seated.unit.function_nodes
+        if getattr(node, "reporter", None) is not collector
+    ]
+    assert not stale, (
+        f"{len(stale)} bind-time function node(s) still carry the first "
+        f"opener's reporter (first={type(stale[0].reporter).__name__} on "
+        f"{stale[0].name!r}); the frame owner read out of this roster owns no "
+        "registration table, so retention refuses it as absent"
+    )
+
+
+def test_the_bind_time_module_bindings_are_seated(seated_first_party) -> None:
+    """GUARD: ``module_direct_bindings`` is the same bind-time roster.
+
+    Separate from ``function_nodes`` deliberately: they are two attributes
+    written by ``bind_typed_module`` from the same materialization, and a fix
+    that reaches one and not the other leaves half the leak open.
+    """
+    seated, collector = seated_first_party
+    stale = [
+        statement
+        for statements in seated.unit.module_direct_bindings.values()
+        for statement in statements
+        if getattr(statement, "reporter", None) is not collector
+    ]
+    assert not stale, (
+        f"{len(stale)} bind-time module binding statement(s) still carry the "
+        f"first opener's reporter (first={type(stale[0].reporter).__name__})"
+    )
+
+
+def test_the_seated_roster_is_actually_registered(seated_first_party) -> None:
+    """GUARD: rebinding is not seating.
+
+    ``object.__setattr__(node, "reporter", ...)`` alone moves the label and
+    registers nothing, so ``retain_registered_node_from`` would then take the
+    FOREIGN arm ("producer owns a roster; this node is not in it") instead of
+    the ABSENT one -- a renamed refusal, not a repair. Both arms stay closed
+    only if the roster is registered on the channel it now names.
+    """
+    seated, collector = seated_first_party
+    registered = {id(node) for node in collector.registered}
+    missing = [
+        node for node in seated.unit.function_nodes if id(node) not in registered
+    ]
+    assert not missing, (
+        f"{len(missing)} bind-time function node(s) were relabelled onto this "
+        "reporter without being registered on it; retention would refuse them "
+        "as foreign rather than absent -- the same hole, renamed"
+    )
+
+
+def test_a_second_file_is_seated_the_same_way() -> None:
+    """GUARD: not a property of one file.
+
+    A fix that special-cases the file under test is answered by the tooth above.
+    This repeats the whole measurement on an unrelated first-party module, so
+    the seating walk has to be general.
+    """
+    target = Path(__file__).resolve()
+    seated, collector = _resident_bare_then_seated(target, target.parent)
+    stale = [
+        node
+        for node in seated.unit.function_nodes
+        if getattr(node, "reporter", None) is not collector
+    ]
+    assert not stale, (
+        f"{len(stale)} bind-time function node(s) unseated on a second file; "
+        "the seating walk is not general"
+    )

--- a/implementations/python/sugar-lift-python-source/tests/test_enumerate_door_seats_the_registration_channel.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_enumerate_door_seats_the_registration_channel.py
@@ -31,6 +31,16 @@ THE ENTRANCE IS THE CENSUS ENTRANCE: ``measure_file_via_enumerate``. A bare
 The fix is NOT to let the retention check accept a ``NullReporter`` -- that
 check is the instrument, and it is what caught this.
 ``test_retention_refusal_names_which_fault.py`` pins both of its arms.
+
+CLOSED. #7382 seated the two bare enumerate opens and added
+``_seat_roll_call_reporter`` for the residency-hit leak; #7383 routed the
+``auditFrontier`` facts leaf through the construction door. Both fixed WHICH
+reporter reaches the door. Neither could fix WHICH NODES the seating walk
+reaches -- and the seating walk was minting the very shells it seated, leaving
+the bind-time roster (``function_nodes`` / ``module_direct_bindings``) on the
+first opener's ``NULL_REPORTER`` forever. That roster is where the frame owner
+handed to retention comes from. See
+``test_bind_time_roster_is_seated_too.py``.
 """
 
 from __future__ import annotations
@@ -212,29 +222,23 @@ def measured_seat(measured_prefix) -> dict[str, Any]:
     return measured_prefix[0]
 
 
-STILL_HOLED = pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "io/parsers/readers.py is STILL a census hole: a producer this walk "
-        "resolves through is born on NULL_REPORTER from a door not yet found. "
-        "Seating the two enumerate doors and re-seating a residency hit closed "
-        "tests/io/excel/test_writers.py (see test_census_reexport_memo_hole) "
-        "but not this seat. Recorded strict so the day it banks a row this "
-        "tooth is told. The full-corpus profile agrees: 828 panics / 592 "
-        "completed / 1 instrument-failure, unchanged, and this is the 1."
-    ),
-)
+# CLOSED at #7385+1 (this branch). The fourth door was not a bare open at all:
+# ``_seat_roll_call_reporter`` walked ``source_file.nodes()``, and because
+# ``Node.__getattr__`` memoizes child slots under a key containing
+# ``self.reporter``, that walk MINTS the shells it then seats. The bind-time
+# roster handed to ``SourceUnit.bind_typed_module`` -- ``function_nodes`` and
+# ``module_direct_bindings`` -- is never on that walk, and it is exactly where
+# ``SourceUnit`` reads the definition that becomes
+# ``SourceVisibleCallFrameV1.owner``, the producer handed to retention. Seating
+# that roster is the repair; see
+# ``sugar-lift-python-source/tests/test_bind_time_roster_is_seated_too.py``,
+# whose teeth are first-party and run in 20s.
+#
+# The three guards below were strict xfails and all three XPASSed on the repair,
+# which is the machinery doing its job. Their markers are removed, not
+# loosened: they are ordinary guards now and a regression must be red.
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "pre-existing bare AttributeError in _populate_same_module_class_"
-        "manager_uses ('SpreadCallSugar' object has no attribute 'args'), "
-        "revealed once the retention defect stopped shadowing it; this seat is "
-        "still a census hole, for a different cause"
-    ),
-)
 def test_seat_banks_a_countable_terminal(measured_seat: dict[str, Any]) -> None:
     """GUARD: the seat banks a row, not a hole.
 
@@ -249,7 +253,6 @@ def test_seat_banks_a_countable_terminal(measured_seat: dict[str, Any]) -> None:
     )
 
 
-@STILL_HOLED
 def test_no_producer_is_born_without_a_registration_table(
     measured_prefix: tuple[dict[str, Any], list[str]],
 ) -> None:
@@ -272,7 +275,6 @@ def test_no_producer_is_born_without_a_registration_table(
     )
 
 
-@STILL_HOLED
 def test_seat_never_names_an_unregistered_producer(
     measured_seat: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
Run `31076183814` measured all eight shards clean (**90 panics / 88 completed / 0 instrument-failures** each) and compose still refused with three instrument failures, all one message:

```
BACKEND DEFECT [ConstructionTestimonyReporterV1.retain_registered_node_from]
  blame:    pandas/io/parsers/readers.py:2116:0
  observed: producer reporter owns no registration table
            (producer=NullReporter, node_reporter=NullReporter)
```

Instrumenting `Call._project_constructed_value_for_testimony` across the sixty enrolled seats leading to that one showed producer and consumer sharing **ONE `SourceUnit` object while carrying DIFFERENT reporters** — consumer `ConstructionTestimonyReporterV1`, producer `NullReporter`. Not a second tree, not a second seat spelling, not a foreign roll. Two views of one tree, one stale.

## Why every previous seating fix looked like it worked

`Node.__getattr__` memoizes child slots under a key that **includes `self.reporter`**. Seating a parent therefore does not move its children — it makes the next read mint FRESH child shells on the new reporter.

`_seat_roll_call_reporter` walked `source_file.nodes()`, which is exactly that read. **It was seating a tree the walk itself was creating**, and never visited the shells materialized at `Backend.materialize_module` time and handed to `SourceUnit.bind_typed_module` as `function_nodes` / `module_direct_bindings`. Those keep the first opener's reporter.

That is why #7382 (three null-seated doors) and #7383 (auditFrontier construction door) both passed their teeth and left this alive.

## Verified on battleaxe

`test_bind_time_roster_is_seated_too.py` + `test_enumerate_door_seats_the_registration_channel.py` → **9 passed** (617s, through the enumerate door).

## Context

Sealed baseline `frontierWidth 779 / filesCompleted 642` at `a60ed9dfb5fa` (#7374); numpy stub-seat #7385 then improved the walk to 90/88 per shard. This is the last aggregate-level blocker.

Toward the in-population drain; the off-population fork remains #7384.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reporter registration for bind-time functions and module bindings when source files are seated.
  * Prevented duplicate seating and ensured nested definitions and additional source files are handled consistently.

* **Tests**
  * Added regression coverage for reporter identity and registration.
  * Updated safeguards so future seating regressions are reported immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Seat bind-time rosters during `_seat_roll_call_reporter` walk
> - `_seat_roll_call_reporter` now iterates `unit.function_nodes` and `unit.module_direct_bindings` before walking `source_file.nodes()`, ensuring nodes materialized at bind-time are seated and registered with the construction reporter.
> - Adds an id-keyed map to deduplicate seating by identity across all three sources.
> - New tests in [`test_bind_time_roster_is_seated_too.py`](https://github.com/TSavo/sugar/pull/7386/files#diff-81e60dae54fa25e7e541fbdf0c5fa889ae1b52c6af9c0e6d839a9618ce7cefd8) verify that both rosters carry the construction reporter and are present in the registration set after a bare-then-construction open.
> - Previously `xfail`-marked tests in [`test_enumerate_door_seats_the_registration_channel.py`](https://github.com/TSavo/sugar/pull/7386/files#diff-2bfeccb022861bf1d705e895694c0098ae87257286db09e359e1f32a163b31f6) now run as normal tests and will fail on regression.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0882e83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->