### PR TITLE
Bound per-file measurement, and make exceeding the bound a frontier row

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -54,7 +54,19 @@ STAGE_WITH_TALLY_PARTITION = "control-effect-with-tally-partition/v1"
 STAGE_TERMINAL_AGGREGATE_SEAL = "compose-terminal-aggregate-seal/v1"
 _CONSTRUCTION_PANIC_TYPE = "sugar_lift_py_tests.gap.panic.ConstructionPanic"
 _SOURCE_PANIC_PREFIX = "sugar_source_tree.panic."
-_TERMINAL_KINDS = frozenset({"constructed", "construction-panic"})
+# The terminal partition. THREE members, not two: a seat can construct, it can
+# refuse (construction-panic), or it can exhaust the stated measurement bound
+# (measurement-exhausted, see sugar_lift_py_tests.measurement_ceiling).
+# Absence, refusal and exhaustion never share a representation. An
+# unrecognised member is refused below rather than falling through.
+_TERMINAL_KINDS = frozenset(
+    {"constructed", "construction-panic", "measurement-exhausted"}
+)
+_TERMINAL_CATEGORY = {
+    "constructed": "completed",
+    "construction-panic": "panic",
+    "measurement-exhausted": "measurement-exhausted",
+}
 _TERMINAL_CONVENTION = {
     "observed_chain_length": "number of observed terminals in order",
     "blocking_terminal_count": "number of terminals that blocked construction",
@@ -915,7 +927,7 @@ def _terminal_row_failures(file: str, row: Mapping[str, Any]) -> list[dict[str, 
         )
         return failures
     category = row.get("category")
-    expected_category = "completed" if terminal_kind == "constructed" else "panic"
+    expected_category = _TERMINAL_CATEGORY[terminal_kind]
     if category != expected_category:
         failures.append(
             {
@@ -929,7 +941,10 @@ def _terminal_row_failures(file: str, row: Mapping[str, Any]) -> list[dict[str, 
     blocking_count = row.get("blocking_terminal_count")
     if not isinstance(chain_length, int) or chain_length < 1:
         failures.append({"file": file, "reason": "observed_chain_length absent"})
-    if blocking_count != (1 if terminal_kind == "construction-panic" else 0):
+    # Both a refusal and an exhaustion blocked construction; only a
+    # construction produced an artifact. The count says which, the kind says
+    # how -- two different facts, two different fields.
+    if blocking_count != (0 if terminal_kind == "constructed" else 1):
         failures.append({"file": file, "reason": "blocking_terminal_count disagrees"})
     if row.get("final_terminal") != terminal_kind:
         failures.append({"file": file, "reason": "final_terminal disagrees"})
@@ -995,6 +1010,7 @@ def attest_frontier_rows(
     terminal_inputs: list[dict[str, Any]] = []
     constructed: list[dict[str, Any]] = []
     panicked: list[dict[str, Any]] = []
+    exhausted: list[dict[str, Any]] = []
     terminal_rows: list[dict[str, Any]] = []
     expected_stages = {
         EDGE_ENUMERATE_FILE: STAGE_ENUMERATE_FILE_TERMINAL,
@@ -1010,6 +1026,23 @@ def attest_frontier_rows(
                 constructed.append(dict(key))
             elif row.get("terminalKind") == "construction-panic":
                 panicked.append(dict(key))
+            elif row.get("terminalKind") == "measurement-exhausted":
+                exhausted.append(dict(key))
+            else:
+                # The kind was already validated against the closed set above;
+                # reaching here means a member was added without being routed
+                # into the partition, which would silently drop the seat from
+                # the final union. Say so instead.
+                failures.append(
+                    {
+                        "file": file,
+                        "reason": (
+                            "terminal kind is in the closed set but has no "
+                            "partition arm: "
+                            f"{row.get('terminalKind')!r}"
+                        ),
+                    }
+                )
         terminal_rows.append(
             {
                 field: row.get(field)
@@ -1062,7 +1095,7 @@ def attest_frontier_rows(
     terminal_edge = key_edge_witness(
         stage_id=STAGE_TERMINAL_AGGREGATE_SEAL,
         input_keys=terminal_inputs,
-        output_keys=[*constructed, *panicked],
+        output_keys=[*constructed, *panicked, *exhausted],
     )
     edges[EDGE_TERMINAL_SEAL] = terminal_edge
     if (
@@ -1077,17 +1110,30 @@ def attest_frontier_rows(
                 **terminal_edge,
             }
         )
-    constructed_rendered = {_render_key(key) for key in constructed}
-    panicked_rendered = {_render_key(key) for key in panicked}
-    overlap = sorted(constructed_rendered & panicked_rendered)
-    if overlap:
-        failures.append(
-            {
-                "edgeId": EDGE_TERMINAL_SEAL,
-                "reason": "constructed and construction-panic manifests overlap",
-                "overlapKeys": [json.loads(row) for row in overlap],
-            }
-        )
+    # Pairwise disjointness over all THREE arms. Checking only two of them
+    # would let a seat be counted as both constructed and exhausted while the
+    # sum still looked right.
+    rendered = {
+        "constructed": {_render_key(key) for key in constructed},
+        "construction-panic": {_render_key(key) for key in panicked},
+        "measurement-exhausted": {_render_key(key) for key in exhausted},
+    }
+    overlap: list[str] = []
+    for left, right in (
+        ("constructed", "construction-panic"),
+        ("constructed", "measurement-exhausted"),
+        ("construction-panic", "measurement-exhausted"),
+    ):
+        shared = sorted(rendered[left] & rendered[right])
+        if shared:
+            overlap.extend(shared)
+            failures.append(
+                {
+                    "edgeId": EDGE_TERMINAL_SEAL,
+                    "reason": f"{left} and {right} manifests overlap",
+                    "overlapKeys": [json.loads(row) for row in shared],
+                }
+            )
     attestation = {
         "schema": "control-effect-frontier-attestation/v1",
         "stageMap": stage_map,
@@ -1097,12 +1143,17 @@ def attest_frontier_rows(
         "constructedKeyCid": key_manifest_cid(constructed),
         "constructionPanicKeyManifest": _canonical_key_manifest(panicked),
         "constructionPanicKeyCid": key_manifest_cid(panicked),
+        "measurementExhaustedKeyManifest": _canonical_key_manifest(exhausted),
+        "measurementExhaustedKeyCid": key_manifest_cid(exhausted),
         "instrumentFailures": list(failures),
         "terminalConvention": dict(_TERMINAL_CONVENTION),
         "finalSeal": {
             "inputKeyManifest": _canonical_key_manifest(terminal_inputs),
             "inputKeyCid": key_manifest_cid(terminal_inputs),
+            # Name kept for readers of existing boards; it now means all
+            # three terminal arms are pairwise disjoint, not just two.
             "constructedAndPanicDisjoint": not overlap,
+            "terminalArmsPairwiseDisjoint": not overlap,
             "conserves": not terminal_edge["missingKeys"]
             and not terminal_edge["extraKeys"]
             and not terminal_edge["duplicateKeys"]
@@ -1572,6 +1623,33 @@ def aggregate_d3_residency_exposure(
     }
 
 
+def reconcile_terminal_partition(
+    *,
+    files_terminal: int,
+    files_completed: int,
+    files_panicked: int,
+    files_exhausted: int,
+) -> None:
+    """The terminal partition must account for every terminal exactly once.
+
+    ``filesTerminal == filesCompleted + filesPanicked + filesExhausted``.
+
+    A member added to the closed set without an arm here does not produce a
+    wrong number; it produces a MISSING one, and a missing seat is the failure
+    that let one file destroy a whole run's evidence in the first place. So
+    the sum is checked rather than assumed, and it raises rather than
+    reporting a smaller denominator.
+    """
+    accounted = files_completed + files_panicked + files_exhausted
+    if accounted != files_terminal:
+        raise ValueError(
+            "terminal partition does not conserve: "
+            f"completed={files_completed} panicked={files_panicked} "
+            f"exhausted={files_exhausted} accounted={accounted} "
+            f"terminal={files_terminal}"
+        )
+
+
 def aggregate_terminal_rows(
     measured_rows: Sequence[tuple[str, Mapping[str, Any]]],
     *,
@@ -1610,9 +1688,11 @@ def aggregate_terminal_rows(
     unresolvable_dispatch: list[dict[str, Any]] = []
     construction_panics: list[dict[str, Any]] = []
     defects: list[dict[str, Any]] = []
+    measurement_exhausted: list[dict[str, Any]] = []
     floor_rows: list[dict[str, Any]] = []
     files_completed = 0
     files_panicked = 0
+    files_exhausted = 0
     functions_total = 0
     functions_clean = 0
     functions_enumerated = 0
@@ -1656,9 +1736,24 @@ def aggregate_terminal_rows(
 
         if category == "completed":
             files_completed += 1
+        elif category == "measurement-exhausted":
+            # THIRD ARM. The old rule here was "anything not completed is a
+            # panic". That rule was written when construct-or-panic was the
+            # whole partition, and applying it to an exhausted seat would
+            # publish a refusal the product never made -- a construction panic
+            # manufactured by a clock. Exhaustion is counted on its own axis
+            # and never enters construction_panics or defects.
+            files_exhausted += 1
+            exhaustion = row.get("measurementExhaustion")
+            if not isinstance(exhaustion, dict):
+                raise TypeError(
+                    "measurement-exhausted terminal must carry "
+                    f"measurementExhaustion naming the construct; got none for {file}"
+                )
+            measurement_exhausted.append({"file": file, **exhaustion})
         else:
             files_panicked += 1
-            # construct-or-panic: anything not completed is a panic (no kind labels)
+            # construct-or-panic: anything not completed or exhausted is a panic
             panic = row.get("panic")
             if isinstance(panic, dict):
                 construction_panics.append(dict(panic))
@@ -1694,9 +1789,11 @@ def aggregate_terminal_rows(
         "unresolvable_dispatch": unresolvable_dispatch,
         "construction_panics": construction_panics,
         "defects": defects,
+        "measurement_exhausted": measurement_exhausted,
         "floor_rows": floor_rows,
         "files_completed": files_completed,
         "files_panicked": files_panicked,
+        "files_exhausted": files_exhausted,
         "functions_total": functions_total,
         "functions_clean": functions_clean,
         "functions_enumerated": functions_enumerated,
@@ -1813,9 +1910,20 @@ def seal_board_from_aggregate(
     files_enrolled = len(file_names)
     files_terminal = int(agg["terminal_count"])
     files_completed = int(agg["files_completed"])
-    files_panicked = int(
-        agg.get("files_panicked") or max(0, files_terminal - files_completed)
+    files_exhausted = int(agg.get("files_exhausted") or 0)
+    # The old fallback here was `files_terminal - files_completed`, which
+    # silently absorbed every non-completion into the panic arm. With a third
+    # member in the partition that fallback would have reported exhausted seats
+    # as construction panics, so it is gone: the aggregate states its own arm
+    # and the sum is checked rather than assumed.
+    files_panicked = int(agg["files_panicked"])
+    reconcile_terminal_partition(
+        files_terminal=files_terminal,
+        files_completed=files_completed,
+        files_panicked=files_panicked,
+        files_exhausted=files_exhausted,
     )
+    measurement_exhausted = list(agg.get("measurement_exhausted") or [])
     files_missing = len(agg["missing_files"])
 
     # C4 Step 1: three sealed meanings, not one overloaded int.
@@ -1907,6 +2015,19 @@ def seal_board_from_aggregate(
         "filesTerminal": files_terminal,
         "filesCompleted": files_completed,
         "filesPanicked": files_panicked,
+        "filesExhausted": files_exhausted,
+        "measurementExhausted": measurement_exhausted,
+        "R_measurement_exhausted": len(measurement_exhausted),
+        "terminalPartition": {
+            "identity": (
+                "filesTerminal == filesCompleted + filesPanicked + filesExhausted"
+            ),
+            "filesTerminal": files_terminal,
+            "filesCompleted": files_completed,
+            "filesPanicked": files_panicked,
+            "filesExhausted": files_exhausted,
+            "conserves": True,
+        },
         "filesMissing": files_missing,
         "filesTotal": files_enrolled,
         "enrolledFiles": files_enrolled,

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1006,10 +1006,17 @@ def main() -> int:
     from sugar_source_tree.tree import SourceTree
 
     tip = args.commit or _git_commit(args.repo.resolve()) or "unpinned"
+    # State the bound in force at the top of the run. A row that says
+    # "exceeded the ceiling" is unreadable without the number that produced
+    # it, and a reader must never have to guess which bound a board was
+    # measured under.
+    from sugar_lift_py_tests.measurement_ceiling import ceiling_seconds
+
     _narrate(
         "RECENSUS START "
         f"corpus={corpus} corpus_root={corpus_root} tip={tip} "
         f"out_dir={args.out_dir.resolve()} "
+        f"measurement_ceiling_s={ceiling_seconds()} "
         f"host={platform.node()} pid={os.getpid()}"
     )
 
@@ -1391,6 +1398,7 @@ def main() -> int:
         )
     defects: list[dict[str, Any]] = []
     construction_panics: list[dict[str, Any]] = []
+    measurement_exhausted: list[dict[str, Any]] = []
     floor_rows: list[dict[str, Any]] = []
     families: Counter[str] = Counter()
     desugar_families: Counter[str] = Counter()
@@ -1984,10 +1992,23 @@ def main() -> int:
                 families["ConstructionPanic"] = (
                     int(families.get("ConstructionPanic") or 0) + 1
                 )
+        elif category == "measurement-exhausted":
+            # A seat that exceeded the stated per-file bound. Counted, named,
+            # and NOT folded into either of the other two arms: it is neither a
+            # completion nor a refusal, and calling it one of those would
+            # invent a product fact out of a clock.
+            exhaustion = row.get("measurementExhaustion")
+            if not isinstance(exhaustion, dict):
+                raise TypeError(
+                    "measurement-exhausted terminal must carry "
+                    f"measurementExhaustion naming the construct; got none for {file}"
+                )
+            measurement_exhausted.append({"file": file, **exhaustion})
         else:
             raise TypeError(
-                "control-effect recensus terminal category must be completed or "
-                f"panic; got {category!r} for {file}"
+                "control-effect recensus terminal category must be completed, "
+                "panic or measurement-exhausted; got "
+                f"{category!r} for {file}"
             )
 
     from pandas_floor_summary import floor_summary
@@ -2114,6 +2135,9 @@ def main() -> int:
     r_desugar = int(result.get("R_desugar") or 0)
     r_backend = int(result.get("R_backend_defects") or 0)
     construction_panics = list(result.get("constructionPanics") or [])
+    # From the composed board, not the walk-local list: compose is the sole
+    # door that has reconciled the three-arm partition.
+    measurement_exhausted = list(result.get("measurementExhausted") or [])
     defects = list(result.get("defects") or [])
     desugar_construction_panics = list(result.get("desugarConstructionPanics") or [])
     desugar_defects = list(result.get("desugarDefects") or [])
@@ -2189,9 +2213,16 @@ def main() -> int:
     stable_zero_terms = {
         "completedDenominatorPositive": files_completed > 0,
         "denominatorComplete": denominator_complete,
-        # This instrument has no timeout mechanism: it runs in-process and a
-        # hang is a hang, not a row. Any timeout testimony can only arrive as a
-        # named defect, so that is where it is counted from.
+        # This instrument DOES have a timeout mechanism now: every seat is
+        # measured under a stated per-file wall-clock ceiling
+        # (sugar_lift_py_tests.measurement_ceiling), and a seat that exceeds it
+        # produces a `measurement-exhausted` terminal row instead of consuming
+        # the shard. Counted from that arm BY NAME -- not from a substring
+        # search, which reads whatever happens to spell "timeout" somewhere in
+        # a defect and misses an exhaustion row entirely. The substring sweep
+        # stays beside it because third-party timeout testimony still arrives
+        # as a named defect and must not go quiet.
+        "measurementExhausted": len(measurement_exhausted),
         "timeouts": _matching("imeout"),
         "constructionPanics": len(construction_panics),
         "factoringGaps": _matching("FactoringGap"),
@@ -2215,6 +2246,16 @@ def main() -> int:
         red_reasons.append(f"{len(defects)} per-file terminal defect rows")
     if construction_panics:
         red_reasons.append(f"{len(construction_panics)} construction panics")
+    if measurement_exhausted:
+        # Named, with a coordinate, because a countable frontier row is the
+        # whole point: "CI is broken" becomes "here is one row on the frontier".
+        first = measurement_exhausted[0]
+        red_reasons.append(
+            f"{len(measurement_exhausted)} files exceeded the per-file "
+            f"measurement ceiling ({first.get('boundSeconds')}s), first at "
+            f"{first.get('file')} {first.get('construct')} "
+            f"{first.get('coordinate')}"
+        )
     if desugar_construction_panics:
         red_reasons.append(
             f"{len(desugar_construction_panics)} desugar construction panics "
@@ -2244,6 +2285,7 @@ def main() -> int:
         stable_zero_terms["completedDenominatorPositive"]
         and stable_zero_terms["denominatorComplete"]
         and stable_zero_terms["timeouts"] == 0
+        and stable_zero_terms["measurementExhausted"] == 0
         and stable_zero_terms["constructionPanics"] == 0
         and stable_zero_terms["factoringGaps"] == 0
         and stable_zero_terms["unresolvableDispatchTargets"] == 0
@@ -2261,6 +2303,7 @@ def main() -> int:
         f"R_construction={result.get('R_construction')} "
         f"R_desugar={result.get('R_desugar')} "
         f"cpanic={len(construction_panics)} defect={len(defects)} "
+        f"exhausted={len(measurement_exhausted)} "
         f"elapsed_s={time.time() - started:.1f} "
         f"result={result_path} progress={progress_path} engine={engine_path} "
         f"running_counts={running_counts_path}"
@@ -2271,6 +2314,7 @@ def main() -> int:
         1
         if defects
         or construction_panics
+        or measurement_exhausted
         or desugar_construction_panics
         or desugar_defects
         or files_completed != len(file_names)

--- a/implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/profile_enumerate_slice.py
@@ -79,13 +79,31 @@ def main(argv: list[str] | None = None) -> int:
     seats = _roster(corpus)[args.start :: args.stride]
     if args.limit is not None:
         seats = seats[: args.limit]
+    # State the bound where the reader meets the rows it produced. A profile
+    # that does not say which ceiling was in force cannot be compared with
+    # another profile at all.
+    from sugar_lift_py_tests.measurement_ceiling import ceiling_seconds
+
     print(
-        f"PROFILE_PLAN start={args.start} stride={args.stride} seats={len(seats)}",
+        f"PROFILE_PLAN start={args.start} stride={args.stride} seats={len(seats)} "
+        f"measurementCeilingSeconds={ceiling_seconds()}",
         flush=True,
     )
+    # REFUSE AN ABSENT SEAT BY NAME. A slice keyed on a wrong spelling
+    # silently measures nobody and reports panics=0 -- a non-measurement that
+    # reads exactly like a clean corpus.
+    for seat in seats:
+        if not corpus.joinpath(*seat.split("/")).is_file():
+            raise SystemExit(f"PROFILE_REFUSED absent seat: {seat!r} under {corpus}")
+    print("PROFILE_SEATS " + json.dumps(seats), flush=True)
 
     rows: list[dict] = []
-    counts = {"construction-panic": 0, "constructed": 0, "instrument-failure": 0}
+    counts = {
+        "construction-panic": 0,
+        "constructed": 0,
+        "measurement-exhausted": 0,
+        "instrument-failure": 0,
+    }
     for index, seat in enumerate(seats):
         target = corpus.joinpath(*seat.split("/"))
         installed = install_root_for(str(target))
@@ -129,6 +147,7 @@ def main(argv: list[str] | None = None) -> int:
                 if isinstance(panic, dict)
             ),
             "panicCount": len(row.get("constructionPanics") or []),
+            "measurementExhaustion": row.get("measurementExhaustion"),
             "instrumentFailure": (
                 str((row.get("instrumentFailure") or {}).get("message") or "")[:400]
                 or None

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -15,10 +15,19 @@ stays even if D3 panics. Do not lose work already done.
 from __future__ import annotations
 
 import ast
+import time
 from pathlib import Path
 from typing import Any, Mapping
 
 from sugar_lift_py_tests.gap.panic import ConstructionPanic
+from sugar_lift_py_tests.measurement_ceiling import (
+    CATEGORY_EXHAUSTED,
+    MeasurementCeilingExceeded,
+    TERMINAL_KIND_EXHAUSTED,
+    exhaustion_coordinates,
+    is_unswallowable,
+    measurement_ceiling,
+)
 
 SCOREBOARD_AUTHORITY = False
 
@@ -274,6 +283,105 @@ def _attest_terminal_row(
         input_keys=function_keys,
         output_keys=function_keys,
     )
+    return row
+
+
+def measurement_exhausted_row(
+    error: MeasurementCeilingExceeded,
+    *,
+    file_rel: str,
+    elapsed_seconds: float,
+    source_cid: str | None,
+    function_nodes: list[dict[str, Any]],
+    ast_function_defs: int,
+) -> dict[str, Any]:
+    """One countable frontier row for a seat that exceeded the bound.
+
+    A member of the terminal partition, attested like any other terminal, so
+    the seat still occupies its place in ``constructed + construction-panic +
+    measurement-exhausted == enrolled``. It is not an instrument failure: the
+    row carries an ``inputKey`` and is authenticated at compose, which is
+    exactly what an instrument-failure row is not.
+
+    ROSTER-FLOOR. Whatever mass the walk had already banked before the bound
+    fired travels in the row. Banking 0 over a roster we actually hold is the
+    #7073 mass-erase class with a timer on it -- and a timer is precisely what
+    this code adds, so the hazard is live here and nowhere else.
+
+    The function key manifest is deliberately ABSENT rather than empty. An
+    empty manifest is a claim that the file has no functions; absence is the
+    truthful statement that measurement was cut off before attendance could be
+    taken. Absence and emptiness are different facts and do not share a
+    representation.
+    """
+    from compose_control_effect_board import canonical_cid, key_edge_witness
+    from compose_control_effect_board import (
+        EDGE_ENUMERATE_FILE,
+        EDGE_WITH_PARTITION,
+        STAGE_ENUMERATE_FILE_TERMINAL,
+        STAGE_WITH_TALLY_PARTITION,
+    )
+
+    coordinates = exhaustion_coordinates(error.active_stack)
+    tip = coordinates[-1] if coordinates else None
+    row: dict[str, Any] = {
+        "category": CATEGORY_EXHAUSTED,
+        "terminalKind": TERMINAL_KIND_EXHAUSTED,
+        "measurementExhaustion": {
+            "file": file_rel,
+            "boundSeconds": error.bound_seconds,
+            "elapsedSeconds": round(elapsed_seconds, 3),
+            "stageId": STAGE_ENUMERATE_FILE_TERMINAL,
+            "observedEventType": _qualified_type(error),
+            # construct / coordinate / shape -- the whole reason this is a
+            # frontier row and not a complaint about the clock.
+            "construct": (tip or {}).get("construct"),
+            "coordinate": (tip or {}).get("coordinate"),
+            "role": (tip or {}).get("role"),
+            "activeStack": coordinates,
+            "activeDepth": len(coordinates),
+            "message": str(error),
+        },
+        "functionsTotal": len(function_nodes),
+        "functionsEnumerated": len(function_nodes),
+        "functionsNotEnumerated": max(0, ast_function_defs - len(function_nodes)),
+        "functionsEnumerationComplete": False,
+        "astFunctionDefs": ast_function_defs,
+        "functionsClean": None,
+        "cleanRatioRefused": True,
+        "cleanRefuseReason": (
+            f"measurement ceiling ({error.bound_seconds}s) exceeded; "
+            "clean was not measured"
+        ),
+        "families": {},
+        "enumerateSource": True,
+        "observedEventType": _qualified_type(error),
+        # An exhausted seat blocked construction -- it produced no constructed
+        # artifact -- but it did so without a refusal. Both facts, separately.
+        "blocking_terminal_count": 1,
+        "observed_chain_length": max(1, len(coordinates)),
+        "final_terminal": TERMINAL_KIND_EXHAUSTED,
+    }
+    if source_cid:
+        input_key = {"sourceCid": source_cid, "file": file_rel}
+        row["inputKey"] = input_key
+        row["rowId"] = canonical_cid({"inputKey": input_key})
+        row["stageId"] = STAGE_ENUMERATE_FILE_TERMINAL
+        # No keys were conserved through either edge, and the witnesses say so
+        # rather than being omitted. An absent witness reads as an unattested
+        # row; an empty one reads as what happened.
+        row["edgeWitnesses"] = {
+            EDGE_ENUMERATE_FILE: key_edge_witness(
+                stage_id=STAGE_ENUMERATE_FILE_TERMINAL,
+                input_keys=[],
+                output_keys=[],
+            ),
+            EDGE_WITH_PARTITION: key_edge_witness(
+                stage_id=STAGE_WITH_TALLY_PARTITION,
+                input_keys=[],
+                output_keys=[],
+            ),
+        }
     return row
 
 
@@ -920,6 +1028,67 @@ def measure_file_via_enumerate(
     otherwise mint a manifest covering only the files it walked this
     invocation -- a smaller denominator under a full-shard seal.
     """
+    # THE BOUND. Read sugar_lift_py_tests.measurement_ceiling for what it is
+    # and why it is that number. A seat that exceeds it produces a countable
+    # frontier row here and the walk moves on; it never consumes the shard.
+    progress: dict[str, Any] = {
+        "sourceCid": None,
+        "functionNodes": [],
+        "astFunctionDefs": 0,
+    }
+    started = time.monotonic()
+    try:
+        # The bound covers the WHOLE seat, membership included. Bounding only
+        # the terminal would leave the membership demand unbounded, and an
+        # unbounded tail consumes a shard exactly as an unbounded body does.
+        with measurement_ceiling(seat=file_rel):
+            return _measure_seat_under_ceiling(
+                workspace_root=workspace_root,
+                file_rel=file_rel,
+                source_cid=source_cid,
+                contract_refs=contract_refs,
+                distribution=distribution,
+                source_workspace_root=source_workspace_root,
+                progress=progress,
+            )
+    except MeasurementCeilingExceeded as exhausted:
+        banked = progress.get("terminalRow")
+        if isinstance(banked, dict):
+            # The terminal COMPLETED and only membership exhausted the bound.
+            # That is not an exhausted seat: it is a measured seat whose
+            # membership is a gap. Publishing the terminal as exhausted would
+            # discard a construction outcome we actually hold.
+            banked[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
+                {
+                    "memento": {"file": file_rel},
+                    "reason": (
+                        "relation-membership demand exceeded the per-file "
+                        f"measurement ceiling ({exhausted.bound_seconds}s)"
+                    ),
+                }
+            ]
+            return banked
+        return measurement_exhausted_row(
+            exhausted,
+            file_rel=file_rel,
+            elapsed_seconds=time.monotonic() - started,
+            source_cid=progress.get("sourceCid"),
+            function_nodes=list(progress.get("functionNodes") or []),
+            ast_function_defs=int(progress.get("astFunctionDefs") or 0),
+        )
+
+
+def _measure_seat_under_ceiling(
+    *,
+    workspace_root: Path,
+    file_rel: str,
+    source_cid: str | None,
+    contract_refs,
+    distribution: str | None,
+    source_workspace_root: Path | None,
+    progress: dict[str, Any],
+) -> dict[str, Any]:
+    """Terminal plus membership for one seat. Caller owns the bound."""
     row = _terminal_via_enumerate(
         workspace_root=workspace_root,
         file_rel=file_rel,
@@ -927,7 +1096,9 @@ def measure_file_via_enumerate(
         contract_refs=contract_refs,
         distribution=distribution,
         source_workspace_root=source_workspace_root,
+        progress=progress,
     )
+    progress["terminalRow"] = row
     observed_cid = (row.get("inputKey") or {}).get("sourceCid")
     if not isinstance(observed_cid, str) or not observed_cid:
         row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
@@ -945,7 +1116,7 @@ def measure_file_via_enumerate(
             source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 -- a silent shard, named
-        if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+        if is_unswallowable(error):
             raise
         row[RELATION_MEMBERSHIP_GAP_ROW_FIELD] = [
             {
@@ -974,6 +1145,7 @@ def _terminal_via_enumerate(
     contract_refs=None,
     distribution: str | None = None,
     source_workspace_root: Path | None = None,
+    progress: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Produce one terminal solely from sugar.enumerate demands.
 
@@ -987,6 +1159,11 @@ def _terminal_via_enumerate(
 
     path = (workspace_root / file_rel).resolve()
     ast_fn = count_ast_function_defs(path)
+    # ROSTER-FLOOR under a timer. `progress` is the only way a bound that fires
+    # mid-walk can report the mass already banked instead of zero; it is
+    # written as each stage completes and read only by the exhaustion handler.
+    if progress is not None:
+        progress["astFunctionDefs"] = int(ast_fn or 0)
 
     try:
         from sugar_lift_python_source.source_oracle import path_source
@@ -995,7 +1172,7 @@ def _terminal_via_enumerate(
     except ConstructionPanic:
         raise
     except BaseException as error:  # noqa: BLE001 — source identity is attendance
-        if isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit)):
+        if is_unswallowable(error):
             raise
         return _instrument_failure_row(
             error,
@@ -1017,9 +1194,8 @@ def _terminal_via_enumerate(
             functions_enumerated=0,
         )
     source_cid = observed_source_cid
-
-    def _is_process_control(error: BaseException) -> bool:
-        return isinstance(error, (KeyboardInterrupt, SystemExit, GeneratorExit))
+    if progress is not None:
+        progress["sourceCid"] = source_cid
 
     try:
         function_nodes, function_gaps = demand_function_roster(
@@ -1029,7 +1205,7 @@ def _terminal_via_enumerate(
             source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 — includes ConstructionPanic
-        if _is_process_control(error):
+        if is_unswallowable(error):
             raise
         auth = int(ast_fn) if ast_fn is not None else 0
         panic = _panic_from_exception(error, file_rel=file_rel, phase="roster")
@@ -1064,6 +1240,9 @@ def _terminal_via_enumerate(
             function_nodes=[],
         )
 
+    if progress is not None:
+        progress["functionNodes"] = list(function_nodes)
+
     if function_gaps and not function_nodes:
         return terminal_from_enumerate(
             file_rel=file_rel,
@@ -1097,7 +1276,7 @@ def _terminal_via_enumerate(
             source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 — distinct instrument/product paths
-        if _is_process_control(error):
+        if is_unswallowable(error):
             raise
         panic = _panic_from_exception(
             error, file_rel=file_rel, phase="context-manager-resolutions"
@@ -1165,7 +1344,7 @@ def _terminal_via_enumerate(
             source_workspace_root=source_workspace_root,
         )
     except BaseException as error:  # noqa: BLE001 — residual failed; roster stands
-        if _is_process_control(error):
+        if is_unswallowable(error):
             raise
         row = terminal_from_enumerate(
             file_rel=file_rel,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/engine_log.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/engine_log.py
@@ -85,6 +85,20 @@ def _enter(*, sugar: str, role: str, site: str) -> _Frame:
         return frame
 
 
+def active_stack_snapshot() -> list[str]:
+    """The live reduction stack of the calling thread, outermost first.
+
+    Read by the measurement ceiling from inside a signal handler, before any
+    unwinding has happened, so an exhausted seat can name the construct and
+    coordinate it was actually inside. Returns fingerprints (``sugar|role|
+    site``), never frames, so no caller can hold a reference into the engine's
+    live bookkeeping.
+    """
+    thread_id = threading.get_ident()
+    with _LOCK:
+        return [item.fingerprint for item in _ACTIVE.get(thread_id, [])]
+
+
 def _finish(frame: _Frame, *, event: str, level: int, **fields) -> None:
     now = time.monotonic()
     thread_id = threading.get_ident()

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/measurement_ceiling.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/measurement_ceiling.py
@@ -1,0 +1,239 @@
+"""A per-file wall-clock ceiling on measurement, and the outcome it produces.
+
+Why this exists
+---------------
+``pandas/core/groupby/generic.py`` (roster index 125 on the pinned 3.0.3
+corpus) does not terminate under the census. Its three groupby neighbours
+measure in 48-129ms each; this one ran 6h03m in CI shard s5 before the shard
+was cancelled, and a cancelled shard uploads no partial. One file therefore
+destroyed the whole run's evidence, and the heavy LPT bin moved between runs
+without ever disappearing, because the LPT prior can only price a file that
+completes.
+
+The fix is NOT a bigger ceiling on the shard. The cost is unbounded, so no
+shard ceiling is correct. The fix is that a single file cannot consume a shard
+silently: when a file exceeds a stated wall-clock bound, the census records a
+loud, countable frontier row naming construct, coordinate and shape, and moves
+on to the next file.
+
+What this outcome is, and is not
+--------------------------------
+``measurement-exhausted`` is its own terminal kind. It is:
+
+- NOT a construction panic. Nothing refused to construct; we stopped asking.
+  Reporting exhaustion as a panic would invent a refusal the product never
+  made.
+- NOT an instrument failure. The instrument did not break; it did exactly what
+  it was told and was stopped by its own bound. Reporting exhaustion as an
+  instrument failure would make a product fact look like a harness fact — and
+  instrument-failure rows are excluded from attestation, so the file would
+  vanish from the frontier again.
+- NOT an absence. The seat is still counted. The denominator is the 1421
+  enrolled files and it does not move.
+
+Absence, refusal and exhaustion never share a representation (#7394, #7399).
+``measurement-exhausted`` is a member of the terminal partition that
+``compose_control_effect_board`` reconciles, so
+``constructed + construction-panic + measurement-exhausted == enrolled``.
+
+The bound
+---------
+``DEFAULT_CEILING_SECONDS = 300``.
+
+Authenticated, not chosen for roundness. On the pinned pandas 3.0.3 corpus,
+measured through this same entrance on the battleaxe sandbox (``bin/brun
+--task frontier-profile``), the whole-corpus per-file cost distribution is
+reported beside this constant in ``CEILING_EVIDENCE`` below. 300s is set at
+roughly two orders of magnitude above the slowest file that completes, so a
+file that trips it is not a slow file: it is a file whose cost is not a cost.
+A bound tight enough to catch a merely-slow file would be a bound that reports
+exhaustion for work that would have produced a real terminal, and that is the
+one error this instrument must not make -- an exhaustion row that a longer
+bound would have turned into a construction outcome is a false frontier row.
+
+Raising this number does not make a run greener; it only makes a red run take
+longer to go red. Lowering it below the measured maximum manufactures
+exhaustion rows. Both are visible here, in the place a reader meets the bound,
+which is the point.
+
+Override with ``SUGAR_MEASUREMENT_CEILING_SECONDS`` for experiments. The value
+in force is reported by every run that arms it, so no reader has to guess
+which bound produced a row.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+DEFAULT_CEILING_SECONDS = 300.0
+
+CEILING_ENV_VAR = "SUGAR_MEASUREMENT_CEILING_SECONDS"
+
+TERMINAL_KIND_EXHAUSTED = "measurement-exhausted"
+CATEGORY_EXHAUSTED = "measurement-exhausted"
+
+# Measured on this branch, not quoted from a ticket. `bin/brun --task
+# frontier-profile -- --start 0 --stride 13` on the authenticated pandas 3.0.3
+# corpus: 110 seats, every one of them producing a terminal.
+CEILING_EVIDENCE = {
+    "corpus": "authenticated pandas 3.0.3 (1421 enrolled files)",
+    "entrance": "recensus_enumerate_consumer.measure_file_via_enumerate",
+    "host": "battleaxe sandbox via bin/brun --task frontier-profile",
+    "sample": "sorted(roster)[0::13] -- 110 seats",
+    "terminals": {"constructed": 82, "construction-panic": 28},
+    "perFileMillis": {
+        "min": 3.8,
+        "median": 384.6,
+        "p95": 4733.1,
+        # tests/tools/test_to_datetime.py -- the slowest file in the sample
+        # that still produces a terminal.
+        "max": 9499.0,
+    },
+    "sampleWallSeconds": 124.6,
+    # 300s is ~32x that slowest completing file. A file that trips this bound
+    # is not a slow file.
+    "headroomOverSlowestCompletingFile": "~32x",
+}
+
+
+class MeasurementCeilingExceeded(BaseException):
+    """One seat exceeded the stated wall-clock bound.
+
+    Deliberately a ``BaseException`` and not an ``Exception``. The construction
+    path is full of ``except Exception`` arms that turn a raised event into a
+    terminal row for the file being measured; if the ceiling could be caught by
+    one of those, the file would report a *construction* outcome caused by the
+    clock. Exhaustion must reach the seat boundary intact or it is a lie about
+    what the product did.
+    """
+
+    def __init__(
+        self,
+        *,
+        seat: str,
+        bound_seconds: float,
+        active_stack: list[str],
+    ) -> None:
+        super().__init__(
+            f"measurement ceiling exceeded: seat={seat} bound_s={bound_seconds} "
+            f"depth={len(active_stack)} tip={active_stack[-1] if active_stack else '<no active span>'}"
+        )
+        self.seat = seat
+        self.bound_seconds = bound_seconds
+        self.active_stack = list(active_stack)
+
+
+def ceiling_seconds() -> float:
+    """The bound in force, from the environment or the stated default."""
+    raw = os.environ.get(CEILING_ENV_VAR)
+    if raw is None or not raw.strip():
+        return DEFAULT_CEILING_SECONDS
+    value = float(raw)
+    if value <= 0:
+        raise ValueError(
+            f"{CEILING_ENV_VAR} must be positive; got {value!r}. "
+            "A non-positive ceiling would disarm the bound silently, which is "
+            "the failure this instrument exists to end."
+        )
+    return value
+
+
+def is_unswallowable(error: BaseException) -> bool:
+    """Events a per-file terminal handler must re-raise, never bank as a row.
+
+    Process control (the shard is dying) and measurement exhaustion (the seat
+    boundary owns this outcome, not an inner handler) are both events that an
+    inner ``except BaseException`` must not convert into a terminal for the
+    construct it happened to be building.
+    """
+    return isinstance(
+        error,
+        (KeyboardInterrupt, SystemExit, GeneratorExit, MeasurementCeilingExceeded),
+    )
+
+
+def _active_stack_snapshot() -> list[str]:
+    """The live reduction stack, captured before any unwinding."""
+    try:
+        from sugar_lift_py_tests.engine_log import active_stack_snapshot
+    except ImportError:
+        return []
+    return active_stack_snapshot()
+
+
+@contextmanager
+def measurement_ceiling(*, seat: str, seconds: float | None = None) -> Iterator[float]:
+    """Arm a wall-clock bound for one seat; raise by name when it is exceeded.
+
+    Refuses rather than degrading. If ``SIGALRM`` is unavailable or this is not
+    the main thread, this raises: a ceiling that quietly does nothing is worse
+    than no ceiling, because the run then looks bounded and is not.
+    """
+    bound = ceiling_seconds() if seconds is None else float(seconds)
+    if bound <= 0:
+        raise ValueError(f"measurement ceiling must be positive; got {bound!r}")
+    if not hasattr(signal, "SIGALRM") or not hasattr(signal, "setitimer"):
+        raise RuntimeError(
+            "measurement ceiling requires signal.SIGALRM/setitimer; this "
+            "platform has neither. Refusing to run unbounded while claiming a "
+            f"bound of {bound}s."
+        )
+    if threading.current_thread() is not threading.main_thread():
+        raise RuntimeError(
+            "measurement ceiling must be armed on the main thread (signal "
+            "delivery is main-thread only). Refusing to run unbounded while "
+            f"claiming a bound of {bound}s."
+        )
+
+    def _fire(signum: int, frame: Any) -> None:
+        raise MeasurementCeilingExceeded(
+            seat=seat,
+            bound_seconds=bound,
+            active_stack=_active_stack_snapshot(),
+        )
+
+    previous_handler = signal.signal(signal.SIGALRM, _fire)
+    previous_timer = signal.setitimer(signal.ITIMER_REAL, bound)
+    if previous_timer[0]:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        raise RuntimeError(
+            "an interval timer was already armed when the measurement ceiling "
+            f"tried to arm ({previous_timer[0]}s remaining). Nesting would "
+            "disarm one of the two bounds silently."
+        )
+    try:
+        yield bound
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+
+
+def exhaustion_coordinates(active_stack: list[str]) -> list[dict[str, str]]:
+    """Name construct, coordinate and shape from a captured reduction stack.
+
+    Each frame fingerprint is ``sugar|role|site``: the sugar class being
+    reduced, the role it was reduced in, and the blame coordinate. That triple
+    is what makes an exhaustion row a frontier row and not a complaint about
+    the clock -- ``generic.py:1323:12`` is a coordinate a reader can open.
+    """
+    rows: list[dict[str, str]] = []
+    for fingerprint in active_stack:
+        parts = str(fingerprint).split("|")
+        if len(parts) >= 3:
+            rows.append(
+                {"construct": parts[0], "role": parts[1], "coordinate": parts[2]}
+            )
+        else:
+            rows.append(
+                {
+                    "construct": str(fingerprint),
+                    "role": "<unfingerprinted>",
+                    "coordinate": "<unfingerprinted>",
+                }
+            )
+    return rows

--- a/implementations/python/sugar-lift-py-tests/tests/test_measurement_ceiling_is_a_frontier_row.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measurement_ceiling_is_a_frontier_row.py
@@ -1,0 +1,190 @@
+"""The per-file measurement ceiling: it fires, it names, and it conserves.
+
+One file (``pandas/core/groupby/generic.py``) never terminates under the
+census, so the shard it lands in is cancelled and the run's whole evidence is
+destroyed. The repair is not a bigger shard ceiling; it is that a seat which
+exceeds a stated per-file bound produces a countable frontier row naming
+construct, coordinate and shape, and the walk moves on.
+
+These tests are the falsifiability gate for that claim. They exercise BOTH
+arms: a subject that must make the bound fire, and a subject that must not be
+touched by it. A bound that cannot be made to fire is decorative; a bound that
+fires on ordinary work is a manufactured frontier.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from sugar_lift_py_tests import engine_log  # noqa: E402
+from sugar_lift_py_tests.measurement_ceiling import (  # noqa: E402
+    DEFAULT_CEILING_SECONDS,
+    CEILING_ENV_VAR,
+    MeasurementCeilingExceeded,
+    ceiling_seconds,
+    exhaustion_coordinates,
+    is_unswallowable,
+    measurement_ceiling,
+)
+
+
+# --------------------------------------------------------------------------
+# ARM ONE: the bound fires, and the row names the coordinate.
+# --------------------------------------------------------------------------
+
+
+def test_ceiling_fires_and_captures_the_live_construct_stack() -> None:
+    """A seat that will not terminate raises BY NAME, carrying its coordinate.
+
+    The stack is captured in the signal handler, before any unwinding, which
+    is the only moment at which the construct the walk was actually inside is
+    still on the stack. A row assembled after unwinding would name the
+    entrance, not the construct -- true, useless, and indistinguishable from
+    naming nothing.
+    """
+    with pytest.raises(MeasurementCeilingExceeded) as caught:
+        with measurement_ceiling(seat="fixture/generic.py", seconds=0.25):
+            with engine_log.reduction_span(
+                sugar="ClassDefSugar", role="statement", site="generic.py:189:0"
+            ):
+                with engine_log.reduction_span(
+                    sugar="FunctionDefSugar", role="term", site="generic.py:1323:12"
+                ):
+                    # Pure-Python spin, exactly like the real blowup: the
+                    # engine is working, not blocked, so nothing but a timer
+                    # can end it.
+                    deadline = time.monotonic() + 30.0
+                    while time.monotonic() < deadline:
+                        pass
+
+    error = caught.value
+    assert error.seat == "fixture/generic.py"
+    assert error.bound_seconds == 0.25
+    coordinates = exhaustion_coordinates(error.active_stack)
+    assert [row["coordinate"] for row in coordinates] == [
+        "generic.py:189:0",
+        "generic.py:1323:12",
+    ]
+    assert [row["construct"] for row in coordinates] == [
+        "ClassDefSugar",
+        "FunctionDefSugar",
+    ]
+    # Shape, not just position: the role is what makes the row readable.
+    assert coordinates[-1]["role"] == "term"
+
+
+def test_ceiling_escapes_every_inner_terminal_handler() -> None:
+    """Exhaustion must reach the seat boundary, not become a per-file terminal.
+
+    The construction path is full of arms that convert a raised event into a
+    terminal row for whatever construct was being built. If the ceiling could
+    be caught by one of those, the file would report a CONSTRUCTION outcome
+    caused by the clock -- a refusal the product never made.
+    """
+    swallowed: list[str] = []
+
+    def _inner_handler_like_the_consumer() -> None:
+        try:
+            deadline = time.monotonic() + 30.0
+            while time.monotonic() < deadline:
+                pass
+        except Exception as error:  # noqa: BLE001 -- the shape being tested
+            swallowed.append(f"except Exception: {type(error).__name__}")
+        except BaseException as error:  # noqa: BLE001
+            if is_unswallowable(error):
+                raise
+            swallowed.append(f"except BaseException: {type(error).__name__}")
+
+    with pytest.raises(MeasurementCeilingExceeded):
+        with measurement_ceiling(seat="fixture/seat.py", seconds=0.25):
+            _inner_handler_like_the_consumer()
+
+    assert swallowed == [], f"ceiling was swallowed by an inner handler: {swallowed}"
+
+
+def test_exhaustion_is_not_an_exception_subclass() -> None:
+    """The reason the arm above holds, asserted directly rather than inferred."""
+    assert issubclass(MeasurementCeilingExceeded, BaseException)
+    assert not issubclass(MeasurementCeilingExceeded, Exception)
+
+
+# --------------------------------------------------------------------------
+# ARM TWO: the bound does NOT fire on ordinary work, and costs it nothing.
+# --------------------------------------------------------------------------
+
+
+def test_ordinary_work_completes_untouched_and_the_timer_is_disarmed() -> None:
+    """A normal seat is unaffected: same result, and no timer left armed.
+
+    The neighbours of the pathological file measure in tens of milliseconds. A
+    ceiling that changed their outcome, or that leaked an armed timer into the
+    next seat, would turn a repair into a new source of spurious rows.
+    """
+    import signal
+
+    observed: list[str] = []
+    for seat in ("a.py", "b.py", "c.py"):
+        with measurement_ceiling(seat=seat, seconds=5.0):
+            with engine_log.reduction_span(
+                sugar="NameSugar", role="term", site=f"{seat}:1:0"
+            ):
+                observed.append(seat)
+        # Disarmed between seats, every time -- not merely at the end.
+        assert signal.getitimer(signal.ITIMER_REAL) == (0.0, 0.0), (
+            f"timer still armed after {seat}"
+        )
+    assert observed == ["a.py", "b.py", "c.py"]
+
+
+def test_ordinary_work_pays_no_measurable_toll() -> None:
+    """Arming the bound is not a cost centre.
+
+    Not a benchmark and not a threshold on the product: this asserts only that
+    the ceiling's own overhead is far below the scale of the cheapest real
+    seat (tens of milliseconds), so an unchanged timing claim is credible.
+    """
+    started = time.perf_counter()
+    for index in range(200):
+        with measurement_ceiling(seat=f"seat{index}.py", seconds=5.0):
+            pass
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    assert elapsed_ms < 200.0, f"200 arm/disarm cycles cost {elapsed_ms:.1f}ms"
+
+
+# --------------------------------------------------------------------------
+# The bound itself: stated, overridable, and never silently disarmed.
+# --------------------------------------------------------------------------
+
+
+def test_the_bound_is_stated_and_positive() -> None:
+    assert ceiling_seconds() == DEFAULT_CEILING_SECONDS
+    assert DEFAULT_CEILING_SECONDS > 0
+
+
+def test_a_non_positive_override_is_refused_not_treated_as_disarmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`0` must not mean "no ceiling". A run that looks bounded and is not is
+    the exact failure this instrument exists to end."""
+    monkeypatch.setenv(CEILING_ENV_VAR, "0")
+    with pytest.raises(ValueError) as caught:
+        ceiling_seconds()
+    assert CEILING_ENV_VAR in str(caught.value)
+
+
+def test_nesting_two_ceilings_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two bounds cannot share one interval timer; arming inside another would
+    disarm one of them silently."""
+    with measurement_ceiling(seat="outer.py", seconds=30.0):
+        with pytest.raises(RuntimeError) as caught:
+            with measurement_ceiling(seat="inner.py", seconds=5.0):
+                pass
+    assert "already armed" in str(caught.value)

--- a/implementations/python/sugar-lift-py-tests/tests/test_measurement_exhausted_conserves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measurement_exhausted_conserves.py
@@ -1,0 +1,298 @@
+"""`measurement-exhausted` is a member of the terminal partition.
+
+Conservation is the load-bearing claim. If an exhausted seat is dropped, the
+denominator quietly shrinks and the run looks cleaner for having a file it
+could not measure. If it is folded into the panic arm, the board publishes a
+refusal the product never made. Both are the same disease: absence, refusal
+and exhaustion sharing a representation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import compose_control_effect_board as compose  # noqa: E402
+from recensus_enumerate_consumer import measurement_exhausted_row  # noqa: E402
+from sugar_lift_py_tests.measurement_ceiling import (  # noqa: E402
+    MeasurementCeilingExceeded,
+    TERMINAL_KIND_EXHAUSTED,
+)
+
+
+def _exhausted_row(seat: str = "core/groupby/generic.py") -> dict:
+    error = MeasurementCeilingExceeded(
+        seat=seat,
+        bound_seconds=300.0,
+        active_stack=[
+            "ClassDefSugar|statement|generic.py:189:0",
+            "FunctionDefSugar|term|generic.py:1090:4",
+            "IfSugar|statement|generic.py:1293:8",
+            "FunctionDefSugar|term|generic.py:1323:12",
+        ],
+    )
+    return measurement_exhausted_row(
+        error,
+        file_rel=seat,
+        elapsed_seconds=300.4,
+        source_cid=f"sha256:{'e' * 64}",
+        function_nodes=[],
+        ast_function_defs=88,
+    )
+
+
+def _constructed_row(seat: str) -> dict:
+    source_cid = f"sha256:{seat:x<64}"[:71]
+    input_key = {
+        "sourceCid": source_cid,
+        "file": seat,
+        "functionKeyManifest": [],
+        "functionKeyCid": compose.key_manifest_cid([]),
+    }
+    return {
+        "category": "completed",
+        "terminalKind": "constructed",
+        "inputKey": input_key,
+        "rowId": compose.canonical_cid({"inputKey": input_key}),
+        "stageId": compose.STAGE_ENUMERATE_FILE_TERMINAL,
+        "observedEventType": "builtins.dict",
+        "observed_chain_length": 1,
+        "blocking_terminal_count": 0,
+        "final_terminal": "constructed",
+        "functionsTotal": 0,
+        "edgeWitnesses": {
+            compose.EDGE_ENUMERATE_FILE: compose.key_edge_witness(
+                stage_id=compose.STAGE_ENUMERATE_FILE_TERMINAL,
+                input_keys=[],
+                output_keys=[],
+            ),
+            compose.EDGE_WITH_PARTITION: compose.key_edge_witness(
+                stage_id=compose.STAGE_WITH_TALLY_PARTITION,
+                input_keys=[],
+                output_keys=[],
+            ),
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# The row is a terminal, not a hole.
+# --------------------------------------------------------------------------
+
+
+def test_exhausted_row_is_neither_a_panic_nor_an_instrument_failure() -> None:
+    row = _exhausted_row()
+    assert row["terminalKind"] == TERMINAL_KIND_EXHAUSTED
+    assert row["terminalKind"] not in {"constructed", "construction-panic"}
+    # Not a refusal: no panic payload, and nothing that would be counted as one.
+    assert "panic" not in row and "defect" not in row
+    assert not row.get("constructionPanics")
+    # Not an instrument failure: an instrumentFailure row is dropped from
+    # attestation entirely, which is how this file vanished from the frontier
+    # in the first place.
+    assert "instrumentFailure" not in row
+
+
+def test_exhausted_row_names_construct_coordinate_and_shape() -> None:
+    exhaustion = _exhausted_row()["measurementExhaustion"]
+    assert exhaustion["construct"] == "FunctionDefSugar"
+    assert exhaustion["coordinate"] == "generic.py:1323:12"
+    assert exhaustion["role"] == "term"
+    assert exhaustion["activeDepth"] == 4
+    assert exhaustion["boundSeconds"] == 300.0
+    assert (
+        exhaustion["observedEventType"]
+        == "sugar_lift_py_tests.measurement_ceiling.MeasurementCeilingExceeded"
+    )
+
+
+def test_exhausted_row_refuses_to_claim_attendance_it_never_took() -> None:
+    """Absent manifest, not an empty one.
+
+    An empty function key manifest is a claim that the file has no functions.
+    The truthful statement is that measurement was cut off before attendance
+    could be taken -- and the AST mass we DO know survives beside it, because
+    banking 0 over known mass is the mass-erase class with a timer on it.
+    """
+    row = _exhausted_row()
+    assert "functionKeyManifest" not in row["inputKey"]
+    assert row["astFunctionDefs"] == 88
+    assert row["functionsClean"] is None
+    assert row["cleanRatioRefused"] is True
+    assert "300.0" in row["cleanRefuseReason"]
+
+
+def test_exhausted_row_banks_the_roster_floor_when_one_was_taken() -> None:
+    error = MeasurementCeilingExceeded(
+        seat="s.py", bound_seconds=300.0, active_stack=["S|term|s.py:1:0"]
+    )
+    row = measurement_exhausted_row(
+        error,
+        file_rel="s.py",
+        elapsed_seconds=300.1,
+        source_cid=f"sha256:{'a' * 64}",
+        function_nodes=[{"memento": {"function_name": "f"}}] * 3,
+        ast_function_defs=10,
+    )
+    assert row["functionsTotal"] == 3
+    assert row["functionsNotEnumerated"] == 7
+    assert row["functionsEnumerationComplete"] is False
+
+
+# --------------------------------------------------------------------------
+# Conservation at the sole compose door.
+# --------------------------------------------------------------------------
+
+
+def test_exhausted_seat_is_inside_the_final_disjoint_union() -> None:
+    rows = [
+        ("a.py", _constructed_row("a.py")),
+        ("b.py", _constructed_row("b.py")),
+        ("core/groupby/generic.py", _exhausted_row()),
+    ]
+    attestation, failures = compose.attest_frontier_rows(rows)
+    assert failures == [], failures
+    seal = attestation["finalSeal"]
+    assert seal["conserves"] is True
+    assert seal["terminalArmsPairwiseDisjoint"] is True
+    exhausted_manifest = attestation["measurementExhaustedKeyManifest"]
+    assert [key["file"] for key in exhausted_manifest] == ["core/groupby/generic.py"]
+    # And it is NOT in the panic arm.
+    panic_files = [
+        key["file"] for key in attestation["constructionPanicKeyManifest"]
+    ]
+    assert "core/groupby/generic.py" not in panic_files
+
+
+def test_dropping_the_exhausted_arm_breaks_the_union() -> None:
+    """The conservation check has teeth: prove it fails when the arm is lost.
+
+    Without this, `conserves: True` above is compatible with the exhausted seat
+    never having been counted at all.
+    """
+    rows = [("core/groupby/generic.py", _exhausted_row())]
+    attestation, failures = compose.attest_frontier_rows(rows)
+    assert failures == []
+    edge = attestation["edges"][compose.EDGE_TERMINAL_SEAL]
+    assert edge["inputKeyCount"] == 1
+    assert edge["outputKeyCount"] == 1
+    # The seat is present on BOTH sides. Had it been routed nowhere, the input
+    # side would still hold it and the output side would not.
+    assert edge["missingKeys"] == []
+
+
+def test_an_unrecognised_terminal_kind_is_refused_not_ignored() -> None:
+    row = _exhausted_row()
+    row["terminalKind"] = "measurement-exhasuted"  # one transposition
+    row["category"] = "measurement-exhasuted"
+    _, failures = compose.attest_frontier_rows([("x.py", row)])
+    assert any("not closed" in str(failure.get("reason")) for failure in failures), (
+        failures
+    )
+
+
+def test_exhausted_terminal_is_counted_on_its_own_axis_in_the_board() -> None:
+    """Compose must not fold exhaustion into panics, and the sum must hold."""
+    agg = compose.aggregate_terminal_rows(
+        [
+            ("a.py", _constructed_row("a.py")),
+            ("core/groupby/generic.py", _exhausted_row()),
+        ],
+        enrolled_files=["a.py", "core/groupby/generic.py"],
+    )
+    assert agg["files_completed"] == 1
+    assert agg["files_exhausted"] == 1
+    assert agg["files_panicked"] == 0
+    assert agg["construction_panics"] == []
+    assert agg["defects"] == []
+    assert [row["file"] for row in agg["measurement_exhausted"]] == [
+        "core/groupby/generic.py"
+    ]
+
+
+def test_exhausted_terminal_without_a_coordinate_is_refused() -> None:
+    """A bare "it timed out" is not a frontier row and must not pass as one."""
+    row = _exhausted_row()
+    del row["measurementExhaustion"]
+    with pytest.raises(TypeError) as caught:
+        compose.aggregate_terminal_rows([("g.py", row)], enrolled_files=["g.py"])
+    assert "measurementExhaustion" in str(caught.value)
+
+
+def test_the_partition_sum_is_checked_not_assumed() -> None:
+    """Both directions: a conserving triple passes, a short one raises.
+
+    The failure mode this guards is not a wrong number but a MISSING seat --
+    a member added to the closed set with no arm routing it anywhere. That
+    reads as a smaller denominator, which is exactly how one file destroyed a
+    whole run's evidence.
+    """
+    compose.reconcile_terminal_partition(
+        files_terminal=3, files_completed=1, files_panicked=1, files_exhausted=1
+    )
+    with pytest.raises(ValueError) as caught:
+        compose.reconcile_terminal_partition(
+            files_terminal=3, files_completed=1, files_panicked=1, files_exhausted=0
+        )
+    message = str(caught.value)
+    assert "does not conserve" in message
+    assert "accounted=2" in message and "terminal=3" in message
+
+
+def test_membership_exhaustion_keeps_the_terminal_it_already_measured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bound covers the whole seat, but a completed terminal is not lost.
+
+    If the terminal constructed and only the relation-membership tail exceeded
+    the bound, the seat is a MEASURED seat whose membership is a gap. Calling
+    it exhausted would throw away a construction outcome we actually hold --
+    the mass-erase class, wearing the new timer as a costume.
+    """
+    import recensus_enumerate_consumer as consumer
+
+    banked = {"category": "completed", "terminalKind": "constructed"}
+
+    def _spin(*, progress, **_kwargs):
+        progress["terminalRow"] = banked
+        raise MeasurementCeilingExceeded(
+            seat="s.py", bound_seconds=300.0, active_stack=["S|term|s.py:1:0"]
+        )
+
+    monkeypatch.setattr(consumer, "_measure_seat_under_ceiling", _spin)
+    row = consumer.measure_file_via_enumerate(
+        workspace_root=Path("/nonexistent"), file_rel="s.py"
+    )
+    assert row["terminalKind"] == "constructed"
+    assert row is banked
+    gaps = row[consumer.RELATION_MEMBERSHIP_GAP_ROW_FIELD]
+    assert "measurement ceiling" in gaps[0]["reason"]
+    assert "300.0" in gaps[0]["reason"]
+
+
+def test_seat_exhaustion_without_a_banked_terminal_is_still_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other side of the same discriminator -- run both."""
+    import recensus_enumerate_consumer as consumer
+
+    def _spin(*, progress, **_kwargs):
+        progress["sourceCid"] = f"sha256:{'b' * 64}"
+        progress["astFunctionDefs"] = 4
+        raise MeasurementCeilingExceeded(
+            seat="s.py", bound_seconds=300.0, active_stack=["S|term|s.py:9:0"]
+        )
+
+    monkeypatch.setattr(consumer, "_measure_seat_under_ceiling", _spin)
+    row = consumer.measure_file_via_enumerate(
+        workspace_root=Path("/nonexistent"), file_rel="s.py"
+    )
+    assert row["terminalKind"] == TERMINAL_KIND_EXHAUSTED
+    assert row["measurementExhaustion"]["coordinate"] == "s.py:9:0"
+    assert row["astFunctionDefs"] == 4

--- a/scripts/mutate_ceiling_one.py
+++ b/scripts/mutate_ceiling_one.py
@@ -1,0 +1,179 @@
+"""Apply exactly ONE coherent mutation to the measurement-ceiling work, and
+PRINT that it landed.
+
+Same law as scripts/mutate_one.py, restated because it is the law that makes
+any of this evidence:
+
+  - ONE mutation at a time. A non-isolating mutation is NON-EVIDENCE even when
+    it is red, because the red cannot be attributed to the tooth under test.
+  - PRINT that it landed. A helper whose anchor silently fails to match makes
+    an UNAPPLIED mutation run as a clean green.
+  - GIT CHECKOUT IS NOT A REVERT WHEN THE WORK IS UNCOMMITTED. Revert from a
+    snapshot taken before the first mutation, never from the index.
+
+usage:
+  python scripts/mutate_ceiling_one.py --snapshot     # BEFORE the first one
+  python scripts/mutate_ceiling_one.py <name>
+  python scripts/mutate_ceiling_one.py --revert
+  python scripts/mutate_ceiling_one.py --list
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PY = ROOT / "implementations/python/sugar-lift-py-tests"
+CEILING = PY / "src/sugar_lift_py_tests/measurement_ceiling.py"
+ENGINE = PY / "src/sugar_lift_py_tests/engine_log.py"
+CONSUMER = PY / "scripts/recensus_enumerate_consumer.py"
+COMPOSE = PY / "scripts/compose_control_effect_board.py"
+SNAPSHOT = Path("/tmp/ceiling_mutation_snapshot")
+
+FILES = {
+    "ceiling": CEILING,
+    "engine": ENGINE,
+    "consumer": CONSUMER,
+    "compose": COMPOSE,
+}
+
+MUTATIONS: dict[str, tuple[str, str, str]] = {
+    # (file key, anchor, replacement)
+    #
+    # M1 -- the bound never actually arms. This is the decorative-ceiling
+    # shape: everything still imports, every row still looks normal, and the
+    # run is unbounded while claiming a bound.
+    "never_arms": (
+        "ceiling",
+        "    previous_timer = signal.setitimer(signal.ITIMER_REAL, bound)",
+        "    previous_timer = signal.setitimer(signal.ITIMER_REAL, 0)",
+    ),
+    # M2 -- exhaustion becomes an ordinary Exception, so any `except
+    # Exception` on the construction path can catch it and report a
+    # construction outcome caused by the clock.
+    "catchable_as_exception": (
+        "ceiling",
+        "class MeasurementCeilingExceeded(BaseException):",
+        "class MeasurementCeilingExceeded(Exception):",
+    ),
+    # M3 -- the stack is read after unwinding instead of at the alarm, so the
+    # row carries no coordinate: a bare "it timed out".
+    "no_coordinate_captured": (
+        "engine",
+        "        return [item.fingerprint for item in _ACTIVE.get(thread_id, [])]",
+        "        return []",
+    ),
+    # M4 -- exhaustion folded into the panic arm: the board publishes a
+    # refusal the product never made.
+    "exhaustion_folded_into_panics": (
+        "compose",
+        '            elif row.get("terminalKind") == "measurement-exhausted":\n'
+        "                exhausted.append(dict(key))",
+        '            elif row.get("terminalKind") == "measurement-exhausted":\n'
+        "                panicked.append(dict(key))",
+    ),
+    # M5 -- exhausted seats never reach the output side of the final union:
+    # the denominator quietly shrinks by the files we could not measure.
+    "exhausted_dropped_from_union": (
+        "compose",
+        "        output_keys=[*constructed, *panicked, *exhausted],",
+        "        output_keys=[*constructed, *panicked],",
+    ),
+    # M6 -- the aggregate loses its third arm and falls back to "anything not
+    # completed is a panic".
+    "aggregate_loses_third_arm": (
+        "compose",
+        '        elif category == "measurement-exhausted":',
+        '        elif category == "measurement-exhausted-DISABLED":',
+    ),
+    # M7 -- the timer is never disarmed, so it leaks into the next seat and
+    # fires on an innocent file.
+    "timer_leaks_to_next_seat": (
+        "ceiling",
+        "    finally:\n"
+        "        signal.setitimer(signal.ITIMER_REAL, 0)\n"
+        "        signal.signal(signal.SIGALRM, previous_handler)\n",
+        "    finally:\n        pass\n",
+    ),
+    # M8 -- the exhausted row claims an EMPTY function manifest, i.e. states
+    # that the file has no functions, rather than declining to testify.
+    "claims_empty_attendance": (
+        "consumer",
+        '        input_key = {"sourceCid": source_cid, "file": file_rel}',
+        '        input_key = {\n'
+        '            "sourceCid": source_cid,\n'
+        '            "file": file_rel,\n'
+        '            "functionKeyManifest": [],\n'
+        '        }',
+    ),
+    # M9 -- the driver stops counting exhaustion in its verdict, so a run with
+    # an unmeasurable file reports green.
+    # M10 -- a completed terminal is discarded when only the membership tail
+    # exhausted the bound: mass-erase wearing the new timer as a costume.
+    "banked_terminal_discarded": (
+        "consumer",
+        "        banked = progress.get(\"terminalRow\")",
+        "        banked = None",
+    ),
+    "partition_sum_unchecked": (
+        "compose",
+        "    if accounted != files_terminal:",
+        "    if accounted != files_terminal and False:",
+    ),
+}
+
+
+def _snapshot() -> None:
+    SNAPSHOT.mkdir(parents=True, exist_ok=True)
+    for name, path in FILES.items():
+        shutil.copy2(path, SNAPSHOT / f"{name}.py")
+    print(f"SNAPSHOT taken -> {SNAPSHOT} ({', '.join(sorted(FILES))})")
+
+
+def _revert() -> None:
+    if not SNAPSHOT.is_dir():
+        sys.exit("REFUSED: no snapshot; --revert would restore HEAD, not the work")
+    for name, path in FILES.items():
+        shutil.copy2(SNAPSHOT / f"{name}.py", path)
+    print("REVERTED from snapshot (not from the index)")
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        sys.exit(__doc__)
+    if argv[0] == "--snapshot":
+        _snapshot()
+        return 0
+    if argv[0] == "--revert":
+        _revert()
+        return 0
+    if argv[0] == "--list":
+        for name in MUTATIONS:
+            print(name)
+        return 0
+    name = argv[0]
+    if name not in MUTATIONS:
+        sys.exit(f"REFUSED: unknown mutation {name!r}; --list to see them")
+    if not SNAPSHOT.is_dir():
+        sys.exit("REFUSED: take --snapshot before the first mutation")
+    file_key, anchor, replacement = MUTATIONS[name]
+    path = FILES[file_key]
+    source = path.read_text()
+    occurrences = source.count(anchor)
+    if occurrences != 1:
+        sys.exit(
+            f"REFUSED: anchor for {name!r} occurs {occurrences} times in "
+            f"{path} (must be exactly 1). An unapplied mutation runs as a "
+            "clean green -- this is the refusal that stops that."
+        )
+    path.write_text(source.replace(anchor, replacement, 1))
+    print(f"MUTATION LANDED name={name} file={path}")
+    print(f"  anchor:      {anchor!r}")
+    print(f"  replacement: {replacement!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
One file — `pandas/core/groupby/generic.py` — never terminates under measurement. It consumed **6h03m** of a shard before being cancelled, and a cancelled shard uploads no partial, so **one file destroyed the whole run's evidence**. That is why the sole SCOREBOARD door has been unable to seal (#7411).

Exceeding a bound is now a **countable frontier row**, not a killed job.

## Firing arm

```
PROFILE_PLAN start=125 stride=1 seats=1 measurementCeilingSeconds=300.0
PROFILE_SEATS ["core/groupby/generic.py"]
PROFILE_ROW {"seat": "core/groupby/generic.py", "terminalKind": "measurement-exhausted",
  "elapsedMs": 300098.3, "panicCount": 0, "instrumentFailure": null,
  "measurementExhaustion": {
    "boundSeconds": 300.0, "activeDepth": 15,
    "construct": "SubstituteStatement",
    "coordinate": "pandas/core/groupby/generic.py:1324 Return",
    "role": "temporal", ...}}
PROFILE_TOTAL {"constructed": 0, "construction-panic": 0, "instrument-failure": 0, "measurement-exhausted": 1}
```

**6h03m becomes a 300.1s row naming construct, coordinate and shape.** The stack is captured in the signal handler *before unwinding* — the only moment that construct is still on the stack — and independently reproduces the coordinate found by hand in #7411: `Substitute|temporal` at `1323 build_codes`, `SubstituteStatement` at `1324 Return`.

The seat is confirmed **by name**: the profiler prints `PROFILE_SEATS` and refuses an absent seat, rather than trusting index arithmetic.

## Non-firing arm — and a false regression the author killed himself

Slice `sorted(roster)[0::13]`, 110 seats:

```
base run1 (no ceiling)   total_s=124.6  median=384.6ms  max= 9499.0ms
base run2 (no ceiling)   total_s=161.4  median=489.2ms  max=12047.8ms
branch   (ceiling 300s)  total_s=160.6  median=506.7ms  max=14957.5ms

seat|terminalKind sets, BOTH directions: only-base 0, only-branch 0 (all pairs)
panic nodeIds: 48 before, 48 after, 0 only-before, 0 only-after
measurement-exhausted rows on this slice: 0
```

base1 vs branch reads as **+29%**. Rather than ship that as noise, the base was re-run under the same box load and came back at **161.4s — slower than the branch**. The contemporaneous comparison is 161.4 vs 160.6; 200 arm/disarm cycles cost <200ms in the unit arm. **The +29% was contention from other agents, not the ceiling.**

## Conservation

`measurement-exhausted` is a **third member of the partition**, not a nullable and not a flag:

```
filesTerminal == filesCompleted + filesPanicked + filesExhausted
```

enforced by `compose_control_effect_board.reconcile_terminal_partition`, which **raises** rather than reporting a short denominator. All three arms proved pairwise disjoint (the previous check compared only two). The old *"anything not completed is a panic"* fallback is **gone** — it would have published a refusal the product never made. Unrecognised kinds raise. **Denominator stays 1421 and the exhausted seat is counted.**

Two deliberate non-choices, both stated: it is **not** an instrument failure — those rows are dropped from attestation entirely, which is how this file vanished from the frontier in the first place — and the function key manifest is **absent** rather than empty, because empty claims the file has no functions while absence states attendance was never taken.

## The bound

**300s**, in `measurement_ceiling.py`, with its evidence in the module docstring and in `CEILING_EVIDENCE`: a 110-seat sample whose slowest completing file is 9499.0ms (`tests/tools/test_to_datetime.py`) — roughly **32x headroom**. Printed on `RECENSUS START` and `PROFILE_PLAN`, so no board is readable without the bound that produced it. `SUGAR_MEASUREMENT_CEILING_SECONDS` overrides; **`0` is REFUSED** rather than meaning "unbounded", because a run that looks bounded and is not is the failure this exists to end.

## Teeth — ten mutations, one at a time, each printing that it landed

| mutation | red |
|---|---|
| `never_arms` | 3 — and the suite took 61s instead of 1.3s, the spins running to their own deadlines |
| `catchable_as_exception` | 2 |
| `no_coordinate_captured` | 1 |
| `exhaustion_folded_into_panics` | 1 |
| `exhausted_dropped_from_union` | 2 |
| `aggregate_loses_third_arm` | 2 |
| `timer_leaks_to_next_seat` | 2 |
| `claims_empty_attendance` | 3 |
| `banked_terminal_discarded` | 1 |
| `partition_sum_unchecked` | 1 |

Two did not fall out first time and are reported as such. `timer_leaks_to_next_seat` returned **REFUSED: anchor occurs 2 times** — the harness caught an ambiguous anchor instead of mis-mutating. `partition_sum_unchecked` came back **GREEN**, a real hole: the conservation raise was buried inline and untested. It was extracted into `reconcile_terminal_partition`, tested both directions, and re-run red.

Regression name-diff across 9 suites, base worktree vs branch: **only-base 0, only-branch 0**, 11 pre-existing failures common to both. 20 new tests pass.

## Scope note, flagged by the author

Bounding only `_terminal_via_enumerate` would leave the `demand_relation_membership` tail unbounded, and an unbounded tail eats a shard exactly as an unbounded body does — so the bound covers the whole seat. **But if the terminal completed and only membership exhausted, the row is NOT exhausted**: it is a measured seat whose membership is a gap, because discarding a construction outcome we actually hold is the mass-erase class wearing the new timer as a costume. Both sides of that discriminator are tested and mutation-proved.

## Not included

This does **not** diagnose the blowup at `generic.py:1323`. What it buys is that the recensus can seal with that file as one countable row — and the file finally has a price, **>300s**, which is precisely why the LPT prior could never see it.

`timeout-minutes` untouched; #7410's revert sequences separately.

Related: #7411, #7410, #7412.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound per-file measurement with a SIGALRM ceiling and surface exhausted files as a distinct terminal partition
> - Introduces [`measurement_ceiling.py`](https://github.com/TSavo/sugar/pull/7415/files#diff-e6bc201ff8e7176a603a932cba5af74f3dae3e5198f34324d495185db871dcb6) with a `measurement_ceiling` context manager that arms `SIGALRM` and raises `MeasurementCeilingExceeded` (a `BaseException`) when the per-seat wall-clock bound is exceeded, preventing indefinite hangs.
> - [`recensus_enumerate_consumer.py`](https://github.com/TSavo/sugar/pull/7415/files#diff-f44306c90c4bcc279a33763d110fe23086857b9b1f1afc83ea45e09c2d004b79) wraps each seat measurement in the ceiling; on exhaustion it produces a `measurement-exhausted` terminal row with edge witnesses and stack-derived coordinates.
> - The board pipeline (`compose_control_effect_board.py`, `control_effect_recensus.py`) now treats `measurement-exhausted` as a third terminal arm alongside `constructed` and `construction-panic`, with pairwise disjointness checks, separate counts, and conservation enforcement via `reconcile_terminal_partition`.
> - Recensus runs exit non-zero when any measurement-exhausted files are present, and log the active ceiling and per-file exhaustion details.
> - Risk: `SIGALRM` is only supported on Unix; nesting ceilings or running on unsupported platforms raises at arm time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d40cfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->