### PR TITLE
Close raw call-definition handle escape

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import builtins
 from dataclasses import dataclass, field as dataclass_field
-from typing import Any
+from enum import Enum
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from sugar_lift_py_tests.context_manager_resolution import SourceFragmentCoordinateV1
 
@@ -13,6 +14,48 @@ from sugar_lift_py_tests.sugar.sugar_base import (
     require_constructed_term_sugar,
 )
 from sugar_lift_py_tests.sugar.witnesses import _call_pair
+
+
+class DefinitionOccurrenceAbsenceReasonV1(str, Enum):
+    """Why a call producer positively claims no source definition occurrence."""
+
+    NOT_SOURCE_RESOLVED = "not-source-resolved"
+    NO_LEXICAL_SOURCE_CALL_ROW = "no-lexical-source-call-row"
+
+
+@dataclass(frozen=True)
+class DefinitionOccurrenceAbsentV1:
+    """Positive absence arm for a call's definition reconciliation fields."""
+
+    reason: DefinitionOccurrenceAbsenceReasonV1
+
+    def __post_init__(self) -> None:
+        if type(self.reason) is not DefinitionOccurrenceAbsenceReasonV1:
+            raise TypeError(
+                "DefinitionOccurrenceAbsentV1.reason must be "
+                "DefinitionOccurrenceAbsenceReasonV1"
+            )
+
+
+if TYPE_CHECKING:
+    from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
+
+    DefinitionOccurrenceReconciliationV1: TypeAlias = (
+        FunctionDef
+        | AsyncFunctionDef
+        | ClassDef
+        | DefinitionOccurrenceAbsentV1
+    )
+else:
+    DefinitionOccurrenceReconciliationV1 = object
+
+
+_DEFINITION_NOT_SOURCE_RESOLVED = DefinitionOccurrenceAbsentV1(
+    DefinitionOccurrenceAbsenceReasonV1.NOT_SOURCE_RESOLVED
+)
+_NO_LEXICAL_SOURCE_CALL_ROW = DefinitionOccurrenceAbsentV1(
+    DefinitionOccurrenceAbsenceReasonV1.NO_LEXICAL_SOURCE_CALL_ROW
+)
 
 
 @dataclass(frozen=True)
@@ -48,11 +91,13 @@ class CallSiteSugar(ConstructedTermSugar):
     source_call_frame: Any = dataclass_field(default=None, compare=False)
     source_call_frame_table: Any = dataclass_field(default=None, compare=False)
     source_call_frame_coordinate: Any = dataclass_field(default=None, compare=False)
-    expected_source_call_frame_owner: Any = dataclass_field(default=None, compare=False)
+    expected_source_call_frame_owner: DefinitionOccurrenceReconciliationV1 = (
+        dataclass_field(default=_NO_LEXICAL_SOURCE_CALL_ROW, compare=False)
+    )
     formal_function_sugar: Any = dataclass_field(default=None, compare=False)
     formal_coordinate_cids: tuple[str, ...] = dataclass_field(default=(), compare=False)
-    expected_definition_ref: object | None = dataclass_field(
-        default=None, compare=False
+    expected_definition_ref: DefinitionOccurrenceReconciliationV1 = dataclass_field(
+        default=_DEFINITION_NOT_SOURCE_RESOLVED, compare=False
     )
     native_operation_formal_coordinates: tuple = dataclass_field(
         default=(), compare=False
@@ -73,6 +118,65 @@ class CallSiteSugar(ConstructedTermSugar):
             raise TypeError(
                 "CallSiteSugar.call_occurrence must be SourceFragmentCoordinateV1"
             )
+        self._require_definition_reconciliation(
+            self.expected_definition_ref,
+            coordinate="CallSiteSugar.expected_definition_ref",
+        )
+        self._require_definition_reconciliation(
+            self.expected_source_call_frame_owner,
+            coordinate="CallSiteSugar.expected_source_call_frame_owner",
+        )
+        if isinstance(
+            self.expected_definition_ref, DefinitionOccurrenceAbsentV1
+        ) and self.source_call_frame is not None:
+            raise TypeError(
+                "CallSiteSugar.expected_definition_ref cannot claim absence "
+                "when source_call_frame is present"
+            )
+        if isinstance(
+            self.expected_source_call_frame_owner,
+            DefinitionOccurrenceAbsentV1,
+        ) and self.source_call_frame_table is not None:
+            raise TypeError(
+                "CallSiteSugar.expected_source_call_frame_owner cannot claim "
+                "absence when source_call_frame_table is present"
+            )
+
+    @staticmethod
+    def _require_definition_reconciliation(
+        value: object, *, coordinate: str
+    ) -> None:
+        from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
+
+        if not isinstance(
+            value,
+            (
+                FunctionDef,
+                AsyncFunctionDef,
+                ClassDef,
+                DefinitionOccurrenceAbsentV1,
+            ),
+        ):
+            raise TypeError(
+                f"{coordinate} must be a projected definition occurrence or "
+                "DefinitionOccurrenceAbsentV1; got "
+                f"{type(value).__name__}"
+            )
+
+    @staticmethod
+    def _reconciled_definition_ref(value: object) -> object | None:
+        from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef, FunctionDef
+
+        match value:
+            case DefinitionOccurrenceAbsentV1():
+                return None
+            case FunctionDef() | AsyncFunctionDef() | ClassDef() as definition:
+                return definition.ref
+            case _:
+                raise TypeError(
+                    "definition reconciliation must be a projected definition "
+                    "occurrence or DefinitionOccurrenceAbsentV1"
+                )
 
     @classmethod
     def witnesses(cls):
@@ -186,32 +290,20 @@ class CallSiteSugar(ConstructedTermSugar):
         )
 
     def desugar(self, ctx: object = None) -> Outcome:
-        if (
-            self.source_call_frame is not None
-            and self.expected_definition_ref is not None
-        ):
+        if self.source_call_frame is not None:
             from sugar_source_tree.panic import SugarNotWritten
             from sugar_source_tree.nodes import (
                 AsyncFunctionDef,
-                ClassDef,
                 FunctionDef,
             )
 
-            # A projected ALLOCATION callee is a ClassDef occurrence, so it
-            # answers with `.ref` exactly as a projected function does. Without
-            # this arm it fell to the raw-handle branch and compared a typed
-            # node against a ref, which never matches.
-            if isinstance(
-                self.expected_definition_ref,
-                (FunctionDef, AsyncFunctionDef, ClassDef),
-            ):
-                owner_matches = (
-                    self.source_call_frame.owner.ref is self.expected_definition_ref.ref
-                )
-            else:
-                owner_matches = (
-                    self.source_call_frame.owner.ref is self.expected_definition_ref
-                )
+            expected_definition_ref = self._reconciled_definition_ref(
+                self.expected_definition_ref
+            )
+            owner_matches = (
+                expected_definition_ref is not None
+                and self.source_call_frame.owner.ref is expected_definition_ref
+            )
             if not owner_matches:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
@@ -342,11 +434,15 @@ class CallSiteSugar(ConstructedTermSugar):
             source_call_frame = self.source_call_frame_table.get(
                 self.source_call_frame_coordinate
             )
-            if (
-                source_call_frame is None
-                or source_call_frame.owner.ref
-                is not self.expected_source_call_frame_owner
-            ):
+            expected_owner_ref = self._reconciled_definition_ref(
+                self.expected_source_call_frame_owner
+            )
+            owner_matches = (
+                source_call_frame is not None
+                and expected_owner_ref is not None
+                and source_call_frame.owner.ref is expected_owner_ref
+            )
+            if source_call_frame is None or not owner_matches:
                 raise SugarNotWritten(
                     owner="CallSiteSugar.desugar",
                     blame=self.site,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -697,13 +697,51 @@ class ConstructionTestimonyReporterV1:
         return None
 
     def present_construction(self, node: Node, value: object) -> None:
-        from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+        from sugar_lift_py_tests.sugar.call_site_sugar import (
+            CallSiteSugar,
+            DefinitionOccurrenceAbsentV1,
+        )
         from sugar_source_tree.nodes import Call, FunctionDef, AsyncFunctionDef
 
         if (
             isinstance(node, Call)
             and isinstance(value, CallSiteSugar)
-            and value.expected_definition_ref is not None
+            and isinstance(
+                value.expected_definition_ref, DefinitionOccurrenceAbsentV1
+            )
+            and value.source_call_frame is not None
+        ):
+            self._testimony_gap(
+                node,
+                value,
+                "constructed value",
+                ValueError(
+                    "source-backed call falsely claims no definition occurrence"
+                ),
+            )
+        if (
+            isinstance(node, Call)
+            and isinstance(value, CallSiteSugar)
+            and isinstance(
+                value.expected_source_call_frame_owner,
+                DefinitionOccurrenceAbsentV1,
+            )
+            and value.source_call_frame_table is not None
+        ):
+            self._testimony_gap(
+                node,
+                value,
+                "constructed value",
+                ValueError(
+                    "seated source-frame table falsely claims no lexical owner"
+                ),
+            )
+        if (
+            isinstance(node, Call)
+            and isinstance(value, CallSiteSugar)
+            and not isinstance(
+                value.expected_definition_ref, DefinitionOccurrenceAbsentV1
+            )
         ):
             from sugar_lift_py_tests.context_manager_resolution import (
                 SourceFragmentCoordinateV1,

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3268,13 +3268,10 @@ class Node(Typed):
             sugar=f"{self.kind}.sugar", role="construction", site=where
         ):
             try:
-                result = self._project_constructed_value_for_testimony(
-                    self._construct_sugar()
-                )
-                # Testimony projection is INSIDE the discharge, not after it.
-                # A constructed value whose testimony cannot be content-
-                # addressed raises ConstructedValueTestimonyNotWritten here, so
-                # the coordinate records the ABSENT answer (memoized panic, gap
+                result = self._construct_sugar()
+                # A constructed value whose testimony cannot be content-addressed
+                # raises ConstructedValueTestimonyNotWritten here, so the
+                # coordinate records the ABSENT answer (memoized panic, gap
                 # already testified through the reporter) instead of a present
                 # answer whose testimony silently failed to exist.
                 self.reporter.present_construction(self, result)
@@ -3364,10 +3361,6 @@ class Node(Typed):
             span.end_line,
             span.end_col,
         )
-
-    def _project_constructed_value_for_testimony(self, value: object) -> object:
-        """Project parser machinery before constructed-value testimony."""
-        return value
 
     def _authenticated_new_constructor_shape(self):
         """Source-owned ``__new__`` allocation shape, or None.
@@ -11361,48 +11354,33 @@ class Call(Expression):
                     seen[node.object_identity_cid] = node
         return tuple(seen.values())
 
-    def _project_constructed_value_for_testimony(self, value: object) -> object:
-        """Replace a parser definition handle with this roll's typed occurrence."""
-        from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
-
-        if not isinstance(value, CallSiteSugar):
-            return value
-        definition_ref = value.expected_definition_ref
-        # An allocation callee's definition occurrence is a ClassDef. It is the
-        # SAME projection -- a parser handle standing in for this roll's typed
-        # occurrence -- and leaving it unprojected left the identity guard
-        # holding a raw `_Handle` and naming the wrong fault.
-        if definition_ref is None or isinstance(
-            definition_ref, (FunctionDef, AsyncFunctionDef, ClassDef)
-        ):
-            return value
-        lookup = getattr(self.reporter, "materialized_node_for_ref", None)
-        if lookup is None:
-            return value
-        definition = lookup(definition_ref)
-        if definition is None and value.source_call_frame is not None:
-            producer_definition = value.source_call_frame.owner
-            if (
-                isinstance(
-                    producer_definition, (FunctionDef, AsyncFunctionDef, ClassDef)
-                )
-                and producer_definition.ref is definition_ref
-            ):
-                retain = getattr(self.reporter, "retain_registered_node_from", None)
-                if retain is not None:
-                    definition = retain(
-                        producer_definition, producer_definition.reporter
-                    )
+    def _project_call_definition_occurrence(
+        self, definition: object, *, coordinate: str
+    ) -> "FunctionDef | AsyncFunctionDef | ClassDef":
+        """Reconcile a producer definition with this call reporter before mint."""
         if not isinstance(definition, (FunctionDef, AsyncFunctionDef, ClassDef)):
-            return value
-        source_call_frame = value.source_call_frame
-        if source_call_frame is not None:
-            source_call_frame = replace(source_call_frame, owner=definition)
-        return replace(
-            value,
-            expected_definition_ref=definition,
-            source_call_frame=source_call_frame,
-        )
+            raise BackendDefect(
+                owner="Call._construct_sugar",
+                blame=self.fragment,
+                observed=f"{coordinate} producer supplied {type(definition).__name__}",
+                requested="a typed source definition occurrence to reconcile",
+                fix="project the parser handle through the call reporter before minting CallSiteSugar",
+            )
+        if self.reporter is definition.reporter:
+            return definition
+        retain = getattr(self.reporter, "retain_registered_node_from", None)
+        if retain is None:
+            return definition
+        projected = retain(definition, definition.reporter)
+        if not isinstance(projected, (FunctionDef, AsyncFunctionDef, ClassDef)):
+            raise BackendDefect(
+                owner="Call._construct_sugar",
+                blame=self.fragment,
+                observed=f"{coordinate} could not project {type(definition.ref).__name__}",
+                requested="this roll's exact typed source definition occurrence",
+                fix="repair definition registration or keep the call loud before CallSiteSugar construction",
+            )
+        return projected
 
     def _construct_sugar(self):
         """A call constructs its callee's sugar WITH the argument sugars.
@@ -11582,7 +11560,11 @@ class Call(Expression):
                 )
         if source_call_frame is not None:
             from sugar_lift_py_tests.source_call_frame import SourceCallBindingGap
-            from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+            from sugar_lift_py_tests.sugar.call_site_sugar import (
+                CallSiteSugar,
+                DefinitionOccurrenceAbsentV1,
+                DefinitionOccurrenceAbsenceReasonV1,
+            )
 
             if any(keyword.arg is None for keyword in self.keywords):
                 raise SourceCallBindingGap(
@@ -11624,6 +11606,11 @@ class Call(Expression):
                     keywords=keyword_sugars,
                     source_call_frame=bound_frame,
                 )
+            projected_definition = self._project_call_definition_occurrence(
+                bound_frame.owner,
+                coordinate="CallSiteSugar.expected_definition_ref",
+            )
+            bound_frame = replace(bound_frame, owner=projected_definition)
             return CallSiteSugar(
                 target_name=f"python:resolved-source-call:{bound_frame.frame_cid}",
                 args=tuple(a.sugar() for a in self.args),
@@ -11649,14 +11636,23 @@ class Call(Expression):
                     coordinate if lexical_row is not None else None
                 ),
                 expected_source_call_frame_owner=(
-                    lexical_row.definition_occurrence_identity
+                    self._project_call_definition_occurrence(
+                        lexical_row.definition_occurrence,
+                        coordinate="CallSiteSugar.expected_source_call_frame_owner",
+                    )
                     if lexical_row is not None
-                    else None
+                    else DefinitionOccurrenceAbsentV1(
+                        DefinitionOccurrenceAbsenceReasonV1.NO_LEXICAL_SOURCE_CALL_ROW
+                    )
                 ),
-                expected_definition_ref=bound_frame.owner.ref,
+                expected_definition_ref=projected_definition,
             )
         if isinstance(self.func, Name):
-            from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+            from sugar_lift_py_tests.sugar.call_site_sugar import (
+                CallSiteSugar,
+                DefinitionOccurrenceAbsentV1,
+                DefinitionOccurrenceAbsenceReasonV1,
+            )
 
             # The call-site coordinate absorbs the callee's spelling instead of
             # its sugar, so the callee never constructs. That absorption IS its
@@ -11788,6 +11784,25 @@ class Call(Expression):
                     )
                 )
 
+            definition_occurrence = (
+                function_definition
+                if function_definition is not None
+                else definition
+            )
+            if definition_occurrence is None:
+                expected_definition = DefinitionOccurrenceAbsentV1(
+                    DefinitionOccurrenceAbsenceReasonV1.NOT_SOURCE_RESOLVED
+                )
+            else:
+                expected_definition = self._project_call_definition_occurrence(
+                    definition_occurrence,
+                    coordinate="CallSiteSugar.expected_definition_ref",
+                )
+                if source_call_frame is not None:
+                    source_call_frame = replace(
+                        source_call_frame, owner=expected_definition
+                    )
+
             return CallSiteSugar(
                 target_name=self.func.id,
                 args=tuple(a.sugar() for a in self.args),
@@ -11799,9 +11814,7 @@ class Call(Expression):
                 source_call_frame=source_call_frame,
                 formal_function_sugar=formal_function_sugar,
                 formal_coordinate_cids=formal_coordinate_cids,
-                expected_definition_ref=(
-                    None if function_definition is None else function_definition.ref
-                ),
+                expected_definition_ref=expected_definition,
                 native_operation_formal_coordinates=tuple(formal_coordinates),
             )
         if isinstance(self.func, Attribute):

--- a/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
+++ b/implementations/python/sugar-source-tree/tests/test_cpython_call_handle_testimony.py
@@ -8,6 +8,11 @@ import pytest
 
 from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
 from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.sugar.call_site_sugar import (
+    CallSiteSugar,
+    DefinitionOccurrenceAbsentV1,
+    DefinitionOccurrenceAbsenceReasonV1,
+)
 
 from sugar_lift_python_source.dependency_artifact import DependencyArtifactGraph
 from sugar_source_tree.backend import materialize
@@ -119,13 +124,12 @@ def test_parser_call_definition_is_materialized_before_reporter_testimony(
 def test_raw_or_reminted_parser_handle_never_becomes_semantic_testimony(
     tmp_path,
 ) -> None:
-    _source, _definition, call = _enum_call()
-    pre_reporter = call._construct_sugar()
-    raw_handle = pre_reporter.expected_definition_ref
-    _reminted_source, _reminted_definition, reminted_call, reminted_reporter = (
+    _source, definition, call = _enum_call()
+    raw_handle = definition.ref
+    _reminted_source, reminted_definition, reminted_call, reminted_reporter = (
         _ordinary_call(tmp_path, helper="_is_single_bit", caller="other_call")
     )
-    reminted_handle = reminted_call._construct_sugar().expected_definition_ref
+    reminted_handle = reminted_definition.ref
     assert reminted_handle is not raw_handle
 
     # The current offender is retained only to prove the adapter object itself
@@ -138,6 +142,71 @@ def test_raw_or_reminted_parser_handle_never_becomes_semantic_testimony(
     with pytest.raises(ConstructedValueTestimonyNotWritten) as reminted_gap:
         reminted_reporter.present_construction(reminted_call, reminted_handle)
     assert "cpython_adapter._Handle" in str(reminted_gap.value)
+
+
+def test_call_site_constructor_refuses_raw_definition_handle(tmp_path) -> None:
+    """The handle escape stops at the field, before testimony can inspect it."""
+    _source, definition, call, _reporter = _ordinary_call(
+        tmp_path, helper="predicate", caller="apply"
+    )
+    raw_handle = definition.ref
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"CallSiteSugar\.expected_definition_ref must be a projected "
+            r"definition occurrence or DefinitionOccurrenceAbsentV1; got _Handle"
+        ),
+    ):
+        CallSiteSugar(
+            target_name="predicate",
+            args=(),
+            site=call.fragment,
+            expected_definition_ref=raw_handle,
+        )
+
+
+def test_call_site_constructor_refuses_raw_frame_owner_handle(tmp_path) -> None:
+    """The primary 24-seat escape cannot inhabit the frame-owner coordinate."""
+    _source, definition, call, _reporter = _ordinary_call(
+        tmp_path, helper="predicate", caller="apply"
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"CallSiteSugar\.expected_source_call_frame_owner must be a projected "
+            r"definition occurrence or DefinitionOccurrenceAbsentV1; got _Handle"
+        ),
+    ):
+        CallSiteSugar(
+            target_name="predicate",
+            args=(),
+            site=call.fragment,
+            expected_source_call_frame_owner=definition.ref,
+        )
+
+
+def test_source_backed_call_refuses_a_false_definition_absence(tmp_path) -> None:
+    """Positive absence cannot bypass source-call identity testimony."""
+    _source, _definition, call, _reporter = _ordinary_call(
+        tmp_path, helper="predicate", caller="apply"
+    )
+    truthful = call._construct_sugar()
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"CallSiteSugar\.expected_definition_ref cannot claim absence "
+            r"when source_call_frame is present"
+        ),
+    ):
+        replace(
+            truthful,
+            expected_definition_ref=DefinitionOccurrenceAbsentV1(
+                DefinitionOccurrenceAbsenceReasonV1.NOT_SOURCE_RESOLVED
+            ),
+        )
 
 
 @pytest.mark.parametrize(
@@ -165,11 +234,17 @@ def test_call_definition_testimony_rejects_foreign_or_wrong_occurrence(
     else:
         lie = definition.sugar
 
-    substituted = replace(truthful, expected_definition_ref=lie)
-    with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
-        reporter.present_construction(call, substituted)
-    assert "CollectingReporter.present_construction" in str(gap.value)
-    assert call.unit.filename in str(gap.value)
+    if axis == "foreign-source":
+        substituted = replace(truthful, expected_definition_ref=lie)
+        with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
+            reporter.present_construction(call, substituted)
+        assert "CollectingReporter.present_construction" in str(gap.value)
+        assert call.unit.filename in str(gap.value)
+    else:
+        with pytest.raises(
+            TypeError, match=r"CallSiteSugar\.expected_definition_ref"
+        ):
+            replace(truthful, expected_definition_ref=lie)
 
 
 # ---------------------------------------------------------------------------
@@ -178,12 +253,7 @@ def test_call_definition_testimony_rejects_foreign_or_wrong_occurrence(
 
 
 def test_every_identity_refusal_names_which_term_refused(tmp_path) -> None:
-    """A countable row is not an actionable one.
-
-    All four axes below are genuinely different defects asking for different
-    repairs. If they all print the same sentence, the board can count them and
-    nobody can fix them.
-    """
+    """Illegal categories stop at mint; a typed foreign definition goes on."""
     _source, definition, call, reporter = _ordinary_call(
         tmp_path, helper="predicate", caller="apply"
     )
@@ -193,26 +263,21 @@ def test_every_identity_refusal_names_which_term_refused(tmp_path) -> None:
     )
     assert foreign_source.unit.source_cid != call.unit.source_cid
 
-    seen = set()
-    for lie in (
-        foreign_definition,
-        foreign_call,
-        definition.body[0],
-        definition.sugar,
-    ):
-        substituted = replace(truthful, expected_definition_ref=lie)
-        with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
-            reporter.present_construction(call, substituted)
-        named = [
-            term
-            for term in ConstructionTestimonyReporterV1.SOURCE_CALL_IDENTITY_TERMS
-            if term in str(gap.value)
-        ]
-        # Exactly one term, never zero (lumped) and never several (ambiguous).
-        assert len(named) == 1, (named, str(gap.value))
-        seen.add(named[0])
-    # The four lies are not all one fault wearing four costumes.
-    assert len(seen) > 1, seen
+    for lie in (foreign_call, definition.body[0], definition.sugar):
+        with pytest.raises(
+            TypeError, match=r"CallSiteSugar\.expected_definition_ref"
+        ):
+            replace(truthful, expected_definition_ref=lie)
+
+    substituted = replace(truthful, expected_definition_ref=foreign_definition)
+    with pytest.raises(ConstructedValueTestimonyNotWritten) as gap:
+        reporter.present_construction(call, substituted)
+    named = [
+        term
+        for term in ConstructionTestimonyReporterV1.SOURCE_CALL_IDENTITY_TERMS
+        if term in str(gap.value)
+    ]
+    assert len(named) == 1, (named, str(gap.value))
 
 
 def test_the_seal_term_is_unreachable_without_a_resolved_definition(tmp_path) -> None:
@@ -234,7 +299,7 @@ def test_the_seal_term_is_unreachable_without_a_resolved_definition(tmp_path) ->
     # ``call-occurrence-mismatch`` (a red that predates this change and is
     # tracked separately). Riding on it would make this tooth report that
     # defect instead of the one it is here to catch.
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     definition = truthful.expected_definition_ref
     call_occurrence = truthful.call_occurrence
     frame = truthful.source_call_frame
@@ -328,7 +393,7 @@ def test_a_cross_file_enrolled_callee_is_not_an_identity_fault(tmp_path) -> None
     our instrument, not a defect in pandas.
     """
     definition, call, reporter = _two_files_one_roll(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = definition.source_visible_call_frame()
 
     fault = reporter._source_call_identity_fault(
@@ -347,7 +412,7 @@ def test_an_unauthenticated_callee_unit_still_refuses_by_its_own_name(
     refused under a DIFFERENT name than the cross-file case above returns.
     """
     definition, call, reporter = _two_files_one_roll(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = definition.source_visible_call_frame()
     object.__setattr__(definition.unit, "source_cid", "")
 
@@ -365,7 +430,7 @@ def test_an_opaque_callee_keeps_its_own_separate_name(tmp_path) -> None:
     relaxing the same-unit demand cannot let one through.
     """
     definition, call, reporter = _two_files_one_roll(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
 
     class _OpaqueHandle:
         """Stands where a raw parser handle arrives: no unit, no fragment."""
@@ -381,7 +446,7 @@ def test_the_frame_site_term_is_keyed_on_the_definitions_unit(tmp_path) -> None:
     callee's file. Keying it on the caller's unit was the same-unit demand
     wearing a second name -- it refused every cross-file call a second time."""
     definition, call, reporter = _two_files_one_roll(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = definition.source_visible_call_frame()
 
     # The callee's own site passes ...
@@ -459,7 +524,7 @@ def test_the_third_authority_accepts_the_true_cross_file_callee(tmp_path) -> Non
     """The truthful arm of the twin, so the refusal below is discrimination
     and not a guard that refuses everything."""
     top_level, _nested, call, reporter = _shadowing_callee_unit(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = top_level.source_visible_call_frame()
 
     # Exactly what `present_construction` now supplies: the caller's unit has
@@ -490,7 +555,7 @@ def test_a_shadowed_same_name_definition_is_REFUSED(tmp_path) -> None:
     out: it would convert 81 loud rows into 81 silent ones.
     """
     _top_level, nested, call, reporter = _shadowing_callee_unit(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = nested.source_visible_call_frame()
 
     # The third authority does NOT return the nested impostor: it reads the
@@ -582,7 +647,7 @@ def test_a_class_callee_carries_a_derivable_constructor_law(tmp_path) -> None:
 def test_the_third_authority_accepts_the_true_allocation_callee(tmp_path) -> None:
     """The truthful arm, so the refusal below is discrimination."""
     top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = top_level.source_visible_constructor_frame()
 
     resolved = _callee_definition_by_name_in_its_unit(top_level)
@@ -606,7 +671,7 @@ def test_a_shadowed_same_name_CLASS_is_REFUSED(tmp_path) -> None:
     would convert 78 loud rows into 78 silent ones.
     """
     _top_level, nested, call, reporter = _shadowing_allocation_unit(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = nested.source_visible_constructor_frame()
 
     resolved = _callee_definition_by_name_in_its_unit(nested)
@@ -630,7 +695,7 @@ def test_a_class_resolving_to_a_function_of_the_same_name_is_REFUSED(
     names the wrong repair.
     """
     top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
     frame = top_level.source_visible_constructor_frame()
     _source, function_definition, _fn_call, _fn_reporter = _ordinary_call(
         tmp_path, helper="Boom", caller="apply_function"
@@ -657,7 +722,7 @@ def test_an_opaque_allocation_callee_still_refuses_by_its_own_name(
     all. An unmaterialized handle is still `definition-not-a-functiondef`.
     """
     top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
-    truthful = call._project_constructed_value_for_testimony(call._construct_sugar())
+    truthful = call._construct_sugar()
 
     class _OpaqueHandle:
         """Stands where a raw parser handle arrives: no unit, no fragment."""
@@ -693,36 +758,11 @@ def test_a_class_definition_shows_up_on_the_roll(tmp_path) -> None:
 def test_an_allocation_handle_is_projected_to_its_typed_class_occurrence(
     tmp_path,
 ) -> None:
-    """The projection arm, which no other tooth reaches.
-
-    On the production path an allocation call carries
-    ``expected_definition_ref=bound_frame.owner.ref`` -- a raw parser handle,
-    not a typed node. Every other allocation tooth hands the guard a typed
-    definition directly and so routes AROUND the projection; a mutation that
-    dropped its ClassDef arm failed nothing at all. This is that tooth.
-    """
-    top_level, _nested, call, reporter = _shadowing_allocation_unit(tmp_path)
+    """The producer closes the field before CallSiteSugar can be minted."""
+    top_level, _nested, call, _reporter = _shadowing_allocation_unit(tmp_path)
     constructed = call._construct_sugar()
-    # Exactly what the preconstruction branch installs.
-    with_handle = replace(constructed, expected_definition_ref=top_level.ref)
-    assert not isinstance(with_handle.expected_definition_ref, ClassDef)
-
-    projected = call._project_constructed_value_for_testimony(with_handle)
-
-    assert isinstance(projected.expected_definition_ref, ClassDef), (
-        projected.expected_definition_ref
-    )
+    assert constructed.expected_definition_ref is top_level
     assert (
-        projected.expected_definition_ref.fragment.seal()
+        constructed.expected_definition_ref.fragment.seal()
         == top_level.fragment.seal()
     )
-    # And the projected occurrence is one the guard can actually admit: a raw
-    # handle stops at term 1, a projected class reaches the seal join.
-    assert reporter._source_call_identity_fault(
-        call,
-        projected,
-        with_handle.expected_definition_ref,
-        top_level,
-        projected.call_occurrence,
-        top_level.source_visible_constructor_frame(),
-    ) == "definition-not-a-functiondef"


### PR DESCRIPTION
## Summary

- closes both `CallSiteSugar` definition-reconciliation coordinates over projected `FunctionDef` / `AsyncFunctionDef` / `ClassDef` occurrences or a typed positive-absence claim
- moves reconciliation into `Call._construct_sugar` before the value is minted, and retires the shallow late testimony-projection hook
- keeps raw `cpython_adapter._Handle` values loud at the constructor, including the primary `expected_source_call_frame_owner` coordinate
- rejects false positive-absence claims when a source frame or frame table is present, with defensive testimony refusals behind the constructor

The bypass was a shallow post-construction rewrite: `Node.sugar()` invoked `Call._project_constructed_value_for_testimony` only after `CallSiteSugar` had already admitted open `Any` / `object | None` fields. That rewrite handled `expected_definition_ref` and `source_call_frame.owner`, but omitted `expected_source_call_frame_owner` and could not reach raw handles nested inside already-constructed values. Construction now carries the typed semantic occurrence itself, or a named absence reason, so the compatibility branch is gone.

Closes #7421.

## Predicted Epsilon R (construction / wall lanes)

| bucket | predicted Δ | why |
| --- | ---: | --- |
| `constructed` | unmeasured | no pandas frontier recensus was run or claimed; this PR measures early category closure, not canonicalization |
| `mandatory_panics` | unmeasured | remaining raw-handle producers are expected to become fewer, earlier coordinate-named failures |
| `suppressed_descendants` | 0 | no suppression policy changed |
| `typed_effects` | 0 | no effect family changed |
| `silent` | 0 | floor: raw handles cannot become accepted testimony |

## Validation

- Authenticated focused baseline on `eeff6262e`: 23 collected, 11 passed, 12 failed.
- Authenticated focused final: 26 collected, 14 passed, 12 failed.
- The exact failing names are identical before and after:
  - `test_a_cross_file_enrolled_callee_is_not_an_identity_fault`
  - `test_an_unauthenticated_callee_unit_still_refuses_by_its_own_name`
  - `test_an_opaque_callee_keeps_its_own_separate_name`
  - `test_the_frame_site_term_is_keyed_on_the_definitions_unit`
  - `test_the_third_authority_accepts_the_true_cross_file_callee`
  - `test_a_shadowed_same_name_definition_is_REFUSED`
  - `test_a_class_callee_carries_a_derivable_constructor_law`
  - `test_the_third_authority_accepts_the_true_allocation_callee`
  - `test_a_shadowed_same_name_CLASS_is_REFUSED`
  - `test_a_class_resolving_to_a_function_of_the_same_name_is_REFUSED`
  - `test_an_opaque_allocation_callee_still_refuses_by_its_own_name`
  - `test_an_allocation_handle_is_projected_to_its_typed_class_occurrence`
- All 12 are pre-existing `BareConstructionDoor` failures; both new raw-handle teeth and the false-absence twin pass.
- Required lying twin: removing the `expected_definition_ref` constructor guard made `test_call_site_constructor_refuses_raw_definition_handle` fail with `DID NOT RAISE TypeError`; restoring it passed.
- Positive-absence lying twin: before the coherence guard, `test_source_backed_call_refuses_a_false_definition_absence` failed with `DID NOT RAISE TypeError`; after the guard it passed.
- Lift-side blast radius: 88 collected, 84 passed, with the same four pre-existing failing names on base and head.
- `test_module_prefix_definition_reporter.py`: 7 passed.
- Reviewer reproduction confirmed the authenticated method frame CID remains byte-identical after moving CallSite-only reconciliation below the method return.
- `py_compile` on all four changed files and `git diff --check` passed.

## Floors preserved

- `silent=0`: raw parser handles and false absence claims remain loud.
- No test was deleted or weakened to obtain green.
- No corpus canonicalization delta is claimed without a census.
- No secrets or data-path changes.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close raw call-definition handle escape in `CallSiteSugar` and `nodes.Call`
> - Introduces `DefinitionOccurrenceAbsentV1` and `DefinitionOccurrenceAbsenceReasonV1` in [call_site_sugar.py](https://github.com/TSavo/sugar/pull/7423/files#diff-d7d594636ed207e69db76dd7b89c48760b0d3de93da23981143b3c45da88a3c7) to represent positive absence of a definition occurrence, with strict type validation at construction time.
> - `CallSiteSugar` now rejects raw/unreconciled parser handles for `expected_definition_ref` and `expected_source_call_frame_owner`, and raises `TypeError` if a positive absence is claimed while a corresponding source frame or table is present.
> - `nodes.Call` in [nodes.py](https://github.com/TSavo/sugar/pull/7423/files#diff-de87dc5ad0986c49884d4bc2021f9de6119f8eab49814fe74b7390e1b80214b0) pre-projects the callee's definition occurrence via the new `_project_call_definition_occurrence` helper before minting `CallSiteSugar`, raising `BackendDefect` for untyped or failed projections.
> - The generic `_project_constructed_value_for_testimony` hook on `Node` is removed; projection is now the responsibility of node-specific construction.
> - Behavioral Change: raw parser handles that previously reached `CallSiteSugar` now cause a hard failure at construction time rather than being reconciled later during testimony.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38b5d66.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->