### PR TITLE
Raise the shard ceiling once so the unpriced set can be priced

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -268,7 +268,17 @@ jobs:
     needs: plan
     runs-on: [self-hosted, Linux, X64]
     # Per-seat budget: serial ~12 min → LPT k=8 pole ~2 min; leave headroom.
-    timeout-minutes: 180
+    # 360, not 180: the LPT prior can only price a file that has been MEASURED.
+    # A shard that times out never uploads its cost delta, so its files stay
+    # unpriced, take the default, and re-clump into whichever bin they land in
+    # next -- the heavy bin MOVES between runs but never disappears. Observed:
+    # s0 177min then 10min, s5 8min then 181min, same corpus. This is a
+    # bootstrap deadlock, not a bad split: k is banked (#7055) and the split KEY
+    # is already correct. Raised once so the unpriced set can complete and be
+    # priced; after that the prior balances and this ceiling should be dead
+    # weight. If a shard ever needs it again, the prior stopped restoring --
+    # look there, do NOT raise this number.
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The census could not seal because **one shard always exceeds `timeout-minutes: 180`** — but never the same one.

```
run 31547040878:  s0 = 177min FAIL   s5 =   8min ok
run 31560109341:  s0 =  10min ok     s5 = 181min CANCELLED
```

Same corpus, same `k`, heavy bin **moves**. That rules out a bad split and rules out a single pathological file staying put.

## The mechanism: a bootstrap deadlock

The LPT prior can only price a file that has been **measured**. A shard that times out **never uploads its cost delta**, so its files stay unpriced, take the default, and re-clump into whichever bin they land in next.

The plan job restored `lpt-recensus-file-costs-…-31547040878-merged` with `entries=1316` — the prior from the run where **s0 timed out**. So s0's files were still unpriced going in, and this time they clumped into bin 5.

Those files cannot be priced until they complete, and they cannot complete inside 180 minutes. The census has been unable to seal for this reason alone since the fleet was repaired.

## Why not the other levers

- **`k` is banked** (#7055, and the comment at the top of this file): *keep k fixed; change the split KEY (prior), not k.*
- **The split key is already correct** — restore-keys use prefix fallback and the prior does restore; it is simply incomplete.
- **Raising the ceiling is not "raise a number until it passes"** here. It is raised **once** so the unpriced set can finish and be recorded. After that the prior balances — the other seven shards land at 6–11 minutes — and this ceiling becomes dead weight.

The comment in the file says exactly that, including the diagnostic for next time:

> If a shard ever needs it again, the prior stopped restoring — look there, do NOT raise this number.

## Context: this is the last of several CI faults cleared today

The autoscaler had been stopped six days; `runs-on` label casing meant the scoreboard door could never requisition its own runners; the runner binary was deprecated and GitHub refused to hand it jobs; shelf bind mounts used Linux paths against a Windows-side daemon and silently mounted an empty directory; and a shelf cell carried creator-only modes. Each was real, and each masked the next. With those cleared, the split balanced immediately — `s0` went from 177 minutes to 10 — leaving only the unpriced remainder.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Double the shard job timeout in the recensus workflow to 360 minutes
> Increases `timeout-minutes` from 180 to 360 in the `shard` job of [control-effect-recensus.yml](.github/workflows/control-effect-recensus.yml) so the unpriced set can complete pricing without hitting the timeout. Adds comments explaining the rationale for the higher limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa38bc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->