### PR TITLE
git checkout is not a revert when the thing you are mutating is uncommitted work

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/probe_class_allocation_census.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_class_allocation_census.py
@@ -1,0 +1,182 @@
+"""Census of CLASS-INSTANTIATION callees over a slice of the enrolled corpus.
+
+STEP 0 CHECK 2 for the `OptionError(...)` seat: is class construction a
+separate door with an in-population `__init__` behind it, or is every class
+instantiation an off-population citation case?
+
+The question is answered at the ONE place the answer exists --
+``SourceUnit.source_allocation_definition_for_call`` -- by wrapping it and
+re-deriving the module binding independently, then classifying the ClassDef's
+constructor law. The wrapper NEVER changes what the method returns; it only
+records. This is an instrument, not a repair, and is reverted before any
+measurement baseline.
+
+Classification, closed set, an unrecognised shape RAISES rather than being
+bucketed as "other":
+
+    own-init            the ClassDef body defines `__init__` -- IN POPULATION
+    own-new             no `__init__`, but an authenticated `__new__` shape
+    inherited-exception no `__init__`, authenticated BaseException ancestry
+    inherited-object    no `__init__`, no exception ancestry -- zero formals
+
+and orthogonally the admission gate actually consulted at the call site:
+
+    gate=True/False     source_class_has_authenticated_default_attribute_behavior
+
+usage:
+  python probe_class_allocation_census.py --start 0 --stride 8 [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _roster(corpus_root: Path) -> list[str]:
+    from sugar_source_tree.tree import SourceTree
+
+    paths = list(SourceTree(corpus_root).paths())
+    return sorted(path.resolve().relative_to(corpus_root).as_posix() for path in paths)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", type=int, default=0)
+    parser.add_argument("--stride", type=int, default=8)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--seat", action="append", default=None)
+    args = parser.parse_args(argv)
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.source_oracle import install_root_for
+    from sugar_lift_py_tests.prebuilt_demand_table import (
+        install_prebuilt_demand_table,
+        mint_prebuilt_demand_table,
+    )
+    from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+    from sugar_source_tree.nodes import ClassDef, FunctionDef, Name, SourceUnit
+
+    import recensus_enumerate_consumer as consumer
+
+    authenticated = authenticated_pandas_corpus()
+    corpus = authenticated.root
+    table = mint_prebuilt_demand_table(authenticated)
+    contract_refs = install_prebuilt_demand_table(table, root=corpus)
+    install_provisional_contract_refs(corpus, contract_refs)
+    print(
+        f"CENSUS_DEMAND_TABLE contentCid={table.content_cid} rows={len(table.rows)}",
+        flush=True,
+    )
+
+    roster = _roster(corpus)
+    if args.seat:
+        seats = []
+        for seat in args.seat:
+            if seat not in roster:
+                # A seat spelling the roster does not use is NO measurement.
+                print(f"CENSUS_SEAT_ABSENT {seat}", flush=True)
+                return 2
+            seats.append(seat)
+    else:
+        seats = roster[args.start :: args.stride]
+        if args.limit is not None:
+            seats = seats[: args.limit]
+    print(f"CENSUS_CORPUS root={corpus} roster={len(roster)} slice={len(seats)}", flush=True)
+
+    counts: Counter[str] = Counter()
+    exemplars: dict[str, list[str]] = {}
+
+    original = SourceUnit.source_allocation_definition_for_call
+
+    def _classify(definition) -> str:
+        has_init = any(
+            isinstance(member, FunctionDef) and member.name == "__init__"
+            for member in definition.body
+        )
+        if has_init:
+            return "own-init"
+        if definition._authenticated_new_constructor_shape() is not None:
+            return "own-new"
+        if definition._inherits_default_exception_constructor():
+            return "inherited-exception"
+        return "inherited-object"
+
+    def _wrapped(self, call):
+        result = original(self, call)
+        try:
+            if isinstance(call.func, Name) and self.typed_module is not None:
+                bindings = (self.module_direct_bindings or {}).get(call.func.id, ())
+                if len(bindings) == 1 and isinstance(bindings[0], ClassDef):
+                    definition = bindings[0]
+                    kind = _classify(definition)
+                    if kind not in (
+                        "own-init",
+                        "own-new",
+                        "inherited-exception",
+                        "inherited-object",
+                    ):
+                        raise AssertionError(f"unrecognised constructor law: {kind}")
+                    gate = (
+                        SourceUnit.source_class_has_authenticated_default_attribute_behavior(
+                            definition
+                        )
+                    )
+                    admitted = result is not None
+                    key = f"{kind}|gate={gate}|admitted={admitted}"
+                    counts[key] += 1
+                    span = call.line_col_span()
+                    seat = f"{self.source_cid[:12]}:{span.start_line}:{span.start_col}:{call.func.id}"
+                    exemplars.setdefault(key, [])
+                    if len(exemplars[key]) < 6:
+                        exemplars[key].append(seat)
+        except BaseException as error:  # noqa: BLE001 -- an instrument, named loudly
+            if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+                raise
+            counts[f"INSTRUMENT-FAILURE:{type(error).__name__}"] += 1
+        return result
+
+    SourceUnit.source_allocation_definition_for_call = _wrapped
+    try:
+        for index, seat in enumerate(seats):
+            target = corpus.joinpath(*seat.split("/"))
+            if not target.is_file():
+                print(f"CENSUS_SEAT_ABSENT {seat} resolved={target}", flush=True)
+                continue
+            installed = install_root_for(str(target))
+            locus_root = corpus if installed is None else Path(installed)
+            try:
+                consumer.measure_file_via_enumerate(
+                    workspace_root=corpus,
+                    file_rel=seat,
+                    contract_refs=contract_refs,
+                    distribution="pandas",
+                    source_workspace_root=locus_root,
+                )
+            except BaseException as error:  # noqa: BLE001
+                if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+                    raise
+                print(
+                    f"CENSUS_SEAT_ERROR {seat} {type(error).__name__}: {error}"[:400],
+                    flush=True,
+                )
+            if (index + 1) % 20 == 0:
+                print(f"CENSUS_PROGRESS {index + 1}/{len(seats)}", flush=True)
+    finally:
+        SourceUnit.source_allocation_definition_for_call = original
+
+    print("CENSUS_TOTAL " + json.dumps(dict(sorted(counts.items())), sort_keys=True), flush=True)
+    for key in sorted(exemplars):
+        print(f"CENSUS_EXEMPLAR {key} {exemplars[key]}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_class_allocation_identity.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_class_allocation_identity.py
@@ -1,0 +1,141 @@
+"""What the identity guard is actually holding when a CLASS is the callee.
+
+The frontier row at ``_config/config.py:131:14`` reads
+``definition-not-a-functiondef``. That names the TYPE the guard rejected; it
+does not say whether a constructor law was available. Those are different
+facts and they ask for opposite repairs: an absent law wants a citation, an
+available law wants the guard's type demand widened.
+
+This probe wraps ``_source_call_identity_fault`` and prints, for every refusal
+at a named seat, the definition's type, whether a source-visible constructor
+frame exists for it, and that frame's parameter law. It changes nothing.
+
+usage:
+  python probe_class_allocation_identity.py _config/config.py [more...]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def main(argv: list[str] | None = None) -> int:
+    seats = list(argv if argv is not None else sys.argv[1:]) or ["_config/config.py"]
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.source_oracle import install_root_for
+    from sugar_lift_py_tests.prebuilt_demand_table import (
+        install_prebuilt_demand_table,
+        mint_prebuilt_demand_table,
+    )
+    from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+    from sugar_source_tree.binding_state import ConstructionTestimonyReporterV1
+    from sugar_source_tree.nodes import ClassDef
+
+    import recensus_enumerate_consumer as consumer
+
+    authenticated = authenticated_pandas_corpus()
+    corpus = authenticated.root
+    table = mint_prebuilt_demand_table(authenticated)
+    contract_refs = install_prebuilt_demand_table(table, root=corpus)
+    install_provisional_contract_refs(corpus, contract_refs)
+    print(
+        f"IDENT_DEMAND_TABLE contentCid={table.content_cid} rows={len(table.rows)}",
+        flush=True,
+    )
+
+    original = ConstructionTestimonyReporterV1._source_call_identity_fault
+    seen: set[str] = set()
+
+    def _wrapped(self, node, value, definition, resolved_definition, call_occurrence, frame):
+        fault = original(
+            self, node, value, definition, resolved_definition, call_occurrence, frame
+        )
+        if fault is not None:
+            try:
+                span = node.line_col_span()
+                record = {
+                    "fault": fault,
+                    "coordinate": f"{span.start_line}:{span.start_col}",
+                    "definitionType": type(definition).__name__,
+                    "definitionName": getattr(definition, "name", None),
+                    "resolvedType": type(resolved_definition).__name__,
+                    "frame": None,
+                }
+                if isinstance(definition, ClassDef):
+                    record["classBases"] = [
+                        getattr(base, "id", type(base).__name__)
+                        for base in definition.bases
+                    ]
+                    record["bodyKinds"] = [
+                        type(member).__name__ for member in definition.body
+                    ]
+                    record["hasOwnInit"] = any(
+                        getattr(member, "name", None) == "__init__"
+                        for member in definition.body
+                    )
+                    record["inheritsExceptionCtor"] = (
+                        definition._inherits_default_exception_constructor()
+                    )
+                    ctor = definition.source_visible_constructor_frame()
+                    record["ctorFrame"] = {
+                        "parameters": list(ctor.parameters),
+                        "parameterKinds": list(ctor.parameter_kinds),
+                        "ownerType": type(ctor.owner).__name__,
+                        "frameCid": ctor.frame_cid,
+                    }
+                if frame is not None:
+                    record["frame"] = {
+                        "parameters": list(frame.parameters),
+                        "parameterKinds": list(frame.parameter_kinds),
+                        "ownerType": type(frame.owner).__name__,
+                        "ownerName": getattr(frame.owner, "name", None),
+                    }
+                line = json.dumps(record, sort_keys=True, default=str)
+                if line not in seen:
+                    seen.add(line)
+                    print("IDENT_FAULT " + line, flush=True)
+            except BaseException as error:  # noqa: BLE001 -- instrument, named
+                if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+                    raise
+                print(
+                    f"IDENT_INSTRUMENT_FAILURE {type(error).__name__}: {error}"[:500],
+                    flush=True,
+                )
+        return fault
+
+    ConstructionTestimonyReporterV1._source_call_identity_fault = _wrapped
+    try:
+        for seat in seats:
+            target = corpus.joinpath(*seat.split("/"))
+            if not target.is_file():
+                print(f"IDENT_SEAT_ABSENT {seat} resolved={target}", flush=True)
+                continue
+            installed = install_root_for(str(target))
+            locus_root = corpus if installed is None else Path(installed)
+            row = consumer.measure_file_via_enumerate(
+                workspace_root=corpus,
+                file_rel=seat,
+                contract_refs=contract_refs,
+                distribution="pandas",
+                source_workspace_root=locus_root,
+            )
+            panics = row.get("constructionPanics") or []
+            print(
+                f"IDENT_SEAT {seat} terminalKind={row.get('terminalKind')} "
+                f"panics={len(panics)}",
+                flush=True,
+            )
+    finally:
+        ConstructionTestimonyReporterV1._source_call_identity_fault = original
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_constructed_value_slot.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_constructed_value_slot.py
@@ -1,0 +1,101 @@
+"""FULL constructed-value refusal text for named seats.
+
+The frontier profile truncates ``observed`` at 200 chars, which is exactly
+where ``constructed_value_cid_v2``'s ``[refused at <slot path> of <type>]``
+suffix lives -- so the profile can say a value did not canonicalize but never
+which SLOT refused. This probe measures the same seats through the same census
+entrance under the same prebuilt demand table and prints the whole string.
+
+usage:
+  python probe_constructed_value_slot.py pandas/_config/config.py [more...]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def main(argv: list[str] | None = None) -> int:
+    seats = list(argv if argv is not None else sys.argv[1:])
+    if not seats:
+        seats = ["pandas/_config/config.py"]
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.source_oracle import install_root_for
+
+    import recensus_enumerate_consumer as consumer
+
+    # SHARD CONDITIONS -- the same prebuilt demand table the profile installs.
+    # Measuring against provisional per-file demands would report a different
+    # population and could not be compared with the frontier rows at all.
+    from sugar_lift_py_tests.prebuilt_demand_table import (
+        install_prebuilt_demand_table,
+        mint_prebuilt_demand_table,
+    )
+    from sugar_lift_py_tests.lift_rpc import install_provisional_contract_refs
+
+    authenticated = authenticated_pandas_corpus()
+    corpus = authenticated.root
+    table = mint_prebuilt_demand_table(authenticated)
+    contract_refs = install_prebuilt_demand_table(table, root=corpus)
+    install_provisional_contract_refs(corpus, contract_refs)
+    print(
+        f"PROBE_DEMAND_TABLE contentCid={table.content_cid} rows={len(table.rows)}",
+        flush=True,
+    )
+
+    print(f"PROBE_CORPUS root={corpus} files={authenticated.file_count}", flush=True)
+
+    for seat in seats:
+        target = corpus.joinpath(*seat.split("/"))
+        # A seat spelling the roster does not use is not a clean measurement,
+        # it is no measurement. Say so rather than reporting `panics=0`.
+        if not target.is_file():
+            print(f"PROBE_SEAT_ABSENT {seat} resolved={target}", flush=True)
+            continue
+        installed = install_root_for(str(target))
+        locus_root = corpus if installed is None else Path(installed)
+        row = consumer.measure_file_via_enumerate(
+            workspace_root=corpus,
+            file_rel=seat,
+            contract_refs=contract_refs,
+            distribution="pandas",
+            source_workspace_root=locus_root,
+        )
+        panics = row.get("constructionPanics") or []
+        print(
+            f"PROBE_SEAT {seat} terminalKind={row.get('terminalKind')} "
+            f"panics={len(panics)} rowKeys={sorted(row)} "
+            f"instrumentFailure={str((row.get('instrumentFailure') or {}).get('message') or '')[:400]}",
+            flush=True,
+        )
+        for panic in panics:
+            if not isinstance(panic, dict):
+                continue
+            print(
+                "PROBE_PANIC "
+                + json.dumps(
+                    {
+                        "seat": seat,
+                        "owner": panic.get("owner"),
+                        "coordinate": panic.get("coordinate"),
+                        # FULL text. No truncation -- that is the point.
+                        "observed": panic.get("observed"),
+                        "requested": panic.get("requested"),
+                        "fix": panic.get("fix"),
+                    },
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/source_call_frame.py
@@ -10,6 +10,51 @@ from sugar_source_tree.fragment import SourceMemento
 from .context_manager_resolution import SourceFragmentCoordinateV1
 
 
+def _term_as_semantic_value(value: object, *, path: str) -> object:
+    """A wire-shaped term, respelled as the VALUE it already is.
+
+    ``MutableGlobalBindingV1.term`` is carried into constructed-value testimony
+    through ``SourceVisibleCallFrameV1.mutable_global_bindings`` ->
+    ``CallSiteSugar.source_call_frame``.  The wire dialect spells a ctor's fixed
+    argument sequence ``list`` -- and ConstructedValueV2 refuses to snapshot a
+    mutable container, correctly, because a snapshot of one authenticates a
+    moment rather than a value.  The sequence cannot move: it arrives as a
+    ``*args`` tuple and nothing appends to it.
+
+    The respelling happens HERE, at the carrier, and not in the wire builders:
+    the verification dialect reads these same terms through ``isinstance(args,
+    list)`` guards, so retagging them at the source would turn a loud refusal
+    into a silently-skipped branch.  Only the copy that becomes testimony is
+    respelled; the wire keeps its wire shape, and ``cid_of_json`` encodes a
+    tuple and a list identically, so no CID moves.
+
+    Categories are CLOSED.  An unrecognised member is a loud refusal, never a
+    reflective guess -- a term carrying something genuinely mutable must still
+    refuse, which is the whole content of the category law being honored.
+    """
+    if isinstance(value, dict):
+        frozen = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise SourceCallBindingGap(
+                    f"mutable global binding term at {path} carries a "
+                    f"non-string key {type(key).__name__}"
+                )
+            frozen[key] = _term_as_semantic_value(item, path=f"{path}.{key}")
+        return frozen
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _term_as_semantic_value(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        )
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    raise SourceCallBindingGap(
+        f"mutable global binding term at {path} carries "
+        f"{type(value).__name__}, which is not a wire term value"
+    )
+
+
 @dataclass(frozen=True)
 class MutableGlobalBindingV1:
     source_cid: str
@@ -26,6 +71,11 @@ class MutableGlobalBindingV1:
             raise ValueError("mutable global binding occurrence/source CID mismatch")
         if not self.name or self.kind not in {"dict", "list", "set"}:
             raise ValueError("mutable global binding requires a closed mutable kind")
+        # Respell FIRST so an unrecognised member is a typed refusal naming its
+        # path, not `cid_of_json`'s bare TypeError -- but hash the wire spelling
+        # below, because `cid_of_json` admits a list and refuses a tuple. The
+        # slot carried into testimony is the value; the coordinate is the wire.
+        semantic_term = _term_as_semantic_value(self.term, path="term")
         object.__setattr__(
             self,
             "cid",
@@ -43,6 +93,7 @@ class MutableGlobalBindingV1:
                 }
             ),
         )
+        object.__setattr__(self, "term", semantic_term)
 
 
 def _reauthenticate_binding_coordinates(coordinates: tuple) -> None:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -191,10 +191,19 @@ class CallSiteSugar(ConstructedTermSugar):
             and self.expected_definition_ref is not None
         ):
             from sugar_source_tree.panic import SugarNotWritten
-            from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef
+            from sugar_source_tree.nodes import (
+                AsyncFunctionDef,
+                ClassDef,
+                FunctionDef,
+            )
 
+            # A projected ALLOCATION callee is a ClassDef occurrence, so it
+            # answers with `.ref` exactly as a projected function does. Without
+            # this arm it fell to the raw-handle branch and compared a typed
+            # node against a ref, which never matches.
             if isinstance(
-                self.expected_definition_ref, (FunctionDef, AsyncFunctionDef)
+                self.expected_definition_ref,
+                (FunctionDef, AsyncFunctionDef, ClassDef),
             ):
                 owner_matches = (
                     self.source_call_frame.owner.ref is self.expected_definition_ref.ref

--- a/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_source_call_frame_coordinate_testimony.py
@@ -265,3 +265,94 @@ def test_bound_result_rejects_missing_or_extra_coordinate(
             corrupt if coordinate_kind == "formal" else formal,
             corrupt if coordinate_kind == "native" else native,
         )
+
+
+# ---------------------------------------------------------------------------
+# The carried term is a VALUE; the wire term stays wire-shaped
+# ---------------------------------------------------------------------------
+
+
+def _binding(term):
+    frame = _frame(filename="mutable_global_value.py")
+    return MutableGlobalBindingV1(
+        source_cid=frame.source_identity_cid,
+        binding_occurrence=frame.owner.fragment.seal(),
+        name="_global_config",
+        kind="dict",
+        term=term,
+        line=frame.owner.lineno,
+        col=frame.owner.col_offset,
+    )
+
+
+def _pin_term():
+    from sugar_lift_python_source.value_pins import mutable_global_pin_term
+
+    return mutable_global_pin_term("_global_config", "dict")
+
+
+def test_a_carried_pin_term_canonicalizes_as_a_value():
+    """The seat behind 78 frontier rows.
+
+    Every `with pandas.option_context(...)` digs `_config/config.py`, whose
+    module-level mutable globals are pinned. The pin already does the honest
+    thing -- it refuses to snapshot the mutable value and carries only the loud
+    ``(name, kind)`` coordinate -- but the wire dialect spells that fixed
+    two-element coordinate ``list``, so ConstructedValueV2 refused the very
+    repair the pin had already made.
+    """
+    from sugar_source_tree.binding_state import constructed_value_cid_v2
+
+    binding = _binding(_pin_term())
+    assert isinstance(binding.term["args"], tuple)
+    assert constructed_value_cid_v2(binding.term).startswith("blake3-512:")
+
+
+def test_respelling_the_carried_term_moves_no_coordinate():
+    """Content is unchanged, so the binding CID must be unchanged.
+
+    The CID is taken of the wire spelling before the slot is respelled --
+    ``cid_of_json`` admits a list and refuses a tuple, so this ordering is
+    load-bearing rather than incidental.
+    """
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    binding = _binding(_pin_term())
+    expected = cid_of_json(
+        {
+            "kind": "mutable-global-binding",
+            "schemaVersion": "1",
+            "sourceCid": binding.source_cid,
+            "bindingOccurrence": binding.binding_occurrence.to_dict(),
+            "name": binding.name,
+            "mutableKind": binding.kind,
+            # the WIRE spelling, list and all
+            "term": _pin_term(),
+            "line": binding.line,
+            "col": binding.col,
+        }
+    )
+    assert binding.cid == expected
+
+
+def test_the_mutable_container_category_was_not_broadened():
+    """A real list in a real slot must still refuse.
+
+    If this passes only because ``_cv2_entries`` learned to absorb lists, the
+    78 rows were bought by authenticating a moment.
+    """
+    from sugar_source_tree.binding_state import (
+        ConstructedValueCategoryGap,
+        constructed_value_cid_v2,
+    )
+
+    with pytest.raises(ConstructedValueCategoryGap) as caught:
+        constructed_value_cid_v2({"kind": "ctor", "args": [{"kind": "var"}]})
+    assert "MUTABLE container" in str(caught.value)
+    assert "builtins.list" in str(caught.value)
+
+
+def test_a_term_member_outside_the_wire_categories_refuses_loudly():
+    """Categories are CLOSED: the respelling is not a reflective deep-copy."""
+    with pytest.raises(SourceCallBindingGap, match="not a wire term value"):
+        _binding({"kind": "ctor", "args": [object()]})

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -681,6 +681,23 @@ class ConstructionTestimonyReporterV1:
 
             definition = value.expected_definition_ref
             resolved_definition = node.unit.source_function_definition_for_call(node)
+            if resolved_definition is None:
+                # The caller's unit is the lexical authority for a call in it,
+                # and for a cross-FILE callee it correctly has no answer -- the
+                # callee is not lexically bound here. Falling straight through
+                # left every cross-file call reading `resolved-not-a-functiondef`,
+                # which named a missing DEFINITION when the truth was that the
+                # wrong unit had been asked.
+                #
+                # The independent authority is the callee's OWN SOURCE TEXT.
+                # Re-pointing this at the import binding would be circular --
+                # `expected_definition_ref` came from there, and a guard that
+                # re-derives from its own source proves nothing. The binding
+                # supplies a NAME; the callee's unit supplies a LOCATION and
+                # CONTENT, and those can disagree.
+                resolved_definition = _callee_definition_by_name_in_its_unit(
+                    definition
+                )
             span = node.line_col_span()
             call_occurrence = SourceFragmentCoordinateV1(
                 node.unit.source_cid,
@@ -782,6 +799,41 @@ class ConstructionTestimonyReporterV1:
 
     def projected_snapshots_for(self, statement: Node):
         return self._trace_builder.projected_snapshots_for(statement, self)
+
+
+def _callee_definition_by_name_in_its_unit(definition: object):
+    """What the callee's NAME resolves to in the callee's own unit.
+
+    The third authority. The import binding says *name N in module M*; this
+    parses nothing new but reads M's own already-materialized definitions and
+    answers *here is the module-scope definition of N, at this span*. The two
+    can disagree -- a renamed definition, a redefined name, a stale ref, a
+    substituted body -- and the seal comparison downstream is what catches it.
+
+    The authority is ``module_direct_bindings`` -- the unit's own module-scope
+    binding table, the same one the in-unit resolver consults -- never a scan of
+    ``function_nodes``. A scan would happily return a NESTED definition that
+    shares the callee's name, which is precisely the lie this exists to catch.
+
+    Exactly one module binding, or nothing: a name bound twice at module scope
+    is ambiguous, and answering with either would be picking. Returning None
+    leaves the caller's existing terms to name the fault, unchanged.
+    """
+    from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef
+
+    if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+        return None
+    unit = getattr(definition, "unit", None)
+    name = getattr(definition, "name", None)
+    if unit is None or not name:
+        return None
+    bindings = (getattr(unit, "module_direct_bindings", None) or {}).get(name, ())
+    if len(bindings) != 1:
+        return None
+    resolved = bindings[0]
+    if not isinstance(resolved, (FunctionDef, AsyncFunctionDef)):
+        return None
+    return resolved
 
 
 def _testimony_blame(node: object) -> str:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -575,6 +575,7 @@ class ConstructionTestimonyReporterV1:
         "call-ref-not-materialized",
         "definition-unit-unauthenticated",
         "resolved-not-a-functiondef",
+        "resolved-definition-kind-mismatch",
         "resolved-seal-mismatch",
         "call-occurrence-mismatch",
         "frame-is-none",
@@ -611,9 +612,27 @@ class ConstructionTestimonyReporterV1:
         structural, and breaking it means deleting a guard rather than
         transposing two lines.
         """
-        from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef
+        from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef, ClassDef
 
-        if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+        # A CLASS is a legitimate callee. `OptionError(msg)` is an allocation,
+        # not a function call, and its definition occurrence is a ClassDef by
+        # construction -- so refusing every non-FunctionDef here refused an
+        # ordinary shape of Python rather than a defect, exactly as the
+        # same-unit demand did before it.
+        #
+        # This does NOT admit an unreadable constructor. The frame the call
+        # already carries is minted by `ClassDef.source_visible_constructor_frame`
+        # from the class's OWN in-population body plus, for an exception type,
+        # the authenticated base-graph law `(*args)` that
+        # `_inherits_default_exception_constructor` derives from the declared
+        # builtin-exception roster. Nothing off-population is read here; the
+        # frame exists whether or not this guard admits it.
+        #
+        # Identity is unchanged in strength: the resolved definition must be
+        # the SAME KIND (below), and `resolved-seal-mismatch` still joins on
+        # the callee's own sealed fragment, so a substituted or nested
+        # same-name class cannot survive.
+        if not isinstance(definition, (FunctionDef, AsyncFunctionDef, ClassDef)):
             return "definition-not-a-functiondef"
         if definition.ref not in self._materialized_by_ref:
             return "definition-ref-not-materialized"
@@ -645,8 +664,19 @@ class ConstructionTestimonyReporterV1:
         # therefore keep DIFFERENT names, which is the whole point.
         if not definition.unit.source_cid:
             return "definition-unit-unauthenticated"
-        if not isinstance(resolved_definition, (FunctionDef, AsyncFunctionDef)):
+        if not isinstance(
+            resolved_definition, (FunctionDef, AsyncFunctionDef, ClassDef)
+        ):
             return "resolved-not-a-functiondef"
+        # A definition and its independent re-derivation must be the same KIND.
+        # A class resolving to a function of the same name (or the reverse) is
+        # a genuine disagreement between the two authorities and is exactly
+        # what this guard exists to catch -- it must not be lumped into the
+        # seal comparison below, whose message would name the wrong fault.
+        if isinstance(definition, ClassDef) is not isinstance(
+            resolved_definition, ClassDef
+        ):
+            return "resolved-definition-kind-mismatch"
         # Reachable only with a resolved definition in hand.
         if resolved_definition.fragment.seal() != definition.fragment.seal():
             return "resolved-seal-mismatch"
@@ -819,9 +849,9 @@ def _callee_definition_by_name_in_its_unit(definition: object):
     is ambiguous, and answering with either would be picking. Returning None
     leaves the caller's existing terms to name the fault, unchanged.
     """
-    from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef
+    from sugar_source_tree.nodes import FunctionDef, AsyncFunctionDef, ClassDef
 
-    if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+    if not isinstance(definition, (FunctionDef, AsyncFunctionDef, ClassDef)):
         return None
     unit = getattr(definition, "unit", None)
     name = getattr(definition, "name", None)
@@ -831,7 +861,14 @@ def _callee_definition_by_name_in_its_unit(definition: object):
     if len(bindings) != 1:
         return None
     resolved = bindings[0]
-    if not isinstance(resolved, (FunctionDef, AsyncFunctionDef)):
+    # The SAME authority answers for an allocation callee. A nested ClassDef
+    # sharing the callee's name is the same lie a nested FunctionDef is, and
+    # the module-scope binding table is what excludes it in both cases. The
+    # KIND the table answers with is not filtered here -- a class binding
+    # answering for a function callee is a real disagreement and belongs to
+    # the caller's `resolved-definition-kind-mismatch` term, not to a silent
+    # None that would print the wrong fault.
+    if not isinstance(resolved, (FunctionDef, AsyncFunctionDef, ClassDef)):
         return None
     return resolved
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -573,7 +573,7 @@ class ConstructionTestimonyReporterV1:
         "definition-not-a-functiondef",
         "definition-ref-not-materialized",
         "call-ref-not-materialized",
-        "definition-foreign-source-cid",
+        "definition-unit-unauthenticated",
         "resolved-not-a-functiondef",
         "resolved-seal-mismatch",
         "call-occurrence-mismatch",
@@ -619,8 +619,32 @@ class ConstructionTestimonyReporterV1:
             return "definition-ref-not-materialized"
         if node.ref not in self._materialized_by_ref:
             return "call-ref-not-materialized"
-        if definition.unit.source_cid != node.unit.source_cid:
-            return "definition-foreign-source-cid"
+        # A callee defined in ANOTHER FILE of the enrolled corpus is ordinary
+        # Python, not a fault. This term used to demand
+        # ``definition.unit.source_cid == node.unit.source_cid`` -- same-unit
+        # sameness -- which no real corpus can satisfy: pandas calls across its
+        # own files constantly, and `_config/config.py` reaching
+        # `util/_exceptions.find_stack_level` is 82 rows of the frontier by
+        # itself. That demand described our instrument, not a defect in pandas.
+        #
+        # What identity actually needs is the callee's OWN unit, and
+        # ``resolved-seal-mismatch`` below already joins on it: a SourceMemento
+        # seals file, source_cid, span and a hash of the fragment text, so a
+        # substituted definition cannot survive it regardless of which file it
+        # lives in. The same-unit demand added no identity, only a false
+        # requirement.
+        #
+        # What remains here is the case the same-unit demand was ALSO silently
+        # covering: a unit with no content address at all. Off-population and
+        # unenrolled callees are refused above and upstream -- the population
+        # membrane never materializes them (measured: of 57 cross-file arrivals
+        # in the stride-8 slice, 50 are materialized FunctionDefs all inside the
+        # enrolled tree, and the other 7 are unmaterialized `_Handle`s caught by
+        # `definition-not-a-functiondef`; zero materialized FunctionDefs came
+        # from outside). "Foreign but authenticated" and "foreign and unknown"
+        # therefore keep DIFFERENT names, which is the whole point.
+        if not definition.unit.source_cid:
+            return "definition-unit-unauthenticated"
         if not isinstance(resolved_definition, (FunctionDef, AsyncFunctionDef)):
             return "resolved-not-a-functiondef"
         # Reachable only with a resolved definition in hand.
@@ -633,7 +657,12 @@ class ConstructionTestimonyReporterV1:
         # Reachable only with a frame in hand.
         if frame.owner.ref is not definition.ref:
             return "frame-owner-ref-mismatch"
-        if frame.definition_site.source_cid != node.unit.source_cid:
+        # Keyed on the DEFINITION's unit, not the call's. A frame describes the
+        # callee's definition, so its site living in the callee's file is
+        # correct; comparing it to the CALLER's unit was the same same-unit
+        # demand wearing a second name, and it refused every cross-file call
+        # a second time even once the term above stopped doing so.
+        if frame.definition_site.source_cid != definition.unit.source_cid:
             return "frame-definition-site-foreign"
         return None
 

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4804,6 +4804,17 @@ class ClassDef(Statement):
     )
 
     def __post_init__(self):
+        # A NODE OFF THE ROLL. `Node.__post_init__` is where registration
+        # happens, and its own docstring is the law: "calling ``cls(...)`` at
+        # all is showing up on the roll -- there is no way to new a node
+        # without it." This override silently was that way: every ClassDef in
+        # the corpus was constructed unregistered, so the identity guard's
+        # `definition-ref-not-materialized` was unsatisfiable for every
+        # allocation callee no matter what the guard admitted.
+        #
+        # The binding-target check below is this class's OWN extra demand and
+        # keeps running; it is not a reason to skip the roll.
+        super().__post_init__()
         if (
             not isinstance(self.binding_target, Name)
             or self.binding_target.id != self.name
@@ -11189,8 +11200,12 @@ class Call(Expression):
         if not isinstance(value, CallSiteSugar):
             return value
         definition_ref = value.expected_definition_ref
+        # An allocation callee's definition occurrence is a ClassDef. It is the
+        # SAME projection -- a parser handle standing in for this roll's typed
+        # occurrence -- and leaving it unprojected left the identity guard
+        # holding a raw `_Handle` and naming the wrong fault.
         if definition_ref is None or isinstance(
-            definition_ref, (FunctionDef, AsyncFunctionDef)
+            definition_ref, (FunctionDef, AsyncFunctionDef, ClassDef)
         ):
             return value
         lookup = getattr(self.reporter, "materialized_node_for_ref", None)
@@ -11200,7 +11215,9 @@ class Call(Expression):
         if definition is None and value.source_call_frame is not None:
             producer_definition = value.source_call_frame.owner
             if (
-                isinstance(producer_definition, (FunctionDef, AsyncFunctionDef))
+                isinstance(
+                    producer_definition, (FunctionDef, AsyncFunctionDef, ClassDef)
+                )
                 and producer_definition.ref is definition_ref
             ):
                 retain = getattr(self.reporter, "retain_registered_node_from", None)
@@ -11208,7 +11225,7 @@ class Call(Expression):
                     definition = retain(
                         producer_definition, producer_definition.reporter
                     )
-        if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):
+        if not isinstance(definition, (FunctionDef, AsyncFunctionDef, ClassDef)):
             return value
         source_call_frame = value.source_call_frame
         if source_call_frame is not None:

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -257,3 +257,132 @@ def test_the_named_term_set_is_closed_over_the_body() -> None:
     ), returned.symmetric_difference(
         ConstructionTestimonyReporterV1.SOURCE_CALL_IDENTITY_TERMS
     )
+
+
+# ---------------------------------------------------------------------------
+# A cross-FILE callee inside the enrolled population is not a fault
+# ---------------------------------------------------------------------------
+
+
+def _two_files_one_roll(tmp_path):
+    """Two units materialized through ONE reporter roll.
+
+    The cross-file case cannot be built from a single file, and it must share a
+    reporter: a definition materialized by a DIFFERENT reporter is a genuinely
+    unregistered ref and is refused by `definition-ref-not-materialized`, which
+    is a different fault and must stay one.
+    """
+    helper_path = tmp_path / "callee_unit.py"
+    helper_path.write_text("def find_level(value):\n    return value\n")
+    caller_path = tmp_path / "caller_unit.py"
+    caller_path.write_text("def apply(value):\n    return find_level(value)\n")
+
+    collector = CollectingReporter()
+    helper_source = SourceFile.from_path(helper_path, reporter=collector)
+    caller_source = SourceFile.from_path(caller_path, reporter=collector)
+    # ONE roll over both units -- `_testimony_root` mints a fresh reporter per
+    # source, and two rolls would make the callee legitimately unregistered.
+    testimony = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(caller_source.unit.source_cid)
+    )
+    helper_root = materialize(helper_source.unit, helper_source.root.ref, testimony)
+    caller_root = materialize(caller_source.unit, caller_source.root.ref, testimony)
+
+    definition = next(
+        node
+        for node in helper_root.walk()
+        if isinstance(node, FunctionDef) and node.name == "find_level"
+    )
+    call = next(
+        node
+        for node in caller_root.walk()
+        if isinstance(node, Call) and node.segment() == "find_level(value)"
+    )
+    assert definition.unit.source_cid != call.unit.source_cid
+    return definition, call, testimony
+
+
+def test_a_cross_file_enrolled_callee_is_not_an_identity_fault(tmp_path) -> None:
+    """`_config/config.py` calling `util/_exceptions.find_stack_level`.
+
+    82 rows of the frontier sat here. The guard demanded the callee be defined
+    in the CALLER's file, which no real corpus can satisfy -- that described
+    our instrument, not a defect in pandas.
+    """
+    definition, call, reporter = _two_files_one_roll(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = definition.source_visible_call_frame()
+
+    fault = reporter._source_call_identity_fault(
+        call, truthful, definition, definition, truthful.call_occurrence, frame
+    )
+    assert fault is None, fault
+
+
+def test_an_unauthenticated_callee_unit_still_refuses_by_its_own_name(
+    tmp_path,
+) -> None:
+    """The boundary that must not move.
+
+    "Foreign but authenticated" and "foreign and unknown" must never collapse
+    into one outcome. A unit carrying no content address is refused, and it is
+    refused under a DIFFERENT name than the cross-file case above returns.
+    """
+    definition, call, reporter = _two_files_one_roll(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = definition.source_visible_call_frame()
+    object.__setattr__(definition.unit, "source_cid", "")
+
+    fault = reporter._source_call_identity_fault(
+        call, truthful, definition, definition, truthful.call_occurrence, frame
+    )
+    assert fault == "definition-unit-unauthenticated"
+
+
+def test_an_opaque_callee_keeps_its_own_separate_name(tmp_path) -> None:
+    """The other half of the same boundary, measured on the real corpus.
+
+    Of 57 cross-file arrivals at this guard in the stride-8 slice, 7 were
+    unmaterialized `_Handle`s. They are caught ABOVE the unit terms, so
+    relaxing the same-unit demand cannot let one through.
+    """
+    definition, call, reporter = _two_files_one_roll(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+
+    class _OpaqueHandle:
+        """Stands where a raw parser handle arrives: no unit, no fragment."""
+
+    fault = reporter._source_call_identity_fault(
+        call, truthful, _OpaqueHandle(), definition, truthful.call_occurrence, None
+    )
+    assert fault == "definition-not-a-functiondef"
+
+
+def test_the_frame_site_term_is_keyed_on_the_definitions_unit(tmp_path) -> None:
+    """A frame describes the CALLEE's definition, so its site lives in the
+    callee's file. Keying it on the caller's unit was the same-unit demand
+    wearing a second name -- it refused every cross-file call a second time."""
+    definition, call, reporter = _two_files_one_roll(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = definition.source_visible_call_frame()
+
+    # The callee's own site passes ...
+    assert (
+        reporter._source_call_identity_fault(
+            call, truthful, definition, definition, truthful.call_occurrence, frame
+        )
+        is None
+    )
+    # ... and a site belonging to neither unit is still refused, by name.
+    foreign_site = replace(frame.definition_site, source_cid="blake3-512:" + "00" * 64)
+    assert (
+        reporter._source_call_identity_fault(
+            call,
+            truthful,
+            definition,
+            definition,
+            truthful.call_occurrence,
+            replace(frame, definition_site=foreign_site),
+        )
+        == "frame-definition-site-foreign"
+    )

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -671,3 +671,41 @@ def test_a_class_definition_shows_up_on_the_roll(tmp_path) -> None:
         )
     kinds = {type(node).__name__ for node in reporter._materialized_by_ref.values()}
     assert "ClassDef" in kinds, sorted(kinds)
+
+
+def test_an_allocation_handle_is_projected_to_its_typed_class_occurrence(
+    tmp_path,
+) -> None:
+    """The projection arm, which no other tooth reaches.
+
+    On the production path an allocation call carries
+    ``expected_definition_ref=bound_frame.owner.ref`` -- a raw parser handle,
+    not a typed node. Every other allocation tooth hands the guard a typed
+    definition directly and so routes AROUND the projection; a mutation that
+    dropped its ClassDef arm failed nothing at all. This is that tooth.
+    """
+    top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
+    constructed = call._construct_sugar()
+    # Exactly what the preconstruction branch installs.
+    with_handle = replace(constructed, expected_definition_ref=top_level.ref)
+    assert not isinstance(with_handle.expected_definition_ref, ClassDef)
+
+    projected = call._project_constructed_value_for_testimony(with_handle)
+
+    assert isinstance(projected.expected_definition_ref, ClassDef), (
+        projected.expected_definition_ref
+    )
+    assert (
+        projected.expected_definition_ref.fragment.seal()
+        == top_level.fragment.seal()
+    )
+    # And the projected occurrence is one the guard can actually admit: a raw
+    # handle stops at term 1, a projected class reaches the seal join.
+    assert reporter._source_call_identity_fault(
+        call,
+        projected,
+        with_handle.expected_definition_ref,
+        top_level,
+        projected.call_occurrence,
+        top_level.source_visible_constructor_frame(),
+    ) == "definition-not-a-functiondef"

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -9,6 +9,7 @@ import pytest
 from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
 from sugar_source_tree.backend import materialize
 from sugar_source_tree.binding_state import (
+    _callee_definition_by_name_in_its_unit,
     ConstructionTestimonyReporterV1,
     SubstitutionTraceBuilderV1,
 )
@@ -386,3 +387,103 @@ def test_the_frame_site_term_is_keyed_on_the_definitions_unit(tmp_path) -> None:
         )
         == "frame-definition-site-foreign"
     )
+
+
+# ---------------------------------------------------------------------------
+# THE FALSIFIABILITY GATE: the third authority must be able to REFUSE
+# ---------------------------------------------------------------------------
+
+
+def _shadowing_callee_unit(tmp_path):
+    """A callee unit where the callee's NAME is also bound nested.
+
+    The module binding of `find_level` is the top-level def. The nested def
+    inside `other` shares the name and is a DIFFERENT span and different text.
+    """
+    helper_path = tmp_path / "shadow_callee.py"
+    helper_path.write_text(
+        "def find_level(value):\n"
+        "    return value\n"
+        "\n"
+        "def other(value):\n"
+        "    def find_level(inner):\n"
+        "        return inner + 1\n"
+        "    return find_level(value)\n"
+    )
+    caller_path = tmp_path / "shadow_caller.py"
+    caller_path.write_text("def apply(value):\n    return find_level(value)\n")
+
+    collector = CollectingReporter()
+    helper_source = SourceFile.from_path(helper_path, reporter=collector)
+    caller_source = SourceFile.from_path(caller_path, reporter=collector)
+    testimony = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(caller_source.unit.source_cid)
+    )
+    helper_root = materialize(helper_source.unit, helper_source.root.ref, testimony)
+    caller_root = materialize(caller_source.unit, caller_source.root.ref, testimony)
+
+    definitions = [
+        node
+        for node in helper_root.walk()
+        if isinstance(node, FunctionDef) and node.name == "find_level"
+    ]
+    assert len(definitions) == 2, definitions
+    top_level = min(definitions, key=lambda d: d.line_col_span().start_line)
+    nested = max(definitions, key=lambda d: d.line_col_span().start_line)
+    call = next(
+        node
+        for node in caller_root.walk()
+        if isinstance(node, Call) and node.segment() == "find_level(value)"
+    )
+    return top_level, nested, call, testimony
+
+
+def test_the_third_authority_accepts_the_true_cross_file_callee(tmp_path) -> None:
+    """The truthful arm of the twin, so the refusal below is discrimination
+    and not a guard that refuses everything."""
+    top_level, _nested, call, reporter = _shadowing_callee_unit(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = top_level.source_visible_call_frame()
+
+    # Exactly what `present_construction` now supplies: the caller's unit has
+    # no answer for a cross-file callee, so the third authority answers.
+    resolved = _callee_definition_by_name_in_its_unit(top_level)
+    # Not `is`: the module binding table holds an equal-but-distinct instance
+    # for the same span. The SEAL is the identity here, which is the whole
+    # point -- content, not object address.
+    assert resolved.fragment.seal() == top_level.fragment.seal()
+    assert (
+        reporter._source_call_identity_fault(
+            call, truthful, top_level, resolved, truthful.call_occurrence, frame
+        )
+        is None
+    )
+
+
+def test_a_shadowed_same_name_definition_is_REFUSED(tmp_path) -> None:
+    """THE LYING TWIN.
+
+    A nested definition sharing the callee's name is handed over as the
+    callee. Same name, same unit, same file -- everything a name-only check
+    would accept. The callee's own source says the module binding of that name
+    is somewhere else entirely, and the seal over file+cid+span+text is what
+    catches it.
+
+    If this ever passes, the third authority is a tautology and must be torn
+    out: it would convert 81 loud rows into 81 silent ones.
+    """
+    _top_level, nested, call, reporter = _shadowing_callee_unit(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = nested.source_visible_call_frame()
+
+    # The third authority does NOT return the nested impostor: it reads the
+    # unit's module binding table, which names the top-level definition.
+    resolved = _callee_definition_by_name_in_its_unit(nested)
+    assert resolved.fragment.seal() != nested.fragment.seal(), (
+        "the authority accepted the impostor"
+    )
+
+    fault = reporter._source_call_identity_fault(
+        call, truthful, nested, resolved, truthful.call_occurrence, frame
+    )
+    assert fault == "resolved-seal-mismatch", fault

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -13,7 +13,7 @@ from sugar_source_tree.binding_state import (
     ConstructionTestimonyReporterV1,
     SubstitutionTraceBuilderV1,
 )
-from sugar_source_tree.nodes import Call, FunctionDef
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef
 from sugar_source_tree.panic import ConstructedValueTestimonyNotWritten
 from sugar_source_tree.reporter import CollectingReporter
 from sugar_source_tree.tree import SourceFile
@@ -487,3 +487,187 @@ def test_a_shadowed_same_name_definition_is_REFUSED(tmp_path) -> None:
         call, truthful, nested, resolved, truthful.call_occurrence, frame
     )
     assert fault == "resolved-seal-mismatch", fault
+
+
+# ---------------------------------------------------------------------------
+# A CLASS is a legitimate callee -- and the same gate applies to it
+# ---------------------------------------------------------------------------
+
+
+def _shadowing_allocation_unit(tmp_path):
+    """A callee unit where an ALLOCATION callee's name is also bound nested.
+
+    ``Boom`` is a module-scope exception class with no ``__init__`` -- the
+    exact shape of ``pandas._config.config.OptionError``. The nested class
+    inside ``other`` shares the name, has a different span and different text,
+    and is the lie.
+    """
+    helper_path = tmp_path / "shadow_allocation_callee.py"
+    helper_path.write_text(
+        "class Boom(ValueError):\n"
+        '    """The module-scope allocation callee."""\n'
+        "\n"
+        "\n"
+        "def other(value):\n"
+        "    class Boom(ValueError):\n"
+        '        """A NESTED class of the same name -- the impostor."""\n'
+        "\n"
+        "    return Boom\n"
+    )
+    caller_path = tmp_path / "shadow_allocation_caller.py"
+    caller_path.write_text("def apply(value):\n    raise Boom(value)\n")
+
+    collector = CollectingReporter()
+    helper_source = SourceFile.from_path(helper_path, reporter=collector)
+    caller_source = SourceFile.from_path(caller_path, reporter=collector)
+    testimony = ConstructionTestimonyReporterV1(
+        collector, SubstitutionTraceBuilderV1(caller_source.unit.source_cid)
+    )
+    helper_root = materialize(helper_source.unit, helper_source.root.ref, testimony)
+    caller_root = materialize(caller_source.unit, caller_source.root.ref, testimony)
+
+    definitions = [
+        node
+        for node in helper_root.walk()
+        if isinstance(node, ClassDef) and node.name == "Boom"
+    ]
+    assert len(definitions) == 2, definitions
+    top_level = min(definitions, key=lambda d: d.line_col_span().start_line)
+    nested = max(definitions, key=lambda d: d.line_col_span().start_line)
+    call = next(
+        node
+        for node in caller_root.walk()
+        if isinstance(node, Call) and node.segment() == "Boom(value)"
+    )
+    return top_level, nested, call, testimony
+
+
+def test_a_class_callee_carries_a_derivable_constructor_law(tmp_path) -> None:
+    """The premise this admission rests on, measured rather than assumed.
+
+    ``Boom`` defines no ``__init__``, so the claim under test is that its
+    constructor law is derivable IN POPULATION -- from its own body plus the
+    authenticated base graph -- and not a body sugar cannot see. If this ever
+    goes red, admitting a ClassDef below stops being sound and the citation
+    road is the correct repair after all.
+    """
+    top_level, _nested, _call, _reporter = _shadowing_allocation_unit(tmp_path)
+    assert not any(
+        getattr(member, "name", None) == "__init__" for member in top_level.body
+    )
+    assert top_level._inherits_default_exception_constructor() is True
+    frame = top_level.source_visible_constructor_frame()
+    assert frame.parameters == ("args",), frame.parameters
+    assert frame.parameter_kinds == ("vararg",), frame.parameter_kinds
+    assert frame.owner is top_level
+
+
+def test_the_third_authority_accepts_the_true_allocation_callee(tmp_path) -> None:
+    """The truthful arm, so the refusal below is discrimination."""
+    top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = top_level.source_visible_constructor_frame()
+
+    resolved = _callee_definition_by_name_in_its_unit(top_level)
+    assert resolved.fragment.seal() == top_level.fragment.seal()
+    assert (
+        reporter._source_call_identity_fault(
+            call, truthful, top_level, resolved, truthful.call_occurrence, frame
+        )
+        is None
+    )
+
+
+def test_a_shadowed_same_name_CLASS_is_REFUSED(tmp_path) -> None:
+    """THE LYING TWIN, allocation arm.
+
+    A nested class sharing the callee's name is handed over as the callee.
+    Same name, same unit, same file, same bases -- everything a name-only or
+    kind-only check would accept. Admitting ClassDef must not cost the seal.
+
+    If this ever passes, the admission is a tautology and must be torn out: it
+    would convert 78 loud rows into 78 silent ones.
+    """
+    _top_level, nested, call, reporter = _shadowing_allocation_unit(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = nested.source_visible_constructor_frame()
+
+    resolved = _callee_definition_by_name_in_its_unit(nested)
+    assert resolved.fragment.seal() != nested.fragment.seal(), (
+        "the authority accepted the impostor"
+    )
+
+    fault = reporter._source_call_identity_fault(
+        call, truthful, nested, resolved, truthful.call_occurrence, frame
+    )
+    assert fault == "resolved-seal-mismatch", fault
+
+
+def test_a_class_resolving_to_a_function_of_the_same_name_is_REFUSED(
+    tmp_path,
+) -> None:
+    """The kind disagreement gets its OWN name.
+
+    The two authorities can disagree about WHAT a name is, not only about
+    where it lives. Lumping that into the seal term would print a fault that
+    names the wrong repair.
+    """
+    top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    frame = top_level.source_visible_constructor_frame()
+    _source, function_definition, _fn_call, _fn_reporter = _ordinary_call(
+        tmp_path, helper="Boom", caller="apply_function"
+    )
+    assert isinstance(function_definition, FunctionDef)
+
+    fault = reporter._source_call_identity_fault(
+        call,
+        truthful,
+        top_level,
+        function_definition,
+        truthful.call_occurrence,
+        frame,
+    )
+    assert fault == "resolved-definition-kind-mismatch", fault
+
+
+def test_an_opaque_allocation_callee_still_refuses_by_its_own_name(
+    tmp_path,
+) -> None:
+    """The boundary that must not move.
+
+    Admitting ClassDef must not admit a callee with no readable definition at
+    all. An unmaterialized handle is still `definition-not-a-functiondef`.
+    """
+    top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
+    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+
+    class _OpaqueHandle:
+        """Stands where a raw parser handle arrives: no unit, no fragment."""
+
+    fault = reporter._source_call_identity_fault(
+        call, truthful, _OpaqueHandle(), top_level, truthful.call_occurrence, None
+    )
+    assert fault == "definition-not-a-functiondef"
+
+
+def test_a_class_definition_shows_up_on_the_roll(tmp_path) -> None:
+    """A NODE OFF THE ROLL.
+
+    ``Node.__post_init__`` states the law: registering in the constructor is
+    what makes ``cls(...)`` show up on the roll, and there is no way to new a
+    node without it. ``ClassDef`` overrode that method and never called it, so
+    every class in the corpus was constructed unregistered -- and
+    ``definition-ref-not-materialized`` was unsatisfiable for every allocation
+    callee no matter what the identity guard admitted.
+
+    This is about the ROLL, not about the guard: a class must be on it for the
+    same reason a function is.
+    """
+    top_level, nested, _call, reporter = _shadowing_allocation_unit(tmp_path)
+    for definition in (top_level, nested):
+        assert reporter.materialized_node_for_ref(definition.ref) is not None, (
+            f"ClassDef at line {definition.line_col_span().start_line} is off the roll"
+        )
+    kinds = {type(node).__name__ for node in reporter._materialized_by_ref.values()}
+    assert "ClassDef" in kinds, sorted(kinds)

--- a/scripts/mutate_one.py
+++ b/scripts/mutate_one.py
@@ -1,0 +1,137 @@
+"""Apply exactly ONE coherent mutation, and PRINT that it landed.
+
+A helper whose `assert anchor in source` fails silently makes an unapplied
+mutation run as a clean green -- that is the ninth wrong figure retired from
+this work. So this prints the file, the anchor, and the replacement it made,
+and exits non-zero with a named reason if it could not make it. Check that
+line before believing any red or green.
+
+usage:
+  python scripts/mutate_one.py <name>
+  python scripts/mutate_one.py --revert
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BINDING = (
+    ROOT
+    / "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py"
+)
+NODES = ROOT / "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py"
+SNAPSHOT = Path("/tmp/citecls_mutation_snapshot")
+
+MUTATIONS = {
+    # The third authority re-derives from its own input: the check proves
+    # nothing about an allocation callee. The lying twin is what distinguishes
+    # a real re-derivation from this.
+    "allocation-tautology": (
+        BINDING,
+        "    resolved = bindings[0]\n",
+        "    if isinstance(definition, ClassDef):\n"
+        "        return definition\n"
+        "    resolved = bindings[0]\n",
+    ),
+    # The kind disagreement falls through to the seal term, which names the
+    # wrong repair.
+    "drop-kind-term": (
+        BINDING,
+        "        if isinstance(definition, ClassDef) is not isinstance(\n"
+        "            resolved_definition, ClassDef\n"
+        "        ):\n"
+        '            return "resolved-definition-kind-mismatch"\n',
+        "",
+    ),
+    # The admission is broadened past a readable definition: an unmaterialized
+    # handle would stop being refused.
+    "admit-any-object": (
+        BINDING,
+        "        if not isinstance(definition, (FunctionDef, AsyncFunctionDef, ClassDef)):\n"
+        '            return "definition-not-a-functiondef"\n',
+        "        if definition is None:\n"
+        '            return "definition-not-a-functiondef"\n',
+    ),
+    # The allocation callee is not projected to its typed occurrence, so the
+    # guard holds a raw handle again.
+    "drop-classdef-projection": (
+        NODES,
+        "        if not isinstance(definition, (FunctionDef, AsyncFunctionDef, ClassDef)):\n"
+        "            return value\n"
+        "        source_call_frame = value.source_call_frame\n",
+        "        if not isinstance(definition, (FunctionDef, AsyncFunctionDef)):\n"
+        "            return value\n"
+        "        source_call_frame = value.source_call_frame\n",
+    ),
+    # The class definition goes back off the roll.
+    "classdef-off-the-roll": (
+        NODES,
+        "        super().__post_init__()\n"
+        "        if (\n"
+        "            not isinstance(self.binding_target, Name)\n",
+        "        if (\n"
+        "            not isinstance(self.binding_target, Name)\n",
+    ),
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("MUTATION REFUSED: exactly one argument required", flush=True)
+        return 2
+    name = sys.argv[1]
+    # A SNAPSHOT, never `git checkout`. Reverting to HEAD destroyed the very
+    # working change the mutations were testing -- the second mutation then ran
+    # against a tree without it, and the three after that refused because their
+    # anchors no longer existed. The refusals were correct and are the only
+    # reason this was caught; the revert was the defect.
+    if name == "--snapshot":
+        SNAPSHOT.mkdir(parents=True, exist_ok=True)
+        for path in (BINDING, NODES):
+            (SNAPSHOT / path.name).write_text(path.read_text())
+        print(f"SNAPSHOT TAKEN: {[p.name for p in (BINDING, NODES)]}", flush=True)
+        return 0
+    if name == "--revert":
+        missing = [p.name for p in (BINDING, NODES) if not (SNAPSHOT / p.name).is_file()]
+        if missing:
+            print(
+                f"REVERT REFUSED: no snapshot for {missing}. Take one with "
+                "`--snapshot` BEFORE mutating. NOTHING WAS RESTORED.",
+                flush=True,
+            )
+            return 4
+        for path in (BINDING, NODES):
+            path.write_text((SNAPSHOT / path.name).read_text())
+        print("MUTATION REVERTED: restored from snapshot", flush=True)
+        return 0
+    if name not in MUTATIONS:
+        print(
+            f"MUTATION REFUSED: unknown name {name!r}; known: {sorted(MUTATIONS)}",
+            flush=True,
+        )
+        return 2
+    path, anchor, replacement = MUTATIONS[name]
+    source = path.read_text()
+    occurrences = source.count(anchor)
+    if occurrences != 1:
+        print(
+            f"MUTATION REFUSED: anchor for {name!r} occurs {occurrences} times in "
+            f"{path.name}; expected exactly 1. NOTHING WAS APPLIED.",
+            flush=True,
+        )
+        return 3
+    path.write_text(source.replace(anchor, replacement))
+    print(
+        f"MUTATION LANDED: {name} in {path.name}\n"
+        f"  removed: {anchor.strip()[:120]!r}\n"
+        f"  wrote:   {replacement.strip()[:120]!r}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mutate_one.py
+++ b/scripts/mutate_one.py
@@ -6,7 +6,17 @@ this work. So this prints the file, the anchor, and the replacement it made,
 and exits non-zero with a named reason if it could not make it. Check that
 line before believing any red or green.
 
+GIT CHECKOUT IS NOT A REVERT WHEN THE THING YOU ARE MUTATING IS UNCOMMITTED
+WORK. This script's first version reverted with `git checkout -- <files>`,
+which restored HEAD and so DELETED the working change the mutations existed
+to test. Mutation 2 then ran against a tree without it and its red was
+meaningless; mutations 3-5 REFUSED, because their anchors no longer existed.
+Those refusals are the only reason it was caught, and the whole series was
+discarded as non-evidence. Revert from a snapshot taken before the first
+mutation -- `--snapshot` -- and never from the index.
+
 usage:
+  python scripts/mutate_one.py --snapshot     # BEFORE the first mutation
   python scripts/mutate_one.py <name>
   python scripts/mutate_one.py --revert
 """

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -92,6 +92,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py"]
 network = "none"
 
+[tasks.probe-constructed-value-slot]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_constructed_value_slot.py"]
+network = "none"
+
 [tasks.probe-with-gaps]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -176,3 +176,15 @@ capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]
 command = ["bash", "scripts/test-3809-dod-scoreboard.sh"]
 network = "required"
+
+[tasks.probe-class-allocation-census]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_class_allocation_census.py"]
+network = "none"
+
+[tasks.probe-class-allocation-identity]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_class_allocation_identity.py"]
+network = "none"


### PR DESCRIPTION
Puts a hard-won lesson where the next person hits it **before** writing their first mutation, rather than in a ticket nobody re-reads.

A mutation harness reverted with `git checkout -- <files>`, which **deleted the uncommitted change the mutations were testing.** Mutation 2 then ran against a tree without it and reported clean; mutations 3-5 **refused**, because their anchors no longer existed.

**Those refusals are the only reason it was caught** — which is precisely why a mutation harness must print that it landed and exit non-zero rather than silently no-op'ing. The entire first series was discarded as non-evidence.

Now recorded in the commit subject and at the top of `scripts/mutate_one.py`.

Related: #7394, #7403.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a local mutation tool and fix class allocation identity checks
> - Adds [mutate_one.py](https://github.com/TSavo/sugar/pull/7404/files#diff-dce16f7593a7de332b1506823d6d80c553422f127a5058119c2fd9edf4fca6b5), a developer utility to apply named source mutations or snapshot/revert target files locally (note: `git checkout` reverts committed files, not uncommitted work — this tool manages that gap)
> - Fixes identity checks in `ConstructionTestimonyReporterV1._source_call_identity_fault` and `Call._project_constructed_value_for_testimony` so `ClassDef` callees (class constructors) pass correctly instead of always faulting
> - Adds `_callee_definition_by_name_in_its_unit` for third-authority module-scope name resolution used in seal falsifiability checks
> - Canonicalizes `MutableGlobalBindingV1` terms (lists → tuples) while preserving original wire spelling for CID derivation; invalid member types now raise `SourceCallBindingGap`
> - Adds three new build tasks and probe scripts for inspecting class allocation census, identity faults, and constructed value slot panics across a corpus
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 630939f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->