### PR TITLE
Construct With over a cited manager, carrying its ignorance (#7384)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -351,7 +351,8 @@ def _occurrence_key(
 # Conservation: every sync with-item constructs or does not.
 # No kind vocabulary. Unconstructed rows are panics waiting to be written.
 WITH_CENSUS_CONSERVATION_IDENTITY = (
-    "site:with-item == constructed + unconstructed " "(no residual kind taxonomy)"
+    "site:with-item == constructed + cited-opaque + unconstructed "
+    "(no residual kind taxonomy)"
 )
 
 
@@ -432,10 +433,21 @@ def _with_census_partition(
     unconstructed_rows = [
         dict(row) for row in cm_resolution_rows if row.get("outcome") == "unconstructed"
     ]
-    if len(constructed_rows) + len(unconstructed_rows) != len(cm_resolution_rows):
+    # THREE buckets, because there are three facts. A cited-opaque With
+    # CONSTRUCTED -- so it is not unconstructed -- but sugar holds no enter/exit
+    # contract for it, so calling it constructed would report knowledge nobody
+    # has. Known, unknown and absent each get their own column, here and on the
+    # board, or the sealed numbers cannot say what was observed (#7384, #7387).
+    cited_opaque_rows = [
+        dict(row) for row in cm_resolution_rows if row.get("outcome") == "cited-opaque"
+    ]
+    if (
+        len(constructed_rows) + len(cited_opaque_rows) + len(unconstructed_rows)
+        != len(cm_resolution_rows)
+    ):
         raise TypeError("With partition received a row outside its closed outcomes")
     input_keys = [dict(row["inputKey"]) for row in cm_resolution_rows]
-    output_rows = [*constructed_rows, *unconstructed_rows]
+    output_rows = [*constructed_rows, *cited_opaque_rows, *unconstructed_rows]
     output_keys = [dict(row["inputKey"]) for row in output_rows]
     edge_witness = key_edge_witness(
         stage_id=STAGE_WITH_TALLY_PARTITION,
@@ -455,14 +467,16 @@ def _with_census_partition(
         )
     total = int(ast_sites.get("site:with-item", 0))
     constructed = len(constructed_rows)
+    cited_opaque = len(cited_opaque_rows)
     unconstructed = len(unconstructed_rows)
-    accounted = constructed + unconstructed
+    accounted = constructed + cited_opaque + unconstructed
     if accounted != total:
         unaccounted = total - accounted
         raise ValueError(
             "With census does not conserve. "
             f"LAW: {WITH_CENSUS_CONSERVATION_IDENTITY}. "
             f"REFUSED: with_items_total={total} constructed={constructed} "
+            f"citedOpaque={cited_opaque} "
             f"unconstructed={unconstructed} accounted={accounted} "
             f"unaccounted={unaccounted}. "
             "Construct or panic — fix the partition or write the missing construction."
@@ -471,14 +485,17 @@ def _with_census_partition(
         "conservationIdentity": WITH_CENSUS_CONSERVATION_IDENTITY,
         "edgeWitness": edge_witness,
         "constructedRows": constructed_rows,
+        "citedOpaqueRows": cited_opaque_rows,
         "unconstructedRows": unconstructed_rows,
         "with_items_total": total,
         "constructed": constructed,
+        "citedOpaque": cited_opaque,
         "unconstructed": unconstructed,
         "accounted": accounted,
         "unaccounted": 0,
         "reconciliation": (
-            f"{total} = {constructed} constructed + {unconstructed} unconstructed"
+            f"{total} = {constructed} constructed + {cited_opaque} cited-opaque "
+            f"+ {unconstructed} unconstructed"
         ),
         "conserves": True,
     }
@@ -1675,6 +1692,7 @@ def main() -> int:
                         row["withResolutionRows"] = resolution_rows
                         row["cmResolutions"] = {
                             "constructed": with_partition["constructed"],
+                            "citedOpaque": with_partition["citedOpaque"],
                             "unconstructed": with_partition["unconstructed"],
                         }
                         row["astSites"] = dict(sites)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -364,6 +364,137 @@ class ContextManagerContractRefV1:
     semantics: ContextManagerSemanticsV1
 
 
+_OPAQUE_CITED_MANAGER_AUTHORITY = object()
+
+
+@dataclass(frozen=True)
+class OpaqueCitedContextManagerRefV1:
+    """An authenticated statement that this manager's enter/exit are UNCITED.
+
+    This is not a gap and not a default.  It is a POSITIVE claim of unknown,
+    seated by the producer that authenticated WHICH callee stands at the
+    ``with`` head and then failed to reach a body for it because the callee is
+    off-population.
+
+    Three spellings that must never merge:
+
+    - **absence** -- no resolution at this coordinate at all.  ``With`` panics
+      through ``require``; nothing was ever authenticated.
+    - **known** -- ``ContextManagerContractRefV1`` and the ``SourceDerived*``
+      family, which carry real enter/exit testimony CIDs.
+    - **unknown** -- this ref.  The citation is authenticated; the semantics
+      are authenticated as ABSENT FROM OUR KNOWLEDGE, which is a different
+      fact from being absent from the program.
+
+    It deliberately carries NO ``semantics``, NO ``contract_cid`` and NO
+    enter/exit testimony CID, and ``__post_init__`` refuses any attempt to give
+    it one.  A consumer that wants enter/exit semantics off this ref must fail
+    to find them -- that is the whole design.  ``roster`` is the authenticated
+    ``OpaqueSourceCallRosterV1``: every owner whose frame projection walked
+    through this call and parked an obligation on it.  The obligation is what
+    travels; this ref is its seat at the ``with`` head.
+
+    Constructing over this ref is honest exactly as long as the opacity is
+    CARRIED.  The moment a consumer reasons as if the manager were
+    transparent, the construction becomes a lie and is worse than the refusal
+    it replaced.
+    """
+
+    use_site: SourceFragmentCoordinateV1
+    target_name: str
+    roster: OpaqueSourceCallRosterV1
+    citation_cid: str
+    _authority: object = field(init=False, repr=False, compare=False, default=None)
+
+    #: Named so a reader of one row can see the claim without the docstring.
+    #: This is testimony, never a bucket key.
+    uncited: str = "enter-exit-semantics-uncited"
+
+    def __post_init__(self) -> None:
+        if self._authority is not _OPAQUE_CITED_MANAGER_AUTHORITY:
+            raise ContractRefProtocolError(
+                "opaque-cited context-manager ref lacks producer authority"
+            )
+        if type(self.roster) is not OpaqueSourceCallRosterV1:
+            raise ContractRefProtocolError(
+                "opaque-cited context-manager ref requires an authenticated "
+                "opaque source-call roster"
+            )
+        if self.roster.coordinate != self.use_site:
+            raise ContractRefProtocolError(
+                "opaque-cited context-manager ref and its roster name different "
+                "call coordinates"
+            )
+        if self.roster.target_name != self.target_name:
+            raise ContractRefProtocolError(
+                "opaque-cited context-manager ref and its roster name different "
+                "call targets"
+            )
+        if self.uncited != "enter-exit-semantics-uncited":
+            raise ContractRefProtocolError(
+                "opaque-cited context-manager ref may state only that its "
+                "enter/exit semantics are uncited"
+            )
+
+    @property
+    def semantics(self):
+        """There is none, and asking is the bug this ref exists to make loud.
+
+        A cited manager has no enter/exit semantics BY CONSTRUCTION.  Returning
+        ``None`` here would let a consumer's ``isinstance`` check fall through
+        to a default arm and reason as if the manager were transparent; that is
+        the exact failure mode the ruling names.  So the attribute exists and
+        REFUSES, which turns a silent misread into a named panic at the
+        consumer that misread it.
+        """
+        raise ContractRefProtocolError(
+            "opaque-cited context-manager ref has no enter/exit semantics: the "
+            f"manager {self.target_name!r} at {self.use_site} is cited, not "
+            "materialized. Carry the undischarged obligation; never substitute "
+            "assumed semantics"
+        )
+
+
+def mint_opaque_cited_context_manager_ref(
+    *,
+    roster: OpaqueSourceCallRosterV1,
+) -> OpaqueCitedContextManagerRefV1:
+    """The sole door that mints an opaque-cited manager ref.
+
+    Requires a real authenticated roster: a ref cannot be conjured for a
+    manager nobody parked an obligation against.
+    """
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    if type(roster) is not OpaqueSourceCallRosterV1:
+        raise ContractRefProtocolError(
+            "opaque-cited context-manager ref requires an authenticated roster"
+        )
+    citation_cid = cid_of_json(
+        {
+            "schemaVersion": 1,
+            "kind": "opaque-cited-context-manager-ref",
+            "useSite": roster.coordinate.wire(),
+            "targetName": roster.target_name,
+            "resolutionKind": roster.resolution_kind,
+            "owners": sorted(row.resolved_object_cid for row in roster.obligations),
+            "uncited": "enter-exit-semantics-uncited",
+        }
+    )
+    ref = object.__new__(OpaqueCitedContextManagerRefV1)
+    for name, value in (
+        ("use_site", roster.coordinate),
+        ("target_name", roster.target_name),
+        ("roster", roster),
+        ("citation_cid", citation_cid),
+        ("uncited", "enter-exit-semantics-uncited"),
+    ):
+        object.__setattr__(ref, name, value)
+    object.__setattr__(ref, "_authority", _OPAQUE_CITED_MANAGER_AUTHORITY)
+    ref.__post_init__()
+    return ref
+
+
 @dataclass(frozen=True)
 class ContextManagerResolutionGapV1:
     """One unresolved context-manager demand: a structural kind beside its data.
@@ -511,7 +642,23 @@ def effective_context_manager_resolutions_for_source(
 
 
 def context_manager_resolution_outcome(resolution: object) -> str:
-    """Closed census projection: exactly constructed or unconstructed."""
+    """Closed census projection: constructed, cited-opaque, or unconstructed.
+
+    THREE values, not two.  ``cited-opaque`` is its own row because the other
+    two would both misreport it:
+
+    - ``constructed`` would claim sugar holds this manager's enter/exit
+      contract.  It does not, and the audit wire would carry that claim
+      onward.
+    - ``unconstructed`` would say the demand is unresolved.  It IS resolved --
+      resolved to an authenticated statement of ignorance, which is a
+      different measurement from a gap nobody has looked at.
+
+    Known, unknown and absent each get their own spelling.  A census that
+    cannot tell them apart cannot say what it observed.
+    """
+    if isinstance(resolution, OpaqueCitedContextManagerRefV1):
+        return "cited-opaque"
     if isinstance(
         resolution,
         (

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/__init__.py
@@ -28,6 +28,7 @@ from .conditional_expression_runtime_effect import ConditionalExpressionRuntimeE
 from .constructor_runtime_effect import ConstructorRuntimeEffect
 from .context_manager_unpack_runtime_effect import ContextManagerUnpackRuntimeEffect
 from .context_manager_exit_runtime_effect import ContextManagerExitRuntimeEffect
+from .context_manager_enter_runtime_effect import ContextManagerEnterRuntimeEffect
 from .call_result_type_runtime_effect import CallResultTypeRuntimeEffect
 from .callable_argument_binding_runtime_effect import (
     CallableArgumentBindingRuntimeEffect,
@@ -105,6 +106,7 @@ __all__ = [
     "ConstructorRuntimeEffect",
     "ContextManagerUnpackRuntimeEffect",
     "ContextManagerExitRuntimeEffect",
+    "ContextManagerEnterRuntimeEffect",
     "CallResultTypeRuntimeEffect",
     "CallableArgumentBindingRuntimeEffect",
     "runtime_callable_argument_binding",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/context_manager_enter_runtime_effect.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/effect/context_manager_enter_runtime_effect.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .runtime_effect import RuntimeEffect
+
+
+@dataclass(frozen=True)
+class ContextManagerEnterRuntimeEffect(RuntimeEffect):
+    """A runtime-selected manager decides whether ``__enter__`` completes."""
+
+    def kind(self) -> type[RuntimeEffect]:
+        return ContextManagerEnterRuntimeEffect

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/opaque_manager_protocol_coordinate.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/opaque_manager_protocol_coordinate.py
@@ -1,0 +1,164 @@
+"""Open protocol coordinates for a manager whose body sugar cannot see.
+
+An off-population ``with`` manager -- ``pytest.raises(...)``,
+``warnings.catch_warnings()`` -- is CITED, never materialized.  Sugar
+authenticates WHICH callee stands at the ``with`` head and authenticates that
+it does not know what that callee's ``__enter__`` and ``__exit__`` do.  Those
+are two different claims and this module carries the second one.
+
+Python's ``with`` law is the manager's own semantics is not.  Independent
+of any manager, the language guarantees:
+
+    enter is attempted; the body runs only if enter completed; exit runs over
+    every outgoing body edge.
+
+Everything the MANAGER decides stays open:
+
+- does ``__enter__`` complete, or halt?
+- what does ``__enter__`` project?
+- does ``__exit__`` suppress an exceptional body edge?
+- does ``__exit__`` itself halt?
+
+None of those has lift-time evidence, and inventing one would fabricate the
+very fact the off-population refusal exists to protect.  So each is modelled
+the way this tree already models every runtime-selected outcome: an
+authenticated per-occurrence coordinate plus the complementary guard pair
+``g`` / ``not g``.  This is deliberately the SAME mechanism as
+``floor/store_outcome_coordinate.py`` and ``floor/branch_result_coordinate.py``,
+not a second one.
+
+**No biconditional is emitted, and that is the point.**  Tying a coordinate to
+a lift-time formula would be exactly the invented enter/exit semantics the
+ruling forbids.  The coordinates stay open; both faces survive; every claim
+that depends on the manager's behaviour reaches the emitted FOL as an
+undischarged obligation instead of being decided here by silence.
+
+Absence, unknown and known do not share a spelling.  A manager with no
+resolution at all is a construction panic (absence).  A manager whose contract
+IS derived carries ``ContextManagerContractRefV1`` and real enter/exit
+testimony (known).  A cited-opaque manager carries THESE coordinates
+(unknown) -- a positive term, minted per occurrence, never a default and never
+a sentinel.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from sugar_lift_py_tests.floor.floor_value import FloorValue
+
+
+def opaque_manager_occurrence_address(site, *, slot: str) -> str:
+    """The authenticated address of THIS manager occurrence's protocol slot.
+
+    Two textually identical ``with pytest.raises(ValueError):`` sites mint two
+    distinct coordinates, and one site evaluated once mints one.  ``slot``
+    separates the enter question from the exit question at the same occurrence:
+    they are independent unknowns and must never share a symbol.
+    """
+    return f"opaque-manager:{slot}:{site.filename}:{site.line}:{site.col}"
+
+
+@dataclass(frozen=True)
+class OpaqueManagerProtocolCoordinate(FloorValue):
+    """An open per-occurrence coordinate over a cited, unmaterialized manager.
+
+    ``symbol`` names WHICH question is open (enter completion, enter result,
+    exit result).  ``manager`` is the manager's own authenticated term, so the
+    coordinate is authenticated by the callee it actually names -- a coordinate
+    over ``pytest.raises(ValueError)`` is not the same symbol as one over
+    ``warnings.catch_warnings()``.
+    """
+
+    occurrence: str
+    symbol: str
+    manager: object
+    site: object = field(default=None, compare=False)
+    symbol_kind: str = field(default="coordinate", init=False)
+
+    def to_term(self, *, owner: str):
+        from sugar_lift_py_tests.ir import ctor, str_const
+
+        return ctor(
+            self.symbol,
+            [str_const(self.occurrence), self.manager],
+        )
+
+    def truth(self, site):
+        from sugar_lift_py_tests.floor.predicate_value import PredicateValue
+        from sugar_lift_py_tests.ir import py_truthy
+        from sugar_lift_py_tests.outcome import Complete
+
+        return Complete(PredicateValue(py_truthy(self.to_term(owner=str(site))), site))
+
+
+def _coordinate(manager_term, site, *, slot: str, symbol: str):
+    return OpaqueManagerProtocolCoordinate(
+        opaque_manager_occurrence_address(site, slot=slot),
+        symbol,
+        manager_term,
+        site,
+    )
+
+
+def opaque_enter_completed_coordinate(manager_term, site):
+    """``true`` exactly when this occurrence's ``__enter__`` completed."""
+    return _coordinate(
+        manager_term, site, slot="enter", symbol="python:cm_enter_completed"
+    )
+
+
+def opaque_enter_result_coordinate(manager_term, site):
+    """What ``__enter__`` projected here.  An opaque function symbol, not a value.
+
+    This is what an ``as`` target binds.  It is not a claim that the manager
+    returns itself, nor that it returns anything in particular -- it is the
+    same position ``SymbolicValue`` and ``py.getattr`` already occupy.
+    """
+    return _coordinate(
+        manager_term, site, slot="enter-result", symbol="python:cm_enter_result"
+    )
+
+
+def opaque_exit_completed_coordinate(manager_term, site):
+    """``true`` exactly when this occurrence's ``__exit__`` completed.
+
+    Separate from suppression on purpose: an ``__exit__`` that RAISES and an
+    ``__exit__`` that returns falsey are different outcomes, and collapsing
+    them would claim a cited manager cannot fail while closing.
+    """
+    return _coordinate(
+        manager_term, site, slot="exit", symbol="python:cm_exit_completed"
+    )
+
+
+def opaque_exit_result_coordinate(manager_term, site):
+    """What ``__exit__`` returned.  Its TRUTHINESS decides suppression.
+
+    Handed to ``ExitSet.and_exit_truthiness`` exactly as a source-derived
+    exit's real return value is.  Because this coordinate is undecidable, that
+    router keeps BOTH faces -- suppressed under its truth, the body's original
+    effect restored under its falsity.  That is where the opacity propagates.
+    """
+    return _coordinate(
+        manager_term, site, slot="exit-result", symbol="python:cm_exit_result"
+    )
+
+
+def opaque_completed_guard(coordinate):
+    """``g`` -- the guard formula for an open completion coordinate."""
+    from sugar_lift_py_tests.sugar.if_sugar import predicate_formula
+
+    return predicate_formula(coordinate, coordinate.site)
+
+
+def opaque_halted_guard(coordinate):
+    """``not g`` -- the complementary face.
+
+    ``ExitSet._is_negation`` recognises the pair, so the two arms partition
+    exactly and normalization can merge or kill them the same way it does for a
+    branch result or a store outcome.
+    """
+    from sugar_lift_py_tests.ir import not_
+
+    return not_(opaque_completed_guard(coordinate))

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_opaque_cited_manager_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_opaque_cited_manager_sugar.py
@@ -1,0 +1,292 @@
+"""``with`` over a CITED manager: Python's law kept, the manager's law open.
+
+Constructed only from an authenticated ``OpaqueCitedContextManagerRefV1``.
+The producer seated that ref because it authenticated WHICH callee stands at
+the ``with`` head and then found the callee off-population -- cited, never
+materialized.  This node is what ``With`` builds over that citation.
+
+What this node asserts, exactly:
+
+* the manager expression was evaluated (its own outcome comes from its own
+  sugar, unchanged by this node);
+* ``__enter__`` was attempted;
+* the body ran ONLY on the face where ``__enter__`` completed;
+* ``__exit__`` ran over EVERY outgoing body edge.
+
+That is Python's ``with`` law, which holds whatever the manager is.  What this
+node does NOT assert -- and must never be read as asserting:
+
+* that ``__enter__`` completes;
+* what ``__enter__`` projects;
+* that ``__exit__`` suppresses an exceptional body edge, or that it does not;
+* that ``__exit__`` itself completes.
+
+Each of those rides an open per-occurrence coordinate from
+``floor/opaque_manager_protocol_coordinate.py`` with both faces retained.  The
+suppression question in particular is handed to ``ExitSet.and_exit_truthiness``
+exactly as a source-derived exit's REAL return value is: because the
+coordinate is undecidable, that router emits the completed face under its
+truth and restores the body's original effect under its falsity, and neither
+face is discarded.  A downstream claim that depends on suppression therefore
+cannot be discharged in either direction -- it reaches the emitted FOL as an
+undischarged obligation.
+
+This runs the SAME ExitSet algebra as ``WithResourceSugar``.  It is not a
+second control model and not a soft survival arm: the refusal is not rescued
+here, it was replaced upstream by a positive seated citation.  Compare
+``SoftUnresolvedWithSugar``, which dresses a gap as an ``Incomplete`` and is
+forbidden in production for exactly that reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+
+from sugar_lift_py_tests.outcome import Outcome
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+
+
+@dataclass(frozen=True)
+class WithOpaqueCitedManagerSugar(Sugar):
+    """Resource-shaped ``with`` whose manager protocol is cited, not known."""
+
+    manager: Sugar
+    body: tuple
+    contract_ref: object
+    enter_slot_id: str | None = None
+    site: object = dataclass_field(compare=False, default=None)
+
+    def __post_init__(self) -> None:
+        from sugar_lift_py_tests.context_manager_resolution import (
+            OpaqueCitedContextManagerRefV1,
+        )
+
+        if type(self.contract_ref) is not OpaqueCitedContextManagerRefV1:
+            raise ValueError(
+                "WithOpaqueCitedManagerSugar requires an authenticated "
+                "OpaqueCitedContextManagerRefV1; a cited manager is never "
+                "inferred from the absence of a contract"
+            )
+
+    @classmethod
+    def witnesses(cls):
+        """Both arms epistemic-red: neither may be guessed.
+
+        A cited manager's suppression is undecidable, so a body that halts
+        leaves as both faces.  Any harness that reported ``sat`` or ``unsat``
+        for a claim standing behind such a ``with`` would be reasoning as if
+        the manager were transparent -- which is the one outcome this node
+        exists to prevent.  ``unwitnessed`` is the honest verdict on BOTH
+        arms, and that is what makes this pair lawful rather than a missing
+        discrimination.
+        """
+        from sugar_lift_py_tests.sugar.witnesses import (
+            SugarUnwitnessedPair,
+            WitnessSource,
+        )
+
+        prefix = "import pytest\n\ndef A(z):\n    with pytest.raises(ValueError):\n        pass\n    return z\n\n"
+        return SugarUnwitnessedPair(
+            name="with_opaque_cited_manager_suppression_undecided",
+            owner_sugar="WithOpaqueCitedManagerSugar",
+            family="opaque-cited-manager-unwitnessed",
+            truthful=WitnessSource(
+                source=prefix + "def test_a():\n    assert A(1) == 1\n",
+                expected="unwitnessed",
+            ),
+            lying=WitnessSource(
+                source=prefix + "def test_a():\n    assert A(1) == 2\n",
+                expected="unwitnessed",
+            ),
+        )
+
+    def _manager_term(self, manager_value):
+        """The manager's own authenticated term, or refuse.
+
+        The coordinates are authenticated BY the callee they name.  A manager
+        value that cannot project a term cannot authenticate a coordinate, and
+        minting one anyway would produce a symbol that two different managers
+        would share.
+        """
+        from sugar_source_tree.panic import SugarNotWritten
+
+        project = getattr(manager_value, "to_term", None)
+        if project is None:
+            raise SugarNotWritten(
+                blame=self.site,
+                owner="WithOpaqueCitedManagerSugar.desugar",
+                observed=(
+                    "cited manager value projects no term, so its open "
+                    "enter/exit coordinates cannot be authenticated by the "
+                    "callee they name"
+                ),
+                requested=(
+                    "a manager value with to_term, so the opaque protocol "
+                    "coordinates name this callee and no other"
+                ),
+                fix=(
+                    "keep an unprojectable cited manager loud; never mint a "
+                    "protocol coordinate that two managers would share"
+                ),
+            )
+        return project(owner="WithOpaqueCitedManagerSugar")
+
+    def _enter_exitset(self, manager_value):
+        """Enter: completed under ``g``, halted under ``not g``.  Both kept."""
+        from sugar_lift_py_tests.effect import ContextManagerEnterRuntimeEffect
+        from sugar_lift_py_tests.effect.runtime_effect import runtime_effect_evidence
+        from sugar_lift_py_tests.floor.opaque_manager_protocol_coordinate import (
+            opaque_completed_guard,
+            opaque_enter_completed_coordinate,
+            opaque_enter_result_coordinate,
+            opaque_halted_guard,
+        )
+        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+
+        manager_term = self._manager_term(manager_value)
+        completed = opaque_enter_completed_coordinate(manager_term, self.site)
+        result = opaque_enter_result_coordinate(manager_term, self.site)
+        effect = ContextManagerEnterRuntimeEffect(
+            reason=(
+                "__enter__ of cited manager "
+                f"{self.contract_ref.target_name!r} may halt: the callee is "
+                "off-population, so its enter semantics are uncited"
+            ),
+            **runtime_effect_evidence(
+                "python:cm_enter", manager_value, self.site
+            ),
+        )
+        return ExitSet(
+            (
+                Completed(opaque_completed_guard(completed), result),
+                Halted(opaque_halted_guard(completed), effect, None),
+            )
+        )
+
+    def _exit_exitset(self, manager_value):
+        """Exit: completed with an OPEN result under ``g``, halted under ``not g``.
+
+        The completed face carries the exit's open result coordinate rather
+        than a decided boolean.  ``and_exit_truthiness`` reads its truthiness
+        and, finding it undecidable, keeps both suppression faces.  The halted
+        face is what keeps ``__exit__`` fallible: collapsing it would claim a
+        cited manager cannot fail while closing.
+        """
+        from sugar_lift_py_tests.effect import ContextManagerExitRuntimeEffect
+        from sugar_lift_py_tests.effect.runtime_effect import runtime_effect_evidence
+        from sugar_lift_py_tests.floor.opaque_manager_protocol_coordinate import (
+            opaque_completed_guard,
+            opaque_exit_completed_coordinate,
+            opaque_exit_result_coordinate,
+            opaque_halted_guard,
+        )
+        from sugar_lift_py_tests.outcome.exit_set import Completed, ExitSet, Halted
+
+        manager_term = self._manager_term(manager_value)
+        completed = opaque_exit_completed_coordinate(manager_term, self.site)
+        result = opaque_exit_result_coordinate(manager_term, self.site)
+        effect = ContextManagerExitRuntimeEffect(
+            reason=(
+                "__exit__ of cited manager "
+                f"{self.contract_ref.target_name!r} may halt or suppress: the "
+                "callee is off-population, so its exit disposition is uncited"
+            ),
+            **runtime_effect_evidence("python:cm_exit", manager_value, self.site),
+        )
+        return ExitSet(
+            (
+                Completed(opaque_completed_guard(completed), result),
+                Halted(opaque_halted_guard(completed), effect, None),
+            )
+        )
+
+    def desugar(self, ctx: object = None) -> Outcome:
+        from sugar_lift_py_tests.outcome.exit_set import ExitSet, Halted
+        from sugar_lift_py_tests.outcome.resource_bindings import (
+            EnterResultBinding,
+            prepend_facts_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.exit_set_routing import (
+            exitset_to_outcome,
+            promote_raise_halts,
+            sugar_outcome_to_exitset,
+        )
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            _ReducedBlock,
+            reduce_block_to_exitset,
+        )
+
+        manager_es = sugar_outcome_to_exitset(self.manager.desugar(ctx))
+        parts: list = []
+
+        for mgr_exit in manager_es.exits:
+            if isinstance(mgr_exit, Halted):
+                # The manager expression itself halted; enter is never reached.
+                parts.append(ExitSet((mgr_exit,)))
+                continue
+
+            enter_es = self._enter_exitset(mgr_exit.value)
+            exit_es = self._exit_exitset(mgr_exit.value)
+
+            for enter_exit in enter_es.exits:
+                face_guard = _and_guards(mgr_exit.guard, enter_exit.guard)
+                if isinstance(enter_exit, Halted):
+                    # Enter halted: the body never ran and exit never runs.
+                    # Python does not call __exit__ when __enter__ raised.
+                    parts.append(
+                        ExitSet(
+                            (
+                                Halted(
+                                    face_guard,
+                                    enter_exit.effect,
+                                    enter_exit.state,
+                                    enter_exit.faces,
+                                    enter_exit.pending_contracts,
+                                ),
+                            )
+                        )
+                    )
+                    continue
+
+                enter_facts = ()
+                if self.enter_slot_id is not None:
+                    enter_facts = EnterResultBinding(
+                        self.enter_slot_id, enter_exit.value
+                    ).to_facts(site=self.site)
+
+                body_es = promote_raise_halts(
+                    reduce_block_to_exitset(self.body, ctx)
+                ).guarded(face_guard)
+
+                for body_exit in body_es.exits:
+                    # ONE router for both questions. A completed body leaves
+                    # completed unless exit halts; a halted body leaves as BOTH
+                    # faces under the exit result's undecidable truthiness.
+                    after = ExitSet((body_exit,)).and_exit_truthiness(
+                        exit_es, site=self.site
+                    )
+                    parts.append(prepend_facts_to_exitset(after, enter_facts))
+
+        if not parts:
+            routed = ExitSet.completed(
+                _ReducedBlock(entries=(), can_fall_through=True, fall_through=())
+            )
+        else:
+            routed = parts[0]
+            for part in parts[1:]:
+                routed = routed.union(part)
+
+        return exitset_to_outcome(routed)
+
+
+def _and_guards(left, right):
+    from sugar_lift_py_tests.ir import and_
+    from sugar_lift_py_tests.outcome.exit_set import true_guard
+
+    if left == true_guard():
+        return right
+    if right == true_guard():
+        return left
+    if left == right:
+        return left
+    return and_([left, right])

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_cited_manager_ref.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_cited_manager_ref.py
@@ -1,0 +1,342 @@
+"""The opaque-cited manager ref: construction that CARRIES its ignorance.
+
+Ruling #7384. A ``with`` over an off-population manager (``pytest.raises``,
+``warnings.catch_warnings``) may construct, but only while carrying an
+authenticated statement that its enter/exit semantics are UNCITED.
+
+The load-bearing property is PROPAGATION. Every tooth below that matters is a
+tooth about a downstream claim staying UNDISCHARGED. A construct that lets
+anything reason as if the manager were transparent is worse than the refusal
+it replaced, so each tooth asserts the SPECIFIC face or the SPECIFIC refusal
+text -- never merely that something went red.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContractRefProtocolError,
+    OpaqueCitedContextManagerRefV1,
+    OpaqueSourceCallObligationV1,
+    SourceFragmentCoordinateV1,
+    context_manager_resolution_outcome,
+    mint_opaque_cited_context_manager_ref,
+    opaque_source_call_roster_of,
+)
+from sugar_lift_py_tests.effect import (
+    ContextManagerEnterRuntimeEffect,
+    ContextManagerExitRuntimeEffect,
+    RaiseEffect,
+)
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_lift_py_tests.outcome import Complete, Incomplete
+from sugar_lift_py_tests.sugar.sugar_base import Sugar
+from sugar_lift_py_tests.sugar.with_opaque_cited_manager_sugar import (
+    WithOpaqueCitedManagerSugar,
+)
+
+SOURCE_CID = "blake3-512:" + "aa" * 64
+OWNER_CID = "blake3-512:" + "bb" * 64
+
+
+@dataclass(frozen=True)
+class Frag:
+    filename: str = "t.py"
+    line: int = 10
+    col: int = 4
+    source_cid: str = SOURCE_CID
+
+
+@dataclass(frozen=True)
+class ManagerSugar(Sugar):
+    """A cited manager operand: an opaque call-site term, never a body."""
+
+    name: str = "pytest.raises"
+
+    @classmethod
+    def witnesses(cls):
+        return None
+
+    def desugar(self, ctx=None):
+        return Complete(
+            SymbolicValue(ctor(f"call:{self.name}", [str_const("ValueError")]))
+        )
+
+
+@dataclass(frozen=True)
+class RaisingBody(Sugar):
+    """A body statement that halts with an authenticated ValueError."""
+
+    @classmethod
+    def witnesses(cls):
+        return None
+
+    def desugar(self, ctx=None):
+        return Incomplete(
+            RaiseEffect(
+                exception_type_coordinate=ctor("py.type", [str_const("ValueError")]),
+                occurrence="t.py:11:8",
+                exception_name="ValueError",
+                blame="t.py:11",
+            )
+        )
+
+
+def _coordinate(*, line: int = 10) -> SourceFragmentCoordinateV1:
+    return SourceFragmentCoordinateV1(SOURCE_CID, line, 4, line, 30)
+
+
+def _roster(*, kind: str = "call-target-off-population", target: str = "pytest.raises"):
+    return opaque_source_call_roster_of(
+        OpaqueSourceCallObligationV1(_coordinate(), target, OWNER_CID, kind)
+    )
+
+
+def _ref(**kwargs):
+    return mint_opaque_cited_context_manager_ref(roster=_roster(**kwargs))
+
+
+def _node(body=(), *, site=None, ref=None):
+    return WithOpaqueCitedManagerSugar(
+        manager=ManagerSugar(),
+        body=body,
+        contract_ref=ref if ref is not None else _ref(),
+        site=site if site is not None else Frag(),
+    )
+
+
+def _faces(node):
+    """(can_fall_through, [(effect type, guard text)]) for one desugared With."""
+    outcome = node.desugar()
+    block = outcome.value
+    rows = []
+    for statement in block.statements:
+        guard = " ".join(str(g) for g in getattr(statement, "branch_conditions", ()))
+        rows.append((type(statement.effect).__name__, guard))
+    return block.can_fall_through, rows
+
+
+def _guard_for(rows, effect_name: str) -> str:
+    matches = [guard for name, guard in rows if name == effect_name]
+    assert matches, f"no {effect_name} face; faces present: {[n for n, _ in rows]}"
+    assert len(matches) == 1, f"{effect_name} appears {len(matches)} times"
+    return matches[0]
+
+
+# ---------------------------------------------------------------- propagation
+
+
+def test_body_halt_leaves_as_both_suppression_faces():
+    """THE tooth. A body that raises must NOT be decided either way.
+
+    Suppression belongs to a manager sugar cannot see, so the body's own
+    RaiseEffect must survive under the open exit-result coordinate, and the
+    suppressed face must survive as fall-through. Losing either one is the
+    construct becoming a lie: without the RaiseEffect face sugar claims the
+    exception is definitely swallowed; without fall-through it claims the
+    exception definitely escapes.
+    """
+    can_fall_through, rows = _faces(_node((RaisingBody(),)))
+
+    # The suppressed face: the with-statement completes.
+    assert can_fall_through is True
+
+    # The NOT-suppressed face: the body's own effect, guarded on the OPEN
+    # exit-result coordinate -- not unconditional, not dropped.
+    guard = _guard_for(rows, "RaiseEffect")
+    assert "python:cm_exit_result" in guard, guard
+    assert "python:cm_enter_completed" in guard, guard
+
+
+def test_enter_may_halt_face_survives():
+    """``__enter__`` of a cited manager may raise; the body then never runs."""
+    _, rows = _faces(_node((RaisingBody(),)))
+    guard = _guard_for(rows, ContextManagerEnterRuntimeEffect.__name__)
+    assert "not" in guard and "python:cm_enter_completed" in guard, guard
+
+
+def test_exit_may_halt_face_survives():
+    """``__exit__`` of a cited manager may itself raise, on any body edge."""
+    _, rows = _faces(_node((RaisingBody(),)))
+    guard = _guard_for(rows, ContextManagerExitRuntimeEffect.__name__)
+    assert "not" in guard and "python:cm_exit_completed" in guard, guard
+
+
+def test_empty_body_still_carries_enter_and_exit_openness():
+    """Opacity is a property of the MANAGER, not of what the body happens to do."""
+    can_fall_through, rows = _faces(_node(()))
+    names = {name for name, _ in rows}
+    assert can_fall_through is True
+    assert ContextManagerEnterRuntimeEffect.__name__ in names
+    assert ContextManagerExitRuntimeEffect.__name__ in names
+
+
+# ------------------------------------------------------- coordinate identity
+
+
+def test_two_managers_at_one_site_mint_different_symbols():
+    """A coordinate is authenticated by the callee it names.
+
+    ``pytest.raises`` and ``warnings.catch_warnings`` at the same coordinate
+    must not share an open symbol, or one manager's unknown would be the
+    other's.
+    """
+    _, raises_rows = _faces(_node(()))
+    warnings_node = WithOpaqueCitedManagerSugar(
+        manager=ManagerSugar(name="warnings.catch_warnings"),
+        body=(),
+        contract_ref=_ref(),
+        site=Frag(),
+    )
+    _, warnings_rows = _faces(warnings_node)
+    assert _guard_for(raises_rows, ContextManagerEnterRuntimeEffect.__name__) != (
+        _guard_for(warnings_rows, ContextManagerEnterRuntimeEffect.__name__)
+    )
+
+
+def test_two_occurrences_mint_different_coordinates():
+    """Two textually identical ``with`` sites are two independent unknowns."""
+    _, first = _faces(_node(()))
+    _, second = _faces(_node((), site=Frag(line=99)))
+    assert _guard_for(first, ContextManagerEnterRuntimeEffect.__name__) != (
+        _guard_for(second, ContextManagerEnterRuntimeEffect.__name__)
+    )
+
+
+# ------------------------------------------------------------- the ref itself
+
+
+def test_semantics_refuses_rather_than_answering_none():
+    """Asking a cited ref for semantics is the bug; it must be LOUD.
+
+    ``None`` would let a consumer's isinstance chain fall through to a default
+    arm and reason as if the manager were transparent.
+    """
+    with pytest.raises(ContractRefProtocolError) as raised:
+        _ref().semantics
+    message = str(raised.value)
+    assert "cited, not " in message
+    assert "materialized" in message
+    assert "never substitute" in message
+
+
+def test_ref_cannot_be_constructed_without_producer_authority():
+    """Only the mint door speaks. A hand-built citation is not testimony."""
+    with pytest.raises(ContractRefProtocolError) as raised:
+        OpaqueCitedContextManagerRefV1(
+            _coordinate(), "pytest.raises", _roster(), "blake3-512:cid"
+        )
+    assert "lacks producer authority" in str(raised.value)
+
+
+def test_ref_refuses_a_roster_naming_another_call():
+    """Citation and roster must name ONE call; cross-wired testimony refuses."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        _OPAQUE_CITED_MANAGER_AUTHORITY,
+    )
+
+    ref = _ref()
+    other = SourceFragmentCoordinateV1(SOURCE_CID, 77, 0, 77, 9)
+    clone = object.__new__(OpaqueCitedContextManagerRefV1)
+    for name, value in (
+        ("use_site", other),
+        ("target_name", ref.target_name),
+        ("roster", ref.roster),
+        ("citation_cid", ref.citation_cid),
+        ("uncited", ref.uncited),
+        ("_authority", _OPAQUE_CITED_MANAGER_AUTHORITY),
+    ):
+        object.__setattr__(clone, name, value)
+    with pytest.raises(ContractRefProtocolError) as raised:
+        clone.__post_init__()
+    assert "different call coordinates" in str(raised.value)
+
+
+def test_node_refuses_a_ref_that_is_not_a_citation():
+    """Opacity is never inferred from the absence of a contract."""
+    with pytest.raises(ValueError) as raised:
+        WithOpaqueCitedManagerSugar(
+            manager=ManagerSugar(), body=(), contract_ref=None, site=Frag()
+        )
+    assert "never inferred from the absence" in str(raised.value)
+
+
+# ------------------------------------------------------------ census / wire
+
+
+def test_census_projects_a_third_value_not_constructed_or_unconstructed():
+    """Known, unknown and absent each get their own spelling."""
+    outcome = context_manager_resolution_outcome(_ref())
+    assert outcome == "cited-opaque"
+    assert outcome not in {"constructed", "unconstructed"}
+
+
+def test_context_manager_edge_wire_refuses_a_citation():
+    """A citation must not ride the CM edge wire as if it were a contract."""
+    from sugar_lift_py_tests.kit_rpc import ContextManagerEdgeDtoV1
+    from sugar_lift_py_tests.kit_rpc.context_manager_edge_dto import (
+        ContextManagerEdgeTransportError,
+    )
+
+    ref = _ref()
+    with pytest.raises(ContextManagerEdgeTransportError) as raised:
+        ContextManagerEdgeDtoV1.from_resolved(ref, ref.use_site)
+    assert "authenticated derived ref" in str(raised.value)
+
+
+# --------------------------------------------------- absence is not unknown
+
+
+def test_only_off_population_is_cited():
+    """Lookup-failure must NEVER acquire the spelling of authenticated unknown.
+
+    ``call-target-export-unresolved`` means we could not resolve the callee at
+    all. Citing it would claim we know which callee is opaque when we do not
+    even know which callee it is.
+    """
+    from sugar_lift_python_source.manager_construction import (
+        _seat_opaque_cited_manager_ref,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+        empty_resolved_contract_refs,
+    )
+
+    coordinate = _coordinate()
+    for kind, expect_seated in (
+        ("call-target-export-unresolved", False),
+        ("call-graph-cycle", False),
+        ("call-target-off-population", True),
+    ):
+        context = TreeConstructionContextV1(
+            contract_refs=empty_resolved_contract_refs()
+        )
+        context.opaque_source_call_obligations[coordinate] = _roster(kind=kind)
+        _seat_opaque_cited_manager_ref(context, coordinate)
+        seated = context.source_derived_contract_refs.get(coordinate)
+        assert (seated is not None) is expect_seated, kind
+        if expect_seated:
+            assert isinstance(seated, OpaqueCitedContextManagerRefV1)
+
+
+def test_a_real_contract_is_never_downgraded_to_a_citation():
+    """Known beats unknown. A derived contract at this seat is not replaced."""
+    from sugar_lift_python_source.manager_construction import (
+        _seat_opaque_cited_manager_ref,
+    )
+    from sugar_lift_py_tests.context_manager_resolution import (
+        TreeConstructionContextV1,
+        empty_resolved_contract_refs,
+    )
+
+    coordinate = _coordinate()
+    context = TreeConstructionContextV1(contract_refs=empty_resolved_contract_refs())
+    sentinel = object()
+    context.source_derived_contract_refs[coordinate] = sentinel
+    context.opaque_source_call_obligations[coordinate] = _roster()
+    _seat_opaque_cited_manager_ref(context, coordinate)
+    assert context.source_derived_contract_refs[coordinate] is sentinel

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_census_conservation.py
@@ -1,8 +1,13 @@
 """With census conservation: construct-or-panic partition teeth.
 
 Conservation identity (binding):
-  site:with-item == constructed + unconstructed
+  site:with-item == constructed + cited-opaque + unconstructed
   over the effective use-site set With construction sees.
+
+THREE columns because there are three facts (#7384). A cited-opaque With
+constructed, so it is not unconstructed; sugar holds no enter/exit contract
+for it, so it is not constructed either. Collapsing it into either neighbour
+is how a sealed board comes to report knowledge nobody has.
 
 The tally owns canonical coordinate-keyed rows. The partition consumes those
 same keys exactly once while splitting the closed constructed/unconstructed
@@ -47,6 +52,44 @@ def _resolution_row(index: int, outcome: str) -> dict[str, object]:
         "observedEventType": "tests.PlantedResolution",
         "outcome": outcome,
     }
+
+
+def test_cited_opaque_is_its_own_column_and_conserves():
+    """A citation is countable on the board, in neither neighbour's bucket."""
+    module = _load()
+    rows = [
+        *[_resolution_row(index, "constructed") for index in range(1, 3)],
+        *[_resolution_row(index, "cited-opaque") for index in range(3, 7)],
+        *[_resolution_row(index, "unconstructed") for index in range(7, 9)],
+    ]
+    partition = module._with_census_partition(rows, Counter({"site:with-item": 8}))
+    assert partition["constructed"] == 2
+    assert partition["citedOpaque"] == 4
+    assert partition["unconstructed"] == 2
+    assert partition["conserves"] is True
+    assert partition["unaccounted"] == 0
+    # The citation is NOT laundered into either neighbour.
+    assert len(partition["citedOpaqueRows"]) == 4
+    assert all(row["outcome"] == "constructed" for row in partition["constructedRows"])
+    assert all(
+        row["outcome"] == "unconstructed" for row in partition["unconstructedRows"]
+    )
+    assert "cited-opaque" in partition["conservationIdentity"]
+    assert "4 cited-opaque" in partition["reconciliation"]
+
+
+def test_a_citation_never_seals_as_a_constructed_contract():
+    """The board must not be able to spell a citation 'constructed'.
+
+    If it could, this construct would launder ignorance into apparent
+    knowledge -- the one outcome that makes it worse than the refusal it
+    replaced (#7384, #7387).
+    """
+    module = _load()
+    rows = [_resolution_row(index, "cited-opaque") for index in range(1, 4)]
+    partition = module._with_census_partition(rows, Counter({"site:with-item": 3}))
+    assert partition["constructed"] == 0
+    assert partition["citedOpaque"] == 3
 
 
 def test_conservation_identity_is_stated_on_partition_and_refusal():

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -3952,6 +3952,7 @@ def _install_opaque_call_obligation(
         context.opaque_source_call_obligations[coordinate] = (
             opaque_source_call_roster_of(obligation)
         )
+        _seat_opaque_cited_manager_ref(context, coordinate)
         return
     seated = existing.owner(obligation.resolved_object_cid)
     if seated is not None:
@@ -3986,6 +3987,52 @@ def _install_opaque_call_obligation(
             fix="resolve the callee for every owner, or name why they differ",
         )
     context.opaque_source_call_obligations[coordinate] = existing.seating(obligation)
+    _seat_opaque_cited_manager_ref(context, coordinate)
+
+
+def _seat_opaque_cited_manager_ref(
+    context: TreeConstructionContextV1,
+    coordinate,
+) -> None:
+    """Seat the positive citation for an OFF-POPULATION call, and only that.
+
+    The ``with`` door must never infer opacity from the absence of a contract.
+    So the producer that authenticated the callee and classified it
+    off-population seats the claim here, positively, at the exact coordinate
+    the manager use-site will read.  ``With._prebound_manager_resolution``
+    then finds it through the existing ``source_derived_contract_refs`` lookup
+    with no consumer-side inference at all.
+
+    ONLY ``call-target-off-population`` is cited.  The sibling kinds are a
+    different fact and must not share this spelling:
+
+    - ``call-target-export-unresolved`` -- we FAILED TO LOOK UP the callee.
+      That is lookup-failure, and citing it would claim we know which callee
+      is opaque when we do not even know which callee it is.
+    - ``call-graph-cycle`` -- a construction limit of ours, not a property of
+      the target.
+
+    Off-population is the only kind where the callee IS authenticated and the
+    only missing thing is its body, by deliberate measurement policy. That is
+    the precise condition under which "we authenticate that we do not know"
+    is a true statement.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueCitedContextManagerRefV1,
+        mint_opaque_cited_context_manager_ref,
+    )
+
+    roster = context.opaque_source_call_obligations.get(coordinate)
+    if roster is None or roster.resolution_kind != "call-target-off-population":
+        return
+    seated = context.source_derived_contract_refs.get(coordinate)
+    if seated is not None and not isinstance(seated, OpaqueCitedContextManagerRefV1):
+        # A real derived contract already stands here. Known beats unknown;
+        # never downgrade authenticated enter/exit testimony to a citation.
+        return
+    context.source_derived_contract_refs[coordinate] = (
+        mint_opaque_cited_context_manager_ref(roster=roster)
+    )
 
 
 def _install_source_call_frame(

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1965,6 +1965,10 @@ def _install_local_derivation_gap(
             "targetSymbol": target_symbol,
         }
     )
+    if _seat_off_population_citation(
+        context, coordinate, target_symbol, kind, demand_cid
+    ):
+        return
     gap = ContextManagerResolutionGapV1(
         demand_cid,
         coordinate,
@@ -3139,6 +3143,53 @@ def _gap_kind_and_detail(gap) -> tuple[str, str | None]:
     return str(kind), (str(detail) if detail else None)
 
 
+def _seat_off_population_citation(
+    context, coordinate, target_symbol, kind: str, owner_cid: str
+) -> bool:
+    """Seat the positive citation where an off-population gap would go.
+
+    Derivation reaches this point having AUTHENTICATED the callee and then
+    declined to materialize it, because the population membrane refuses to
+    rebuild a distribution the pin does not enroll. That is not the same fact
+    as failing to find the callee, and it must not produce the same row:
+    off-population is "we know exactly which callee this is, and we have
+    decided not to look inside it".
+
+    Returns True when the citation was seated, so the caller skips the gap.
+    Only ``call-target-off-population`` qualifies, and only with a known
+    ``target_symbol`` -- a citation naming no callee would claim knowledge we
+    do not have, which is the lookup-failure spelling wearing this one's
+    clothes.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+        mint_opaque_cited_context_manager_ref,
+        opaque_source_call_roster_of,
+    )
+
+    if kind != "call-target-off-population" or not target_symbol:
+        return False
+    roster = context.opaque_source_call_obligations.get(coordinate)
+    if roster is None:
+        roster = opaque_source_call_roster_of(
+            OpaqueSourceCallObligationV1(
+                coordinate,
+                str(target_symbol),
+                owner_cid,
+                "call-target-off-population",
+            )
+        )
+        context.opaque_source_call_obligations[coordinate] = roster
+    elif roster.resolution_kind != "call-target-off-population":
+        # Another owner classified this same call differently. Their testimony
+        # stands; do not overwrite it with a citation.
+        return False
+    context.source_derived_contract_refs[coordinate] = (
+        mint_opaque_cited_context_manager_ref(roster=roster)
+    )
+    return True
+
+
 def _install_derivation_gap(
     context, coordinate, receipt, kind: str, detail: str | None = None
 ) -> None:
@@ -3153,8 +3204,13 @@ def _install_derivation_gap(
         ContextManagerResolutionGapV1,
     )
 
+    demand_cid = receipt.demand.get("cid", receipt.use["cid"])
+    if _seat_off_population_citation(
+        context, coordinate, receipt.target_symbol, kind, demand_cid
+    ):
+        return
     gap = ContextManagerResolutionGapV1(
-        receipt.demand.get("cid", receipt.use["cid"]),
+        demand_cid,
         coordinate,
         receipt.target_symbol,
         kind,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -7962,8 +7962,20 @@ class With(Statement):
         from sugar_lift_py_tests.outcome import Completed
         from .panic import UnsupportedContextManagerSemantics
 
+        from sugar_lift_py_tests.context_manager_resolution import (
+            OpaqueCitedContextManagerRefV1,
+        )
+
         if isinstance(resolution, ContextManagerResolutionGapV1):
             self._raise_resolution_gap(resolution)
+        if isinstance(resolution, OpaqueCitedContextManagerRefV1):
+            # A POSITIVE seated citation, not a rescued refusal. This arm never
+            # catches a panic and never infers opacity from a missing contract:
+            # the producer authenticated the callee and authenticated that its
+            # enter/exit semantics are uncited. Semantics are deliberately
+            # unreachable on this ref -- reading `.semantics` raises -- so the
+            # admitted-semantics checks below cannot silently pass it through.
+            return resolution
         if isinstance(resolution, FactoredSourceDerivedContextManagerRefV1):
             faces = getattr(resolution.boundary_faces, "exits", ())
             completed = tuple(face for face in faces if isinstance(face, Completed))
@@ -8218,6 +8230,57 @@ class With(Statement):
             from sugar_lift_py_tests.context_manager_resolution import (
                 SourceDerivedGeneratorResourceRefV1,
             )
+
+            from sugar_lift_py_tests.context_manager_resolution import (
+                OpaqueCitedContextManagerRefV1,
+            )
+
+            if isinstance(resolved_ref, OpaqueCitedContextManagerRefV1):
+                from sugar_lift_py_tests.sugar.with_opaque_cited_manager_sugar import (
+                    WithOpaqueCitedManagerSugar,
+                )
+
+                # An `as` target on a cited manager binds the OPEN enter-result
+                # coordinate. A simple Name was already discharged by
+                # substitution; any other target is a real store, and
+                # `_bind_store_target` declines to rewrite this contract (it
+                # admits only ProtocolResource semantics), so the binding would
+                # otherwise be silently dropped. A dropped binding is the one
+                # outcome no contract admits -- stay loud.
+                if binds_enter_result and as_name is None:
+                    from .panic import UnsupportedWithBindingTarget
+
+                    panic = UnsupportedWithBindingTarget(
+                        blame=item.optional_vars.fragment,
+                        owner="With._construct_sugar",
+                        observed=(
+                            "cited-opaque manager as-binding to a "
+                            f"{item.optional_vars.kind} store target"
+                        ),
+                        requested=(
+                            "a cited-opaque manager bound to a simple Name, or "
+                            "no target"
+                        ),
+                        fix=(
+                            "authenticate a store projection for the open "
+                            "enter-result coordinate, or keep the store target "
+                            "loud -- never drop the binding"
+                        ),
+                    )
+                    self.reporter.report_gap(self, panic)
+                    raise panic
+                enter_slot = (
+                    f"{item._manager_slot_id()}#enter_result"
+                    if binds_enter_result
+                    else None
+                )
+                return WithOpaqueCitedManagerSugar(
+                    manager=item.context_expr.sugar(),
+                    body=tuple(stmt.sugar() for stmt in self.body),
+                    contract_ref=resolved_ref,
+                    enter_slot_id=enter_slot,
+                    site=self.fragment,
+                )
 
             generator_protocol = (
                 resolved_ref.generator_protocol

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8778,6 +8778,29 @@ class With(Statement):
             from sugar_lift_py_tests.context_manager_contract import (
                 EffectBoundarySemanticsV1,
             )
+            from sugar_lift_py_tests.context_manager_resolution import (
+                OpaqueCitedContextManagerRefV1,
+            )
+
+            if isinstance(resolved_ref, OpaqueCitedContextManagerRefV1):
+                # A citation declares no contract, so it declares no
+                # observation slot. `as` binds the OPEN enter-result
+                # coordinate -- the same slot `_construct_sugar` binds.
+                #
+                # This arm is REQUIRED, not defensive tidiness. The
+                # EffectBoundary test below reads `.semantics` through
+                # `getattr(..., None)`, whose default only absorbs
+                # AttributeError; the citation's typed refusal is not one, so
+                # it would escape this frame-projection path as an INSTRUMENT
+                # FAILURE rather than a countable row. Asking a citation for
+                # semantics stays loud -- the answer is that this consumer
+                # must not ask.
+                enter_slot = f"{item._manager_slot_id()}#enter_result"
+                return self._with_assignment_binding(
+                    item,
+                    item._make_observation_ref(enter_slot, ENTER_RESULT),
+                    scope,
+                )
 
             if resolved_ref is not None and isinstance(
                 getattr(resolved_ref, "semantics", None), EffectBoundarySemanticsV1


### PR DESCRIPTION
Owner ruling on #7384: enrolling pytest REJECTED (vendoring a test framework corrupts the 1421 denominator); terrain REJECTED (502 files halting at their first `with` means never measuring a third of the corpus). **Opaque-cited manager ref ACCEPTED.**

> **What a `With` proof asserts under an opaque manager**
>
> Only Python's own `with` law, which holds whatever the manager is: the manager expression was evaluated; `__enter__` was attempted; the body ran **only** on the face where `__enter__` completed; `__exit__` ran over **every** outgoing body edge.
>
> Everything the manager decides stays open, each on an authenticated per-occurrence coordinate with both faces retained and **no biconditional emitted**: whether `__enter__` completes, what it projects, whether `__exit__` suppresses an exceptional body edge, and whether `__exit__` itself halts.
>
> Concretely: a body halt leaves as **both** a completed face (guarded on the exit result's opaque truthiness) and a halted face carrying the body's original effect (guarded on its negation). No downstream claim depending on suppression can be discharged in either direction — it reaches the emitted FOL as an undischarged obligation.

Built on existing machinery, not new mechanism: `ContextManagerExitRuntimeEffect` (existed, zero production callers), `ExitSet.and_exit_truthiness` (already emits both faces under complementary guards with a minted partition), `store_outcome_coordinate` as the idiom, `UndeterminedRaiseEffect` as the halt type. `RuntimeEffect`'s constructor panics unless the operand is genuinely runtime-dependent — **cited-means-unknown is enforced by construction, not convention.**

## The board gets a third column

A citation cannot be spelled `constructed` (reports a contract nobody holds) or `unconstructed` (claims a demand nobody resolved). The With partition is now three-way and must reconcile:

```
site:with-item == constructed + cited-opaque + unconstructed
```

## Authenticated measurement — 178 identical seats, `--start 0 --stride 8`

| | constructed | panic | instrument-failure | off-population rows |
|---|---|---|---|---|
| base `b3e82613b982` | 82 | 96 | 0 | **326** |
| after `a37517662c0d` | **121** | **57** | **0** | **3** |

Node-ID diff, both directions:

```
CLEARED  (base \ after): 39
REVEALED (after \ base):  0
still panicking        : 57
```

**39 cleared, zero revealed.** Those files did not halt deeper — they completed. Zero instrument failures preserved.

## Two defects the corpus caught that static reading missed

**A.** `With.substitution_binding` used `getattr(resolved_ref, "semantics", None)`. **`getattr`'s default absorbs only `AttributeError`** — a typed `ContractRefProtocolError` escapes it and became an instrument failure. Fixed by handling the citation *before* the getattr, NOT by softening `.semantics` — that would have re-enabled the silent fallthrough the ref exists to prevent. This generalizes: any `getattr`-with-default over a property that raises a typed refusal has the same hole, and it is invisible to attribute-access greps.

**B.** Only the parked-obligation path was cited; most off-population With sites reach the table via `_install_derivation_gap` / `_install_local_derivation_gap`. Both are now seated, producer-side, guards tight.

## Gate

M1 (decide suppression true) authenticated on battleaxe: **1 failed, 13 passed** — `test_body_halt_leaves_as_both_suppression_faces`, alone. The body's exception vanishes exactly when suppression is decided.

Not the sin already ruled on: the refusal is never rescued at the consumer. The producer seats a positive typed ref upstream that authorizes construction. `R_soft_unresolved_sugar_return = 0`.

Closes the mechanism behind #7384. Related: #7387.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cited-opaque context manager support to with-statement desugaring
> - Introduces `OpaqueCitedContextManagerRefV1`, a new ref type for context managers that are cited but have no enter/exit semantics; accessing `.semantics` raises `ContractRefProtocolError`.
> - Adds `WithOpaqueCitedManagerSugar` to desugar `with`-statements whose manager is cited-opaque, modeling open enter/exit behavior with guarded exit sets and optional enter-result binding.
> - Extends `context_manager_resolution_outcome` to classify `OpaqueCitedContextManagerRefV1` as `'cited-opaque'`, and updates census partition logic to track it as a distinct third bucket alongside `'constructed'` and `'unconstructed'`.
> - Adds `OpaqueManagerProtocolCoordinate` and related factory/guard helpers to produce standardized predicates over opaque manager protocol slots.
> - Seats cited-opaque refs automatically during obligation installation and summary derivation when a call target is off-population, replacing gap construction in those cases.
> - Risk: `with`-statements using a non-`Name` store target with a cited-opaque manager now raise a panic instead of silently dropping the binding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a375176.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authenticated opaque context-manager references when calls cannot be fully resolved.
  * Added complete handling for `with` statements, including enter/exit outcomes, halts, result bindings, and suppression behavior.
  * Added runtime reporting for context-manager entry effects.

* **Bug Fixes**
  * Preserved unresolved context-manager details without misclassifying valid contracts.

* **Documentation**
  * Updated resolution accounting to report `cited-opaque` separately and maintain conservation totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->