### PR TITLE
A seat the bound stopped owes no membership testimony — and the seal door needed the third arm too

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -257,7 +257,24 @@ _RELATION_MEMBER_MANIFEST_SCHEMA = "recensus-relation-member-manifest/v1"
 # The relations whose population a sealed width is taken to describe. Both
 # receipts at frontierWidth=477 carried ZERO testimony for either of them.
 RELATION_MEMBERSHIP_RELATIONS = ("lexical-call", "target-pattern")
-_RELATION_MEMBERSHIP_FIELDS = frozenset({"schema", "relations"})
+# `measurementExhaustedSeats` is part of the attestation's own vocabulary, not
+# a tolerance bolted onto it. A seat the measurement ceiling stopped could not
+# have produced membership testimony, and its silence means something entirely
+# different from a seat that walked, finished, and still said nothing:
+#
+#   absent because measurement stopped   -> named here, countable, expected
+#   absent because nothing was found     -> a refusal, and still a refusal
+#
+# Those two never share a representation. The field is REQUIRED (possibly
+# empty) rather than optional, so a shard cannot omit it and leave a reader
+# unable to tell "no seats were exempt" from "this shard does not report
+# exemptions".
+_RELATION_MEMBERSHIP_FIELDS = frozenset(
+    {"schema", "relations", "measurementExhaustedSeats"}
+)
+_RELATION_MEMBERSHIP_EXEMPT_SEAT_FIELDS = frozenset(
+    {"file", "boundSeconds", "construct", "coordinate"}
+)
 _RELATION_MEMBER_MANIFEST_FIELDS = frozenset(
     {"schema", "relation", "memberCids", "memberCount", "manifestCid"}
 )
@@ -270,6 +287,10 @@ _RELATION_MEMBERSHIP_MALFORMED = "relation-membership-attestation-malformed"
 _RELATION_MEMBERSHIP_MISSING = "relation-membership-missing"
 _RELATION_MEMBERSHIP_EXTRA = "relation-membership-extra"
 _RELATION_MEMBERSHIP_DUPLICATE = "relation-membership-duplicate"
+# A seat claimed exempt with no exhausted terminal row behind it. This is the
+# only way the exemption could become a blanket "tolerate missing membership",
+# so it is a named refusal rather than a silent pass.
+_RELATION_MEMBERSHIP_EXEMPTION_UNSUPPORTED = "relation-membership-exemption-unsupported"
 _RELATION_MEMBERSHIP_REFUSAL_CODES = frozenset(
     {
         _RELATION_MEMBERSHIP_ABSENT,
@@ -277,6 +298,7 @@ _RELATION_MEMBERSHIP_REFUSAL_CODES = frozenset(
         _RELATION_MEMBERSHIP_MISSING,
         _RELATION_MEMBERSHIP_EXTRA,
         _RELATION_MEMBERSHIP_DUPLICATE,
+        _RELATION_MEMBERSHIP_EXEMPTION_UNSUPPORTED,
     }
 )
 
@@ -498,6 +520,38 @@ def authenticate_relation_membership(
             f"extra={sorted(set(relations) - set(RELATION_MEMBERSHIP_RELATIONS))}"
         )
 
+    exempt_seats = attestation.get("measurementExhaustedSeats")
+    if not isinstance(exempt_seats, list):
+        return malformed("measurementExhaustedSeats must be a list")
+    exempt_wire: list[dict[str, Any]] = []
+    for seat in exempt_seats:
+        if not isinstance(seat, Mapping):
+            return malformed("measurementExhaustedSeats entries must be objects")
+        if set(seat) != _RELATION_MEMBERSHIP_EXEMPT_SEAT_FIELDS:
+            return malformed(
+                "measurementExhaustedSeats entry has closed fields "
+                f"{sorted(_RELATION_MEMBERSHIP_EXEMPT_SEAT_FIELDS)}; got "
+                f"{sorted(seat)}"
+            )
+        # An exemption must NAME what stopped and where. "this one timed out"
+        # is not testimony; it is the absence of testimony with a label on it.
+        if not isinstance(seat.get("file"), str) or not seat["file"]:
+            return malformed("measurementExhaustedSeats entry lacks a file")
+        if not isinstance(seat.get("boundSeconds"), (int, float)):
+            return malformed(
+                f"measurementExhaustedSeats entry {seat.get('file')!r} lacks the "
+                "bound it exceeded"
+            )
+        if not isinstance(seat.get("coordinate"), str) or not seat["coordinate"]:
+            return malformed(
+                f"measurementExhaustedSeats entry {seat.get('file')!r} lacks the "
+                "coordinate measurement stopped at"
+            )
+        exempt_wire.append(dict(seat))
+    exempt_files = [str(seat["file"]) for seat in exempt_wire]
+    if len(set(exempt_files)) != len(exempt_files):
+        return malformed("measurementExhaustedSeats names a file twice")
+
     findings: list[tuple[str, str | None]] = []
     details: list[str] = []
     wire_relations: dict[str, Any] = {}
@@ -555,7 +609,14 @@ def authenticate_relation_membership(
             _authority=_RELATION_MEMBERSHIP_AUTHORITY,
         )
     return RelationMembershipConservedV1(
-        wire={"schema": _RELATION_MEMBERSHIP_SCHEMA, "relations": wire_relations},
+        wire={
+            "schema": _RELATION_MEMBERSHIP_SCHEMA,
+            "relations": wire_relations,
+            # Carried into the sealed body: a reader of the board can see
+            # exactly which seats were exempt and why, without having to
+            # reconcile the attestation against the terminal rows by hand.
+            "measurementExhaustedSeats": exempt_wire,
+        },
         _authority=_RELATION_MEMBERSHIP_AUTHORITY,
     )
 
@@ -1241,7 +1302,24 @@ def _validate_frontier_attestation_for_common_seal(
     terminal = validated[EDGE_TERMINAL_SEAL]
     constructed = frontier_attestation.get("constructedKeyManifest")
     panicked = frontier_attestation.get("constructionPanicKeyManifest")
-    if not isinstance(constructed, list) or not isinstance(panicked, list):
+    # THREE arms here too. This validator is a SECOND, independent copy of the
+    # final union -- attest_frontier_rows conserves at the shard door, and this
+    # one re-derives it at the seal door on purpose, so that a board cannot be
+    # sealed on the strength of a claim it carries about itself. Two doors that
+    # must agree only agree if BOTH know the partition has three members;
+    # teaching one of them and not the other is how a board that conserves at
+    # the shard is refused at the seal.
+    exhausted = frontier_attestation.get("measurementExhaustedKeyManifest")
+    if exhausted is None:
+        # Older boards predate the third member. An absent manifest is an
+        # empty arm, NOT an unknown one -- those boards were sealed before a
+        # seat could be exhausted at all.
+        exhausted = []
+    if (
+        not isinstance(constructed, list)
+        or not isinstance(panicked, list)
+        or not isinstance(exhausted, list)
+    ):
         raise ValueError("frontier terminal partition manifests absent")
     if len(panicked) != expected_panic_count:
         raise ValueError(
@@ -1251,7 +1329,7 @@ def _validate_frontier_attestation_for_common_seal(
     final_edge = key_edge_witness(
         stage_id=STAGE_TERMINAL_AGGREGATE_SEAL,
         input_keys=terminal["inputKeyManifest"],
-        output_keys=[*constructed, *panicked],
+        output_keys=[*constructed, *panicked, *exhausted],
     )
     if (
         final_edge["missingKeys"]
@@ -1259,11 +1337,24 @@ def _validate_frontier_attestation_for_common_seal(
         or final_edge["duplicateKeys"]
     ):
         raise ValueError("frontier final disjoint union does not conserve")
-    overlap = {_render_key(row) for row in constructed if isinstance(row, Mapping)} & {
-        _render_key(row) for row in panicked if isinstance(row, Mapping)
+    rendered_arms = {
+        "constructed": {
+            _render_key(row) for row in constructed if isinstance(row, Mapping)
+        },
+        "construction-panic": {
+            _render_key(row) for row in panicked if isinstance(row, Mapping)
+        },
+        "measurement-exhausted": {
+            _render_key(row) for row in exhausted if isinstance(row, Mapping)
+        },
     }
-    if overlap:
-        raise ValueError("frontier constructed and panic manifests overlap")
+    for left, right in (
+        ("constructed", "construction-panic"),
+        ("constructed", "measurement-exhausted"),
+        ("construction-panic", "measurement-exhausted"),
+    ):
+        if rendered_arms[left] & rendered_arms[right]:
+            raise ValueError(f"frontier {left} and {right} manifests overlap")
     final_seal = frontier_attestation.get("finalSeal")
     if (
         not isinstance(final_seal, Mapping)
@@ -1398,6 +1489,7 @@ def mint_partial(
     panics: list[dict[str, Any]] = []
     families: Counter[str] = Counter()
     instrument_defects: list[dict[str, Any]] = []
+    shard_exhausted: list[dict[str, Any]] = []
     for file, raw in terminals:
         cat = str(raw.get("category") or "")
         families.update(raw.get("families") or {})
@@ -1407,6 +1499,20 @@ def mint_partial(
                 panics.append(dict(panic))
             elif "ConstructionPanic" not in (raw.get("families") or {}):
                 families["ConstructionPanic"] += 1
+        elif cat == "measurement-exhausted":
+            # NOT an instrument defect. The instrument did what it was told
+            # and was stopped by its own stated bound; calling that a defect
+            # would report a harness fault for a product fact, and would put
+            # exhaustion back in a bag it does not belong in.
+            exhaustion = raw.get("measurementExhaustion")
+            shard_exhausted.append(
+                # `file` LAST: the payload carries its own `file` and letting
+                # it win would key the shard's row on whatever the payload
+                # said rather than on the seat actually walked.
+                {**exhaustion, "file": file}
+                if isinstance(exhaustion, Mapping)
+                else {"file": file, "reason": "measurementExhaustion absent"}
+            )
         elif cat not in {"completed", ""}:
             defect = raw.get("defect")
             instrument_defects.append(
@@ -1450,6 +1556,30 @@ def mint_partial(
         relation_membership_attestation
     )
     membership_reason = shard_membership.refusal_reason()
+    if membership_reason is None:
+        # THE TOOTH ON THE EXEMPTION. The attestation is written by the same
+        # shard whose seats it exempts, so a shape check there proves nothing
+        # about whether the seat was really stopped by the bound. Here -- the
+        # one place that holds the terminal rows AND the attestation -- every
+        # claimed exemption must be backed by an exhausted terminal row in
+        # THIS shard. Without this, "exempt" is a word a shard can write next
+        # to any silent file.
+        exhausted_files = {str(row["file"]) for row in shard_exhausted}
+        claimed = {
+            str(seat.get("file"))
+            for seat in shard_membership.conserved_wire().get(
+                "measurementExhaustedSeats"
+            )
+            or []
+        }
+        unsupported = sorted(claimed - exhausted_files)
+        if unsupported:
+            membership_reason = (
+                f"{_RELATION_MEMBERSHIP_EXEMPTION_UNSUPPORTED}: "
+                f"{len(unsupported)} seat(s) claimed exempt from membership "
+                "with no measurement-exhausted terminal row in this shard: "
+                f"{unsupported[:10]}"
+            )
     if membership_reason is not None and unmeasured_reason is None:
         status = "unmeasured"
         unmeasured_reason = membership_reason
@@ -1502,6 +1632,8 @@ def mint_partial(
             "constructionPanics": panics,
             "families": dict(families),
             "instrumentDefects": instrument_defects,
+            "measurementExhausted": shard_exhausted,
+            "R_measurement_exhausted_shard": len(shard_exhausted),
             "R_construction_panics_shard": len(panics),
         },
         "d3ResidencyExposure": aggregate_d3_residency_exposure(
@@ -2234,6 +2366,12 @@ def compose_from_partials(
         relation: {"expected": [], "observed": []}
         for relation in RELATION_MEMBERSHIP_RELATIONS
     }
+    # Exempt seats union across shards exactly as members do. A seat the
+    # ceiling stopped in s4 must still be visible, by name, on the corpus
+    # board -- otherwise the width is sealed over a seat nobody can see was
+    # never measured, which is the unknown denominator this attestation
+    # exists to make impossible.
+    shard_exempt_seats: list[dict[str, Any]] = []
     for i in range(k):
         seat = f"s{i:02d}"
         p = by_index.get(i)
@@ -2342,6 +2480,9 @@ def compose_from_partials(
             shard_membership_members[relation]["observed"].extend(
                 pair["observed"]["memberCids"]
             )
+        shard_exempt_seats.extend(
+            dict(seat) for seat in shard_wire["measurementExhaustedSeats"]
+        )
 
     if missing:
         return "unmeasured", unmeasured_envelope(
@@ -2446,6 +2587,12 @@ def compose_from_partials(
             }
             for relation in RELATION_MEMBERSHIP_RELATIONS
         },
+        # Sorted for determinism. A file belongs to exactly one bin, so a
+        # repeated name here is two shards claiming the same seat -- the
+        # authenticator refuses that rather than deduplicating it away.
+        "measurementExhaustedSeats": sorted(
+            shard_exempt_seats, key=lambda seat: str(seat.get("file"))
+        ),
     }
     board = seal_board_from_aggregate(
         agg,

--- a/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/control_effect_recensus.py
@@ -1458,6 +1458,7 @@ def main() -> int:
         live_done = 0
         live_panic = 0  # ConstructionPanic only (file-level kit panic)
         live_defect = 0
+        live_exhausted = 0  # seats the measurement ceiling stopped
         live_fns = 0
         live_clean = 0
         live_clean_refused = False  # any file refused clean → no clean% identity
@@ -1488,6 +1489,8 @@ def main() -> int:
                 )
                 if cat == "panic":
                     live_panic += 1
+                elif cat == "measurement-exhausted":
+                    live_exhausted += 1
                 elif cat not in {"completed", ""}:
                     live_defect += 1
                 live_done += 1
@@ -1774,6 +1777,12 @@ def main() -> int:
                     status = "cpanic"
                 elif cat == "completed":
                     status = "done"
+                elif cat == "measurement-exhausted":
+                    # Its own live counter. Adding it to `defect` would make
+                    # the progress line say the instrument broke on a seat
+                    # where the instrument worked exactly as specified.
+                    live_exhausted += 1
+                    status = "exhausted"
                 else:
                     live_defect += 1
                     status = cat

--- a/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/recensus_enumerate_consumer.py
@@ -620,6 +620,38 @@ RELATION_MEMBERSHIP_ROW_FIELD = "relationMembership"
 RELATION_MEMBERSHIP_GAP_ROW_FIELD = "relationMembershipGaps"
 
 
+def _measurement_exhausted_exemption(
+    file_rel: object, row: object
+) -> dict[str, Any] | None:
+    """The seat's exemption from membership, or None if it is not exempt.
+
+    AUTHENTICATED, not asserted. A row is exempt only if it is an exhausted
+    terminal AND carries the exhaustion payload naming the bound it exceeded
+    and the coordinate it stopped at. A row that merely spells the kind is not
+    exempt -- otherwise the exemption would be a blanket "tolerate missing
+    membership", which re-opens the hole the ceiling exists to close.
+    """
+    if not isinstance(row, Mapping):
+        return None
+    if row.get("terminalKind") != TERMINAL_KIND_EXHAUSTED:
+        return None
+    exhaustion = row.get("measurementExhaustion")
+    if not isinstance(exhaustion, Mapping):
+        return None
+    bound = exhaustion.get("boundSeconds")
+    coordinate = exhaustion.get("coordinate")
+    if not isinstance(bound, (int, float)) or not isinstance(coordinate, str):
+        return None
+    if not coordinate:
+        return None
+    return {
+        "file": str(file_rel),
+        "boundSeconds": bound,
+        "construct": str(exhaustion.get("construct")),
+        "coordinate": coordinate,
+    }
+
+
 def shard_relation_membership_attestation(
     rows,
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -629,6 +661,15 @@ def shard_relation_membership_attestation(
     saw. That shard then stays UNMEASURED and the reason names the files. A
     manifest assembled from the files that could testify would be a smaller
     denominator wearing a seal, which is the #7351 casualty exactly.
+
+    ONE exception, and it is not a tolerance: a seat the measurement ceiling
+    stopped never got far enough to produce membership testimony, so its
+    silence is EXPECTED rather than unexplained. Those seats are named in
+    ``measurementExhaustedSeats`` with the bound they exceeded and the
+    coordinate they stopped at, and the attendance conserves --
+    ``walked == testified + exempt``. Absent-because-measurement-stopped and
+    absent-because-nothing-was-found are two different facts and do not share
+    a representation. Every seat that actually finished must still testify.
     """
     from compose_control_effect_board import RELATION_MEMBERSHIP_RELATIONS
 
@@ -637,7 +678,20 @@ def shard_relation_membership_attestation(
         for relation in RELATION_MEMBERSHIP_RELATIONS
     }
     silent: list[str] = []
+    exempt: list[dict[str, Any]] = []
+    walked = 0
+    testified = 0
     for file_rel, row in rows:
+        walked += 1
+        exemption = _measurement_exhausted_exemption(file_rel, row)
+        if exemption is not None:
+            # A seat the ceiling stopped could not have produced membership
+            # testimony. Refusing the shard for that absence would punish it
+            # for the bound working -- but the seat is NAMED here, not waved
+            # through, and the requirement below still bites for every seat
+            # that actually finished.
+            exempt.append(exemption)
+            continue
         membership = row.get(RELATION_MEMBERSHIP_ROW_FIELD) if isinstance(row, Mapping) else None
         if not isinstance(membership, Mapping):
             silent.append(str(file_rel))
@@ -645,17 +699,28 @@ def shard_relation_membership_attestation(
         if set(membership) != set(RELATION_MEMBERSHIP_RELATIONS):
             silent.append(str(file_rel))
             continue
+        malformed_side = False
         for relation in RELATION_MEMBERSHIP_RELATIONS:
             side = membership[relation]
             if not isinstance(side, Mapping) or set(side) != {"expected", "observed"}:
                 silent.append(str(file_rel))
+                malformed_side = True
                 break
             populations[relation]["expected"].extend(side["expected"])
             populations[relation]["observed"].extend(side["observed"])
+        if not malformed_side:
+            testified += 1
     if silent:
         return None, (
             "relation-membership testimony absent for "
             f"{len(silent)} walked file(s): {sorted(set(silent))[:10]}"
+        )
+    # Counted on the way through, not derived from each other -- `testified =
+    # walked - exempt` would be a tautology dressed as a conservation check.
+    if testified + len(exempt) != walked:
+        raise ValueError(
+            "membership attendance does not conserve: "
+            f"walked={walked} testified={testified} exempt={len(exempt)}"
         )
     from compose_control_effect_board import (
         _RELATION_MEMBERSHIP_SCHEMA,
@@ -665,6 +730,7 @@ def shard_relation_membership_attestation(
     return (
         {
             "schema": _RELATION_MEMBERSHIP_SCHEMA,
+            "measurementExhaustedSeats": exempt,
             "relations": {
                 relation: {
                     "expected": _member_manifest_wire(

--- a/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_board_number_meanings.py
@@ -339,4 +339,8 @@ def _relation_membership(module, files):
     return {
         "schema": "recensus-relation-membership-attestation/v1",
         "relations": relations,
+        # Required, not optional: an empty list says "no seat was exempt",
+        # which is a different fact from a shard that does not report
+        # exemptions at all.
+        "measurementExhaustedSeats": [],
     }

--- a/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_frontier_attestation_seal.py
@@ -812,4 +812,8 @@ def _relation_membership(module, files):
     return {
         "schema": "recensus-relation-membership-attestation/v1",
         "relations": relations,
+        # Required, not optional: an empty list says "no seat was exempt",
+        # which is a different fact from a shard that does not report
+        # exemptions at all.
+        "measurementExhaustedSeats": [],
     }

--- a/implementations/python/sugar-lift-py-tests/tests/test_membership_exempts_only_exhausted_seats.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_membership_exempts_only_exhausted_seats.py
@@ -1,0 +1,402 @@
+"""Membership testimony: exempt the exhausted seat, and ONLY the exhausted seat.
+
+The ceiling worked — eight shards ran to completion, no hangs — and then shard
+4 refused itself anyway, because `core/groupby/generic.py` produced no
+relation-membership testimony and the membership check knew only two outcomes:
+testified, or silent. A seat the bound stopped never got far enough to testify,
+so refusing the shard for that absence punishes it for the bound working.
+
+The mirror of the discriminator already in this branch. Both arms, because a
+blanket "tolerate missing membership" would re-open the hole the ceiling
+closed: every seat that actually FINISHED must still testify.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import compose_control_effect_board as compose  # noqa: E402
+from recensus_enumerate_consumer import (  # noqa: E402
+    RELATION_MEMBERSHIP_ROW_FIELD,
+    shard_relation_membership_attestation,
+)
+
+_RELATIONS = compose.RELATION_MEMBERSHIP_RELATIONS
+
+
+def _testifying_row() -> dict:
+    return {
+        "category": "completed",
+        "terminalKind": "constructed",
+        RELATION_MEMBERSHIP_ROW_FIELD: {
+            relation: {"expected": [], "observed": []} for relation in _RELATIONS
+        },
+    }
+
+
+def _silent_row() -> dict:
+    """Walked, finished, said nothing. Still a refusal."""
+    return {"category": "completed", "terminalKind": "constructed"}
+
+
+def _exhausted_row(file: str = "core/groupby/generic.py") -> dict:
+    return {
+        "category": "measurement-exhausted",
+        "terminalKind": "measurement-exhausted",
+        "measurementExhaustion": {
+            "file": file,
+            "boundSeconds": 300.0,
+            "construct": "SubstituteStatement",
+            "coordinate": "pandas/core/groupby/generic.py:1324 Return",
+        },
+    }
+
+
+# --------------------------------------------------------------------------
+# ARM ONE: the exhausted seat is exempt, and NAMED.
+# --------------------------------------------------------------------------
+
+
+def test_exhausted_seat_does_not_refuse_the_shard() -> None:
+    """Shard 4's exact shape: 177 testifying seats and one the bound stopped."""
+    rows = [(f"f{index}.py", _testifying_row()) for index in range(177)]
+    rows.append(("core/groupby/generic.py", _exhausted_row()))
+    attestation, reason = shard_relation_membership_attestation(rows)
+    assert reason is None, reason
+    assert attestation is not None
+
+
+def test_the_exemption_names_the_bound_and_the_coordinate() -> None:
+    """Not a tolerance — testimony about why testimony is absent.
+
+    "absent because measurement stopped" is a different fact from "absent
+    because nothing was found", and a bare exemption list would let them
+    share a representation.
+    """
+    attestation, reason = shard_relation_membership_attestation(
+        [("core/groupby/generic.py", _exhausted_row())]
+    )
+    assert reason is None
+    seats = attestation["measurementExhaustedSeats"]
+    assert [seat["file"] for seat in seats] == ["core/groupby/generic.py"]
+    assert seats[0]["boundSeconds"] == 300.0
+    assert seats[0]["coordinate"] == "pandas/core/groupby/generic.py:1324 Return"
+    assert seats[0]["construct"] == "SubstituteStatement"
+
+
+def test_the_exemption_survives_the_seal_door() -> None:
+    """The authenticator must accept it and carry it into the conserved wire.
+
+    An exemption the seal drops is an exemption no board reader can audit.
+    """
+    attestation, _ = shard_relation_membership_attestation(
+        [("g.py", _exhausted_row()), ("ok.py", _testifying_row())]
+    )
+    verdict = compose.authenticate_relation_membership(attestation)
+    assert verdict.refusal_reason() is None
+    wire = verdict.conserved_wire()
+    assert [seat["file"] for seat in wire["measurementExhaustedSeats"]] == ["g.py"]
+
+
+def test_attendance_conserves_walked_equals_testified_plus_exempt() -> None:
+    rows = [("a.py", _testifying_row()), ("b.py", _testifying_row())]
+    rows.append(("g.py", _exhausted_row()))
+    attestation, reason = shard_relation_membership_attestation(rows)
+    assert reason is None
+    assert len(attestation["measurementExhaustedSeats"]) == 1
+    # 3 walked = 2 testified + 1 exempt. The producer raises if that fails;
+    # this is the arm that proves the sum is over real counts.
+    assert len(rows) == 2 + len(attestation["measurementExhaustedSeats"])
+
+
+# --------------------------------------------------------------------------
+# ARM TWO: the requirement STILL BITES for every seat that finished.
+# --------------------------------------------------------------------------
+
+
+def test_a_finished_seat_that_says_nothing_still_refuses_the_shard() -> None:
+    """The whole point of not making this a blanket tolerance."""
+    attestation, reason = shard_relation_membership_attestation(
+        [("ok.py", _testifying_row()), ("quiet.py", _silent_row())]
+    )
+    assert attestation is None
+    assert reason is not None
+    assert "quiet.py" in reason
+
+
+def test_a_silent_seat_beside_an_exhausted_one_still_refuses() -> None:
+    """An exempt seat must not carry a silent neighbour through with it."""
+    attestation, reason = shard_relation_membership_attestation(
+        [("g.py", _exhausted_row()), ("quiet.py", _silent_row())]
+    )
+    assert attestation is None
+    assert "quiet.py" in reason
+    assert "g.py" not in reason
+
+
+@pytest.mark.parametrize(
+    "damage,label",
+    [
+        ({"measurementExhaustion": None}, "no exhaustion payload"),
+        ({"measurementExhaustion": {"boundSeconds": 300.0}}, "no coordinate"),
+        (
+            {"measurementExhaustion": {"coordinate": "g.py:1 Return"}},
+            "no bound",
+        ),
+    ],
+)
+def test_a_row_that_merely_spells_the_kind_is_not_exempt(
+    damage: dict, label: str
+) -> None:
+    """AUTHENTICATED, not asserted.
+
+    If spelling `terminalKind` were enough, "exempt" would be a word a shard
+    could write beside any silent file, and the exemption becomes the blanket
+    tolerance it must never be.
+    """
+    row = {**_exhausted_row(), **damage}
+    attestation, reason = shard_relation_membership_attestation([("g.py", row)])
+    assert attestation is None, f"{label} was accepted as an exemption"
+    assert "g.py" in reason
+
+
+# --------------------------------------------------------------------------
+# The seal door's own tooth: an exemption must be backed by a real row.
+# --------------------------------------------------------------------------
+
+
+_DEMAND_CID = "blake3-512:table-a"
+
+
+def _demand_identity() -> dict:
+    from sugar_lift_py_tests.demand_table_identity import DemandTableIdentityV1
+    from compose_control_effect_board import cid_of_json
+
+    seed = DemandTableIdentityV1(
+        content_key="",
+        corpus_manifest_cid="blake3-512:corpus-a",
+        schema_version="python-demand-table/v1",
+        producer_source_cid="blake3-512:producer-a",
+        resolution_config_cid="blake3-512:config-a",
+        parser_identity="cpython-3.12",
+        file_count=2,
+    )
+    return DemandTableIdentityV1(
+        content_key=cid_of_json(dict(seed.preimage())),
+        corpus_manifest_cid=seed.corpus_manifest_cid,
+        schema_version=seed.schema_version,
+        producer_source_cid=seed.producer_source_cid,
+        resolution_config_cid=seed.resolution_config_cid,
+        parser_identity=seed.parser_identity,
+        file_count=seed.file_count,
+    ).as_dict()
+
+
+def _plan(files: list[str]) -> dict:
+    return compose.build_plan(
+        enrolled_files=sorted(files),
+        shard_count=1,
+        measured_commit="c" * 40,
+        aggregate_hash="a" * 64,
+        manifest_shape_cid="sha256:" + "b" * 64,
+        bins=[sorted(files)],
+        split_mode="k1",
+        prior_hits=0,
+        prior_misses=0,
+        estimated_loads=[0.0],
+        demand_table_cid=_DEMAND_CID,
+        demand_table_identity=_demand_identity(),
+    )
+
+
+def test_an_unsupported_exemption_is_refused_at_the_partial_door() -> None:
+    """The attestation is written by the shard whose seats it exempts.
+
+    So a shape check there proves nothing. mint_partial is the one place that
+    holds the terminal rows AND the attestation, and it refuses an exemption
+    with no measurement-exhausted row behind it.
+    """
+    rows = [("quiet.py", _silent_row())]
+    forged = {
+        "schema": compose._RELATION_MEMBERSHIP_SCHEMA,
+        "relations": {
+            relation: {
+                "expected": compose._member_manifest_wire(relation, []),
+                "observed": compose._member_manifest_wire(relation, []),
+            }
+            for relation in _RELATIONS
+        },
+        "measurementExhaustedSeats": [
+            {
+                "file": "quiet.py",
+                "boundSeconds": 300.0,
+                "construct": "X",
+                "coordinate": "quiet.py:1 Return",
+            }
+        ],
+    }
+    partial = compose.mint_partial(
+        plan=_plan(["quiet.py"]),
+        shard_index=0,
+        terminal_rows=rows,
+        measured_commit="c" * 40,
+        demand_table_cid=_DEMAND_CID,
+        demand_table_identity=_demand_identity(),
+        relation_membership_attestation=forged,
+    )
+    assert partial["measured"] is False
+    assert "exemption-unsupported" in str(partial["unmeasuredReason"])
+    assert "quiet.py" in str(partial["unmeasuredReason"])
+
+
+def test_a_supported_exemption_lets_the_shard_publish_a_partial() -> None:
+    """The other side of the same discriminator — run both.
+
+    This is the whole point: shard 4 must be able to write `measured=True`
+    with the bounded seat in it.
+    """
+    rows = [("ok.py", _testifying_row()), ("g.py", _exhausted_row())]
+    attestation, reason = shard_relation_membership_attestation(rows)
+    assert reason is None
+    partial = compose.mint_partial(
+        plan=_plan(["ok.py", "g.py"]),
+        shard_index=0,
+        terminal_rows=rows,
+        measured_commit="c" * 40,
+        demand_table_cid=_DEMAND_CID,
+        demand_table_identity=_demand_identity(),
+        relation_membership_attestation=attestation,
+    )
+    assert partial["measured"] is True, partial["unmeasuredReason"]
+    assert partial["status"] == "completed"
+
+
+def test_an_exhausted_seat_is_not_a_shard_instrument_defect() -> None:
+    """The instrument worked exactly as specified; calling that a defect
+    reports a harness fault for a product fact."""
+    rows = [("g.py", _exhausted_row())]
+    attestation, _ = shard_relation_membership_attestation(rows)
+    partial = compose.mint_partial(
+        plan=_plan(["g.py"]),
+        shard_index=0,
+        terminal_rows=rows,
+        measured_commit="c" * 40,
+        demand_table_cid=_DEMAND_CID,
+        demand_table_identity=_demand_identity(),
+        relation_membership_attestation=attestation,
+    )
+    residuals = partial["shardResiduals"]
+    assert residuals["instrumentDefects"] == []
+    assert residuals["constructionPanics"] == []
+    assert residuals["R_measurement_exhausted_shard"] == 1
+    assert residuals["measurementExhausted"][0]["file"] == "g.py"
+    assert (
+        residuals["measurementExhausted"][0]["coordinate"]
+        == "pandas/core/groupby/generic.py:1324 Return"
+    )
+
+
+def test_a_lying_twin_cannot_buy_exemption_with_a_payload_alone() -> None:
+    """THE tooth. A seat that CONSTRUCTED but carries an exhaustion payload.
+
+    Every other silent fixture in this file lacks the payload, so they are all
+    still refused even if the terminal-kind check is deleted — which means
+    none of them can tell whether that check does any work. This one can: it
+    is well-formed in every respect the payload validator looks at, and the
+    ONLY thing standing between it and an exemption is that its terminalKind
+    says it constructed.
+
+    If this passes without the kind check, "exempt" is purchasable with a
+    payload, and the exemption is the blanket tolerance it must never be.
+    """
+    twin = {
+        "category": "completed",
+        "terminalKind": "constructed",
+        "measurementExhaustion": {
+            "file": "twin.py",
+            "boundSeconds": 300.0,
+            "construct": "SubstituteStatement",
+            "coordinate": "twin.py:1 Return",
+        },
+    }
+    attestation, reason = shard_relation_membership_attestation([("twin.py", twin)])
+    assert attestation is None, (
+        "a constructed seat bought a membership exemption with a payload"
+    )
+    assert "twin.py" in reason
+
+
+def test_the_honest_twin_of_that_pair_is_still_exempt() -> None:
+    """Both sides of the discriminator. Same payload, exhausted kind."""
+    honest = {
+        "category": "measurement-exhausted",
+        "terminalKind": "measurement-exhausted",
+        "measurementExhaustion": {
+            "file": "twin.py",
+            "boundSeconds": 300.0,
+            "construct": "SubstituteStatement",
+            "coordinate": "twin.py:1 Return",
+        },
+    }
+    attestation, reason = shard_relation_membership_attestation([("twin.py", honest)])
+    assert reason is None
+    assert [s["file"] for s in attestation["measurementExhaustedSeats"]] == ["twin.py"]
+
+
+def test_the_exempt_seat_reaches_the_corpus_board_by_name() -> None:
+    """The union must carry it, not just the shard.
+
+    A seat that is exempt in s4 and invisible on the corpus board is a width
+    sealed over a file no reader can see was never measured — the unknown
+    denominator this attestation exists to make impossible.
+    """
+    shard = shard_relation_membership_attestation(
+        [("ok.py", _testifying_row()), ("g.py", _exhausted_row())]
+    )[0]
+    verdict = compose.authenticate_relation_membership(shard)
+    composed = {
+        "schema": compose._RELATION_MEMBERSHIP_SCHEMA,
+        "relations": verdict.conserved_wire()["relations"],
+        "measurementExhaustedSeats": verdict.conserved_wire()[
+            "measurementExhaustedSeats"
+        ],
+    }
+    corpus = compose.authenticate_relation_membership(composed)
+    assert corpus.refusal_reason() is None
+    assert [s["file"] for s in corpus.conserved_wire()["measurementExhaustedSeats"]] == [
+        "g.py"
+    ]
+
+
+def test_two_shards_claiming_the_same_exempt_seat_are_refused() -> None:
+    """A file belongs to exactly one bin.
+
+    The same name twice is two shards claiming one seat, which is a fault to
+    name — not a duplicate to quietly collapse.
+    """
+    seat = {
+        "file": "g.py",
+        "boundSeconds": 300.0,
+        "construct": "SubstituteStatement",
+        "coordinate": "g.py:1 Return",
+    }
+    composed = {
+        "schema": compose._RELATION_MEMBERSHIP_SCHEMA,
+        "relations": {
+            relation: {
+                "expected": compose._member_manifest_wire(relation, []),
+                "observed": compose._member_manifest_wire(relation, []),
+            }
+            for relation in _RELATIONS
+        },
+        "measurementExhaustedSeats": [dict(seat), dict(seat)],
+    }
+    verdict = compose.authenticate_relation_membership(composed)
+    assert verdict.refusal_reason() is not None

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_demand_table_agreement.py
@@ -395,4 +395,8 @@ def _relation_membership(module, files):
     return {
         "schema": "recensus-relation-membership-attestation/v1",
         "relations": relations,
+        # Required, not optional: an empty list says "no seat was exempt",
+        # which is a different fact from a shard that does not report
+        # exemptions at all.
+        "measurementExhaustedSeats": [],
     }

--- a/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_seal.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_recensus_relation_membership_seal.py
@@ -194,6 +194,10 @@ def _membership_attestation(
     return {
         "schema": "recensus-relation-membership-attestation/v1",
         "relations": relations,
+        # Required, not optional: an empty list says "no seat was exempt",
+        # which is a different fact from a shard that does not report
+        # exemptions at all.
+        "measurementExhaustedSeats": [],
     }
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_relation_membership_construct.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_relation_membership_construct.py
@@ -101,6 +101,10 @@ def _membership(module, files) -> dict[str, object]:
     return {
         "schema": "recensus-relation-membership-attestation/v1",
         "relations": relations,
+        # Required, not optional: an empty list says "no seat was exempt",
+        # which is a different fact from a shard that does not report
+        # exemptions at all.
+        "measurementExhaustedSeats": [],
     }
 
 
@@ -377,3 +381,96 @@ def test_two_attesting_shards_seal_the_unioned_population() -> None:
             for file in files
         )
     assert body["bodyCid"]
+
+
+def test_a_bounded_seat_in_one_shard_is_named_on_the_sealed_corpus_board() -> None:
+    """Shard 4's shape, composed for real.
+
+    The measurement ceiling stops one seat; that shard must still seal, and
+    the seat must be visible BY NAME on the corpus board. Building the
+    composed attestation by hand would only prove the hand-built object --
+    this drives ``compose_from_partials``, the door the census actually uses.
+    """
+    module = _load()
+    files = ["pandas/f0.py", "pandas/core/groupby/generic.py"]
+    demand_cid = "blake3-512:table-construct"
+    demand_identity = _demand_identity()
+    plan = module.build_plan(
+        enrolled_files=sorted(files),
+        shard_count=2,
+        measured_commit="098bf65aa",
+        aggregate_hash="agg",
+        manifest_shape_cid="manifest",
+        bins=[[file] for file in sorted(files)],
+        split_mode="fixture",
+        prior_hits=0,
+        prior_misses=2,
+        estimated_loads=[1.0, 1.0],
+        demand_table_cid=demand_cid,
+        demand_table_identity=demand_identity,
+    )
+    runtime = _runtime_attestation()
+    bounded = "pandas/core/groupby/generic.py"
+
+    sys.path.insert(0, str(_SCRIPTS))
+    from recensus_enumerate_consumer import (
+        measurement_exhausted_row,
+        shard_relation_membership_attestation,
+    )
+    from sugar_lift_py_tests.measurement_ceiling import MeasurementCeilingExceeded
+
+    # The REAL row builder, not a hand-rolled dict: the frontier attestation
+    # authenticates these rows, and a fixture that skips that path would seal
+    # a shape the census never produces.
+    exhausted_row = measurement_exhausted_row(
+        MeasurementCeilingExceeded(
+            seat=bounded,
+            bound_seconds=300.0,
+            active_stack=[
+                "SubstituteStatement|temporal|"
+                "pandas/core/groupby/generic.py:1324 Return"
+            ],
+        ),
+        file_rel=bounded,
+        elapsed_seconds=300.1,
+        source_cid=module.canonical_cid({"file": bounded}),
+        function_nodes=[],
+        ast_function_defs=88,
+    )
+
+    partials = []
+    for index, file in enumerate(sorted(files)):
+        if file == bounded:
+            rows = [(file, exhausted_row)]
+            membership, refusal = shard_relation_membership_attestation(rows)
+            assert refusal is None, refusal
+        else:
+            rows = [(file, _row(module, file))]
+            membership = _membership(module, [file])
+        partials.append(
+            module.mint_partial(
+                plan=plan,
+                shard_index=index,
+                terminal_rows=rows,
+                demand_table_cid=demand_cid,
+                demand_table_identity=demand_identity,
+                relation_membership_attestation=membership,
+                runtime_attestation=runtime,
+            )
+        )
+    assert all(p["measured"] for p in partials), [
+        p.get("unmeasuredReason") for p in partials
+    ]
+
+    status, body = module.compose_from_partials(
+        plan, partials, runtime_attestation=runtime
+    )
+    assert status == "sealed", (
+        body.get("unmeasuredReasons"),
+        body.get("instrumentFailures"),
+    )
+    sealed = body["relationMembershipAttestation"]
+    exempt = sealed["measurementExhaustedSeats"]
+    assert [seat["file"] for seat in exempt] == [bounded], exempt
+    assert exempt[0]["boundSeconds"] == 300.0
+    assert exempt[0]["coordinate"] == "pandas/core/groupby/generic.py:1324 Return"

--- a/scripts/mutate_ceiling_one.py
+++ b/scripts/mutate_ceiling_one.py
@@ -117,6 +117,73 @@ MUTATIONS: dict[str, tuple[str, str, str]] = {
         "        banked = progress.get(\"terminalRow\")",
         "        banked = None",
     ),
+    # --- membership-exemption layer (#7415 follow-up) ---
+    #
+    # N1 -- exemption granted on the SPELLING of the kind, with no
+    # authenticated payload behind it. "exempt" becomes a word a shard can
+    # write beside any silent file.
+    "exemption_unauthenticated": (
+        "consumer",
+        '    if not isinstance(bound, (int, float)) or not isinstance(coordinate, str):\n'
+        "        return None\n"
+        "    if not coordinate:\n"
+        "        return None\n",
+        "",
+    ),
+    # N2 -- blanket tolerance: every silent seat is treated as exempt, which
+    # re-opens the exact hole the ceiling closed.
+    "blanket_membership_tolerance": (
+        "consumer",
+        '    if row.get("terminalKind") != TERMINAL_KIND_EXHAUSTED:\n        return None',
+        "    pass",
+    ),
+    # N3 -- the seal door stops cross-checking exemptions against the terminal
+    # rows, so a shard can exempt a seat it never bounded.
+    "exemption_crosscheck_dropped": (
+        "compose",
+        "        unsupported = sorted(claimed - exhausted_files)",
+        "        unsupported = []",
+    ),
+    # N4 -- exhausted rows go back in the instrument-defect bag: a harness
+    # fault reported for a product fact.
+    "exhausted_is_an_instrument_defect": (
+        "compose",
+        '        elif cat == "measurement-exhausted":',
+        '        elif cat == "measurement-exhausted-DISABLED":',
+    ),
+    # N5 -- the exemptions are dropped from the conserved wire, so no board
+    # reader can audit which seats were exempt or why.
+    "exemptions_dropped_from_seal": (
+        "compose",
+        '            "measurementExhaustedSeats": exempt_wire,',
+        '            "measurementExhaustedSeats": [],',
+    ),
+    # N6 -- the payload's own `file` key wins over the walked seat, keying the
+    # shard row on whatever the payload said. This was a REAL defect the
+    # falsifiability arm caught, not a hypothetical.
+    "payload_file_key_wins": (
+        "compose",
+        '                {**exhaustion, "file": file}',
+        '                {"file": file, **exhaustion}',
+    ),
+    # N7 -- the compose union drops the exempt seats, so a seat bounded in one
+    # shard is invisible on the corpus board.
+    "union_drops_exempt_seats": (
+        "compose",
+        "        shard_exempt_seats.extend(",
+        "        [].extend(",
+    ),
+    # N8 -- the SEAL-DOOR copy of the final union keeps only two arms. This
+    # was a real gap merged in #7415: the shard door conserved, the seal door
+    # refused, and nothing caught it until a board actually carried an
+    # exhausted seat through compose_from_partials.
+    "seal_door_union_two_arms": (
+        "compose",
+        "        input_keys=terminal[\"inputKeyManifest\"],\n"
+        "        output_keys=[*constructed, *panicked, *exhausted],",
+        "        input_keys=terminal[\"inputKeyManifest\"],\n"
+        "        output_keys=[*constructed, *panicked],",
+    ),
     "partition_sum_unchecked": (
         "compose",
         "    if accounted != files_terminal:",


### PR DESCRIPTION
`#7415` made an exhausted file a countable row. The census then died at aggregation anyway:

```
RECENSUS RELATION MEMBERSHIP REFUSED shard=4
  relation-membership testimony absent for 1 walked file(s): ['pandas/core/groupby/generic.py']
RECENSUS PARTIAL WRITTEN shard=4 measured=False status=unmeasured
```

A file the bound stopped **cannot** have produced membership testimony. Refusing the shard for its absence punishes the shard for the bound working.

## The exemption, and why it is not a blanket tolerance

A seat is exempt only if its `terminalKind` is exhausted **and** it carries the payload naming the bound it exceeded and the coordinate it stopped at. Stated in the attestation's own vocabulary: `measurementExhaustedSeats`, a **required** (possibly empty) field, so *"no seat was exempt"* is distinguishable from *"this shard does not report exemptions"*.

Attendance conserves: `walked == testified + exempt`, over counts taken **on the way through** rather than derived from each other — `testified = walked - exempt` would be a tautology wearing a conservation check's clothes.

Three teeth hold the line: a **constructed** row carrying a well-formed exhaustion payload is still refused; a silent seat beside an exempt one still refuses the shard; and `mint_partial` — the one place holding both the terminal rows and the attestation — refuses an exemption with no exhausted row behind it, because the attestation is written by the same shard whose seats it exempts, so a shape check there proves nothing about whether the seat was really stopped.

## GAP 1 — a defect in #7415 as merged, and the next wall we would have hit

`_common_conservation` at the **seal door** carries a second copy of the final disjoint union:

```python
final_edge = key_edge_witness(
    stage_id=STAGE_TERMINAL_AGGREGATE_SEAL,
    output_keys=[*constructed, *panicked],      # <- two arms
)
```

`#7415` taught `attest_frontier_rows` about the third member and **not this one**. The duplication is deliberate — the seal re-derives the union so a board cannot be sealed on the strength of a claim it makes about itself — but two doors that must agree only agree if both know the partition has three members. A board that conserved at the shard door would be refused at the seal with `frontier final disjoint union does not conserve`.

The census never reached it because s4 died at membership first. **Fix the membership exemption alone and this is exactly what comes next.** Both copies now carry three arms, with pairwise overlap checks at both doors.

*Two proven halves are not a proof; the connective was a third claim and nobody had measured it.*

## GAP 2 — the corpus board could not see the exempt seat

`compose_from_partials` unioned member manifests across shards but **dropped `measurementExhaustedSeats`**. A seat bounded in s4 was invisible on the corpus board — a width sealed over a file no reader could see is the unknown denominator the attestation exists to make impossible. The union now carries them, sorted, and a name appearing twice is **refused rather than deduplicated**: a file belongs to exactly one bin, so a repeat is two shards claiming one seat.

Both gaps were found by the falsifiability arms, not by reading the code.

## Two mutations that came back GREEN — both were real holes

**`blanket_membership_tolerance`**: deleting the terminal-kind check entirely broke nothing. Every silent fixture lacked an exhaustion payload, so all were refused by the *payload* validator regardless of the kind check — none could tell whether that check did any work. The missing subject was the **lying twin**: a seat that CONSTRUCTED but carries a payload well-formed in every respect the validator inspects, with only its `terminalKind` between it and an exemption. With that test the mutation goes red. Without it, "exempt" was purchasable with a payload.

**`union_drops_exempt_seats`**: the first union test built the composed attestation by hand, so it proved the hand-built object rather than the union. Replaced with one that drives `compose_from_partials` for real, with a real `measurement_exhausted_row` — a hand-rolled dict fails the frontier attestation, which is the point.

`seal_door_union_two_arms` was REFUSED for a duplicate anchor before it ran — which is how the seal door's second copy was discovered at all.

| mutation | red |
|---|---|
| `exemption_unauthenticated` | 2 |
| `blanket_membership_tolerance` | 1 *(after the lying twin)* |
| `exemption_crosscheck_dropped` | 1 |
| `exhausted_is_an_instrument_defect` | 2 |
| `exemptions_dropped_from_seal` | 2 |
| `payload_file_key_wins` | 2 |
| `union_drops_exempt_seats` | 1 *(after the real compose door)* |
| `seal_door_union_two_arms` | 1 *(after a unique anchor)* |

`payload_file_key_wins` was a **real defect**, caught on first run: `{"file": file, **exhaustion}` let the payload's own `file` key override the walked seat, keying the shard row on whatever the payload claimed.

## Also

An exhausted seat is no longer counted as a shard `instrumentDefect` — it gets `shardResiduals.measurementExhausted` and `R_measurement_exhausted_shard`. The instrument did what it was told; reporting that as a defect claims a harness fault as a product fact.

## Verification

Name diff both directions, 13 suites vs `fb31a3c7f`: **zero exclusive failures either direction**, 11 pre-existing reds common to both, 112 passed. Five fixtures needed `"measurementExhaustedSeats": []` because the field is **required** rather than optional — the intended blast radius of *absence is not emptiness*: every producer breaks loudly rather than one silently omitting it.

## Not proven

**No real 1421-file census run.** The unit arms drive the real doors with real row builders, and a two-shard board with a bounded seat seals and names it — but shard 4 was not reproduced end to end. That dispatch is the only thing that proves the eight-shard seal composes.

Related: #7415, #7411.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add measurement-exhausted seat exemptions to relation membership attestation
> - Extends the relation membership attestation schema to require a `measurementExhaustedSeats` list; introduces a new refusal code `relation-membership-exemption-unsupported` when claimed exemptions lack supporting exhausted terminal rows.
> - Measurement-exhausted terminals are no longer classified as instrument defects; they are surfaced separately in shard residuals and tracked as `exhausted` in progress accounting.
> - Adds a new `_measurement_exhausted_exemption` helper that grants exemptions only when a terminal row has kind `TERMINAL_KIND_EXHAUSTED` with a valid `measurementExhaustation` payload.
> - Extends frontier attestation seal validation to enforce pairwise disjointness across constructed, construction-panic, and measurement-exhausted key sets (the third arm); older attestations with no exhausted manifest are treated as empty.
> - Composed boards accumulate `measurementExhaustedSeats` across shards, sorted by file for determinism.
> - Risk: existing attestations missing `measurementExhaustedSeats` will be refused; callers must include the field (may be empty).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ba866b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->