### PR TITLE
git checkout is not a revert when the thing you are mutating is uncommitted work

### DIFF
--- a/scripts/mutate_one.py
+++ b/scripts/mutate_one.py
@@ -6,7 +6,17 @@ this work. So this prints the file, the anchor, and the replacement it made,
 and exits non-zero with a named reason if it could not make it. Check that
 line before believing any red or green.
 
+GIT CHECKOUT IS NOT A REVERT WHEN THE THING YOU ARE MUTATING IS UNCOMMITTED
+WORK. This script's first version reverted with `git checkout -- <files>`,
+which restored HEAD and so DELETED the working change the mutations existed
+to test. Mutation 2 then ran against a tree without it and its red was
+meaningless; mutations 3-5 REFUSED, because their anchors no longer existed.
+Those refusals are the only reason it was caught, and the whole series was
+discarded as non-evidence. Revert from a snapshot taken before the first
+mutation -- `--snapshot` -- and never from the index.
+
 usage:
+  python scripts/mutate_one.py --snapshot     # BEFORE the first mutation
   python scripts/mutate_one.py <name>
   python scripts/mutate_one.py --revert
 """


### PR DESCRIPTION
A mutation harness reverted with `git checkout -- <files>`, which **deleted the uncommitted change the mutations were testing.** Mutation 2 then ran against a tree without it and reported clean; mutations 3-5 **refused**, because their anchors no longer existed.

**Those refusals are the only reason it was caught** — which is exactly why a mutation harness must print that it landed and exit non-zero rather than silently no-op'ing. The whole first series was discarded as non-evidence.

Recorded at the top of `scripts/mutate_one.py`, where the next person meets it before writing their first mutation rather than in a ticket nobody re-reads.

Related: #7394, #7403.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify that `git checkout -- <files>` does not revert uncommitted work in `mutate_one.py`
> Updates the top-level usage text in [mutate_one.py](https://github.com/TSavo/sugar/pull/7405/files#diff-dce16f7593a7de332b1506823d6d80c553422f127a5058119c2fd9edf4fca6b5) to warn that `git checkout -- <files>` is ineffective for reverting uncommitted changes made by the mutation script. The correct approach is to take a snapshot before the first mutation using `python scripts/mutate_one.py --snapshot` and restore from that.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a648bd2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->