### PR TITLE
Brand opaque manager producer authority

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -364,7 +364,12 @@ class ContextManagerContractRefV1:
     semantics: ContextManagerSemanticsV1
 
 
-_OPAQUE_CITED_MANAGER_AUTHORITY = object()
+@dataclass(frozen=True, eq=False)
+class _OpaqueCitedManagerAuthority:
+    """Named category whose one producer instance is checked by identity."""
+
+
+_OPAQUE_CITED_MANAGER_AUTHORITY = _OpaqueCitedManagerAuthority()
 
 
 @dataclass(frozen=True)
@@ -404,7 +409,15 @@ class OpaqueCitedContextManagerRefV1:
     target_name: str
     roster: OpaqueSourceCallRosterV1
     citation_cid: str
-    _authority: object = field(init=False, repr=False, compare=False, default=None)
+    _authority: _OpaqueCitedManagerAuthority = field(
+        init=False,
+        repr=False,
+        compare=False,
+        # The public dataclass constructor receives a same-category lie, so it
+        # still reaches the identity guard and refuses. Only the mint door
+        # overwrites this field with the producer singleton below.
+        default_factory=_OpaqueCitedManagerAuthority,
+    )
 
     #: Named so a reader of one row can see the claim without the docstring.
     #: This is testimony, never a bucket key.

--- a/implementations/python/sugar-lift-py-tests/tests/test_opaque_cited_manager_ref.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_opaque_cited_manager_ref.py
@@ -38,6 +38,7 @@ from sugar_lift_py_tests.sugar.sugar_base import Sugar
 from sugar_lift_py_tests.sugar.with_opaque_cited_manager_sugar import (
     WithOpaqueCitedManagerSugar,
 )
+from sugar_source_tree.binding_state import constructed_value_cid_v2
 
 SOURCE_CID = "blake3-512:" + "aa" * 64
 OWNER_CID = "blake3-512:" + "bb" * 64
@@ -233,6 +234,28 @@ def test_ref_cannot_be_constructed_without_producer_authority():
     assert "lacks producer authority" in str(raised.value)
 
 
+def test_ref_refuses_a_nonproducer_value_of_the_authority_category():
+    """Naming the category must not let a caller mint producer testimony."""
+    from sugar_lift_py_tests.context_manager_resolution import (
+        _OPAQUE_CITED_MANAGER_AUTHORITY,
+    )
+
+    ref = _ref()
+    clone = object.__new__(OpaqueCitedContextManagerRefV1)
+    for name, value in (
+        ("use_site", ref.use_site),
+        ("target_name", ref.target_name),
+        ("roster", ref.roster),
+        ("citation_cid", ref.citation_cid),
+        ("uncited", ref.uncited),
+        ("_authority", type(_OPAQUE_CITED_MANAGER_AUTHORITY)()),
+    ):
+        object.__setattr__(clone, name, value)
+    with pytest.raises(ContractRefProtocolError) as raised:
+        clone.__post_init__()
+    assert "lacks producer authority" in str(raised.value)
+
+
 def test_ref_refuses_a_roster_naming_another_call():
     """Citation and roster must name ONE call; cross-wired testimony refuses."""
     from sugar_lift_py_tests.context_manager_resolution import (
@@ -286,6 +309,11 @@ def test_context_manager_edge_wire_refuses_a_citation():
     with pytest.raises(ContextManagerEdgeTransportError) as raised:
         ContextManagerEdgeDtoV1.from_resolved(ref, ref.use_site)
     assert "authenticated derived ref" in str(raised.value)
+
+
+def test_producer_authority_has_a_named_constructed_value_category():
+    """The real With seat canonicalizes without inventing a reflected category."""
+    assert constructed_value_cid_v2(_node()).startswith("blake3-512:")
 
 
 # --------------------------------------------------- absence is not unknown


### PR DESCRIPTION
Fixes #7420.

## Ruling

Take rung 1: brand the sentinel and retain the identity guard.

`OpaqueCitedContextManagerRefV1` exposes a generated dataclass constructor. That constructor is refused today only because its non-producer `_authority` reaches the identity check in `__post_init__`; deleting the field and guard would make direct construction succeed. Repository-wide symbol search found one legitimate minter, but Python's public constructor and `object.__new__` mean the producer door is not structurally the only door. Rung 2's premise is therefore not established.

## Change

- Replace the bare `object()` sentinel with a frozen, identity-only `_OpaqueCitedManagerAuthority` category.
- Type `_authority` as that category. The public constructor receives a fresh same-category lie; only the producer overwrites it with the accepted singleton.
- Preserve the runtime identity guard.
- Add a real `WithOpaqueCitedManagerSugar` canonicalization tooth and a same-category non-producer lying twin.

This shape generalizes to the other bare producer-authority sentinels listed in #7420: name each category, preserve singleton identity, and retain its guard unless that ref's constructor is first made structurally producer-only. This PR converts only the opaque-cited manager seat.

## Delta-epsilon

- Predicted epsilon: remove the `builtins.object` constructed-value category gap at `.contract_ref._authority` for this seat.
- Observed focused result: the new canonicalization test first failed at exactly that path, then passed after branding.
- No live pandas corpus recensus was run, so this PR does not claim a current file-count delta.
- Floors preserved: non-producer refs still refuse; direct construction still refuses; no other authority idiom was softened.

## Lying twin

`test_ref_refuses_a_nonproducer_value_of_the_authority_category` constructs a complete ref carrying a fresh value of the new authority category. With the guard present it raises `ContractRefProtocolError`. Temporarily deleting only the guard made the test fail with `DID NOT RAISE`; the guard was then restored and the focused file rerun green.

## Validation

Baseline failing test names before change: `<none>`.

Focused failing test names after change: `<none>`.

The focused file's 16 zero-argument tests were executed serially through a direct Python harness with the three required source roots. The repository's authenticated `bpytest` runner was attempted first, but failed before collection with exit 125 because Docker received a WSL UNC path (`\\wsl.localhost\\...`) rather than an absolute Linux path; that infrastructure failure is not reported as a test failure.

Additional checks:

- `black==26.5.1 --check` on both changed files
- `python3 -m py_compile` on both changed files
- `git diff --check`

A targeted Pyright probe was not a clean receipt: it reported ten diagnostics outside the changed lines, including unresolved `pytest` in the ad-hoc environment and existing attribute/override diagnostics. Per the brief, no full suite or corpus sweep was run locally; CI is the remaining broad telemetry.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Brand opaque manager producer authority with a named dataclass type
> Replaces the bare `object()` singleton used as producer authority in `OpaqueCitedContextManagerRefV1` with a dedicated frozen dataclass `_OpaqueCitedManagerAuthority` (eq=False), preserving identity-based checks while giving the authority a named type.
>
> - The module-level singleton `_OPAQUE_CITED_MANAGER_AUTHORITY` is now an instance of `_OpaqueCitedManagerAuthority` rather than a plain `object()`.
> - `OpaqueCitedContextManagerRefV1._authority` field type is updated to `_OpaqueCitedManagerAuthority`; `__post_init__` still enforces identity against the singleton.
> - New tests verify that a non-singleton instance of the same category type is rejected with `'lacks producer authority'`, and that the authority node produces a blake3-512 CID prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3760db7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->