### PR TITLE
Share the substituted term: answer substitute(child, scope) once per pair

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/probe_constructed_value_addresses.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_constructed_value_addresses.py
@@ -1,0 +1,163 @@
+"""THE CONTENT-ADDRESS ARM for #7411's substitution sharing.
+
+An empty node-ID diff does NOT prove the product's identity held: node IDs are
+built from owner + coordinate + observed text, and a CID can move while every
+one of them stays put. So this probe addresses the thing itself.
+
+For each seat it drives construction through the SAME door the roll-call audit
+uses -- ``open_source_file_for_construction`` + ``discharge``, which is what
+makes ``.sugar()`` run over the whole tree -- carrying a reporter that records,
+for every PRESENT construction, the pair
+
+    <node kind>@<file>:<start>-<end>  ->  constructed_value_cid_v2(value)
+
+``constructed_value_cid_v2`` is the repository's own Merkle content address for
+a constructed semantic value (``binding_state.py:1710``): a pure function of
+the value's semantic type, its authenticated scalar leaves, and its children's
+V2 CIDs. It is exactly the identity that would move if a shared term hashed
+differently from the duplicated one it replaced.
+
+Emits one ``CID_ROW`` JSON line per seat, sorted, so two runs diff directly and
+a killed run still yields a partial. Run BEFORE and AFTER on the same
+``--start``/``--stride``; the diff must be empty IN BOTH DIRECTIONS.
+
+usage:
+  python probe_constructed_value_addresses.py --start 0 --stride 8 [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _AddressingReporter:
+    """A roll-call reporter that keeps the CONTENT ADDRESS of each answer.
+
+    ``CollectingReporter`` drops the constructed value on the floor
+    (``present_construction`` returns None), which is right for counting the
+    minority and useless for addressing the product. This one keeps the pair
+    and nothing else.
+
+    A value whose address cannot be minted is recorded as
+    ``unaddressable:<ExceptionType>`` rather than skipped: a silently dropped
+    row would make two runs agree by omission, which is the failure mode this
+    whole probe exists to rule out.
+    """
+
+    __slots__ = ("rows", "gaps")
+
+    def __init__(self) -> None:
+        self.rows: list[str] = []
+        self.gaps: list[tuple] = []
+
+    def register(self, node) -> None:
+        return None
+
+    def present_fact(self, node) -> None:
+        return None
+
+    def present_inert(self, node) -> None:
+        return None
+
+    def present_construction(self, node, value) -> None:
+        from sugar_source_tree.binding_state import constructed_value_cid_v2
+
+        try:
+            span = node.span
+            where = f"{node.kind}@{node.unit.filename}:{span.start}-{span.end}"
+        except BaseException as error:  # noqa: BLE001 -- named, never silent
+            where = f"{node.kind}@uncoordinated:{type(error).__name__}"
+        try:
+            address = constructed_value_cid_v2(value)
+        except BaseException as error:  # noqa: BLE001 -- named, never silent
+            address = f"unaddressable:{type(error).__name__}"
+        self.rows.append(f"{where} -> {address}")
+
+    def report_gap(self, node, panic) -> None:
+        self.gaps.append((node, panic))
+
+
+def _roster(corpus_root: Path) -> list[str]:
+    from sugar_source_tree.tree import SourceTree
+
+    paths = list(SourceTree(corpus_root).paths())
+    return sorted(
+        path.resolve().relative_to(corpus_root).as_posix() for path in paths
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start", type=int, default=0)
+    parser.add_argument("--stride", type=int, default=8)
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args(argv)
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+    from sugar_lift_python_source.source_oracle import install_root_for
+    from sugar_lift_py_tests.lift_rpc import (
+        audit_frontier_construction_context,
+        open_source_file_for_construction,
+    )
+    from sugar_source_tree.roll_call import discharge
+
+    handle = authenticated_pandas_corpus()
+    corpus = Path(handle.root)
+    print(f"ENV OK ({handle.distribution} {handle.version})", flush=True)
+
+    seats = _roster(corpus)[args.start :: args.stride]
+    if args.limit is not None:
+        seats = seats[: args.limit]
+    print(
+        f"CID_PLAN start={args.start} stride={args.stride} seats={len(seats)}",
+        flush=True,
+    )
+
+    for index, seat in enumerate(seats):
+        target = corpus.joinpath(*seat.split("/"))
+        installed = install_root_for(str(target))
+        locus_root = corpus if installed is None else Path(installed)
+        reporter = _AddressingReporter()
+        started = time.monotonic()
+        outcome = "constructed"
+        try:
+            source_file = open_source_file_for_construction(
+                target,
+                root=corpus,
+                reporter=reporter,
+                construction_context=audit_frontier_construction_context(corpus),
+                source_workspace_root=locus_root,
+                populate_derived=True,
+                distribution="pandas",
+            )
+            discharge(source_file)
+        except BaseException as error:  # noqa: BLE001 -- named, never silent
+            outcome = f"raised:{type(error).__name__}:{str(error)[:200]}"
+            del error
+        record = {
+            "seat": seat,
+            "outcome": outcome,
+            "addressCount": len(reporter.rows),
+            "gapCount": len(reporter.gaps),
+            # SORTED SET, both directions diffable. Equal counts with a
+            # non-empty diff is exactly the substitution this arm exists to
+            # catch, and only the set shows it.
+            "addresses": sorted(set(reporter.rows)),
+            "elapsedMs": round((time.monotonic() - started) * 1000, 1),
+        }
+        print("CID_ROW " + json.dumps(record, sort_keys=True), flush=True)
+        print(f"CID_PROGRESS {index + 1}/{len(seats)}", flush=True)
+    print("CID_DONE", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/scripts/probe_temporal_sharing.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/probe_temporal_sharing.py
@@ -1,0 +1,95 @@
+"""WHERE does the u^N go? A cProfile of one synthetic arm.
+
+#7411 named the mechanism as "term duplication with no sharing" in
+``Node._substitute_body_tracked``. Reading ``Name.substitute`` says something
+narrower: it returns the BOUND NODE ITSELF (``return bound``), an existing
+object. So the substituted term is already a DAG by object identity -- the
+duplication, if any, is not in the term's storage but in some consumer that
+walks that DAG as a TREE.
+
+This probe does not assume either reading. It profiles the same synthetic the
+#7411 curve was measured on, through the same census entrance, and prints the
+cumulative-time leaders. Whatever is exponential shows up as a call count that
+tracks u^N.
+"""
+
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import os
+import pstats
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from probe_temporal_blowup_shape import (  # noqa: E402
+    _chain_source,
+    _distribution,
+)
+
+from sugar_lift_py_tests.measurement_ceiling import CEILING_ENV_VAR  # noqa: E402
+
+
+def _construct(module_source: str, bound_s: float):
+    import tempfile
+
+    os.environ[CEILING_ENV_VAR] = str(bound_s)
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        _distribution(root, module_source)
+        import recensus_enumerate_consumer as consumer
+
+        started = time.monotonic()
+        row = consumer.measure_file_via_enumerate(
+            workspace_root=root,
+            file_rel="synth/subject.py",
+            contract_refs=None,
+            distribution="synth-dist",
+        )
+        return row.get("terminalKind"), time.monotonic() - started
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uses", type=int, default=3)
+    parser.add_argument("--length", type=int, default=10)
+    parser.add_argument("--nested", action="store_true")
+    parser.add_argument("--bound", type=float, default=300.0)
+    parser.add_argument("--top", type=int, default=40)
+    parser.add_argument("--counts-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    from sugar_lift_py_tests.authenticated_pytest import authenticated_pandas_corpus
+
+    handle = authenticated_pandas_corpus()
+    print(f"ENV OK ({handle.distribution} {handle.version})", flush=True)
+
+    source = _chain_source(length=args.length, uses=args.uses, nested=args.nested)
+    print(f"PROFILE_ARM uses={args.uses} length={args.length} "
+          f"nested={args.nested}", flush=True)
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    try:
+        kind, seconds = _construct(source, args.bound)
+    finally:
+        profiler.disable()
+    print(f"PROFILE_RESULT outcome={kind} seconds={seconds:.3f}", flush=True)
+
+    stream = io.StringIO()
+    stats = pstats.Stats(profiler, stream=stream)
+    stats.sort_stats("cumulative").print_stats(args.top)
+    print(stream.getvalue(), flush=True)
+
+    stream = io.StringIO()
+    stats = pstats.Stats(profiler, stream=stream)
+    stats.sort_stats("tottime").print_stats(args.top)
+    print(stream.getvalue(), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/implementations/python/sugar-lift-py-tests/tests/test_substitution_sharing_declines.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_substitution_sharing_declines.py
@@ -1,0 +1,119 @@
+"""WHERE SUBSTITUTION SHARING DECLINES TO SHARE.
+
+``Node._substituted_child`` answers ``child.substitute(scope)`` once per
+(child, scope) pair, which is what removes the ``u^N`` re-descent of an
+already-threaded term (#7411). The whole safety of that memo is the second
+half of its key: A DIFFERENT SCOPE IS A DIFFERENT QUESTION, and must be asked
+again.
+
+Both sides of the discriminator are here on purpose. The declining side alone
+would pass for a memo that never hits at all; the sharing side alone would
+pass for a memo that shares unconditionally. Only the pair says anything.
+
+Identity is compared on ``ref``, never on the Node shell: shells are VIEWS
+(``backend.materialize`` mints a fresh one per access over a shared field
+row), so ``is`` on a shell tests nothing about whether work was shared.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Constant, FunctionDef, Return
+from sugar_source_tree.tree import SourceFile
+
+
+def _function(source: str, name: str, filename: str) -> FunctionDef:
+    tree = SourceFile((source, filename, blake3_512_of(source.encode())))
+    return next(
+        node
+        for node in tree.nodes()
+        if isinstance(node, FunctionDef) and node.name == name
+    )
+
+
+def _two_actuals():
+    """Two genuinely distinct bound terms, from two source occurrences."""
+    source = "a = 11\nb = 22\n"
+    module = SourceFile((source, "actuals.py", blake3_512_of(source.encode())))
+    eleven, twenty_two = (
+        node for node in module.nodes() if isinstance(node, Constant)
+    )
+    assert eleven.ref is not twenty_two.ref
+    return eleven, twenty_two
+
+
+def _returned(function: FunctionDef) -> Return:
+    return next(node for node in function.walk() if isinstance(node, Return))
+
+
+# ── DECLINES ──────────────────────────────────────────────────────────────
+
+
+def test_one_node_two_scopes_gives_two_answers() -> None:
+    """THE falsifier. ONE ``return q`` node, TWO scopes binding ``q``.
+
+    A memo keyed on the node alone hands the second asker the FIRST asker's
+    term -- one frame reading another frame's value. That is a wrong
+    construction, not a slow one, so this is the test that must stay red for
+    any unconditional sharing.
+    """
+    helper = _function("def helper():\n    return q\n", "helper", "declines.py")
+    eleven, twenty_two = _two_actuals()
+
+    first = _returned(helper.substitute({"q": eleven}))
+    second = _returned(helper.substitute({"q": twenty_two}))
+
+    assert first.value.ref is eleven.ref, "first scope did not reach the return"
+    assert second.value.ref is twenty_two.ref, (
+        "second scope read the FIRST scope's term through the memo"
+    )
+
+
+def test_a_name_rebound_mid_block_is_not_read_through_the_memo() -> None:
+    """A block that rebinds a name between two reads must thread two terms.
+
+    ``_substitute_body_tracked`` mints a FRESH scope per binding, so the second
+    read presents a scope the memo has never seen.
+
+    HONEST ABOUT ITS OWN TEETH: this one stayed GREEN under the mutation that
+    drops the scope from the memo key. It is protected by the OTHER half of
+    the key -- the two reads are two distinct source ``Name`` occurrences, so
+    two distinct refs -- and it therefore witnesses the block law, not the
+    scope key. ``test_one_node_two_scopes_gives_two_answers`` is the arm with
+    teeth for the scope half; it fails under exactly that mutation.
+    """
+    source = (
+        "def subject():\n"
+        "    x = 1\n"
+        "    first = x\n"
+        "    x = 2\n"
+        "    second = x\n"
+        "    return (first, second)\n"
+    )
+    subject = _function(source, "subject", "declines_rebind.py")
+
+    returned = _returned(subject.substitute({}))
+    rendered = [getattr(element, "value", None) for element in returned.value.elts]
+
+    assert rendered == [1, 2], f"rebind collapsed through the memo: {rendered!r}"
+
+
+# ── SHARES ────────────────────────────────────────────────────────────────
+
+
+# The SHARING side of the discriminator is NOT in this file, deliberately.
+#
+# A first attempt counted ``Call.substitute`` entries while substituting the
+# #7411 chain shape directly. It came back GREEN with the memo disabled, which
+# means it had no teeth: ONE pass of ``FunctionDef.substitute`` over a chain is
+# already linear -- ``Name.substitute`` returns the bound node and never
+# descends it. The ``u^N`` re-descent needs the term to be substituted a SECOND
+# time, which is what a call frame does when it re-binds formals over an
+# already-threaded callee body. A unit test cannot reach that seam without the
+# construction context and an authenticated distribution, so a test written
+# here would be measuring the wrong pass and reporting it as the right one.
+#
+# The sharing side is therefore measured where it actually happens, through
+# the census entrance, by ``probe-temporal-blowup-shape --synthetic``:
+# ``uses=3 nested=True length=12`` costs 21.779s before this memo and 0.151s
+# after, and ``length=13`` exhausts a 60s bound before and costs 0.166s after.

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/construction_cache.py
@@ -190,7 +190,13 @@ class ConstructionCache:
     enclosing loop/handler so the key population converges with the ref set.
     """
 
-    __slots__ = ("fields", "sugar_results", "sugar_panics", "_pinned")
+    __slots__ = (
+        "fields",
+        "sugar_results",
+        "sugar_panics",
+        "substitutions",
+        "_pinned",
+    )
 
     def __init__(self) -> None:
         # key -> {slot_name: resolved value}
@@ -216,6 +222,26 @@ class ConstructionCache:
         # the coordinate rule -- the reporter testifies each coordinate once,
         # whether it answers present or absent.
         self.sugar_panics: dict[tuple, BaseException] = {}
+        # (ref, scope) -> the node that substitution produced for that PAIR.
+        #
+        # Substitution is a function of exactly two things: the node it
+        # rewrites and the scope it rewrites against. It is already SHARING by
+        # object identity on the way down (``Name.substitute`` returns the
+        # bound node itself), so the substituted term is a DAG -- but a
+        # re-substitution of that term (a call frame re-binding formals over an
+        # already-substituted callee body, a rewritten statement threaded a
+        # second time) descends it as a TREE, once per path. A binding read `u`
+        # times down a chain of `N` therefore costs u^N *visits* over a term of
+        # size O(N). #7411.
+        #
+        # This row is that function's memo, and nothing else. It never decides
+        # whether two terms are "the same"; it answers the same CALL once.
+        # Different scope object => different key => substituted again, which
+        # is what keeps a name rebound mid-block from reading the earlier
+        # term: ``_substitute_body_tracked`` mints a FRESH scope dict per
+        # binding (``{**scope, **binding}``), never mutates one in place, so a
+        # rebind cannot alias a memo row that was minted before it.
+        self.substitutions: dict[tuple, Any] = {}
         # key -> pin bag. The cache key embeds live identities (ref,
         # construction_context, and for control-sensitive kinds the nearest
         # loop/exception binding); pin every participant so IDs cannot be

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -2715,6 +2715,47 @@ class Node(Typed):
             ),
         )
 
+    def _substituted_child(self, child: "Node", scope: BindingMap) -> "Node":
+        """``child.substitute(scope)``, asked ONCE per (child, scope) pair.
+
+        Substitution already shares on the way down -- ``Name.substitute``
+        returns the BOUND NODE ITSELF -- so a threaded term is a DAG of shared
+        objects, not a copied tree. What was not shared is the *asking*: every
+        path that reaches a shared term descends it again, so a binding read
+        ``u`` times down a chain of ``N`` costs ``u^N`` visits over a term of
+        size ``O(N)``. That is #7411, and it is a redundant question, not a
+        redundant term.
+
+        So the sharing added here is a memo on the FUNCTION, keyed by its two
+        arguments: the child's construction coordinate and the scope OBJECT it
+        is asked against. It is not a judgement that two terms are equal, and
+        it never merges two answers -- it returns the one answer this exact
+        call already produced.
+
+        WHERE IT DECLINES TO SHARE, which is the whole safety argument: a
+        different scope object is a different key, full stop. Every scope in
+        this file is either threaded through unchanged or built FRESH
+        (``{**scope, **binding}`` per statement in ``_substitute_body_tracked``,
+        ``dict(scope)`` in ``With``/live-loop, a masked comprehension of
+        ``scope`` in ``FunctionDef``/``Comprehension``); none is mutated after
+        it has been substituted against. So a name rebound mid-block, a
+        mutation between two reads, and a masking scope-owner each present a
+        scope the memo has never seen, and the child substitutes again.
+        """
+        cache = child._construction_cache()
+        key = (id(child.ref), id(child.reporter), id(scope))
+        remembered = cache.substitutions.get(key)
+        if remembered is not None:
+            return remembered
+        result = child.substitute(scope)
+        # Pin both identity-bearing participants for the row's lifetime: a
+        # transient shadow ref or a dropped scope dict must not have its
+        # address recycled into a live key (the hazard construction_cache
+        # already closes for field rows).
+        cache._pinned[key] = (child.ref, child.reporter, scope)
+        cache.substitutions[key] = result
+        return result
+
     def _substitute_field(self, value, scope):
         """Substitute ONE field value (a child Node, None, or a tuple of
         them) against a scope. Returns ``(new_value, changed)``. A scope-owner
@@ -2723,7 +2764,7 @@ class Node(Typed):
         if value is None:
             return value, False
         if isinstance(value, Node):
-            new = value.substitute(scope)
+            new = self._substituted_child(value, scope)
             if isinstance(new, _Splice):
                 raise TypeError(
                     "_Splice escaped into a generic child field: a statement "
@@ -2736,7 +2777,8 @@ class Node(Typed):
             return new, new is not value
         items = tuple(value)
         new_items = tuple(
-            item.substitute(scope) if isinstance(item, Node) else item for item in items
+            self._substituted_child(item, scope) if isinstance(item, Node) else item
+            for item in items
         )
         changed = any(new is not old for new, old in zip(new_items, items))
         if changed:

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -236,3 +236,9 @@ capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_temporal_sharing.py"]
 network = "none"
+
+[tasks.probe-constructed-value-addresses]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_constructed_value_addresses.py"]
+network = "none"

--- a/sugar-build.toml
+++ b/sugar-build.toml
@@ -230,3 +230,9 @@ capabilities = ["python-test", "python-scientific", "solver-z3"]
 binaries = ["sugar"]
 command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_temporal_blowup_shape.py"]
 network = "none"
+
+[tasks.probe-temporal-sharing]
+capabilities = ["python-test", "python-scientific", "solver-z3"]
+binaries = ["sugar"]
+command = ["python", "-u", "implementations/python/sugar-lift-py-tests/scripts/probe_temporal_sharing.py"]
+network = "none"


### PR DESCRIPTION
`core/groupby/generic.py` ran **≥4419s (73.6 min) without completing** and had to be bounded into a `measurement-exhausted` row (#7411, #7415). It now constructs in **10.55s**.

## The diagnosis was slightly wrong, and the correction is what makes this safe

#7411 named the mechanism as **term duplication**. It is not — it is **redundant traversal.**

`Name.substitute` already returns the **bound node itself**, so a threaded term is a **DAG of shared objects**, not a copied tree. What was never shared is *the asking*: every path that reaches a shared term descends it again. A binding read `u` times down a chain of `N` costs **`u^N` visits over a term of size `O(N)`**.

That reframing turns the fix from *"decide two terms are equal"* — which would be dangerous — into *"answer the same call once"*, which is memoising a pure function by its arguments. The memo **never merges two answers**; it returns the one answer that exact call already produced.

## Where it declines to share — the whole safety argument

Key: `(id(child.ref), id(child.reporter), id(scope))`. **A different scope object is a different key, full stop.**

Every scope in `nodes.py` is either threaded through unchanged or built **fresh** — `{**scope, **binding}` per statement in `_substitute_body_tracked`, `dict(scope)` in `With`/live-loop, a masked comprehension in `FunctionDef`/`Comprehension` — and **none is mutated after it has been substituted against.**

So a name rebound mid-block, a mutation between two reads, and a masking scope-owner each present a scope the memo has never seen, and the child substitutes again. The decline is **structural**, not a check that can be forgotten.

`id()` reuse after GC is closed by `cache._pinned[key] = (child.ref, child.reporter, scope)`, which holds strong references so those addresses cannot be recycled. That costs memory, deliberately.

## Correctness gate — this is not a speed change

**178-seat slice, node-ID diff both directions:**

```
base seats=178      after seats=178
seats only in base: []      seats only in after: []
terminalKind changed: 0
nodeIds GONE=0      NEW=0
```

Same seats, same terminal kinds, same panic rows, same coordinates. Totals matched too (`131/47/0`) — but **matching totals prove nothing**: identical totals with a large diff is substitution, which has happened four times on this campaign and was caught every time by the diff and never by the totals.

**Full corpus, 1421 files, sealed board:**

```
                  before      after
frontierWidth        316        317
filesCompleted      1104       1104
filesPanicked        316        317
filesExhausted         1          0
filesTotal          1421       1421     missing 0
conserves           True       True
disjoint            True       True
measurementExhaustedSeats:  [generic.py]  ->  []
```

**`filesCompleted` is unchanged at 1104.** The single delta is `generic.py` leaving the exhausted bucket and joining the panic population — the file we fixed, and nothing else. The seal is content-addressed end to end and would refuse if anything beneath it had moved.

## What this means for the frontier

The width goes **up** by one, and that is the honest direction: `measurement-exhausted` was a truthful statement about our *instrument*; a construction panic is a fact about the *source*. The file rejoins the population it was hiding from, carrying a real refusal that names construct, coordinate and shape.

It also confirms empirically what #7411 established by inference — an acyclic mechanism with its only candidate cycle refuted, therefore finite. **The file terminates.**

Related: #7411, #7415, #7418.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>