### PR TITLE
CI: match the autoscaler's runner label casing on the scoreboard door

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -19,6 +19,16 @@ name: Control-effect recensus (authoritative scoreboard)
 # - Missing or failed seat → UNMEASURED envelope naming the missing shards;
 #   NEVER seal over the shards that finished.
 # - fail-fast: false so compose always sees the receipt set.
+# - RUNNER LABELS ARE CASE-SENSITIVE TO THE AUTOSCALER. runs-on MUST be
+#   [self-hosted, Linux, X64] — the exact spelling of RUNNER_LABELS in the
+#   autoscaler pool. poolMatchesJob() is `jobLabels.every(l => pool.includes(l))`,
+#   a plain string compare, and it gates BOTH the webhook and the reconciler.
+#   This file shipped `linux, x64` from #6984; every other workflow in the repo
+#   uses `Linux, X64`. Consequence: the autoscaler NEVER spawned a runner for
+#   the scoreboard door — it only ever ran by scavenging runners spawned for
+#   other workflows. Seats that found no scavenged runner sat queued until
+#   GitHub cancelled them (run 31331282506, s6: 36m queued, no runner ever
+#   assigned, conclusion=cancelled).
 # - CORPUS PIN GATE (exit 78): every plan and every shard job refuses unless the
 #   runner's pandas matches docs/ledgers/pins/pandas-3.0.3.pin.json
 #   (3.0.3 / 1421 files). A sealed board against the wrong pin is worse than
@@ -66,7 +76,7 @@ jobs:
   # Does not measure. planCid is the content-addressed identity workers bind.
   plan:
     name: LPT plan
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     outputs:
       root: ${{ steps.population.outputs.root }}
@@ -256,7 +266,7 @@ jobs:
   shard:
     name: recensus shard s${{ matrix.shard }}
     needs: plan
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, Linux, X64]
     # Per-seat budget: serial ~12 min → LPT k=8 pole ~2 min; leave headroom.
     timeout-minutes: 180
     strategy:
@@ -386,7 +396,7 @@ jobs:
     name: compose seal (sole SCOREBOARD door)
     needs: [plan, shard]
     if: always() && needs.plan.result == 'success'
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
The `control-effect-recensus` workflow is the only workflow in the repo that spells `runs-on: [self-hosted, linux, x64]`. The other 32 job definitions use `[self-hosted, Linux, X64]`.

The autoscaler pool advertises `RUNNER_LABELS=self-hosted,Linux,X64,vault` and admits a job with a plain case-sensitive compare (`src/webhook.ts:55`):

```ts
return jobLabels.every((jobLabel) => poolLabels.includes(jobLabel));
```

It gates **both** the webhook handler (`webhook.ts:109`) and the reconciler (`reconciler.ts:126`). `"linux"` is not `"Linux"`, so every recensus job is rejected. Observed live:

```
2026-08-10T01:14:19.101Z job_id=93329484175 action=queued
  result.action=ignored
  reason="pool labels [self-hosted,Linux,X64,vault] dont cover job labels [self-hosted,linux,x64]"
```

That is the `LPT plan` job of run 31346569227, which sat queued with zero `tsavo-sugar-runner-*` containers on the host and no prospect of one.

**Consequence:** the sole SCOREBOARD door has never been able to requisition capacity. Since #6984 it has run only when runners spawned for *other* workflows happened to be idle. In run 31331282506, shard s6 found none: 36m17s queued, `runner_id: 0`, no log blob, conclusion `cancelled` — and compose could not seal.

This changes only which runner the jobs land on. Nothing about what the census measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2LL3G3Rp6s6R62yvo7oJH

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix runner label casing in CI workflow to match autoscaler expectations
> Runner labels in [control-effect-recensus.yml](https://github.com/TSavo/sugar/pull/7407/files#diff-7e202e700aa9f13d566241432324fdcbab9681d436e4227693482c2c51b3acd0) are case-sensitive; using lowercase `linux` and `x64` caused jobs to not be picked up by the autoscaler. Updates all three jobs (`plan`, `shard`, `compose`) to use `[self-hosted, Linux, X64]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bf5e68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the required case-sensitive runner labels.
  * Documented the previous queueing and cancellation behavior.

* **Bug Fixes**
  * Updated workflow runner targeting to use the correct Linux and X64 labels, improving job scheduling on self-hosted runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->