### PR TITLE
An assignment target that is an Attribute or Subscript binds no name

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
@@ -183,6 +183,7 @@ def main(argv: list[str] | None = None) -> int:
             from sugar_lift_py_tests.lift_rpc import (
                 open_source_file_for_construction,
             )
+            from sugar_lift_python_source.source_oracle import install_root_for
         except ModuleNotFoundError as error:
             # A verification arm that quietly does not run is worse than one
             # that fails: it reads as a clean confirmation. Say so and refuse.
@@ -193,12 +194,19 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"WIDTH_SEAT_ABSENT {seat}", flush=True)
                 return 2
             path = corpus.joinpath(*seat.split("/"))
+            # An installed file's address is the seat its DISTRIBUTION
+            # recorded, not the spelling the roster happens to use. The
+            # roster says `_config/config.py`; the recorded seat is
+            # `pandas/_config/config.py`, and opening against the package
+            # root mints an address no other checkout resolves.
+            installed = install_root_for(str(path))
+            locus_root = corpus if installed is None else Path(installed)
             # The SOLE construction door -- never the bare `SourceFile`
             # entrance, which seats no construction context.
             source_file = open_source_file_for_construction(
                 path,
                 root=corpus,
-                source_workspace_root=corpus,
+                source_workspace_root=locus_root,
                 distribution="pandas",
             )
             table = source_file.unit.module_direct_bindings or {}

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
@@ -82,7 +82,6 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
-    from sugar_source_tree.tree import SourceTree
 
     authenticated = authenticated_pandas_corpus()
     corpus = authenticated.root
@@ -94,9 +93,19 @@ def main(argv: list[str] | None = None) -> int:
 
     roster = sorted(
         path.resolve().relative_to(corpus).as_posix()
-        for path in SourceTree(corpus).paths()
+        for path in corpus.rglob("*.py")
     )
     print(f"WIDTH_ROSTER files={len(roster)}", flush=True)
+    # The walk is not the authority on the population; the authenticated pin
+    # is. If they disagree the census is over the wrong universe, and that is
+    # a refusal, not a footnote.
+    if len(roster) != authenticated.file_count:
+        print(
+            f"WIDTH_ROSTER_DISAGREES walked={len(roster)} "
+            f"authenticated={authenticated.file_count}",
+            flush=True,
+        )
+        return 4
 
     files_touched = 0
     statements_touched = 0
@@ -170,17 +179,28 @@ def main(argv: list[str] | None = None) -> int:
         print(f"WIDTH_EXEMPLAR {line}", flush=True)
 
     if args.verify_table:
-        from sugar_lift_python_source.source_oracle import install_root_for
-        from sugar_source_tree.source_file import SourceFile
-
-        install_root_for(corpus)
+        try:
+            from sugar_lift_py_tests.lift_rpc import (
+                open_source_file_for_construction,
+            )
+        except ModuleNotFoundError as error:
+            # A verification arm that quietly does not run is worse than one
+            # that fails: it reads as a clean confirmation. Say so and refuse.
+            print(f"WIDTH_TABLE_ARM_UNAVAILABLE {error}", flush=True)
+            return 5
         for seat in args.verify_table:
             if seat not in roster:
                 print(f"WIDTH_SEAT_ABSENT {seat}", flush=True)
                 return 2
             path = corpus.joinpath(*seat.split("/"))
-            source_file = SourceFile.from_path(path)
-            source_file.sugar()
+            # The SOLE construction door -- never the bare `SourceFile`
+            # entrance, which seats no construction context.
+            source_file = open_source_file_for_construction(
+                path,
+                root=corpus,
+                source_workspace_root=corpus,
+                distribution="pandas",
+            )
             table = source_file.unit.module_direct_bindings or {}
             names = args.name or sorted(table)
             for name in names:

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
@@ -1,0 +1,204 @@
+"""WIDTH of the ``module_direct_bindings`` attribute-target over-count (#7394).
+
+``_module_statement_bound_names`` collected every ``Name`` in a module-level
+assignment TARGET subtree, so ``get_option.__module__ = "pandas"`` published a
+binding of ``get_option``.  This probe counts, over the WHOLE authenticated
+corpus, how wide that is -- and separately the number that actually matters:
+names the over-count made look AMBIGUOUS to a by-name authority that must
+refuse more than one module-scope binding.
+
+The rules are re-derived here from the stdlib ``ast`` over the corpus source,
+INDEPENDENTLY of the typed tree, so the two instruments can disagree; the
+disagreement is the finding.  ``--verify-table`` additionally re-asks the real
+``SourceUnit.module_direct_bindings`` at named seats, which is the arm that
+proves the source-level reading describes the table and not just the grammar.
+
+An absent seat is REFUSED by name; it never reads as a clean file.
+
+usage:
+  python probe_attribute_target_binding_width.py [--verify-table SEAT ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections import Counter
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+_ASSIGNABLE = (ast.Name, ast.Tuple, ast.List, ast.Starred, ast.Attribute, ast.Subscript)
+
+
+def _old_rule(target: ast.expr) -> set[str]:
+    """Every ``Name`` anywhere under the target -- the defect, reproduced."""
+    if isinstance(target, ast.Name):
+        return {target.id}
+    return {node.id for node in ast.walk(target) if isinstance(node, ast.Name)}
+
+
+def _new_rule(target: ast.expr) -> set[str]:
+    """Names the target BINDS.  Closed over the assignment grammar."""
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: set[str] = set()
+        for element in target.elts:
+            names |= _new_rule(element)
+        return names
+    if isinstance(target, ast.Starred):
+        return _new_rule(target.value)
+    if isinstance(target, (ast.Attribute, ast.Subscript)):
+        return set()
+    raise AssertionError(f"target is not an assignable construct: {type(target).__name__}")
+
+
+def _statement_names(statement: ast.stmt, rule) -> set[str]:
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return {statement.name}
+    if isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+        targets = (
+            statement.targets
+            if isinstance(statement, ast.Assign)
+            else (statement.target,)
+        )
+        names: set[str] = set()
+        for target in targets:
+            names |= rule(target)
+        return names
+    if isinstance(statement, (ast.Import, ast.ImportFrom)):
+        return {alias.asname or alias.name.split(".", 1)[0] for alias in statement.names}
+    return set()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verify-table", action="append", default=None)
+    parser.add_argument("--name", action="append", default=None)
+    args = parser.parse_args(argv)
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_source_tree.tree import SourceTree
+
+    authenticated = authenticated_pandas_corpus()
+    corpus = authenticated.root
+    print(
+        f"WIDTH_CORPUS root={corpus} fileCount={authenticated.file_count} "
+        f"manifestCid={authenticated.manifest_cid}",
+        flush=True,
+    )
+
+    roster = sorted(
+        path.resolve().relative_to(corpus).as_posix()
+        for path in SourceTree(corpus).paths()
+    )
+    print(f"WIDTH_ROSTER files={len(roster)}", flush=True)
+
+    files_touched = 0
+    statements_touched = 0
+    spurious_pairs = 0
+    disambiguated = 0  # (file, name): count > 1 under the old rule, == 1 under the new
+    vanished = 0       # (file, name): had a binding ONLY because of the over-count
+    target_kinds: Counter[str] = Counter()
+    exemplars: list[str] = []
+    read_ok = 0
+    refused: list[str] = []
+
+    for seat in roster:
+        path = corpus.joinpath(*seat.split("/"))
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=seat)
+        except (OSError, SyntaxError, UnicodeDecodeError) as error:
+            # Loud, by name -- never a silently skipped file.
+            refused.append(f"{seat}: {type(error).__name__}: {error}")
+            continue
+        read_ok += 1
+
+        old: dict[str, int] = {}
+        new: dict[str, int] = {}
+        touched_here = False
+        for statement in tree.body:
+            old_names = _statement_names(statement, _old_rule)
+            new_names = _statement_names(statement, _new_rule)
+            for name in old_names:
+                old[name] = old.get(name, 0) + 1
+            for name in new_names:
+                new[name] = new.get(name, 0) + 1
+            if old_names != new_names:
+                statements_touched += 1
+                touched_here = True
+                if isinstance(statement, ast.Assign):
+                    for target in statement.targets:
+                        target_kinds[type(target).__name__] += 1
+                else:
+                    target_kinds[type(statement.target).__name__] += 1
+                if len(exemplars) < 12:
+                    exemplars.append(
+                        f"{seat}:{statement.lineno}:{statement.col_offset} "
+                        f"spurious={sorted(old_names - new_names)}"
+                    )
+        if touched_here:
+            files_touched += 1
+        for name, count in old.items():
+            after = new.get(name, 0)
+            if after == count:
+                continue
+            spurious_pairs += 1
+            if after == 0:
+                vanished += 1
+            elif count > 1 and after == 1:
+                disambiguated += 1
+
+    print(f"WIDTH_READ_OK {read_ok} REFUSED {len(refused)}", flush=True)
+    for line in refused:
+        print(f"WIDTH_REFUSED {line}", flush=True)
+    print(
+        f"WIDTH_FILES_AFFECTED {files_touched}\n"
+        f"WIDTH_STATEMENTS_AFFECTED {statements_touched}\n"
+        f"WIDTH_NAME_SEATS_AFFECTED {spurious_pairs}\n"
+        f"WIDTH_FALSELY_AMBIGUOUS_NOW_SINGLE {disambiguated}\n"
+        f"WIDTH_NAME_SEATS_LOSING_ALL_BINDINGS {vanished}",
+        flush=True,
+    )
+    for kind, count in sorted(target_kinds.items(), key=lambda item: -item[1]):
+        print(f"WIDTH_TARGET_KIND {kind} {count}", flush=True)
+    for line in exemplars:
+        print(f"WIDTH_EXEMPLAR {line}", flush=True)
+
+    if args.verify_table:
+        from sugar_lift_python_source.source_oracle import install_root_for
+        from sugar_source_tree.source_file import SourceFile
+
+        install_root_for(corpus)
+        for seat in args.verify_table:
+            if seat not in roster:
+                print(f"WIDTH_SEAT_ABSENT {seat}", flush=True)
+                return 2
+            path = corpus.joinpath(*seat.split("/"))
+            source_file = SourceFile.from_path(path)
+            source_file.sugar()
+            table = source_file.unit.module_direct_bindings or {}
+            names = args.name or sorted(table)
+            for name in names:
+                if name not in table:
+                    print(f"WIDTH_TABLE_NAME_ABSENT {seat} name={name}", flush=True)
+                    return 3
+                rows = table[name]
+                spelled = ", ".join(
+                    f"{type(row).__name__}@{row.line_col_span().start_line}:"
+                    f"{row.line_col_span().start_col}"
+                    for row in rows
+                )
+                print(
+                    f"WIDTH_TABLE {seat} name={name} entries={len(rows)} [{spelled}]",
+                    flush=True,
+                )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -1857,17 +1857,60 @@ class SourceUnit:
                 if isinstance(statement, Assign)
                 else (statement.target,)
             )
-            return {
-                node.id
-                for target in targets
-                for node in ((target,) if isinstance(target, Name) else target.walk())
-                if isinstance(node, Name)
-            }
+            names: set[str] = set()
+            for target in targets:
+                names |= SourceUnit._assignment_target_bound_names(target, statement)
+            return names
         if statement.kind in ("Import", "ImportFrom"):
             return {
                 alias.asname or alias.name.split(".", 1)[0] for alias in statement.names
             }
         return set()
+
+    @staticmethod
+    def _assignment_target_bound_names(
+        target: "Node", statement: "Node"
+    ) -> set[str]:
+        """The names an assignment TARGET binds -- a closed grammar decision.
+
+        ``X.attr = v`` and ``X[k] = v`` MUTATE the object ``X`` already denotes.
+        Neither BINDS the name ``X``.  The former reading collected every
+        ``Name`` in the whole target subtree, so ``get_option.__module__ =
+        "pandas"`` at ``_config/config.py:950`` published a second module-scope
+        binding of ``get_option`` -- and the by-name authority that must refuse
+        an ambiguous name then refused a name that is not ambiguous.  Two
+        different facts, "assigns to an attribute OF this name" and "binds this
+        name", were sharing one table (#7394).
+
+        A name-binding table must never be widened to make a lookup succeed, so
+        this is a decision over the target grammar rather than a filter: Python
+        admits exactly Name, Tuple, List, Starred, Attribute and Subscript in an
+        assignment target.  Anything else is a producer defect and PANICS naming
+        the construct, the coordinate and the shape -- it is not bucketed as
+        "binds nothing", because a silently empty answer here is indistinguish-
+        able from a legitimately non-binding target.
+        """
+        if isinstance(target, Name):
+            return {target.id}
+        if isinstance(target, (Tuple_, List)):
+            names: set[str] = set()
+            for element in target.elts:
+                names |= SourceUnit._assignment_target_bound_names(element, statement)
+            return names
+        if isinstance(target, Starred):
+            return SourceUnit._assignment_target_bound_names(target.value, statement)
+        if isinstance(target, (Attribute, Subscript)):
+            # Mutates an existing object; binds no module-scope name.
+            return set()
+        raise BackendDefect(
+            blame=getattr(target, "fragment", None) or statement.fragment,
+            owner="SourceUnit._assignment_target_bound_names",
+            observed=(
+                f"assignment target is not an assignable construct: {target.kind}"
+            ),
+            requested="Name, Tuple, List, Starred, Attribute or Subscript",
+            fix="produce assignment targets from the Python assignment grammar",
+        )
 
     def exception_type_identity(self, node: "Name"):
         """Return the authenticated exception-class coordinate reaching ``node``.

--- a/implementations/python/sugar-source-tree/tests/test_module_binding_table_excludes_attribute_targets.py
+++ b/implementations/python/sugar-source-tree/tests/test_module_binding_table_excludes_attribute_targets.py
@@ -1,0 +1,214 @@
+"""``X.attr = v`` mutates X; it does not BIND X (#7394).
+
+``module_direct_bindings`` collected every ``Name`` anywhere under a
+module-level assignment target, so the pandas 3.0.3 pin's
+
+    950| get_option.__module__ = "pandas"
+
+published a SECOND module-scope binding of ``get_option`` beside its
+``FunctionDef`` at 143.  The by-name authority that must refuse a name with
+several module-scope bindings then refused a name that has exactly one.
+
+Two facts -- "assigns to an attribute OF this name" and "binds this name" --
+were sharing one table.  These teeth pin the separation, and the FALSIFIABILITY
+arm is the point of the file: a name that genuinely IS bound twice at module
+scope must still be refused as ambiguous.  A repair that cannot refuse anything
+is a tautology, so the lying twin runs beside the truthful one and the two must
+disagree.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.binding_state import _callee_definition_by_name_in_its_unit
+from sugar_source_tree.nodes import Assign, FunctionDef
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.tree import SourceFile
+
+
+def _sf(source: str, name: str) -> SourceFile:
+    return SourceFile((source, name, blake3_512_of(source.encode("utf-8"))))
+
+
+def _bindings(tree: SourceFile, name: str):
+    return (tree.unit.module_direct_bindings or {}).get(name, ())
+
+
+def _fn(tree: SourceFile, name: str) -> FunctionDef:
+    return next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == name
+    )
+
+
+# The pin's shape, reduced: one definition and five ``__module__`` patches.
+_PIN_SHAPE = '''\
+def get_option(pat):
+    return pat
+
+
+def set_option(pat, value):
+    return value
+
+
+# import set_module here would cause circular import
+get_option.__module__ = "pandas"
+set_option.__module__ = "pandas"
+'''
+
+
+def test_attribute_target_does_not_bind_its_base_name() -> None:
+    """The pin's own shape: ONE binding for ``get_option``, the FunctionDef."""
+    tree = _sf(_PIN_SHAPE, "pin_attribute_target.py")
+    bindings = _bindings(tree, "get_option")
+    assert len(bindings) == 1, [type(row).__name__ for row in bindings]
+    assert isinstance(bindings[0], FunctionDef)
+    assert bindings[0].name == "get_option"
+    # And the patching statement is not silently absent from the module either
+    # -- it is simply not a BINDING of that name.
+    assert not any(isinstance(row, Assign) for row in bindings)
+
+
+def test_subscript_target_does_not_bind_its_base_name() -> None:
+    """``registry[key] = v`` mutates the mapping; the name keeps one binding."""
+    tree = _sf(
+        "registry = {}\nregistry['a'] = 1\nregistry['b'] = 2\n",
+        "pin_subscript_target.py",
+    )
+    bindings = _bindings(tree, "registry")
+    assert len(bindings) == 1
+    assert isinstance(bindings[0], Assign)
+
+
+def test_the_value_side_of_an_attribute_assignment_binds_nothing() -> None:
+    """The base ``Name`` under a chained attribute target is still not bound."""
+    tree = _sf(
+        "import types\nns = types.SimpleNamespace()\nns.inner.deep = 1\n",
+        "pin_chained_attribute.py",
+    )
+    assert len(_bindings(tree, "ns")) == 1
+    assert "inner" not in (tree.unit.module_direct_bindings or {})
+
+
+def test_destructuring_targets_still_bind_every_name() -> None:
+    """The repair must NOT be a filter that loses real bindings."""
+    tree = _sf(
+        "a, (b, c) = 1, (2, 3)\nfirst, *rest = [1, 2, 3]\n[p, q] = (4, 5)\n",
+        "pin_destructuring.py",
+    )
+    table = tree.unit.module_direct_bindings or {}
+    for name in ("a", "b", "c", "first", "rest", "p", "q"):
+        assert len(table.get(name, ())) == 1, f"{name} -> {table.get(name, ())}"
+
+
+def test_mixed_target_binds_the_name_and_not_the_attribute_base() -> None:
+    """One statement, both shapes: ``obj.attr = value = 1``."""
+    tree = _sf(
+        "class Holder:\n    attr = 0\n\n\nobj = Holder()\nobj.attr = value = 1\n",
+        "pin_mixed_target.py",
+    )
+    table = tree.unit.module_direct_bindings or {}
+    assert len(table.get("value", ())) == 1
+    # ``obj`` keeps ONLY its real binding, the ``obj = Holder()`` assignment.
+    assert len(table.get("obj", ())) == 1
+    assert isinstance(table["obj"][0], Assign)
+    assert table["obj"][0].line_col_span().start_line == 5
+
+
+def test_augmented_attribute_target_does_not_bind_its_base_name() -> None:
+    """``AugAssign``/``AnnAssign`` go through the same closed decision."""
+    tree = _sf(
+        "import types\ncount = 0\nns = types.SimpleNamespace()\n"
+        "ns.total += 1\nns.label: str = 'x'\n",
+        "pin_aug_attribute.py",
+    )
+    table = tree.unit.module_direct_bindings or {}
+    assert len(table.get("ns", ())) == 1
+    assert "total" not in table and "label" not in table
+    assert len(table.get("count", ())) == 1
+
+
+# ---------------------------------------------------------------------------
+# FALSIFIABILITY -- the corrected table must still REFUSE a genuine ambiguity.
+# ---------------------------------------------------------------------------
+
+_LYING_TWIN = '''\
+def find_level(depth):
+    return depth
+
+
+def find_level(depth):
+    return depth + 1
+
+
+find_level.__module__ = "pandas"
+'''
+
+_TRUTHFUL = '''\
+def find_level(depth):
+    return depth
+
+
+find_level.__module__ = "pandas"
+'''
+
+
+def test_a_genuinely_doubly_bound_name_is_STILL_refused_as_ambiguous() -> None:
+    """LYING TWIN: two real module-scope ``def``s, plus the same attribute patch.
+
+    Everything the truthful arm has, and one more real binding.  If the repair
+    were "drop the second entry" or "take the first binding", this would resolve
+    -- and it must not.
+    """
+    tree = _sf(_LYING_TWIN, "twin_two_real_bindings.py")
+    callee = _fn(tree, "find_level")
+    assert _callee_definition_by_name_in_its_unit(callee) is None, (
+        "a name with two module-scope bindings has no by-name answer"
+    )
+
+
+def test_the_lying_twins_table_holds_exactly_the_two_REAL_bindings() -> None:
+    """The twin's SHAPE, kept apart from the twin's REFUSAL.
+
+    Asserting both in one test made a tooth that dies for two unrelated
+    reasons: restoring the attribute-target defect reddens it because the
+    count becomes three, which says nothing about whether the ambiguity is
+    still refused.  Split, each fact has its own lever.
+    """
+    tree = _sf(_LYING_TWIN, "twin_two_real_bindings.py")
+    bindings = _bindings(tree, "find_level")
+    assert len(bindings) == 2, [type(row).__name__ for row in bindings]
+    assert all(isinstance(row, FunctionDef) for row in bindings)
+
+
+def test_the_truthful_arm_resolves_to_exactly_one_definition() -> None:
+    """TRUTHFUL: same file minus the second ``def`` -- the authority answers."""
+    tree = _sf(_TRUTHFUL, "twin_one_real_binding.py")
+    bindings = _bindings(tree, "find_level")
+    assert len(bindings) == 1
+
+    callee = _fn(tree, "find_level")
+    resolved = _callee_definition_by_name_in_its_unit(callee)
+    assert resolved is not None
+    assert resolved.fragment.seal() == callee.fragment.seal()
+
+
+def test_an_unassignable_target_PANICS_rather_than_binding_nothing() -> None:
+    """Closed set: an unrecognised target is a producer defect, named loudly.
+
+    A silently empty answer for an unknown target shape is indistinguishable
+    from a legitimately non-binding one, which is the exact conflation this
+    repair exists to end.
+    """
+    from sugar_source_tree.nodes import SourceUnit
+
+    tree = _sf("value = 1\n", "pin_closed_set.py")
+    statement = tree.unit.typed_module.body[0]
+    # A Constant is never an assignment target; hand one over directly.
+    not_a_target = statement.value
+    with pytest.raises(BackendDefect) as raised:
+        SourceUnit._assignment_target_bound_names(not_a_target, statement)
+    assert "not an assignable construct" in str(raised.value)
+    assert not_a_target.kind in str(raised.value)

--- a/scripts/mutate_binding_target.py
+++ b/scripts/mutate_binding_target.py
@@ -1,0 +1,134 @@
+"""Apply exactly ONE coherent mutation to the #7394 repair, and PRINT that it landed.
+
+Same doctrine as ``scripts/mutate_one.py``, separate mutation set so the two
+campaigns do not share anchors:
+
+    * a helper whose ``assert anchor in source`` fails silently makes an
+      unapplied mutation run as a clean green, so this prints the file, the
+      anchor and the replacement, and exits non-zero with a named reason
+      when it could not make one;
+    * ``git checkout`` is NOT a revert when the thing being mutated is
+      uncommitted work -- revert from ``--snapshot``, taken BEFORE the first
+      mutation;
+    * ONE at a time, never batched.
+
+usage:
+  python scripts/mutate_binding_target.py --snapshot
+  python scripts/mutate_binding_target.py <name>
+  python scripts/mutate_binding_target.py --revert
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+NODES = ROOT / "implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py"
+BINDING = (
+    ROOT
+    / "implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py"
+)
+FILES = (NODES, BINDING)
+SNAPSHOT = Path("/tmp/bindtarget_mutation_snapshot")
+
+MUTATIONS = {
+    # THE DEFECT ITSELF, restored: an attribute/subscript target binds its base
+    # name again. This is the state of main.
+    "attribute-target-binds-base": (
+        NODES,
+        "        if isinstance(target, (Attribute, Subscript)):\n"
+        "            # Mutates an existing object; binds no module-scope name.\n"
+        "            return set()\n",
+        "        if isinstance(target, (Attribute, Subscript)):\n"
+        "            return {\n"
+        "                node.id for node in target.walk() if isinstance(node, Name)\n"
+        "            }\n",
+    ),
+    # The closed set stops being closed: an unrecognised target quietly binds
+    # nothing, which is indistinguishable from a legitimately non-binding one.
+    "unassignable-target-silently-binds-nothing": (
+        NODES,
+        "        raise BackendDefect(\n"
+        '            blame=getattr(target, "fragment", None) or statement.fragment,\n'
+        '            owner="SourceUnit._assignment_target_bound_names",\n',
+        "        return set()\n"
+        "        raise BackendDefect(\n"
+        '            blame=getattr(target, "fragment", None) or statement.fragment,\n'
+        '            owner="SourceUnit._assignment_target_bound_names",\n',
+    ),
+    # The repair over-narrows: a starred target stops binding its name, so a
+    # real destructuring binding is LOST. A filter that loses rows is the other
+    # half of the same defect.
+    "starred-target-binds-nothing": (
+        NODES,
+        "        if isinstance(target, Starred):\n"
+        "            return SourceUnit._assignment_target_bound_names("
+        "target.value, statement)\n",
+        "        if isinstance(target, Starred):\n"
+        "            return set()\n",
+    ),
+    # THE FORBIDDEN RELAXATION, made explicit so a tooth stands against it:
+    # the by-name authority takes the first binding instead of refusing an
+    # ambiguous name. With the table corrected this coincidentally gives the
+    # right answer at the pandas seat -- which is exactly why it needs a twin.
+    "take-the-first-binding": (
+        BINDING,
+        "    if len(bindings) != 1:\n        return None\n",
+        "    if not bindings:\n        return None\n",
+    ),
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("MUTATION REFUSED: exactly one argument required", flush=True)
+        return 2
+    name = sys.argv[1]
+    if name == "--snapshot":
+        SNAPSHOT.mkdir(parents=True, exist_ok=True)
+        for path in FILES:
+            (SNAPSHOT / path.name).write_text(path.read_text())
+        print(f"SNAPSHOT TAKEN: {[p.name for p in FILES]}", flush=True)
+        return 0
+    if name == "--revert":
+        missing = [p.name for p in FILES if not (SNAPSHOT / p.name).is_file()]
+        if missing:
+            print(
+                f"REVERT REFUSED: no snapshot for {missing}. Take one with "
+                "`--snapshot` BEFORE mutating. NOTHING WAS RESTORED.",
+                flush=True,
+            )
+            return 4
+        for path in FILES:
+            path.write_text((SNAPSHOT / path.name).read_text())
+        print("MUTATION REVERTED: restored from snapshot", flush=True)
+        return 0
+    if name not in MUTATIONS:
+        print(
+            f"MUTATION REFUSED: unknown name {name!r}; known: {sorted(MUTATIONS)}",
+            flush=True,
+        )
+        return 2
+    path, anchor, replacement = MUTATIONS[name]
+    source = path.read_text()
+    occurrences = source.count(anchor)
+    if occurrences != 1:
+        print(
+            f"MUTATION REFUSED: anchor for {name!r} occurs {occurrences} times in "
+            f"{path.name}; expected exactly 1. NOTHING WAS APPLIED.",
+            flush=True,
+        )
+        return 3
+    path.write_text(source.replace(anchor, replacement))
+    print(
+        f"MUTATION LANDED: {name} in {path.name}\n"
+        f"  removed: {anchor.strip()[:160]!r}\n"
+        f"  wrote:   {replacement.strip()[:160]!r}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -92,6 +92,12 @@ binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py"]
 network = "none"
 
+[tasks.probe-attribute-target-binding-width]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py"]
+network = "none"
+
 [tasks.probe-constructed-value-slot]
 capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]


### PR DESCRIPTION
`module_direct_bindings` walked **every `Name` under an assignment target** and counted each as a binding. So

```python
get_option.__module__ = "pandas"     # Assign, target=Attribute, value=Name
```

registered a second binding of `get_option`, and a by-name authority — which must refuse a name with several module-scope bindings — refused a name that has exactly one.

## The result: the 78 DRAIN

Slice `--start 0 --stride 8`, same demand table `blake3-512:7471c00c…` (118,211 rows), 178/178 seats, **0 instrument failures both arms**. Baseline measured from scratch in a separate pristine worktree at the same commit.

| | seats | constructed | panic | panic rows |
|---|---|---|---|---|
| base `e40a6b54d` | 178 | 124 | 54 | **187** |
| after | 178 | **131** | **47** | **109** |

**Node-ID diff both directions: GONE 80 / NEW 2 / unchanged 107.** Net **−78**.

All 80 gone rows carry one reason — `source-body-gap for manager 'python:pandas.option_context'` at `config.py:512:27`. **That coordinate no longer appears anywhere on the board.**

**Seven seats move construction-panic → constructed and bank**: `indexes/base_class/test_constructors.py`, `indexes/datetimes/test_formats.py`, `io/formats/test_to_string.py`, `plotting/test_converter.py`, `reductions/test_reductions.py`, `reshape/merge/test_multi.py`, `series/test_formats.py`.

### The 2 new rows are an advance, verified rather than assumed

Both in `tests/indexing/test_chaining_and_caching.py`, both **nested inside the two outer `with` blocks that now construct**:

```
GONE 116:8-127:50 (outer, option_context)  ->  NEW 123:12-124:31 (inner)
GONE 338:8-353:42 (outer, option_context)  ->  NEW 344:12-345:39 (inner)
```

Construction now reaches into the body and finds a *different* manager refusing at a line it could never previously reach. Newly reachable, not newly created; that seat's panic count is unchanged at 12.

## Corpus width of the defect

Whole authenticated corpus, 1421 files, `READ_OK 1421 REFUSED 0`, manifest `6f317a5a…`. Old and new rules re-derived independently from stdlib `ast`:

```
FILES_AFFECTED                  11
STATEMENTS_AFFECTED             50
NAME_SEATS_AFFECTED             23
FALSELY_AMBIGUOUS_NOW_SINGLE    22
NAME_SEATS_LOSING_ALL_BINDINGS   0
TARGET_KIND   Subscript 38 | Attribute 12
```

**Zero names lose all their bindings** — the "a filter removes real rows" hazard does not fire anywhere in the corpus, not merely in the fixtures.

**`X[k] = v` outnumbers `X.attr = v` three to one.** The subscript half was the larger one and #7394 only ever named the attribute case.

## The repair

`SourceUnit._assignment_target_bound_names` — a **closed decision over the assignment-target grammar**, replacing the subtree `Name` walk. `Name`/`Tuple`/`List`/`Starred` bind; `Attribute`/`Subscript` bind nothing; anything else **panics naming construct, coordinate and shape**.

## Falsifiability gate — through `bin/bpytest`, correct pin in the banner

Control 10 passed before and after. Four coherent mutations, one at a time, each printing that it landed, snapshot-reverted:

| mutation | fails |
|---|---|
| `attribute-target-binds-base` (defect restored) | 7 — and **leaves the ambiguity refusal green** |
| `starred-target-binds-nothing` | **1**, destructuring only |
| `unassignable-target-silently-binds-nothing` | **1**, the closed-set panic only |
| `take-the-first-binding` (the forbidden relaxation) | **1**, the lying twin only |

The lying twin — a unit defining `find_level` **twice** at module scope *plus* the same `__module__` patch — is **still refused as ambiguous**. The repair does not relax the ambiguity rule; it stops manufacturing false ambiguity.

## Recorded during the work

A non-isolating tooth was discarded and its whole series re-run from scratch. A `symtable`-agreement tooth that survived every mutation was **deleted rather than kept** as a green that proves nothing. A runner that silently produced no verdict — indistinguishable from a pass — was made loud as an instrument failure.

Three probe defects, each caught because it failed loudly rather than printing nothing: `sugar_source_tree` not importable in that task image; the bare `SourceFile` door having no `.sugar()`; and opening `_config/config.py` against the package root being refused because **an installed file's address is the seat its distribution recorded**. The probe now refuses a population whose walked file count disagrees with the authenticated pin.

Related: #7394, #7411.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix module binding table to exclude names under Attribute and Subscript assignment targets
> - `SourceUnit._module_statement_bound_names` previously walked all descendant `ast.Name` nodes under assignment targets, causing attribute/subscript bases (e.g. `obj.attr = x`) to be incorrectly recorded as module-level bindings.
> - A new static helper [`_assignment_target_bound_names`](https://github.com/TSavo/sugar/pull/7413/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) replaces this walk with a grammar-aligned rule: `Name` binds itself, `Tuple`/`List`/`Starred` recurse, and `Attribute`/`Subscript` bind nothing.
> - Unrecognized target kinds now raise `BackendDefect` instead of being silently ignored.
> - A new [test suite](https://github.com/TSavo/sugar/pull/7413/files#diff-a38574064ee09ee123082c8bec7385f228672be2e13f9eb761b8109c471ba685) covers attribute/subscript exclusion, destructuring, starred targets, mixed targets, and the `BackendDefect` path.
> - A [probe script](https://github.com/TSavo/sugar/pull/7413/files#diff-58636cfd5a03a36ef83f86672cd34f27ada88e25a7c4218f2f52b680da13fc6a) was added to measure the impact of this rule change across a corpus of real Python files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f677dad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->