### PR TITLE
Thread bindings through the module prefix before sugaring it

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/probe_prefix_threading.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_prefix_threading.py
@@ -1,0 +1,172 @@
+"""Discriminator: does the module-prefix door reach the block-threading construct?
+
+Diagnostic only -- reports, never repairs.
+
+Two doors construct a statement sequence in this codebase:
+
+  A. ``FunctionDef.source_visible_call_frame`` (nodes.py:3814)
+         substituted_body, _ = self._substitute_body(filtered_body, formal_scope)
+         ... self._sugar_body_statement(statement) for statement in substituted_body
+     SUBSTITUTE the block, THEN sugar each statement.
+
+  B. ``manager_construction._module_prefix_outcome`` (:1002)
+         sugars = tuple(... statement.sugar() ... for statement in prefix)
+         return reduce_block_to_exitset(sugars)
+     Sugar each statement. Never substitute.
+
+``_substitute_body_tracked`` is what threads a statement's binding into the
+rest of the block, and it is what splices a ``for`` that dissolved over a
+concrete iterable (``_Splice``). Door B never calls it, so a module-level
+``for`` over a module-level constant cannot dissolve and falls to
+``For.sugar``, which is deliberately unwritten because a SURVIVING ``For`` is
+the symbolic fold.
+
+This probe runs BOTH arms over the SAME authenticated prefix statements and
+reports what each produces. It writes nothing and repairs nothing.
+
+usage:
+  python probe_prefix_threading.py pandas pandas 34
+      <top-level> <module> <export-locus-line>
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+
+def main(argv: list[str]) -> int:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.dependency_artifact import (
+        authenticate_dependency_top_level,
+    )
+    from sugar_lift_python_source.resolution_session import walk_session_for
+    from sugar_source_tree.panic import SugarNotWritten
+    from sugar_source_tree.tree import SourceFile
+
+    top_level, module_name, locus_line = argv[0], argv[1], int(argv[2])
+    corpus = authenticated_pandas_corpus()
+    print(f"CORPUS {corpus.distribution} {corpus.version} files={corpus.file_count}")
+    session = walk_session_for(
+        corpus.root, enrolled_distributions=frozenset({"pandas"})
+    )
+    graph = authenticate_dependency_top_level(top_level)
+    module = graph.modules[module_name]
+    print(f"MODULE {module_name} seat={module.source_seat}")
+
+    from sugar_lift_python_source.manager_construction import (
+        TreeConstructionContextV1,
+    )
+    from sugar_source_tree.binding_state import (
+        ConstructionTestimonyReporterV1,
+        SubstitutionTraceBuilderV1,
+    )
+    from sugar_source_tree.reporter import NULL_REPORTER
+
+    def fresh_prefix():
+        """A cold prefix: door A and door B must not share a construction memo."""
+        source_file = SourceFile(
+            (module.source, module.source_seat, module.source_cid),
+            reporter=ConstructionTestimonyReporterV1(
+                NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+            ),
+            construction_context=(
+                TreeConstructionContextV1.for_source_call_construction()
+            ),
+        )
+        prefix = tuple(
+            statement
+            for statement in source_file.root.body
+            if statement.line_col_span().start_line < locus_line
+        )
+        return source_file, prefix
+
+    source_file, prefix = fresh_prefix()
+    print(f"PREFIX {len(prefix)} statements before line {locus_line}")
+    for statement in prefix:
+        span = statement.line_col_span()
+        print(f"  line {span.start_line:>4} {statement.kind}")
+
+    # ---- DOOR B (what _module_prefix_outcome does today) --------------------
+    print("\nDOOR B -- sugar each statement, no substitute (current prefix door)")
+    for statement in prefix:
+        span = statement.line_col_span()
+        if statement.kind not in ("For", "While", "Try"):
+            continue
+        try:
+            statement.sugar()
+            print(f"  line {span.start_line} {statement.kind}: sugar OK")
+        except SugarNotWritten as exc:
+            print(
+                f"  line {span.start_line} {statement.kind}: "
+                f"SugarNotWritten [{exc.owner}] {exc.observed}"
+            )
+        except BaseException as exc:  # a probe names its own death
+            print(f"  line {span.start_line} {statement.kind}: {type(exc).__name__}: {exc}")
+
+    # ---- DOOR A (block-substitute first, exactly as a function body does) ---
+    print("\nDOOR A -- _substitute_body over the SAME prefix, then sugar")
+    source_file, prefix = fresh_prefix()
+    root = source_file.root
+    try:
+        substituted, changed = root._substitute_body(prefix, {})
+    except SugarNotWritten as exc:
+        print(f"  _substitute_body RAISED SugarNotWritten [{exc.owner}] {exc.observed}")
+        return 0
+    except BaseException:
+        print("  _substitute_body RAISED:")
+        traceback.print_exc()
+        return 0
+    print(f"  changed={changed}  {len(prefix)} statements -> {len(substituted)}")
+    kinds_before = [s.kind for s in prefix]
+    kinds_after = [s.kind for s in substituted]
+    print(f"  kinds before: {kinds_before}")
+    print(f"  kinds after : {kinds_after}")
+    print(f"  For survived substitution: {'For' in kinds_after}")
+    for statement in substituted:
+        span = statement.line_col_span()
+        if statement.kind not in ("For", "While", "Try"):
+            continue
+        try:
+            statement.sugar()
+            print(f"  line {span.start_line} {statement.kind}: sugar OK")
+        except SugarNotWritten as exc:
+            print(
+                f"  line {span.start_line} {statement.kind}: "
+                f"SugarNotWritten [{exc.owner}] {exc.observed}"
+            )
+        except BaseException as exc:
+            print(f"  line {span.start_line} {statement.kind}: {type(exc).__name__}: {exc}")
+
+    # ---- The SECOND gate: even a dissolved For must leave ONE Completed face
+    # `prefix_has_completed_fallthrough` requires len(exits.exits) == 1 with a
+    # true guard. Report the face count so a reader cannot mistake "the For
+    # dissolved" for "the export is now admissible".
+    print("\nEXIT FACES of the substituted prefix (the second gate)")
+    try:
+        from sugar_lift_py_tests.sugar.function_universe_sugar import (
+            reduce_block_to_exitset,
+        )
+
+        sugars = []
+        for statement in substituted:
+            try:
+                sugars.append(statement.sugar())
+            except SugarNotWritten as exc:
+                print(f"  cannot reduce: [{exc.owner}] {exc.observed}")
+                return 0
+        exits = reduce_block_to_exitset(tuple(sugars))
+        print(f"  exit face count = {len(exits.exits)}")
+        for face in exits.exits:
+            print(
+                f"    {type(face).__name__} guard={getattr(face, 'guard', None)!r} "
+                f"can_fall_through="
+                f"{getattr(getattr(face, 'value', None), 'can_fall_through', None)!r}"
+            )
+    except BaseException:
+        traceback.print_exc()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_with_gaps.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_with_gaps.py
@@ -1,0 +1,150 @@
+"""Name, for one authenticated symbol, WHY With has no contract ref.
+
+Diagnostic only -- reports, never repairs. Answers two questions the sealed
+board cannot, because the board records the fused gap kind and not the
+producer testimony behind it:
+
+  * export resolution: what does ``resolve_export`` return, and when it
+    returns ``dynamic-export``, which arm of ``PrefixFallthroughOutcomeV1``
+    actually produced it -- ``ordinary-non-fallthrough`` or a named
+    ``construction-refusal``?
+  * frame projection: when ``resolve_source_visible_frame`` raises
+    ``SugarNotWritten``, what construct, at which coordinate, refused?
+
+usage:
+  python probe_with_gaps.py python:pandas.option_context [more symbols...]
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+
+def _print_outcome(label: str, value: object) -> None:
+    print(f"  {label}: {type(value).__name__}")
+    for field in (
+        "kind",
+        "refusal_kind",
+        "observed_event_type",
+        "detail",
+        "module_name",
+        "exported_name",
+        "target_symbol",
+    ):
+        if hasattr(value, field):
+            print(f"    .{field} = {getattr(value, field)!r}")
+
+
+def probe(symbol: str, corpus_root) -> None:
+    import ast
+
+    from sugar_lift_python_source.dependency_artifact import (
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+    )
+    from sugar_lift_python_source.dependency_export_adapter import (
+        _export_block_with_locus,
+        resolve_export,
+    )
+    from sugar_lift_python_source.manager_construction import (
+        prefix_has_completed_fallthrough,
+        resolve_source_visible_frame,
+    )
+    from sugar_lift_python_source.resolution_session import walk_session_for
+    from sugar_lift_python_source.source_tables import parsed_tree
+
+    print(f"=== {symbol}")
+    dotted = symbol.removeprefix("python:")
+    module_name, _, exported_name = dotted.rpartition(".")
+    top_level = dotted.split(".", 1)[0]
+    session = walk_session_for(
+        corpus_root, enrolled_distributions=frozenset({"pandas"})
+    )
+    graph = authenticate_dependency_top_level(top_level)
+    print(f"  graph.distributionArtifactCid = {graph.distribution_artifact_cid}")
+    print(f"  module {module_name!r} exported {exported_name!r}")
+
+    module = graph.modules.get(module_name)
+    if module is None:
+        print("  MODULE ABSENT from graph")
+        return
+    print(f"  module.source_seat = {module.source_seat}")
+
+    # The prefix arm, read straight from the producer -- this is the fact the
+    # adapter fuses into an untyped ``dynamic-export``.
+    tree = parsed_tree(module.source, module.source_seat)
+    _binding, locus = _export_block_with_locus(tree.body, exported_name, None)
+    if locus is None:
+        print("  no export-binding locus for this name in this module")
+    else:
+        print(f"  export locus: line {locus.lineno} col {locus.col_offset} "
+              f"{type(locus).__name__} :: {ast.unparse(locus)[:160]!r}")
+        outcome = prefix_has_completed_fallthrough(
+            module, locus, graph=graph, session=session
+        )
+        _print_outcome("prefix fallthrough", outcome)
+        # Which prefix statements are NOT statically fall-through: the exact
+        # reason the cheap door declined and the producer had to run.
+        from sugar_lift_python_source.manager_construction import (
+            _ast_stmt_always_falls_through,
+        )
+
+        locus_key = (locus.lineno, locus.col_offset)
+        for statement in tree.body:
+            if (statement.lineno, statement.col_offset) >= locus_key:
+                break
+            if not _ast_stmt_always_falls_through(statement):
+                print(
+                    f"    non-static-fallthrough prefix stmt "
+                    f"line {statement.lineno} {type(statement).__name__}: "
+                    f"{ast.unparse(statement)[:200]!r}"
+                )
+
+    resolved = resolve_export(
+        graph, "probe", module_name, exported_name, (), frozenset(), session=session
+    )
+    _print_outcome("resolve_export", resolved)
+    if not isinstance(resolved, ResolvedPythonObjectV1):
+        return
+
+    from sugar_source_tree.panic import SugarNotWritten
+
+    try:
+        frame_result = resolve_source_visible_frame(
+            resolved, graph=graph, session=session
+        )
+    except SugarNotWritten as exc:
+        print("  resolve_source_visible_frame RAISED SugarNotWritten")
+        for field in ("owner", "observed", "requested", "fix", "blame"):
+            print(f"    .{field} = {getattr(exc, field, None)!r}")
+        traceback.print_exc()
+        return
+    except TypeError:
+        print("  resolve_source_visible_frame RAISED TypeError")
+        traceback.print_exc()
+        return
+    if isinstance(frame_result, tuple):
+        frame, target = frame_result
+        print(f"  FRAME OK: target={type(target).__name__} {target.name!r}")
+    else:
+        _print_outcome("frame gap", frame_result)
+
+
+def main(argv: list[str]) -> int:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    corpus = authenticated_pandas_corpus()
+    print(f"CORPUS {corpus.distribution} {corpus.version} "
+          f"files={corpus.file_count} manifest={corpus.manifest_cid}")
+    for symbol in argv:
+        try:
+            probe(symbol, corpus.root)
+        except BaseException:  # a probe is diagnostic: never hide its own death
+            traceback.print_exc()
+        print(flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/implementations/python/sugar-lift-py-tests/tests/test_module_prefix_threads_before_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_module_prefix_threads_before_sugar.py
@@ -1,0 +1,171 @@
+"""The module-prefix door must thread its block before it sugars it.
+
+``FunctionDef.source_visible_call_frame`` substitutes a body and only then
+sugars each statement (``nodes.py``: ``_substitute_body`` -> per-statement
+sugar). ``manager_construction._module_prefix_outcome`` used to sugar each
+prefix statement where it stood, with nothing threaded. Two doors onto the same
+construct, one of which could not reach it.
+
+The cost, measured on the sealed board: ``pandas/__init__.py:9`` is
+``for _dependency in _hard_dependencies:`` over a tuple bound two lines above.
+Unthreaded, the iterable is symbolic, ``For.substitute`` cannot unroll, and the
+statement falls to ``For.sugar`` -- deliberately unwritten, because a SURVIVING
+``For`` IS the symbolic fold. ``prefix_has_completed_fallthrough`` then reports
+``construction-refusal``, and ``dependency_export_adapter`` fuses that into
+``dynamic-export``. Every ``with pd.option_context(...)`` in the corpus panics
+with a manager the board describes as *dynamically exported* -- which
+``pandas/__init__.py:34`` plainly is not.
+
+TWO ARMS, and both are needed:
+
+* CLEAR -- ``tests/indexes/datetimes/test_formats.py`` carries exactly two
+  ``With._construct_sugar`` panics, both ``option_context`` dynamic-export.
+  Threading the prefix must kill that label and carry construction across the
+  export boundary into ``pandas/_config/config.py``. It does NOT make the seat
+  clean: behind the export is a constructed-value canonicalization gap, owned
+  elsewhere. Clearing a first terminal reveals what it masked; that is
+  discovery, and this tooth stops exactly where threading's authority stops.
+* HOLD -- ``core/arrays/_ranges.py`` carries exactly two, both
+  ``numpy.errstate`` dynamic-export, and those reach the SAME label by a
+  DIFFERENT route: ``numpy/__init__.py``'s prefix already reports ``completed``
+  and the export is declined further down, at an ``If``-block binding locus.
+  Threading must not admit them. A repair that clears this arm too has
+  over-admitted, and the fused label would hide it.
+
+Measured through the census entrance (``measure_file_via_enumerate``) on the
+real authenticated seats, never ``SourceFile.from_path`` -- a different door
+proves nothing about this one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
+
+CLEAR_SEAT = "tests/indexes/datetimes/test_formats.py"
+HOLD_SEAT = "core/arrays/_ranges.py"
+
+
+def _load(name: str) -> ModuleType:
+    if str(_SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS))
+    path = _SCRIPTS / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CONSUMER = _load("recensus_enumerate_consumer")
+
+
+def _measure(seat: str) -> dict:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    corpus = authenticated_pandas_corpus().root
+    target = corpus.joinpath(*seat.split("/"))
+    installed = install_root_for(str(target))
+    locus_root = corpus if installed is None else Path(installed)
+    return CONSUMER.measure_file_via_enumerate(
+        workspace_root=corpus,
+        file_rel=seat,
+        distribution="pandas",
+        source_workspace_root=locus_root,
+    )
+
+
+def _manager_gaps(row: dict, manager: str) -> list[str]:
+    """Every construction panic naming this manager, as its observed text."""
+    return [
+        str(panic.get("observed"))
+        for panic in (row.get("constructionPanics") or [])
+        if isinstance(panic, dict) and manager in str(panic.get("observed"))
+    ]
+
+
+def _instrument_failure(row: dict) -> str | None:
+    message = (row.get("instrumentFailure") or {}).get("message")
+    return str(message) if message else None
+
+
+@pytest.mark.slow
+def test_option_context_construction_crosses_the_export_boundary() -> None:
+    """CLEAR arm: the prefix threads, the For dissolves, the export RESOLVES.
+
+    This asserts what threading owns and nothing further. The ``with`` still
+    refuses -- but at a coordinate INSIDE the manager's own module
+    (``pandas/_config/config.py``), which is only reachable once export
+    resolution succeeded. Unthreaded, construction never got past
+    ``pandas/__init__.py`` and no inner coordinate could appear.
+
+    Deliberately NOT asserted: that the seat goes clean. What is behind the
+    export is a constructed-value canonicalization gap owned elsewhere, and a
+    tooth that waited on it would be asserting someone else's target.
+    """
+    row = _measure(CLEAR_SEAT)
+
+    assert _instrument_failure(row) is None, _instrument_failure(row)
+    observed = _manager_gaps(row, "python:pandas.option_context")
+    assert observed, (
+        "the option_context seats must still be measurable; an empty roster "
+        "here means the measurement stopped reaching them"
+    )
+    assert all("pandas/_config/config.py" in text for text in observed), (
+        "construction must reach INSIDE the resolved manager's module; a "
+        f"refusal naming no inner coordinate means the export never resolved: {observed}"
+    )
+
+
+@pytest.mark.slow
+def test_option_context_refusal_named_dynamic_export_is_gone() -> None:
+    """The SPECIFIC false label must be gone, not merely some panic count.
+
+    Asserted on the refusal TEXT: a repair that swapped one wrong word for
+    another wrong word would keep this red.
+    """
+    row = _measure(CLEAR_SEAT)
+
+    # An absence assertion is worthless if the measurement never happened: a
+    # seat that died at source-identity reports no panics at all and would let
+    # this pass while proving nothing.
+    assert _instrument_failure(row) is None, _instrument_failure(row)
+    fused = [
+        text
+        for text in _manager_gaps(row, "python:pandas.option_context")
+        if "dynamic-export" in text
+    ]
+    assert fused == [], (
+        "pandas/__init__.py:34 is a plain static ImportFrom; no resolution may "
+        f"call option_context a dynamic export: {fused}"
+    )
+
+
+@pytest.mark.slow
+def test_numpy_errstate_with_still_refuses() -> None:
+    """HOLD arm: same label, different route -- threading must not admit it.
+
+    ``numpy/__init__.py``'s prefix already reports ``completed``; its export is
+    declined at an ``If``-block binding locus. Nothing about threading a module
+    prefix touches that, so this refusal must survive intact. If it clears, the
+    repair admitted an export it never proved.
+    """
+    row = _measure(HOLD_SEAT)
+
+    assert _instrument_failure(row) is None, _instrument_failure(row)
+    observed = _manager_gaps(row, "python:numpy.errstate")
+    assert len(observed) == 2, (
+        "core/arrays/_ranges.py holds exactly two numpy.errstate refusals and "
+        f"threading the module prefix must not change that; observed {observed}"
+    )
+    assert all("dynamic-export" in text for text in observed), observed

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -914,6 +914,29 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
         < locus_key
     )
 
+    # THREAD THE BLOCK BEFORE ANYTHING READS IT -- the same order a function
+    # body takes.  ``FunctionDef.source_visible_call_frame`` substitutes its
+    # body and only then sugars each statement; this door used to sugar each
+    # statement where it stood.  Statement-at-a-time construction cannot see the
+    # binding an earlier statement made, so a module-level ``for`` over a
+    # module-level constant (``for _dependency in _hard_dependencies:``) met a
+    # SYMBOLIC iterable, could not unroll, and fell to ``For.sugar`` --
+    # deliberately unwritten, because a SURVIVING ``For`` is the symbolic fold.
+    # The dissolution was already written in ``For.substitute``; this door
+    # simply never reached it.  Nothing here teaches ``For.sugar`` to guess: an
+    # iterable still symbolic after threading keeps the node and stays loud.
+    #
+    # Threading happens HERE, before base-class seating and import-receipt
+    # seating, so every downstream reader sees ONE statement set.  Seating the
+    # unsubstituted classes and then sugaring the substituted ones would key
+    # ``source_class_bases`` on fragment CIDs the sugared statements no longer
+    # carry.
+    #
+    # ``_substitute_body`` may raise SugarNotWritten/TypeError; the caller
+    # (``prefix_has_completed_fallthrough``) already catches exactly those and
+    # turns them into named construction-refusal testimony, never a quiet False.
+    prefix, _threaded = source_file.root._substitute_body(prefix, {})
+
     # Base testimony is installed from exact parser-owned module bindings,
     # never from a class-name scan.  Only earlier module ClassDefs can be a
     # source-visible base at this prefix boundary.

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -92,6 +92,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py"]
 network = "none"
 
+[tasks.probe-with-gaps]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_with_gaps.py"]
+network = "none"
+
 [tasks.authenticated-no-call-body-attribution]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -98,6 +98,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_with_gaps.py"]
 network = "none"
 
+[tasks.probe-prefix-threading]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_prefix_threading.py"]
+network = "none"
+
 [tasks.authenticated-no-call-body-attribution]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]


### PR DESCRIPTION
`_module_prefix_outcome` sugared each prefix statement **in isolation**, so `_hard_dependencies = ("numpy", "dateutil")` never reached the `for` loop two lines below it. A concrete iterable presented as symbolic, `For.sugar` refused (a surviving `For` is the symbolic fold, deliberately unwritten), and the whole export resolution failed — reported as `dynamic-export` for `pandas.option_context`, which is exported by a plain static import.

## Proven before built — both doors over the same authenticated prefix

```
PREFIX 6 statements before line 34:  ImportFrom Assign Assign For Delete Try

DOOR B -- sugar each statement, no substitute (the current prefix door)
  line 9 For: SugarNotWritten [For.sugar] For at pandas/__init__.py:9:0 has no sugar written

DOOR A -- _substitute_body over the SAME prefix, then sugar
  changed=True   6 statements -> 8
  For survived substitution: False
  line 10 Try: sugar OK / line 10 Try: sugar OK / line 20 Try: sugar OK
```

The construct was always there. `_substitute_body_tracked` threads each statement's binding into the rest of the block and splices what a dissolving `for` returns; `FunctionDef.source_visible_call_frame` calls it, `_module_prefix_outcome` never did. **Wrong entrance.**

The second gate does not bite either — the substituted prefix yields **one exit face**, `Completed`, true guard, falls through. No guard-lifter ruling needed.

## The change

One line, placed before base-class and import-receipt seating so every reader sees one statement set (seating unsubstituted classes then sugaring substituted ones would key `source_class_bases` on fragment CIDs the sugared statements no longer carry):

```python
prefix, _threaded = source_file.root._substitute_body(prefix, {})
```

**`For.sugar` is untouched.** An iterable still symbolic after threading keeps the node and stays loud.

## Mutation matrix — one guard at a time

| tree state | crosses-export-boundary | no-dynamic-export-label | HOLD errstate |
|---|---|---|---|
| fix | pass | pass | pass |
| **M1** — threading line removed (coherent revert) | **FAIL** | **FAIL** | pass |
| **M2** — over-admit conditional export, fix intact | pass | pass | **FAIL** |

M2 is an internally-consistent wrong implementation: in `_join_export_states`, when exactly one `If` arm binds the name statically, take it — the first-candidate selection that function's own comment refuses. It flips `numpy.errstate` to `ambiguous-static-export` and the HOLD tooth catches it on the refusal text.

## Before/after — `--start 0 --stride 8`, 178 seats

```
before  {"constructed": 121, "construction-panic": 57, "instrument-failure": 0}
after   {"constructed": 121, "construction-panic": 57, "instrument-failure": 0}
```

Identical totals — **which is exactly why the diff is required**. Node-ID diff both directions over the 98 seats parsed in both arms: **4 cleared, 4 revealed, the same four coordinates.**

```
- dynamic-export for 'python:pandas.option_context'   (4 seats)
+ source-body-gap  for 'python:pandas.option_context'
   constructed value of CallSiteSugar at pandas/_config/config.py:708:8 does not canonicalize:
   ConstructedValueCategoryGap: builtins.list is a MUTABLE container...
```

`numpy.errstate` appears in **neither** direction — no over-admission.

**This does not move width.** It substitutes a **false reason for a true one**, and advances construction across the export boundary into new territory — which turns out to be the canonicalization category. Threading `For` was necessary to *see* that; it was not sufficient to drain the row.

## Limits

- The diff covers 98 of 178 seats: engine-log lines interleave with `PROFILE_ROW` on stdout and 80 after-arm rows were unparseable in the base arm. `PROFILE_ROW` wants its own fd.
- Teeth measure with provisional per-file demands, not the prebuilt demand table the shard uses — a larger population, correct discrimination, but not shard conditions.
- The fusion at `dependency_export_adapter:225` (#7391) is untouched. The false label is gone from these four rows because the refusal is gone, not because the fusion was fixed.

Related: #7391, #7374.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread module prefix through substitution before sugaring in `_module_prefix_outcome`
> - [`_module_prefix_outcome`](https://github.com/TSavo/sugar/pull/7393/files#diff-5adb8e8c9c5328c3f483e4b3176a94652f2030e4089af67cf182ea43897557e1) now calls `root._substitute_body(prefix, {})` on the module prefix block before any sugaring or base class seating, mirroring the existing behavior for `FunctionDef`.
> - This allows module-level constructs (e.g. `For` over a concrete iterable) to dissolve during substitution rather than being passed unsugared to downstream consumers.
> - Adds two diagnostic probe scripts and corresponding build tasks to inspect prefix threading and resolution gaps interactively.
> - Behavioral Change: `SugarNotWritten` or `TypeError` raised during prefix substitution now surface from `_module_prefix_outcome` directly rather than being silently bypassed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10ec30e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->