### PR TITLE
Separate an off-population citation from an absent decorator

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/probe_cm_demand_kinds.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_cm_demand_kinds.py
@@ -1,0 +1,97 @@
+"""Corpus population of context-manager demand kinds, one walk.
+
+Diagnostic only.
+
+A slice of 178 seats understates every population it samples -- it understated
+``@contextmanager`` badly. This gives the whole-corpus denominator for the
+reasons that are decided at DEMAND time, by minting the same table the census
+mints (``_preconstruction_demand_rows``) and counting its ``gapKind``.
+
+What this CAN say: the corpus population of demand-side kinds
+(``runtime-selected`` and ``None`` -- i.e. a call row was joined).
+
+What this CANNOT say: the population of reasons produced at DERIVATION time
+(``source-body-gap``, ``dynamic-export``, ``call-target-off-population``,
+canonicalization refusals). Those exist only once a file is constructed, so
+their corpus population needs a full census, not a walk. Do not read a number
+from here as if it covered them.
+
+For each demanded manager it also records the callee spelling, so the reasons
+can be ranked by what they are actually about.
+
+usage:
+  python probe_cm_demand_kinds.py [--examples N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from collections import Counter, defaultdict
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--examples", type=int, default=10)
+    args = parser.parse_args(argv)
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_py_tests.lift_rpc import _preconstruction_demand_rows
+    from sugar_lift_python_source.source_oracle import SourceUnavailable, path_source
+    from sugar_source_tree.tree import SourceTree
+
+    corpus = authenticated_pandas_corpus()
+    root = corpus.root
+    print(f"CORPUS {corpus.distribution} {corpus.version} files={corpus.file_count}")
+
+    seat_by_cid: dict[str, str] = {}
+    source_by_cid: dict[str, str] = {}
+    for path in SourceTree(root).paths():
+        try:
+            source, _filename, source_cid = path_source(str(path))
+        except SourceUnavailable:
+            continue
+        seat_by_cid.setdefault(source_cid, path.resolve().relative_to(root).as_posix())
+        source_by_cid.setdefault(source_cid, source)
+
+    rows = _preconstruction_demand_rows(root)
+    cm_rows = [row for row in rows if row.get("kind") == "context-manager-demand"]
+    print(f"CM_DEMANDS {len(cm_rows)}  (of {len(rows)} demand rows)")
+
+    kinds: Counter[str] = Counter()
+    symbols: Counter[tuple] = Counter()
+    examples: dict[str, list[str]] = defaultdict(list)
+
+    for row in cm_rows:
+        kind = row.get("gapKind") or "<joined: a call row was found>"
+        kinds[str(kind)] += 1
+        symbols[(str(kind), str(row.get("targetSymbol")))] += 1
+        site = row["useSite"]
+        seat = seat_by_cid.get(site["sourceCid"], "<unknown>")
+        if len(examples[str(kind)]) < args.examples:
+            text = ""
+            source = source_by_cid.get(site["sourceCid"])
+            if source is not None:
+                lines = source.splitlines()
+                if 0 < site["startLine"] <= len(lines):
+                    text = "  |" + lines[site["startLine"] - 1].strip()[:88]
+            examples[str(kind)].append(
+                f"{seat}:{site['startLine']}:{site['startCol']}{text}"
+            )
+
+    print("\nDEMAND KIND -- whole corpus")
+    for kind, count in kinds.most_common():
+        print(f"  {count:>6}  {kind}")
+        for line in examples[kind]:
+            print(f"           {line}")
+
+    print("\nTOP TARGET SYMBOLS PER KIND")
+    for (kind, symbol), count in symbols.most_common(30):
+        print(f"  {count:>6}  [{kind}] {symbol}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_decorator_citation_shape.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_decorator_citation_shape.py
@@ -1,0 +1,161 @@
+"""What does the generator road need from an off-population decorator?
+
+Diagnostic only -- reports, never repairs.
+
+The question that decides whether the citation route is even possible:
+
+  If the road needs enter/exit SEMANTICS it can only get by constructing an
+  off-population body, a citation cannot feed it and the road needs a different
+  shape. If it needs an IDENTITY -- a coordinate -- a citation can carry that,
+  and the repair is to cite instead of construct.
+
+ARM A -- what the road does today.
+  ``_enter_exit_sites_from_class_def`` calls ``source_visible_call_frame()`` on
+  ``_GeneratorContextManager.__enter__``/``__exit__`` -- which substitutes and
+  sugars the whole method body -- and then keeps ONLY ``frame.definition_site``.
+  Everything else it built is discarded. Reaching that requires materializing
+  ``contextlib``, which the population membrane refuses, correctly.
+
+ARM B -- what a citation could supply.
+  ``resolve_authenticated_module_export`` already succeeds for off-population
+  ``contextlib`` (measured: it returns ``ResolvedPythonObjectV1``). This arm
+  asks whether the enter/exit coordinates are obtainable from the authenticated
+  artifact WITHOUT materializing: resolve the class, then locate the methods
+  inside the authenticated class span by parsing the authenticated source --
+  the same stdlib-``ast`` reading ``_export_block_with_locus`` already performs
+  on off-population modules for export resolution.
+
+Also reported: what ``construct_generator_backed_protocol`` actually consumes.
+Its own docstring says "Coordinates alone cannot construct this protocol -- the
+generator frame is load-bearing", and the frame in question is the DECORATED
+function's, which is in-population.
+
+usage:
+  python probe_decorator_citation_shape.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import traceback
+
+TARGET_MODULE = "contextlib"
+DECORATOR = "contextmanager"
+MANAGER_CLASS = "_GeneratorContextManager"
+
+
+def main() -> int:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.dependency_artifact import (
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+        resolve_authenticated_module_export,
+    )
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame,
+    )
+    from sugar_lift_python_source.canonical import blake3_512_of
+    from sugar_lift_python_source.resolution_session import walk_session_for
+
+    # The provider binding cid must be a real content address, not a label.
+    probe_cid = blake3_512_of(b"probe-decorator-citation-shape")
+
+    corpus = authenticated_pandas_corpus()
+    print(f"CORPUS {corpus.distribution} {corpus.version} files={corpus.file_count}")
+    session = walk_session_for(
+        corpus.root, enrolled_distributions=frozenset({"pandas"})
+    )
+    graph = authenticate_dependency_top_level(TARGET_MODULE)
+    print(f"GRAPH {TARGET_MODULE}: artifactKind={graph.artifact_kind!r}")
+    module = graph.modules.get(TARGET_MODULE)
+    print(f"  module present={module is not None} source_cid={getattr(module, 'source_cid', None)}")
+
+    # ---- ARM A: the road as it stands -------------------------------------
+    print("\nARM A -- construct the decorator, as the road does today")
+    resolved = resolve_authenticated_module_export(
+        graph=graph,
+        binding_cid=probe_cid,
+        module_name=TARGET_MODULE,
+        exported_name=DECORATOR,
+        session=session,
+    )
+    print(f"  resolve_authenticated_module_export({DECORATOR!r}) -> {type(resolved).__name__}")
+    if isinstance(resolved, ResolvedPythonObjectV1):
+        print(f"    definition kind={resolved.definition.kind!r} name={resolved.definition.name!r}")
+        frame_result = resolve_source_visible_frame(
+            resolved, graph=graph, session=session
+        )
+        if isinstance(frame_result, tuple):
+            print("    resolve_source_visible_frame -> CONSTRUCTED")
+        else:
+            print(
+                f"    resolve_source_visible_frame -> GAP "
+                f"kind={getattr(frame_result, 'kind', None)!r}"
+            )
+            print(f"      detail={getattr(frame_result, 'detail', None)!r}")
+
+    # ---- ARM B: is the identity obtainable without constructing? -----------
+    print("\nARM B -- cite the identity from the authenticated artifact")
+    resolved_class = resolve_authenticated_module_export(
+        graph=graph,
+        binding_cid=probe_cid,
+        module_name=TARGET_MODULE,
+        exported_name=MANAGER_CLASS,
+        session=session,
+    )
+    print(f"  resolve_authenticated_module_export({MANAGER_CLASS!r}) -> {type(resolved_class).__name__}")
+    if not isinstance(resolved_class, ResolvedPythonObjectV1):
+        print(f"    {resolved_class}")
+        return 0
+    definition = resolved_class.definition
+    print(
+        f"    AUTHENTICATED definition: kind={definition.kind!r} "
+        f"name={definition.name!r} "
+        f"span={definition.start_line}:{definition.start_col}"
+        f"-{definition.end_line}:{definition.end_col}"
+    )
+    print(f"    source_cid={definition.source_cid}")
+    print(f"    matches module source_cid: {definition.source_cid == module.source_cid}")
+
+    # Locate the protocol methods INSIDE the authenticated class span, by
+    # reading the authenticated source with stdlib ast -- no SourceFile, no
+    # MaterializeModule, no sugar.
+    tree = ast.parse(module.source)
+    found = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != MANAGER_CLASS:
+            continue
+        inside = (
+            node.lineno >= definition.start_line
+            and node.end_lineno <= definition.end_line
+        )
+        print(f"    ast ClassDef {node.name} at {node.lineno}-{node.end_lineno} within authenticated span: {inside}")
+        for item in node.body:
+            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name in (
+                "__enter__",
+                "__exit__",
+            ):
+                found[item.name] = (
+                    item.lineno,
+                    item.col_offset,
+                    item.end_lineno,
+                    item.end_col_offset,
+                )
+    for name in ("__enter__", "__exit__"):
+        print(f"    {name}: {found.get(name)}")
+    print(
+        f"    both present and distinct: "
+        f"{len(found) == 2 and found.get('__enter__') != found.get('__exit__')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except BaseException:
+        traceback.print_exc()
+        raise SystemExit(1)

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_errstate_blocker.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_errstate_blocker.py
@@ -1,0 +1,93 @@
+"""Is numpy.errstate's dynamic-export decidable, or does it bottom out off-population?
+
+Diagnostic only.
+
+``numpy/__init__.py`` binds ``errstate`` inside the else arm of
+
+    try:
+        __NUMPY_SETUP__          # noqa: B018
+    except NameError:
+        __NUMPY_SETUP__ = False
+
+    if __NUMPY_SETUP__:
+        sys.stderr.write(...)
+    else:
+        ...
+        from ._core import (... errstate ...)
+
+The export recognizer joins both arms on raw ``ast`` and, because one arm binds
+and the other does not, returns ``("dynamic", locus)``. But the test is not
+obviously symbolic: the ``try/except NameError`` above it binds
+``__NUMPY_SETUP__ = False`` on the ordinary import path, so a THREADED prefix
+might decide the ``If`` outright -- in which case the repair is the #7393 shape
+(one entrance threads, the other reads raw AST) and NOT a guard-lifter.
+
+Threading the prefix means materializing ``numpy``. This probe asks the one
+question that decides which repair is even available:
+
+    is the numpy graph OFF-POPULATION for the session the census uses?
+
+If it is, the prefix cannot be threaded, the ``If`` cannot be decided, and
+``errstate`` bottoms out at off-population like the rest -- a finding, not a
+repair.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.dependency_artifact import (
+        authenticate_dependency_top_level,
+    )
+    from sugar_lift_python_source.manager_construction import (
+        _graph_is_off_population,
+        prefix_has_completed_fallthrough,
+    )
+    from sugar_lift_python_source.resolution_session import walk_session_for
+
+    corpus = authenticated_pandas_corpus()
+    print(f"CORPUS {corpus.distribution} {corpus.version} files={corpus.file_count}")
+
+    # The roster the census installs: one enrolled distribution.
+    session = walk_session_for(
+        corpus.root, enrolled_distributions=frozenset({"pandas"})
+    )
+    print(f"SESSION enrolled_distributions = {sorted(session.enrolled_distributions)}")
+
+    for top in ("numpy", "pandas", "contextlib"):
+        graph = authenticate_dependency_top_level(top)
+        off = _graph_is_off_population(graph, session=session)
+        print(
+            f"  {top:<12} artifactKind={graph.artifact_kind!r:<14} "
+            f"OFF-POPULATION={off}"
+        )
+
+    # And what the prefix door therefore answers for numpy's export locus.
+    import ast
+
+    from sugar_lift_python_source.dependency_export_adapter import (
+        _export_block_with_locus,
+    )
+    from sugar_lift_python_source.source_tables import parsed_tree
+
+    graph = authenticate_dependency_top_level("numpy")
+    module = graph.modules.get("numpy")
+    tree = parsed_tree(module.source, module.source_seat)
+    _binding, locus = _export_block_with_locus(tree.body, "errstate", None)
+    print(f"\nEXPORT LOCUS for numpy.errstate: line {locus.lineno} {type(locus).__name__}")
+    outcome = prefix_has_completed_fallthrough(
+        module, locus, graph=graph, session=session
+    )
+    print(f"  prefix_has_completed_fallthrough -> kind={outcome.kind!r}")
+    print(
+        "  NOTE: 'completed' here may be the off-population SHORT-CIRCUIT, not a\n"
+        "  threaded result. Read it together with OFF-POPULATION above."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_generator_law_subject.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_generator_law_subject.py
@@ -1,0 +1,140 @@
+"""Do the generator laws assert anything the citation route would change?
+
+Diagnostic only. This is the GATE on ruling (A): a pre-existing tooth going
+green because the claim beneath it shrank would invert its value.
+
+What the three failing laws assert, read from the file:
+
+  test_renamed_manager_publishes_identical_body_face_cids
+      enter_halt_faces / exit_halt_faces / yield_faces  -- their .cid and count
+  test_unrelated_source_managers_publish_through_identical_pipeline
+      the same faces, plus lifecycle_cid and guard_source, all as RELATIVE
+      comparisons (alpha != beta), never a pinned absolute CID
+  test_face_kinds_are_phase_separated_not_name_separated
+      face preimage["kind"], temporal_phase, and no manager name in preimages
+
+None of them reads an enter/exit DEFINITION coordinate, the returned manager
+class, or the decorator.
+
+What (A) changes: the enter/exit definitions handed to
+``construct_generator_backed_protocol`` -- hence the protocol preimage and its
+content address. It does not touch the generator frame.
+
+Those faces come from ``_project_generator_lifecycle_faces(generator_target)``,
+which takes ONLY the decorated generator function -- in-population, and
+reachable WITHOUT the decorator road. So the quantity the laws assert can be
+computed independently, right now, before any repair. This records it. After
+(A) the published faces must carry these same CIDs; if they do, the laws'
+subject matter is provably untouched and their green is honest.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+import sys
+from pathlib import Path
+
+_HELPERS = """\
+from contextlib import contextmanager
+
+@contextmanager
+def alpha(flag):
+    if flag:
+        raise ValueError("enter-a")
+    yield "resource-a"
+    raise RuntimeError("exit-a")
+
+@contextmanager
+def beta():
+    yield "resource-b"
+    if True:
+        raise TypeError("then-b")
+    else:
+        raise KeyError("else-b")
+"""
+
+
+def _distribution(root: Path):
+    package = root / "unprivileged"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text(
+        "from unprivileged.helpers import alpha, beta\n", encoding="utf-8"
+    )
+    (package / "helpers.py").write_text(_HELPERS, encoding="utf-8")
+    metadata = root / "unprivileged_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: unprivileged-dist\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    files = (
+        "unprivileged/__init__.py",
+        "unprivileged/helpers.py",
+        "unprivileged_dist-1.0.dist-info/METADATA",
+        "unprivileged_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for file in files:
+            writer.writerow((file, "", ""))
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def main() -> int:
+    import tempfile
+
+    # Bootstraps the authenticated execution environment (and sys.path for the
+    # sibling packages). This probe uses a synthetic corpus, but the setup is
+    # still what makes sugar_source_tree importable.
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    handle = authenticated_pandas_corpus()
+    print(f"ENV OK ({handle.distribution} {handle.version})")
+
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _project_generator_lifecycle_faces,
+    )
+    from sugar_lift_python_source.source_oracle import path_source
+    from sugar_source_tree.nodes import FunctionDef
+    from sugar_source_tree.tree import SourceFile
+
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        _distribution(root)
+        helpers = root / "unprivileged" / "helpers.py"
+        # The generator target alone -- no decorator road, no contract table.
+        tree = SourceFile(path_source(str(helpers)))
+        targets = {
+            node.name: node
+            for node in tree.root.body
+            if isinstance(node, FunctionDef)
+        }
+        print(f"GENERATOR TARGETS {sorted(targets)}")
+        for name in sorted(targets):
+            enter_halts, yield_faces, exit_halts = _project_generator_lifecycle_faces(
+                targets[name]
+            )
+            print(f"\n{name}:")
+            print(
+                f"  counts  enter_halt={len(enter_halts)} "
+                f"yield={len(yield_faces)} exit_halt={len(exit_halts)}"
+            )
+            for label, faces in (
+                ("enter_halt", enter_halts),
+                ("yield", yield_faces),
+                ("exit_halt", exit_halts),
+            ):
+                for index, face in enumerate(faces):
+                    print(f"  {label}[{index}].cid = {face.cid}")
+                    print(f"    kind = {face.preimage.get('kind')!r}")
+                    phase = getattr(face, "temporal_phase", None)
+                    if phase is not None:
+                        print(f"    temporal_phase = {phase!r}")
+                    blob = repr(face.preimage)
+                    print(f"    manager name in preimage: {name in blob}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_local_generator_manager.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_local_generator_manager.py
@@ -1,0 +1,253 @@
+"""Does the generator-CM derivation reach a SAME-MODULE @contextmanager?
+
+Diagnostic only -- reports, never repairs. Opens through
+``open_source_file_for_construction``, never the bare door.
+
+Two halves are written and the diagonal between them is not:
+
+  * ``_populate_same_module_class_manager_uses`` resolves a same-module manager
+    -- "when Call.func Name binds to exactly one module **ClassDef**".
+  * ``_populate_generator_resource_ref`` derives a generator-backed CM protocol
+    -- reached only from an **import receipt**.
+
+A same-module ``@contextlib.contextmanager`` generator (``ensure_removed`` in
+``tests/test_register_accessor.py``, ``set_locale`` in
+``_config/localization.py``) is neither, so it falls through to the demand
+table and is painted ``runtime-selected``.
+
+Before relying on the diagonal being cheap, this probe checks the ONE step that
+might not survive the move off the import road: the decorator step.
+``_protocol_coords_from_generator_decorators`` must produce native enter/exit
+coordinates for ``contextlib.contextmanager`` when the decorated function is
+LOCAL and there is no receipt and no ``graph``. It being true on the import road
+does not make it true here.
+
+  ARM LOCAL   -- local FunctionDef, graph=None
+  ARM IMPORT  -- an import-backed @contextmanager, its own graph (control)
+
+usage:
+  python probe_local_generator_manager.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+
+LOCAL_TARGETS = [
+    ("tests/test_register_accessor.py", "ensure_removed"),
+    ("_config/localization.py", "set_locale"),
+]
+IMPORT_CONTROL = ("pandas._testing", "assert_produces_warning")
+
+
+def _report_decorator_bindings(decorators, session, graph=None) -> None:
+    """Which step of the decorator road declines: the binding, or the class?"""
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _construct_decorator_function,
+        _decorator_module_export_binding,
+        _enter_exit_sites_from_class_def,
+        _sole_returned_manager_class,
+    )
+
+    for decorator in decorators:
+        spelling = getattr(decorator, "id", None) or getattr(decorator, "attr", None)
+        binding = _decorator_module_export_binding(decorator)
+        print(
+            f"      decorator {type(decorator).__name__} {spelling!r} "
+            f"-> module_export_binding = {binding!r}"
+        )
+        if binding is not None:
+            _trace_decorator_export(binding, decorator, session)
+        fn = _construct_decorator_function(decorator, session=session, graph=graph)
+        print(f"        _construct_decorator_function -> {type(fn).__name__ if fn is not None else None}")
+        if fn is None:
+            continue
+        returned = _sole_returned_manager_class(fn)
+        print(f"        _sole_returned_manager_class -> {type(returned).__name__ if returned is not None else None}")
+        if returned is None:
+            continue
+        print(f"        _enter_exit_sites_from_class_def -> {_enter_exit_sites_from_class_def(returned) is not None}")
+
+
+def _trace_decorator_export(binding, decorator, session) -> None:
+    """Replicate the tail of _construct_decorator_function, naming each step.
+
+    "declines because contextlib is not in the graph" and "declines at the
+    population membrane" are different facts and want different repairs.
+    """
+    from sugar_lift_python_source.dependency_artifact import (
+        DependencyArtifactAuthenticationError,
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+        resolve_authenticated_module_export,
+    )
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame,
+    )
+
+    module_name, exported_name = binding
+    top_level = module_name.split(".", 1)[0]
+    try:
+        graph = authenticate_dependency_top_level(top_level)
+    except DependencyArtifactAuthenticationError as exc:
+        print(f"        authenticate_dependency_top_level({top_level!r}) -> REFUSED {exc}")
+        return
+    print(
+        f"        authenticate_dependency_top_level({top_level!r}) -> "
+        f"artifactKind={getattr(graph, 'artifact_kind', None)!r} "
+        f"module_present={module_name in graph.modules}"
+    )
+    resolved = resolve_authenticated_module_export(
+        graph=graph,
+        binding_cid=decorator.fragment.seal().cid,
+        module_name=module_name,
+        exported_name=exported_name,
+        session=session,
+    )
+    print(f"        resolve_authenticated_module_export -> {type(resolved).__name__}")
+    if not isinstance(resolved, ResolvedPythonObjectV1):
+        print(f"          {resolved}")
+        return
+    frame_result = resolve_source_visible_frame(resolved, graph=graph, session=session)
+    if isinstance(frame_result, tuple):
+        _frame, target = frame_result
+        print(f"        resolve_source_visible_frame -> {type(target).__name__}")
+    else:
+        print(
+            f"        resolve_source_visible_frame -> GAP "
+            f"kind={getattr(frame_result, 'kind', None)!r} "
+            f"detail={getattr(frame_result, 'detail', None)!r}"
+        )
+
+
+def _describe_coords(label: str, coords) -> None:
+    if coords is None:
+        print(f"    {label}: coords = None  (decorator step DID NOT produce them)")
+        return
+    enter, exit_ = coords
+    print(f"    {label}: coords OK")
+    for name, coord in (("enter", enter), ("exit", exit_)):
+        print(f"      {name}: {coord}")
+
+
+def arm_local(corpus, session) -> None:
+    from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _protocol_coords_from_generator_decorators,
+    )
+    from sugar_source_tree.nodes import FunctionDef
+
+    for seat, name in LOCAL_TARGETS:
+        print(f"\n  --- {seat}::{name}")
+        from sugar_lift_python_source.source_oracle import install_root_for
+
+        path = corpus.joinpath(*seat.split("/"))
+        installed = install_root_for(str(path))
+        # An installed file's address is the seat its distribution recorded;
+        # open it against the install root, not the package root.
+        locus_root = corpus if installed is None else Path(installed)
+        # root = the enrolled corpus (what the demand table is built over);
+        # source_workspace_root = the install root (what the seat address is
+        # recorded against). Passing the install root as `root` walks all of
+        # site-packages to mint a demand table.
+        source_file = open_source_file_for_construction(
+            path,
+            root=corpus,
+            source_workspace_root=locus_root,
+            distribution="pandas",
+        )
+        binds = (source_file.unit.module_direct_bindings or {}).get(name, ())
+        print(f"    module_direct_bindings[{name!r}] -> {len(binds)} binding(s)")
+        target = None
+        for bound in binds:
+            print(f"      {type(bound).__name__}")
+            if isinstance(bound, FunctionDef):
+                target = bound
+        if target is None:
+            print("    no FunctionDef binding; nothing for the generator road to take")
+            continue
+        decorators = getattr(target, "decorators", ()) or ()
+        print(f"    decorators = {[type(d).__name__ for d in decorators]}")
+        _report_decorator_bindings(decorators, session)
+        try:
+            coords = _protocol_coords_from_generator_decorators(
+                target, session=session, graph=None
+            )
+        except BaseException:
+            print("    decorator step RAISED:")
+            traceback.print_exc()
+            continue
+        _describe_coords("LOCAL (graph=None)", coords)
+
+        # Does anything publish a derived ref for this file's With uses today?
+        context = source_file.unit.construction_context
+        derived = getattr(context, "source_derived_contract_refs", {}) or {}
+        print(f"    source_derived_contract_refs on this open: {len(derived)}")
+        for coordinate, ref in list(derived.items())[:4]:
+            print(f"      {type(ref).__name__} at {coordinate}")
+
+
+def arm_import(corpus, session) -> None:
+    from sugar_lift_python_source.dependency_artifact import (
+        authenticate_dependency_top_level,
+    )
+    from sugar_lift_python_source.dependency_export_adapter import resolve_export
+    from sugar_lift_python_source.manager_construction import (
+        resolve_source_visible_frame,
+    )
+    from sugar_lift_python_source.manager_summary_derivation import (
+        _protocol_coords_from_generator_decorators,
+    )
+
+    module_name, exported = IMPORT_CONTROL
+    print(f"\n  --- CONTROL {module_name}.{exported} (import-backed)")
+    graph = authenticate_dependency_top_level("pandas")
+    resolved = resolve_export(
+        graph, "probe", module_name, exported, (), frozenset(), session=session
+    )
+    print(f"    resolve_export -> {type(resolved).__name__}")
+    frame_result = resolve_source_visible_frame(resolved, graph=graph, session=session)
+    if not isinstance(frame_result, tuple):
+        print(f"    frame gap: {frame_result}")
+        return
+    _frame, target = frame_result
+    decorators = getattr(target, "decorators", ()) or ()
+    print(f"    target = {type(target).__name__} {getattr(target, 'name', None)!r}")
+    print(f"    decorators = {[type(d).__name__ for d in decorators]}")
+    _report_decorator_bindings(decorators, session, graph=graph)
+    coords = _protocol_coords_from_generator_decorators(
+        target, session=session, graph=graph
+    )
+    _describe_coords("IMPORT (its own graph)", coords)
+
+
+def main() -> int:
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.resolution_session import walk_session_for
+
+    corpus_handle = authenticated_pandas_corpus()
+    corpus = corpus_handle.root
+    print(
+        f"CORPUS {corpus_handle.distribution} {corpus_handle.version} "
+        f"files={corpus_handle.file_count}"
+    )
+    session = walk_session_for(corpus, enrolled_distributions=frozenset({"pandas"}))
+
+    print("\nARM LOCAL -- same-module @contextmanager, no receipt, graph=None")
+    try:
+        arm_local(corpus, session)
+    except BaseException:
+        traceback.print_exc()
+
+    print("\nARM IMPORT -- control, the road that already works")
+    try:
+        arm_import(corpus, session)
+    except BaseException:
+        traceback.print_exc()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -2096,20 +2096,26 @@ def _publish_generator_backed_resource_contract(
         construct_generator_backed_protocol,
     )
 
+    declined: list[str] = []
     coords = _protocol_coords_from_generator_decorators(
         generator_target,
         session=session,
         graph=graph,
         dependency_graphs=dependency_graphs,
         distribution_index=distribution_index,
+        declined=declined,
     )
     if coords is None:
+        # Name WHY, per decorator. "unavailable" was true of an off-population
+        # citation, a missing binding and a malformed decorator body alike, so
+        # the row could not say which one a reader was looking at.
         _install_derivation_gap(
             context,
             receiver,
             receipt,
             "generator-protocol",
-            "native enter/exit definition coordinates unavailable",
+            "native enter/exit definition coordinates unavailable"
+            + (f" [{'; '.join(declined)}]" if declined else ""),
         )
         return
     enter, exit_ = coords
@@ -2411,14 +2417,16 @@ def _resolve_nested_generator_function(
     if len(binds) == 1 and isinstance(binds[0], FunctionDef):
         return binds[0]
     if len(binds) == 1 and isinstance(binds[0], ImportFrom):
-        constructed = _construct_decorator_function(
+        outcome = _construct_decorator_function(
             func,
             session=session,
             graph=graph,
             distribution_index=distribution_index,
         )
-        if isinstance(constructed, FunctionDef):
-            return constructed
+        if isinstance(outcome, DecoratorConstructedV1) and isinstance(
+            outcome.function, FunctionDef
+        ):
+            return outcome.function
     return None
 
 
@@ -2733,6 +2741,7 @@ def _protocol_coords_from_generator_decorators(
     graph=None,
     dependency_graphs=None,
     distribution_index=None,
+    declined=None,
 ):
     """Construct enter/exit definition sites from generator decorator testimony."""
     from sugar_source_tree.nodes import FunctionDef
@@ -2743,21 +2752,44 @@ def _protocol_coords_from_generator_decorators(
     if not decorators:
         return None
     published = []
+    # Out-parameter: pass a list and each decorator that could not supply
+    # coordinates appends the NAMED reason it could not. Same shape as
+    # ``_substitute_body_tracked(..., edge_states=...)``; the return contract is
+    # unchanged so existing callers and tests are untouched.
+    if declined is None:
+        declined = []
     for decorator in decorators:
-        decorator_fn = _construct_decorator_function(
+        outcome = _construct_decorator_function(
             decorator,
             session=session,
             graph=graph,
             dependency_graphs=dependency_graphs,
             distribution_index=distribution_index,
         )
-        if decorator_fn is None:
+        # Closed set, reconciled here. A citation is NOT a decline-and-forget:
+        # it is a named, authenticated identity this road cannot yet consume,
+        # and the reason travels so the refusal downstream can say so.
+        if isinstance(outcome, DecoratorCitedV1):
+            declined.append(
+                f"{outcome.module_name}.{outcome.exported_name}: "
+                f"{outcome.membrane_kind}"
+            )
             continue
-        returned_class = _sole_returned_manager_class(decorator_fn)
+        if isinstance(outcome, DecoratorUnresolvedV1):
+            declined.append(f"{outcome.kind}: {outcome.detail}")
+            continue
+        if not isinstance(outcome, DecoratorConstructedV1):
+            raise TypeError(
+                "decorator resolution must be one of the closed outcomes; "
+                f"got {type(outcome).__name__}"
+            )
+        returned_class = _sole_returned_manager_class(outcome.function)
         if returned_class is None:
+            declined.append("decorator body does not return exactly one manager class")
             continue
         coords = _enter_exit_sites_from_class_def(returned_class)
         if coords is None:
+            declined.append("returned class publishes no distinct __enter__/__exit__")
             continue
         published.append(coords)
     # Exactly one decorator arm may yield protocol coordinates; several would
@@ -2765,6 +2797,55 @@ def _protocol_coords_from_generator_decorators(
     if len(published) != 1:
         return None
     return published[0]
+
+
+@dataclass(frozen=True)
+class DecoratorConstructedV1:
+    """The decorator resolved to a source-visible FunctionDef we constructed."""
+
+    function: object
+
+
+@dataclass(frozen=True)
+class DecoratorCitedV1:
+    """The decorator is authenticated but OFF ENROLLED POPULATION.
+
+    Not an absence: the identity is known and content-addressed. The membrane
+    refuses to MaterializeModule it, which is correct -- constructing it would
+    invent testimony about a body sugar cannot see. What a consumer may do with
+    this citation is a separate ruling; what it may NOT do is mistake it for
+    "there was no decorator".
+    """
+
+    module_name: str
+    exported_name: str
+    resolved: object
+    membrane_kind: str
+    membrane_detail: str | None
+
+
+@dataclass(frozen=True)
+class DecoratorUnresolvedV1:
+    """No decorator identity at this site, with the reason named.
+
+    ``absent`` is the only member that means "nothing was there". Every other
+    member is a lookup that failed, and the two must never share a value.
+    """
+
+    kind: Literal[
+        "absent",
+        "artifact-authentication-failed",
+        "module-absent-from-graph",
+        "export-unresolved",
+        "frame-construction-gap",
+        "not-a-function-definition",
+    ]
+    detail: str
+
+
+DecoratorResolutionV1 = (
+    DecoratorConstructedV1 | DecoratorCitedV1 | DecoratorUnresolvedV1
+)
 
 
 def _construct_decorator_function(
@@ -2795,8 +2876,10 @@ def _construct_decorator_function(
         if isinstance(decorator, Name):
             binds = (decorator.unit.module_direct_bindings or {}).get(decorator.id, ())
             if len(binds) == 1 and isinstance(binds[0], FunctionDef):
-                return binds[0]
-        return None
+                return DecoratorConstructedV1(binds[0])
+        return DecoratorUnresolvedV1(
+            "absent", "decorator names no authenticated import or module binding"
+        )
     module_name, exported_name = binding
     graphs = []
     if graph is not None:
@@ -2830,8 +2913,10 @@ def _construct_decorator_function(
             authenticated_dependency = authenticate_dependency_top_level(
                 top_level, distribution_index=distribution_index
             )
-        except DependencyArtifactAuthenticationError:
-            return None
+        except DependencyArtifactAuthenticationError as exc:
+            return DecoratorUnresolvedV1(
+                "artifact-authentication-failed", f"{module_name}: {exc}"
+            )
         if session is not None and session.enabled:
             session.dependency_graphs[top_level] = authenticated_dependency
         if dependency_graphs is not None:
@@ -2855,7 +2940,10 @@ def _construct_decorator_function(
             resolved_graph = candidate
             break
     if resolved is None or resolved_graph is None:
-        return None
+        return DecoratorUnresolvedV1(
+            "export-unresolved",
+            f"{module_name}.{exported_name} did not resolve in any authenticated graph",
+        )
     frame_result = resolve_source_visible_frame(
         resolved,
         graph=resolved_graph,
@@ -2863,11 +2951,30 @@ def _construct_decorator_function(
         session=session,
     )
     if isinstance(frame_result, ManagerConstructionGapV1):
-        return None
+        # OFF-POPULATION IS NOT ABSENCE. The membrane refuses to materialize an
+        # unenrolled module -- correctly -- but the identity it refused to
+        # construct is authenticated and addressable. Returning None here made
+        # that indistinguishable from "there was no decorator", which is how a
+        # citable fact became a silent nothing.
+        if frame_result.kind == "call-target-off-population":
+            return DecoratorCitedV1(
+                module_name=module_name,
+                exported_name=exported_name,
+                resolved=resolved,
+                membrane_kind=frame_result.kind,
+                membrane_detail=frame_result.detail,
+            )
+        return DecoratorUnresolvedV1(
+            "frame-construction-gap",
+            f"{module_name}.{exported_name}: {frame_result.kind}: {frame_result.detail}",
+        )
     _frame, target = frame_result
     if not isinstance(target, FunctionDef):
-        return None
-    return target
+        return DecoratorUnresolvedV1(
+            "not-a-function-definition",
+            f"{module_name}.{exported_name} resolved to {type(target).__name__}",
+        )
+    return DecoratorConstructedV1(target)
 
 
 def _decorator_module_export_binding(decorator) -> tuple[str, str] | None:

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -104,6 +104,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_prefix_threading.py"]
 network = "none"
 
+[tasks.probe-decorator-citation-shape]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_decorator_citation_shape.py"]
+network = "none"
+
 [tasks.probe-cm-demand-kinds]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -110,6 +110,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_decorator_citation_shape.py"]
 network = "none"
 
+[tasks.probe-errstate-blocker]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_errstate_blocker.py"]
+network = "none"
+
 [tasks.probe-cm-demand-kinds]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -122,6 +122,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_local_generator_manager.py"]
 network = "none"
 
+[tasks.probe-generator-law-subject]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_generator_law_subject.py"]
+network = "none"
+
 [tasks.probe-cm-demand-kinds]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -104,6 +104,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_prefix_threading.py"]
 network = "none"
 
+[tasks.probe-cm-demand-kinds]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_cm_demand_kinds.py"]
+network = "none"
+
 [tasks.authenticated-no-call-body-attribution]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -116,6 +116,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_errstate_blocker.py"]
 network = "none"
 
+[tasks.probe-local-generator-manager]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_local_generator_manager.py"]
+network = "none"
+
 [tasks.probe-cm-demand-kinds]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]


### PR DESCRIPTION
`_construct_decorator_function` returned a single `None` for **six distinct facts**: no binding at all, refused artifact authentication, module absent from every graph, unresolved export, frame-construction gap, and a target that was not a function.

One of those is **not an absence at all**. The off-population membrane refusal has an identity that is authenticated and content-addressed — only its *body* is refused. Collapsing it into the same `None` as "there was no decorator" is #7394's defect class at a load-bearing seat.

Replaced with a closed outcome all three call sites reconcile; an unrecognised member raises rather than falling through:

```
DecoratorConstructedV1   carries the FunctionDef
DecoratorCitedV1         off enrolled population; carries the authenticated
                         resolution, the membrane kind and its detail
DecoratorUnresolvedV1    a named reason -- `absent` is the ONLY member that
                         means nothing was there
```

Declines travel by an **out-parameter** — the `_substitute_body_tracked(..., edge_states=...)` idiom this file already uses — so `_protocol_coords_from_generator_decorators` keeps its return contract, and its existing caller and test are untouched. A first attempt changed that signature and was backed out rather than adjusting the test: a test bent to fit a refactor stops being evidence.

The downstream refusal now names which decorator declined and why:

```
"native enter/exit definition coordinates unavailable
   [contextlib.contextmanager: call-target-off-population]"
```

instead of a bare string equally true of a citation, a missing binding and a malformed decorator body.

## Verification

```
sugar-lift-python-source @ ae1862877, own baseline both arms, redirected
  base   239 failed, 991 passed, 14 skipped
  after  239 failed, 991 passed, 14 skipped
  FIXED (base \ after):  <empty>
  NEW   (after \ base):  <empty>
```

Zero fixed, zero new — **exactly right for a repair that changes what a refusal says, not what it decides.** And the fact is now named where it was silent: `_construct_decorator_function -> DecoratorCitedV1` (was `None`) on both `tests/test_register_accessor.py::ensure_removed` and the import-backed `pandas._testing.assert_produces_warning`.

## Also included — diagnosis, no production effect

- **Gate proof (`61a8fecad`)** that the three pre-existing generator-CM laws assert only over faces from `_project_generator_lifecycle_faces(generator_target)` — the in-population decorated function — and that **every quantity they assert already holds today, pre-repair**. They are red because publication never happens, not because their subject matter is unavailable.
- **`739ef2a87`** — `numpy.errstate` bottoms out at off-population too: `numpy` is a distribution artifact that is not *enrolled*, and its `'completed'` was the off-population short-circuit read as a result.
- Corpus denominator and road-measurement probes.

## Explicitly NOT included

The citation itself (option (A)) is **not** in this PR. As built it is unsound: it cites artifacts merely present on the machine, making *"the caller vouched for no graph"* indistinguishable from *"the caller vouched for one and it is off-population"* — the same conflation, one layer deeper. A pre-existing law caught it. That work is quarantined on `frontier-citation-attempt` and must not be merged.

**One added probe drives a bare door deliberately** (it must, to exhibit the forbidden door's output beside the production door's). It needs a `DELIBERATE_OFFENDERS` entry with a stated reason when the construction-context door law lands — it must never be "fixed", because the fix deletes the evidence.

Related: #7397, #7394, #7384, #7388.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added diagnostic probes for context-manager demand gaps, decorator citations, error-state handling, and generator-backed context managers.
  - Added dedicated build tasks for running each diagnostic independently in a controlled, offline environment.

- **Improvements**
  - Enhanced reporting to distinguish successful resolution, authenticated but unavailable references, and unresolved cases.
  - Added more detailed failure reasons, source locations, lifecycle coordinates, and bounded examples to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Separate off-population decorator citation from absent decorator in `_construct_decorator_function`
> - Refactors [`manager_summary_derivation.py`](https://github.com/TSavo/sugar/pull/7398/files#diff-ad30b718e09e12e723e9c40af47b6af7a80c00d8a7a4d382b9f39818b52b3f5c) to return a closed set of structured outcome types (`DecoratorConstructedV1`, `DecoratorCitedV1`, `DecoratorUnresolvedV1`) instead of `None`/`FunctionDef`, explicitly distinguishing off-population citation from absent or otherwise unresolvable decorators.
> - `DecoratorCitedV1` captures the authenticated identity and membrane gap details when a decorator is off-population; `DecoratorUnresolvedV1` encodes other failure modes with a closed `kind` discriminant.
> - Gap reports for missing enter/exit protocol coordinates now append semicolon-separated decline reasons collected via a new `declined` out-parameter on `_protocol_coords_from_generator_decorators`.
> - Adds several diagnostic probe scripts and corresponding build tasks to inspect decorator resolution, generator lifecycle face projection, and off-population blocking in real corpora.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61a8fec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->