### PR TITLE
Split the binding-width census by target kind, with a both bucket

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_attribute_target_binding_width.py
@@ -113,6 +113,8 @@ def main(argv: list[str] | None = None) -> int:
     disambiguated = 0  # (file, name): count > 1 under the old rule, == 1 under the new
     vanished = 0       # (file, name): had a binding ONLY because of the over-count
     target_kinds: Counter[str] = Counter()
+    affected_by_kind: Counter[str] = Counter()
+    ambiguous_by_kind: Counter[str] = Counter()
     exemplars: list[str] = []
     read_ok = 0
     refused: list[str] = []
@@ -130,6 +132,11 @@ def main(argv: list[str] | None = None) -> int:
         old: dict[str, int] = {}
         new: dict[str, int] = {}
         touched_here = False
+        # Which TARGET KIND is responsible for each name's over-count. The
+        # brief called this defect "attribute assignment"; `X[k] = v` is the
+        # same defect through the same walk, so the two are attributed
+        # separately rather than merged into one number.
+        blame_kinds: dict[str, set[str]] = {}
         for statement in tree.body:
             old_names = _statement_names(statement, _old_rule)
             new_names = _statement_names(statement, _new_rule)
@@ -140,11 +147,17 @@ def main(argv: list[str] | None = None) -> int:
             if old_names != new_names:
                 statements_touched += 1
                 touched_here = True
-                if isinstance(statement, ast.Assign):
-                    for target in statement.targets:
-                        target_kinds[type(target).__name__] += 1
-                else:
-                    target_kinds[type(statement.target).__name__] += 1
+                targets_here = (
+                    statement.targets
+                    if isinstance(statement, ast.Assign)
+                    else (statement.target,)
+                )
+                for target in targets_here:
+                    kind = type(target).__name__
+                    target_kinds[kind] += 1
+                    if kind in ("Attribute", "Subscript"):
+                        for name in _old_rule(target) - _new_rule(target):
+                            blame_kinds.setdefault(name, set()).add(kind)
                 if len(exemplars) < 12:
                     exemplars.append(
                         f"{seat}:{statement.lineno}:{statement.col_offset} "
@@ -157,10 +170,14 @@ def main(argv: list[str] | None = None) -> int:
             if after == count:
                 continue
             spurious_pairs += 1
+            kinds = blame_kinds.get(name) or {"unattributed"}
+            key = "+".join(sorted(kinds))
+            affected_by_kind[key] += 1
             if after == 0:
                 vanished += 1
             elif count > 1 and after == 1:
                 disambiguated += 1
+                ambiguous_by_kind[key] += 1
 
     print(f"WIDTH_READ_OK {read_ok} REFUSED {len(refused)}", flush=True)
     for line in refused:
@@ -175,6 +192,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     for kind, count in sorted(target_kinds.items(), key=lambda item: -item[1]):
         print(f"WIDTH_TARGET_KIND {kind} {count}", flush=True)
+    for kind, count in sorted(affected_by_kind.items(), key=lambda item: -item[1]):
+        print(f"WIDTH_NAME_SEATS_BY_KIND {kind} {count}", flush=True)
+    for kind, count in sorted(ambiguous_by_kind.items(), key=lambda item: -item[1]):
+        print(f"WIDTH_FALSELY_AMBIGUOUS_BY_KIND {kind} {count}", flush=True)
     for line in exemplars:
         print(f"WIDTH_EXEMPLAR {line}", flush=True)
 


### PR DESCRIPTION
`#7413` reported `Subscript 38 / Attribute 12`. That is a **statement** count, and it was read as characterising **names** — including in my own summary of that PR.

This teaches the census to report both, separately, with an explicit `both` bucket so a name over-counted by an attribute write in one statement and a subscript write in another is never silently assigned to one kind.

Measured over the whole corpus, 1421 files, `READ_OK 1421 REFUSED 0`:

```
WIDTH_STATEMENTS_AFFECTED            50
WIDTH_TARGET_KIND         Subscript  38   Attribute  12
WIDTH_NAME_SEATS_BY_KIND  Subscript  13   Attribute  10   (total 23)
WIDTH_FALSELY_AMBIGUOUS_BY_KIND
                          Subscript  12   Attribute  10   (total 22)
```

Both splits reconcile with the merged totals (13+10=23, 12+10=22), and the **`both` and `unattributed` buckets are empty** — the attribution is clean, not approximate.

## Why the two counts differ, and which one matters

**By statement subscript dominates three to one. By name it is 12 to 10 — near parity.**

A handful of names take many subscript writes each; `ARGSORT_DEFAULTS` and neighbours in `compat/numpy/function.py` account for most of the 38.

**The name count is the operative one**, because it is names — not statements — that a by-name authority refuses as ambiguous. So the two halves of the defect are roughly equal in the population that affects the resolver, and the attribute half, the only half #7394 ever named, was never the smaller one.

The `Subscript 38 / Attribute 12` framing is retracted in #7394 and replaced by these figures.

Related: #7394, #7413.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split binding-width census by target kind in `probe_attribute_target_binding_width.py`
> Adds per-target-kind attribution to the binding-width census script to identify which target kinds (`Attribute`, `Subscript`, or combinations) are responsible for over-counted name seats.
>
> - Introduces `affected_by_kind` and `ambiguous_by_kind` counters, plus a per-file `blame_kinds` map keyed by name with sets of target kinds.
> - While iterating statements where old and new name sets differ, records which names are removed by the new rule and attributes them to their target kinds.
> - Prints two new summary lines: `WIDTH_NAME_SEATS_BY_KIND` and `WIDTH_FALSELY_AMBIGUOUS_BY_KIND`, with keys like `Attribute`, `Subscript`, `Attribute+Subscript`, or `unattributed`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc5f1af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->