### PR TITLE
Let the host say which bind-path form its engine resolves

### DIFF
--- a/bin/lib/sugar-bx.sh
+++ b/bin/lib/sugar-bx.sh
@@ -488,6 +488,23 @@ exit \"\$st\""
 
 sugar_bx_docker_bind_source() {
   local source="$1" resolved
+  # Docker Desktop's WSL integration decides which bind-path form its engine
+  # resolves, and it CHANGES. Observed on one host inside a single day: first
+  # the UNC form resolved while the plain Linux path silently mounted EMPTY;
+  # later the daemon REJECTED the UNC form outright ("is not an absolute
+  # path") while the plain path resolved correctly. The default below is the
+  # UNC form because the empty mount is the silent failure and the rejection
+  # is the loud one -- prefer the failure you can see.
+  #
+  # SUGAR_BX_BIND_FORM=plain overrides it for a host whose integration is in
+  # the other state. This is NOT a bypass of the empty-mount guard: entrypoint.sh
+  # still verifies SUGAR_BX_MOUNT_PROOF inside the container and refuses with
+  # crime=empty-or-stale-bind-mount if the mount did not resolve. The override
+  # chooses which form to try; the proof still decides whether it worked.
+  if [[ "${SUGAR_BX_BIND_FORM:-}" == plain ]]; then
+    printf '%s\n' "$source"
+    return 0
+  fi
   # On a WSL2 host, Docker Desktop's engine runs in a separate distro: a
   # plain Linux path like /home/tsavo/... does not fail to bind, it silently
   # binds an EMPTY directory. Only the Windows UNC form


### PR DESCRIPTION
Every containerized `brun`/`bpytest` on battleaxe currently dies **before the container starts**:

```
docker: Error response from daemon:
\\wsl.localhost\Ubuntu-E\home\tsavo\remote\sugar-bcargo-<hash>\sugar is not an absolute path
```

Box-wide. Reproduced from independent checkouts by three agents, on `frontier-profile`, `probe-with-gaps` and `bin/bpytest`. Plain `bin/brun -- echo` still works, so ssh/rsync and the remote roots are fine — only the managed-docker path fails.

## The premise inverted

`sugar_bx_docker_bind_source` translates every bind source through `wslpath -w`, on the stated premise that a plain Linux path *"does not fail to bind, it silently binds an EMPTY directory."*

**That was true this morning and is false now.** Same host, same day:

```
earlier:  UNC → real contents          plain → EMPTY (silent)
later:    UNC → REJECTED               plain → real tree
```

```
$ docker run --rm --mount type=bind,src=$(wslpath -w $SRC),dst=/w alpine ls /w
docker: ... \\wsl.localhost\... is not an absolute path
$ docker run --rm --mount type=bind,src=$SRC,dst=/w alpine ls /w
Makefile
bin
bootstrap
```

So the guard is **currently inverted** — it produces the only form that fails.

## The change

`SUGAR_BX_BIND_FORM=plain` selects the other form. **The default stays UNC**, because the empty mount is the *silent* failure and the rejection is the *loud* one: prefer the failure you can see.

**This is not a bypass of the empty-mount guard.** `entrypoint.sh` still verifies `SUGAR_BX_MOUNT_PROOF` inside the container and refuses with `crime=empty-or-stale-bind-mount` if the mount did not resolve. The override chooses which form to *try*; the proof still decides whether it *worked*.

## Why not auto-detect

Attempted, and abandoned deliberately. A "is the mount non-empty" probe is wrong — `artifacts/` is legitimately empty before a run, so an empty directory is indistinguishable from a silently-empty mount. A marker-file probe is correct in principle but building the nested docker/`sh` quoting through the ssh helper produced false negatives, and this is not the moment to land subtle plumbing with the harness down.

A probed form is the right long-term shape; an explicit, documented override is the right thing to land while three agents are blocked.

## Verified

With the override the profile runs **inside the container** and materializes the corpus (heartbeats on `pandas/core/indexes/base.py`, `pandas/io/sql.py`). Without it the daemon rejects the mount.

**The real repair is on the host** — restore Docker Desktop's WSL integration for the distro. This keeps work moving meanwhile and should be revisited, not left as the permanent answer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SUGAR_BX_BIND_FORM=plain` option to `sugar_bx_docker_bind_source` to skip UNC path resolution
> By default, `sugar_bx_docker_bind_source` in [sugar-bx.sh](https://github.com/TSavo/sugar/pull/7412/files#diff-bdd6c46eb799e81d8c3cc8b50ab4a809668391cedbc25e468f6efe8ef9d86ebc) converts WSL paths to UNC form via `wslpath`. When `SUGAR_BX_BIND_FORM=plain` is set, the function now returns the source path as-is, skipping all WSL/UNC resolution. This accommodates Docker Desktop engines that resolve bind-mount paths without needing UNC conversion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e6fd78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving the original source path when plain bind path formatting is selected.
  * Existing path conversion and container-based validation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->