### PR TITLE
Say WHICH slot and WHICH identity term refused, not the whole shape at once

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_constructed_value_v2_merkle.py
@@ -464,6 +464,69 @@ def test_an_unnameable_category_is_a_typed_gap_never_reflection():
     ).replace("  ", " ")
 
 
+def test_a_category_gap_names_the_slot_it_refused_not_only_the_type():
+    """A type tag alone is not actionable.
+
+    The refused value is reached through a PATH from the presented root, and
+    that path is the whole repair instruction: a reader told only
+    ``builtins.list`` must search every slot of a sugar with a dozen ``Any``
+    fields to find which one carried it. The walk already knows the path -- it
+    descended it -- so refusing to say it discards evidence the instrument
+    holds.
+    """
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2(Holder(Pair(1, [2, 3])))
+    message = str(caught.value)
+    # The type is still named -- the path is carried IN ADDITION, never instead.
+    assert "builtins.list" in message
+    assert "MUTABLE container" in message
+    # ... and the slot chain from the presented root to the refused value.
+    assert "at .items.right" in message, message
+
+
+def test_the_refused_slot_path_distinguishes_two_slots_of_one_type():
+    """Two fields of the same type are the case a type tag cannot separate."""
+    left_gap = pytest.raises(ConstructedValueCategoryGap)
+    with left_gap:
+        constructed_value_cid_v2(Pair([1], (2,)))
+    right_gap = pytest.raises(ConstructedValueCategoryGap)
+    with right_gap:
+        constructed_value_cid_v2(Pair((1,), [2]))
+    assert "at .left" in str(left_gap.excinfo.value)
+    assert "at .right" in str(right_gap.excinfo.value)
+    assert str(left_gap.excinfo.value) != str(right_gap.excinfo.value)
+
+
+def test_the_three_slot_kinds_do_not_read_alike():
+    """A field, an index and an unordered member are different coordinates.
+
+    Spelling them all ``.at`` would make ``Pair(left=...)`` and a 0th tuple
+    element render identically, and would invent a slot name for a frozenset
+    member -- which deliberately HAS no coordinate.
+    """
+    with pytest.raises(ConstructedValueCategoryGap) as field_gap:
+        constructed_value_cid_v2(Pair([1], 0))
+    assert "at .left" in str(field_gap.value)
+
+    with pytest.raises(ConstructedValueCategoryGap) as index_gap:
+        constructed_value_cid_v2(Holder((0, [1])))
+    # An index is bracketed, never spelled as a field name.
+    assert "at .items[1]" in str(index_gap.value), str(index_gap.value)
+
+    with pytest.raises(ConstructedValueCategoryGap) as member_gap:
+        constructed_value_cid_v2(Holder(frozenset({object()})))
+    # An unordered member has no slot coordinate; say so rather than name one.
+    assert "at .items{*}" in str(member_gap.value), str(member_gap.value)
+    assert ".None" not in str(member_gap.value)
+
+
+def test_a_refusal_at_the_presented_root_says_root_not_an_empty_path():
+    """An empty path and "the root itself" must not share a spelling."""
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2([1, 2])
+    assert "at <root>" in str(caught.value)
+
+
 def test_a_bare_wire_method_earns_nothing():
     """V1 called ``.wire()`` generically. V2 never does: an arbitrary method's
     inputs cannot be enumerated, so it cannot authenticate anything."""

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -566,6 +566,77 @@ class ConstructionTestimonyReporterV1:
     def report_gap(self, node: Node, panic: object) -> None:
         self._delegate.report_gap(node, panic)
 
+    #: Every identity term this guard can refuse on. Closed and NAMED: a
+    #: caller (or a tooth) can enumerate the faults without reading the body,
+    #: and a term added to the body without a name here is a visible omission.
+    SOURCE_CALL_IDENTITY_TERMS = (
+        "definition-not-a-functiondef",
+        "definition-ref-not-materialized",
+        "call-ref-not-materialized",
+        "definition-foreign-source-cid",
+        "resolved-not-a-functiondef",
+        "resolved-seal-mismatch",
+        "call-occurrence-mismatch",
+        "frame-is-none",
+        "frame-owner-ref-mismatch",
+        "frame-definition-site-foreign",
+    )
+
+    def _source_call_identity_fault(
+        self,
+        node: Node,
+        value: object,
+        definition: object,
+        resolved_definition: object,
+        call_occurrence: object,
+        frame: object,
+    ) -> str | None:
+        """The ONE identity term that refused this call, named, or None.
+
+        TEN FAULTS, NOT ONE. These terms were a flat ``or`` chain behind a
+        single sentence, so every one of them printed the same words and the
+        row was countable but not actionable -- the reader could not tell a
+        cross-FILE callee from a missing materialization from a stale frame,
+        and those ask for three different repairs.
+
+        The terms are also NOT independent, which the ``or`` chain hid. The
+        seal comparison is meaningless unless ``resolved_definition`` is a
+        definition, and every frame term is meaningless unless a frame
+        exists. In the chain, safety was a property of the ORDER: evaluated
+        on its own, ``resolved_definition.fragment`` raises AttributeError on
+        None, so reordering two neighbouring terms would have converted a
+        countable construction panic into an instrument failure. Here each
+        dependent term sits BELOW the ``return`` that establishes its
+        precondition, so it is unreachable without it -- the dependence is
+        structural, and breaking it means deleting a guard rather than
+        transposing two lines.
+        """
+        from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef
+
+        if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+            return "definition-not-a-functiondef"
+        if definition.ref not in self._materialized_by_ref:
+            return "definition-ref-not-materialized"
+        if node.ref not in self._materialized_by_ref:
+            return "call-ref-not-materialized"
+        if definition.unit.source_cid != node.unit.source_cid:
+            return "definition-foreign-source-cid"
+        if not isinstance(resolved_definition, (FunctionDef, AsyncFunctionDef)):
+            return "resolved-not-a-functiondef"
+        # Reachable only with a resolved definition in hand.
+        if resolved_definition.fragment.seal() != definition.fragment.seal():
+            return "resolved-seal-mismatch"
+        if value.call_occurrence != call_occurrence:
+            return "call-occurrence-mismatch"
+        if frame is None:
+            return "frame-is-none"
+        # Reachable only with a frame in hand.
+        if frame.owner.ref is not definition.ref:
+            return "frame-owner-ref-mismatch"
+        if frame.definition_site.source_cid != node.unit.source_cid:
+            return "frame-definition-site-foreign"
+        return None
+
     def present_construction(self, node: Node, value: object) -> None:
         from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
         from sugar_source_tree.nodes import Call, FunctionDef, AsyncFunctionDef
@@ -590,24 +661,17 @@ class ConstructionTestimonyReporterV1:
                 span.end_col,
             )
             frame = value.source_call_frame
-            if (
-                not isinstance(definition, (FunctionDef, AsyncFunctionDef))
-                or definition.ref not in self._materialized_by_ref
-                or node.ref not in self._materialized_by_ref
-                or definition.unit.source_cid != node.unit.source_cid
-                or not isinstance(resolved_definition, (FunctionDef, AsyncFunctionDef))
-                or resolved_definition.fragment.seal() != definition.fragment.seal()
-                or value.call_occurrence != call_occurrence
-                or frame is None
-                or frame.owner.ref is not definition.ref
-                or frame.definition_site.source_cid != node.unit.source_cid
-            ):
+            fault = self._source_call_identity_fault(
+                node, value, definition, resolved_definition, call_occurrence, frame
+            )
+            if fault is not None:
                 self._testimony_gap(
                     node,
                     value,
                     "constructed value",
                     ValueError(
-                        "source call definition is not this call's exact typed occurrence"
+                        "source call definition is not this call's exact typed "
+                        f"occurrence: {fault}"
                     ),
                 )
         try:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1205,6 +1205,46 @@ def _cv2_type_tag(value: object) -> str:
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
+def _cv2_slot_spelling(at: object) -> str:
+    """One slot step, spelled by the arm that produced it.
+
+    The three ``at`` kinds are not interchangeable and must not read alike: a
+    dataclass field / mapping key is ``.name``, a tuple index is ``[i]``, and a
+    frozenset's deliberate absence of a coordinate is ``{*}`` -- an unordered
+    member has no slot to name, and saying ``.None`` would invent one.
+    """
+    if at is None:
+        return "{*}"
+    if isinstance(at, int) and not isinstance(at, bool):
+        return f"[{at}]"
+    return f".{at}"
+
+
+def _cv2_slot_path(
+    target: int, root: int, parent_of: dict[int, tuple[int, object]]
+) -> str:
+    """The slot chain from the presented root down to the refused value.
+
+    A value reachable by several paths through a shared DAG child reports the
+    FIRST path the walk descended -- the one that actually reached it here.
+    That is one true path, not a claim of uniqueness.
+    """
+    if target == root:
+        return "<root>"
+    steps: list[str] = []
+    cursor = target
+    # The parent chain is acyclic by construction: an entry is written once,
+    # when a child is first pushed. The root bound is belt-and-braces so a
+    # reporting path can never outlive its own budget and hang the refusal.
+    while cursor != root and cursor in parent_of and len(steps) <= 512:
+        parent, at = parent_of[cursor]
+        steps.append(_cv2_slot_spelling(at))
+        cursor = parent
+    if cursor != root:
+        return "<unrooted>"
+    return "".join(reversed(steps))
+
+
 _NOT_A_LEAF = object()
 
 # (type, cid) pairs whose ``cid_of_json(preimage) == cid`` has been checked once.
@@ -1521,6 +1561,11 @@ def constructed_value_cid_v2(value: object) -> str:
     # Values whose expansion has begun and not finished -- the DFS "gray" set,
     # which is exactly the cycle predicate.
     expanding: dict[int, object] = {}
+    # id(child) -> (id(parent), at). Written once, when a child is first
+    # pushed, so a refusal deep in the graph can say WHICH slot reached it.
+    # A type tag alone cannot separate two same-typed slots of one value.
+    parent_of: dict[int, tuple[int, object]] = {}
+    root_id = id(value)
     stack: list[tuple[object, bool]] = [(value, False)]
     while stack:
         current, expanded = stack.pop()
@@ -1533,21 +1578,35 @@ def constructed_value_cid_v2(value: object) -> str:
             continue
         row = classified.get(id(current))
         if row is None:
-            row = _cv2_classify(current)
+            try:
+                row = _cv2_classify(current)
+            except ConstructedValueCategoryGap as gap:
+                # The refusal itself is UNCHANGED -- same type, same reason,
+                # same instruction. The walk simply stops discarding the path
+                # it already descended to get here.
+                raise ConstructedValueCategoryGap(
+                    f"{gap} [refused at "
+                    f"{_cv2_slot_path(id(current), root_id, parent_of)} of "
+                    f"{_cv2_type_tag(value)}]"
+                ) from gap
             classified[id(current)] = row
         semantic_type, arity, local_fields, children = row
         pinned.append(current)
         if not expanded:
             expanding[id(current)] = current
             stack.append((current, True))
-            for _at, child in children:
+            for at, child in children:
                 if id(child) in child_cid:
                     continue
+                if id(child) not in parent_of and id(child) != root_id:
+                    parent_of[id(child)] = (id(current), at)
                 if id(child) in expanding:
                     raise ConstructedValueCategoryGap(
                         "constructed value graph is CYCLIC through "
                         f"{_cv2_type_tag(child)}: a cycle has no content "
-                        "coordinate. Keep the coordinate loud."
+                        "coordinate. Keep the coordinate loud. [refused at "
+                        f"{_cv2_slot_path(id(child), root_id, parent_of)} of "
+                        f"{_cv2_type_tag(value)}]"
                     )
                 stack.append((child, False))
             continue

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -152,3 +152,108 @@ def test_call_definition_testimony_rejects_foreign_or_wrong_occurrence(
         reporter.present_construction(call, substituted)
     assert "CollectingReporter.present_construction" in str(gap.value)
     assert call.unit.filename in str(gap.value)
+
+
+# ---------------------------------------------------------------------------
+# TEN FAULTS, NOT ONE: the identity guard names the term it refused on
+# ---------------------------------------------------------------------------
+
+
+def test_every_identity_refusal_names_which_term_refused(tmp_path) -> None:
+    """A countable row is not an actionable one.
+
+    All four axes below are genuinely different defects asking for different
+    repairs. If they all print the same sentence, the board can count them and
+    nobody can fix them.
+    """
+    _source, definition, call, reporter = _ordinary_call(
+        tmp_path, helper="predicate", caller="apply"
+    )
+    truthful = call._construct_sugar()
+    foreign_source, foreign_definition, foreign_call, _foreign = _ordinary_call(
+        tmp_path, helper="predicate", caller="foreign_apply"
+    )
+    assert foreign_source.unit.source_cid != call.unit.source_cid
+
+    seen = set()
+    for lie in (
+        foreign_definition,
+        foreign_call,
+        definition.body[0],
+        definition.sugar,
+    ):
+        substituted = replace(truthful, expected_definition_ref=lie)
+        with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
+            reporter.present_construction(call, substituted)
+        named = [
+            term
+            for term in ConstructionTestimonyReporterV1.SOURCE_CALL_IDENTITY_TERMS
+            if term in str(gap.value)
+        ]
+        # Exactly one term, never zero (lumped) and never several (ambiguous).
+        assert len(named) == 1, (named, str(gap.value))
+        seen.add(named[0])
+    # The four lies are not all one fault wearing four costumes.
+    assert len(seen) > 1, seen
+
+
+def test_the_seal_term_is_unreachable_without_a_resolved_definition(tmp_path) -> None:
+    """The fragility this guard used to carry.
+
+    ``resolved_definition.fragment`` raises AttributeError on None, so as a
+    flat ``or`` chain the guard was safe only because the preceding
+    isinstance term short-circuited first. Transposing two neighbouring lines
+    would have turned a countable construction panic into an INSTRUMENT
+    FAILURE -- a census hole, not a census row. The precondition must hold
+    structurally, not by luck of ordering.
+    """
+    _source, _definition, call, reporter = _ordinary_call(
+        tmp_path, helper="predicate", caller="apply"
+    )
+    # NOT ``call.sugar()``. On this context-less open, ``call_occurrence`` is
+    # minted only under a TreeConstructionContextV1 while the guard compares it
+    # unconditionally, so the truthful path already refuses with
+    # ``call-occurrence-mismatch`` (a red that predates this change and is
+    # tracked separately). Riding on it would make this tooth report that
+    # defect instead of the one it is here to catch.
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    definition = truthful.expected_definition_ref
+    call_occurrence = truthful.call_occurrence
+    frame = truthful.source_call_frame
+
+    # The tooth is only worth anything if it REACHES the seal term. Prove the
+    # earlier terms pass first -- otherwise this returns at term 1 and would
+    # stay green against exactly the transposition it claims to catch.
+    assert (
+        reporter._source_call_identity_fault(
+            call, truthful, definition, definition, call_occurrence, frame
+        )
+        is None
+    )
+
+    class _NotADefinition:
+        """No ``.fragment``: touching the seal term raises AttributeError."""
+
+    for resolved in (None, _NotADefinition()):
+        fault = reporter._source_call_identity_fault(
+            call, truthful, definition, resolved, call_occurrence, frame
+        )
+        # It refuses, by name, WITHOUT reaching the term that would raise.
+        assert fault == "resolved-not-a-functiondef"
+
+
+def test_the_named_term_set_is_closed_over_the_body() -> None:
+    """A term added to the body without a name is a silent lump reappearing."""
+    import inspect
+    import re
+
+    body = inspect.getsource(
+        ConstructionTestimonyReporterV1._source_call_identity_fault
+    )
+    # Only the docstring and the returns quote strings in this function.
+    returned = set(re.findall(r'return "([a-z-]+)"', body))
+    assert returned == set(
+        ConstructionTestimonyReporterV1.SOURCE_CALL_IDENTITY_TERMS
+    ), returned.symmetric_difference(
+        ConstructionTestimonyReporterV1.SOURCE_CALL_IDENTITY_TERMS
+    )


### PR DESCRIPTION
Two message-only commits. **No production behaviour changes**, no category broadened, no refusal weakened.

`ConstructedValueCategoryGap` named the offending *type* but not the *slot*, and the nine-disjunct identity guard reported all ten terms at once. Both refusals were true and unactionable: they named the shape, not the coordinate within it.

`CallSiteSugar` has **twelve** `Any` slots. Canonicalization walks `fields(value)`, so a `_Handle` leaking through any one of them produced the same sentence.

## Evidence

`--start 0 --stride 8`, both arms, from repo root:

```
base    121 constructed / 57 construction-panic / 0 instrument-failure
after   121 constructed / 57 construction-panic / 0 instrument-failure
```

Node-ID diff **both directions**: 190 → 190, seat set identical, the 190 coordinate keys an identical *set*, **zero terminalKind flips**. Exactly 4 observed strings differ, each by an appended term name. **Not substitution** — checked precisely because equal totals demand it. Parse rate **178/178 = 100%** both runs. Instrument-failure floor **held at 0**.

## Teeth — 6 new, 4 mutations each applied alone

| mutation | catches |
|---|---|
| collapse three slot spellings to `.{at}` | `test_the_three_slot_kinds_do_not_read_alike` alone |
| always report `<root>` | 2 path teeth + slot-kind tooth; the root tooth **correctly keeps passing** (it asserts exactly the string the mutation always emits) |
| re-lump the guard message | `test_every_identity_refusal_names_which_term_refused` alone |
| transpose the seal term above its precondition | `test_the_seal_term_is_unreachable_without_a_resolved_definition` alone, with the predicted `AttributeError: 'NoneType' object has no attribute 'fragment'` |

One tooth caught itself being fake: the seal tooth's first draft passed `definition=object()`, returned at term 1 and never reached the term it claimed to guard — it would have stayed green against its own mutation. It now asserts the earlier terms pass before probing.

The guard fragility is addressed: each dependent term now sits below the `return` establishing its precondition, so breaking it means deleting a guard rather than transposing two lines.

## What this does NOT do — stated plainly

- **It does not split absence from lookup-failure.** `Call._project_constructed_value_for_testimony` is untouched; its four silent `return value` escapes still hand a known-unprojectable `_Handle` to canonicalization, still reported as a missing *category* when the truth is a failed *lookup*. This is #7394's defect class and it remains in place with better wording. Follow-up is scoped separately.
- `GuardedBindingRead` (2 rows) and `WithOpaqueCitedManagerSugar` bare `object` (12 rows) were **not diagnosed**. Counts and seats only.
- The nine-disjunct guard's 4 rows are **irreducible at this door** — all four report `definition-foreign-source-cid`, a cross-FILE callee where the guard demands same-unit identity. That needs a ruling on whether a cross-unit callee is legitimate identity. This makes it *sayable*, not fixed.
- Teeth are unit-door, **not** through the census entrance.
- The guard-order fix rides in `d357289f4` rather than its own commit, as it should have.
- The two commits were profiled together, not one at a time. Both are message-only and the diff proves conservation.

## Slice composition — a correction to the board's scoping

Of 190 panics in the slice, the canonicalization category is **33**: `_Handle` 15, bare `object` 12, nine-disjunct 4, `GuardedBindingRead` 2. The remaining **154 are `With._construct_sugar`** — a different owner — plus 3 `roll_call.discharge`.

Related: #7394, #7382, #7387.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved construction error messages by identifying the specific source-call validation issue.
  - Error messages now show the full path to rejected values, including fields, tuple indexes, unordered members, and the root.
  - Safely reject calls when the resolved definition is missing or malformed.

- **Tests**
  - Added regression coverage for source-call identity errors and constructed-value path reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include the specific slot path and identity term in `ConstructedValueCategoryGap` refusal messages
> - `constructed_value_cid_v2` in [binding_state.py](https://github.com/TSavo/sugar/pull/7395/files#diff-1b664ec8aefadd4725220316e83263615391d340ba859576e2ac417ab1cc5e40) now tracks parent-child relationships during DFS and augments `ConstructedValueCategoryGap` exceptions with the slot path from the presented root (e.g. `at .items.right`, `at [1]`, `at {*}`, or `at <root>`).
> - New helpers `_cv2_slot_spelling` and `_cv2_slot_path` compute the path string, distinguishing field (`.name`), index (`[n]`), and unordered member (`{*}`) slot kinds.
> - `ConstructionTestimonyReporterV1` gains `_source_call_identity_fault`, which inspects the definition, resolved definition, call occurrence, and frame to return the exact fault code (one of `SOURCE_CALL_IDENTITY_TERMS`) instead of a generic failure; this code is appended to the `ValueError` message in `present_construction`.
> - Tests in [test_constructed_value_v2_merkle.py](https://github.com/TSavo/sugar/pull/7395/files#diff-068882ce08054949e73197ec7a1a6220bc46b939728d16853b9c1a368557f722) and [test_cpython_call_handle_testimony.py](https://github.com/TSavo/sugar/pull/7395/files#diff-018cba0c19f5511472c3270abe4106053b2aa58888c1f0a3899ac629f05f0799) enforce that every refusal names exactly one specific slot and one specific identity term.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d357289.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->