### PR TITLE
One With outcome vocabulary, read by both doors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -355,6 +355,12 @@ WITH_CENSUS_CONSERVATION_IDENTITY = (
     "(no residual kind taxonomy)"
 )
 
+# The outcome vocabulary the identity above names, in ONE place. The intake
+# gate and the partition MUST read the same set: they are two doors onto one
+# question, and when they disagreed the gate rejected `cited-opaque` as a
+# malformed event before the partition could count it.
+_WITH_RESOLUTION_OUTCOMES = frozenset({"constructed", "cited-opaque", "unconstructed"})
+
 
 def _tally_cm_resolutions(
     context=None,
@@ -385,7 +391,14 @@ def _tally_cm_resolutions(
             if (
                 not isinstance(key, dict)
                 or key.get("sourceCid") != source_cid
-                or outcome not in {"constructed", "unconstructed"}
+                # The SAME three facts the partition below counts. This gate
+                # runs upstream of `_with_census_partition`, so a value it
+                # rejects never reaches the bucket built for it: #7388 added
+                # `cited-opaque` to the law and to the partition and left this
+                # closed set at two. Every cited row then failed here as a
+                # malformed event and voided its whole file -- 86 instrument
+                # failures in run 31128314243 where the census before had zero.
+                or outcome not in _WITH_RESOLUTION_OUTCOMES
                 or not isinstance(observed_type, str)
                 or "." not in observed_type
             ):

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resolution_outcome_vocabulary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resolution_outcome_vocabulary.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+"""The intake gate and the partition must read ONE outcome vocabulary.
+
+`_tally_cm_resolutions` validates incoming With resolution events against a
+closed outcome set, and `_with_census_partition` counts them into buckets.
+They are two doors onto one question, and the gate runs FIRST.
+
+#7388 added `cited-opaque` to the conservation identity and to the partition
+and left the gate's set at two values. Every cited row was then rejected as a
+malformed event before the bucket built for it could count it -- 86 instrument
+failures in run 31128314243 where the previous census had zero. An instrument
+failure voids the whole file, so this did not merely miscount: it destroyed the
+measurement for every file containing a cited manager.
+
+The repair is one vocabulary read by both doors. These teeth fail if they
+diverge again.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+import pytest
+
+_SCRIPTS = (
+    pathlib.Path(__file__).resolve().parents[1] / "scripts"
+)
+
+
+def _load():
+    path = _SCRIPTS / "control_effect_recensus.py"
+    spec = importlib.util.spec_from_file_location("_cer_vocab", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_identity_names_exactly_the_vocabulary_the_gate_admits() -> None:
+    """The LAW string and the gate's closed set must agree, term for term.
+
+    The identity is the human-readable statement of the partition; the set is
+    what the gate enforces. If they drift, the board's stated law stops
+    describing what it actually admits.
+    """
+    cer = _load()
+    identity = cer.WITH_CENSUS_CONSERVATION_IDENTITY
+    named = set(re.findall(r"[a-z]+(?:-[a-z]+)*", identity.split("==", 1)[1]))
+    for outcome in cer._WITH_RESOLUTION_OUTCOMES:
+        assert outcome in named, (
+            f"gate admits {outcome!r} but the conservation identity does not "
+            f"name it: {identity!r}"
+        )
+
+
+def test_cited_opaque_is_admitted_by_the_intake_gate() -> None:
+    """The planted arm: a cited row must survive intake.
+
+    Before the repair this raised `malformed With resolution event` and the
+    file became an instrument failure.
+    """
+    cer = _load()
+    assert "cited-opaque" in cer._WITH_RESOLUTION_OUTCOMES
+
+
+def test_the_partition_counts_every_outcome_the_gate_admits() -> None:
+    """No admitted value may fall outside the buckets.
+
+    A value the gate lets in but the partition does not count would break the
+    closed-outcomes reconciliation downstream -- the arithmetic stops matching
+    and the row is dropped without anyone naming it.
+    """
+    cer = _load()
+    source = (_SCRIPTS / "control_effect_recensus.py").read_text()
+    body = source.split("def _with_census_partition", 1)[1]
+    for outcome in cer._WITH_RESOLUTION_OUTCOMES:
+        assert f'"{outcome}"' in body, (
+            f"gate admits {outcome!r} but _with_census_partition never "
+            "mentions it; an admitted value with no bucket is dropped silently"
+        )


### PR DESCRIPTION
#7388 added `cited-opaque` to the conservation identity and to `_with_census_partition`, and left the intake gate in `_tally_cm_resolutions` at two values. **That gate runs upstream of the partition**, so every cited row was rejected as a malformed event before the bucket built for it could count it.

Run [`31128314243`](https://github.com/TSavo/sugar/actions/runs/31128314243):

```
86 instrument-failure / 80 completed / 12 panic
all 86 at phase=main-file-producer
every one: "malformed With resolution event: {... 'outcome': 'cited-opaque' ...}"
```

The census before it had **zero** instrument failures. An instrument failure voids the whole file, so this did not merely miscount — it destroyed the measurement for every file containing a cited manager.

## Why the evidence for #7388 could not see it

That merge was mutation-proved (10 mutations, one at a time), propagation-proved (M1 flipping the propagation tooth alone, authenticated), and measured on a 178-seat slice: off-population rows 326 → 3, 39 cleared, 0 revealed, 0 instrument failures.

**The profile mints its own demand table and never passes through `_tally_cm_resolutions`.** The census does. So the change was correct, well-tested, and still broke the census, because the evidence ranged over a universe that excluded the failing door — the same shape as the `getattr`-with-default the corpus caught after a static audit came back clean.

## The fix

One `frozenset` read by both doors:

```python
_WITH_RESOLUTION_OUTCOMES = frozenset({"constructed", "cited-opaque", "unconstructed"})
```

Teeth assert that the law string, the intake gate, and the partition all name the same values — so divergence fails a test instead of voiding 86 files:

- `test_the_identity_names_exactly_the_vocabulary_the_gate_admits`
- `test_cited_opaque_is_admitted_by_the_intake_gate`
- `test_the_partition_counts_every_outcome_the_gate_admits`

**Verified on battleaxe: 3 passed.** Mutation — removing `cited-opaque` from the vocabulary — fails `test_cited_opaque_is_admitted_by_the_intake_gate` **alone**; restored, 3 pass.

Related: #7374, #7384, #7388, #7391.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Accept 'cited-opaque' as a valid outcome in `_tally_cm_resolutions` intake gate
> - Extracts the outcome vocabulary into a module-level `_WITH_RESOLUTION_OUTCOMES` frozenset (`{'constructed', 'cited-opaque', 'unconstructed'}`) in [`control_effect_recensus.py`](https://github.com/TSavo/sugar/pull/7392/files#diff-8d4e8c9a036a9961ecdf837ddbedf4f04e967f783ed2d9ead7daa05c7db08b5d), replacing a hard-coded two-member set.
> - The intake gate in `_tally_cm_resolutions` and `_with_census_partition` now share this single source of truth, ensuring both read the same closed vocabulary.
> - Adds a new test module [`test_with_resolution_outcome_vocabulary.py`](https://github.com/TSavo/sugar/pull/7392/files#diff-59bca6fffa769b8ee50dfbadb4d7d4ee589df3c6e2992c9fe10877b3c1b40465) that asserts vocabulary consistency between the gate and the partition.
> - Behavioral Change: events with outcome `'cited-opaque'` are no longer rejected as malformed by the intake gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc7dcbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated With-resolution handling to recognize the `cited-opaque` outcome alongside existing outcomes.
  * Ensured accepted resolution outcomes are consistently included in census partitioning and conservation checks.

* **Tests**
  * Added coverage verifying validation, accounting, and partitioning for all supported With-resolution outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->