### PR TITLE
Drain six restored parents[N] walks to zero

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_enumerate_rpc.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from sugar_lift_py_tests.repo_root import resolve_repo_root
+
 import pytest
 
 from sugar_lift_py_tests import lift_rpc
@@ -873,7 +875,7 @@ def test_full_tree_universe_carries_source_constructed_attribute_sidecars(
 ) -> None:
     """An incomplete body must keep its testimony without becoming complete."""
     source = (
-        Path(__file__).parents[4]
+        resolve_repo_root()
         / "examples/numpy-attribute-safety-showcase/good/src/numpy_box.py"
     ).read_text(encoding="utf-8")
     subject = tmp_path / "numpy_box.py"
@@ -1106,9 +1108,7 @@ def test_assertion_exact_seek_returns_the_identical_observed_locus(
     )
     observed = _enumerate("call_sites", project, at=function)["nodes"][0]
 
-    result = _enumerate(
-        "assertions", project, at=observed["memento"], seek=True
-    )
+    result = _enumerate("assertions", project, at=observed["memento"], seek=True)
 
     assert result["gaps"] == []
     assert result["nodes"] == [observed]

--- a/implementations/python/sugar-lift-py-tests/tests/test_measurement_ceiling_is_a_frontier_row.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measurement_ceiling_is_a_frontier_row.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import sys
 import time
 from pathlib import Path
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
@@ -34,7 +35,6 @@ from sugar_lift_py_tests.measurement_ceiling import (  # noqa: E402
     is_unswallowable,
     measurement_ceiling,
 )
-
 
 # --------------------------------------------------------------------------
 # ARM ONE: the bound fires, and the row names the coordinate.
@@ -138,9 +138,10 @@ def test_ordinary_work_completes_untouched_and_the_timer_is_disarmed() -> None:
             ):
                 observed.append(seat)
         # Disarmed between seats, every time -- not merely at the end.
-        assert signal.getitimer(signal.ITIMER_REAL) == (0.0, 0.0), (
-            f"timer still armed after {seat}"
-        )
+        assert signal.getitimer(signal.ITIMER_REAL) == (
+            0.0,
+            0.0,
+        ), f"timer still armed after {seat}"
     assert observed == ["a.py", "b.py", "c.py"]
 
 

--- a/implementations/python/sugar-lift-py-tests/tests/test_measurement_exhausted_conserves.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_measurement_exhausted_conserves.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
@@ -164,9 +165,7 @@ def test_exhausted_seat_is_inside_the_final_disjoint_union() -> None:
     exhausted_manifest = attestation["measurementExhaustedKeyManifest"]
     assert [key["file"] for key in exhausted_manifest] == ["core/groupby/generic.py"]
     # And it is NOT in the panic arm.
-    panic_files = [
-        key["file"] for key in attestation["constructionPanicKeyManifest"]
-    ]
+    panic_files = [key["file"] for key in attestation["constructionPanicKeyManifest"]]
     assert "core/groupby/generic.py" not in panic_files
 
 
@@ -192,9 +191,9 @@ def test_an_unrecognised_terminal_kind_is_refused_not_ignored() -> None:
     row["terminalKind"] = "measurement-exhasuted"  # one transposition
     row["category"] = "measurement-exhasuted"
     _, failures = compose.attest_frontier_rows([("x.py", row)])
-    assert any("not closed" in str(failure.get("reason")) for failure in failures), (
-        failures
-    )
+    assert any(
+        "not closed" in str(failure.get("reason")) for failure in failures
+    ), failures
 
 
 def test_exhausted_terminal_is_counted_on_its_own_axis_in_the_board() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_membership_exempts_only_exhausted_seats.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_membership_exempts_only_exhausted_seats.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 import pytest
 
-_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
@@ -327,9 +328,9 @@ def test_a_lying_twin_cannot_buy_exemption_with_a_payload_alone() -> None:
         },
     }
     attestation, reason = shard_relation_membership_attestation([("twin.py", twin)])
-    assert attestation is None, (
-        "a constructed seat bought a membership exemption with a payload"
-    )
+    assert (
+        attestation is None
+    ), "a constructed seat bought a membership exemption with a payload"
     assert "twin.py" in reason
 
 
@@ -370,9 +371,9 @@ def test_the_exempt_seat_reaches_the_corpus_board_by_name() -> None:
     }
     corpus = compose.authenticate_relation_membership(composed)
     assert corpus.refusal_reason() is None
-    assert [s["file"] for s in corpus.conserved_wire()["measurementExhaustedSeats"]] == [
-        "g.py"
-    ]
+    assert [
+        s["file"] for s in corpus.conserved_wire()["measurementExhaustedSeats"]
+    ] == ["g.py"]
 
 
 def test_two_shards_claiming_the_same_exempt_seat_are_refused() -> None:

--- a/implementations/python/sugar-lift-py-tests/tests/test_profile_enumerate_slice_driver.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_profile_enumerate_slice_driver.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
 
 import pytest
 
@@ -20,7 +21,7 @@ SPEC = os.environ.get("PROFILE_SLICE")
 
 @pytest.mark.skipif(not SPEC, reason="PROFILE_SLICE not set")
 def test_profile_slice() -> None:
-    scripts = Path(__file__).resolve().parents[1] / "scripts"
+    scripts = sugar_lift_py_tests_package_root() / "scripts"
     if str(scripts) not in sys.path:
         sys.path.insert(0, str(scripts))
     import profile_enumerate_slice

--- a/implementations/python/sugar-lift-py-tests/tests/test_with_resolution_outcome_vocabulary.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_with_resolution_outcome_vocabulary.py
@@ -19,15 +19,14 @@ diverge again.
 from __future__ import annotations
 
 import importlib.util
-import pathlib
 import re
 import sys
 
 import pytest
 
-_SCRIPTS = (
-    pathlib.Path(__file__).resolve().parents[1] / "scripts"
-)
+from sugar_lift_py_tests.repo_root import sugar_lift_py_tests_package_root
+
+_SCRIPTS = sugar_lift_py_tests_package_root() / "scripts"
 
 
 def _load():


### PR DESCRIPTION
`recensus-path-smoke (PATH integrity)` has been red on main since at least **2026-08-13**, on every run including `eeff6262e`. Nobody owned it. This drains it.

It is honest red. #6989 drained fixed `Path(__file__).parents[N]` walks to zero, and the smoke enforces that as a zero-only law. Six had come back:

```
R_repo_root_by_parents_count_outside_package_src=6
  package_tests=6
  test_enumerate_rpc.py:876                          parents[4]
  test_measurement_ceiling_is_a_frontier_row.py:23   parents[1] / "scripts"
  test_measurement_exhausted_conserves.py:17         parents[1] / "scripts"
  test_membership_exempts_only_exhausted_seats.py:21 parents[1] / "scripts"
  test_profile_enumerate_slice_driver.py:23          parents[1] / "scripts"
  test_with_resolution_outcome_vocabulary.py:29      parents[1] / "scripts"
```

Five of the six are in tests **this campaign added** (measurement-ceiling, exhausted-conservation, membership-exemption), so this is our own regression, not drift from elsewhere.

The workflow comment predicted it verbatim — *"an unrelated landing restored one within hours; its removal census could not judge whether the replacement door was lawful"*. The guard worked. The repair is to use the doors that already exist:

- five `parents[1] / "scripts"` sites → `sugar_lift_py_tests_package_root()`
- one `parents[4]` repo-root walk → `resolve_repo_root()`

## Verified the mechanism, not the green

A census that goes to zero because the path stopped pointing anywhere would be worse than the red. So I checked the replacements resolve to the **same** directories:

```
scripts old: .../implementations/python/sugar-lift-py-tests/scripts
scripts new: .../implementations/python/sugar-lift-py-tests/scripts
SAME: True | exists: True

root old: <repo root>
root new: <repo root>
SAME: True | example exists: True
```

## Both sides of the law

Observed red at 6, observed zero after — the census falsified itself in the course of this change, so it is not a tautology.

```
before: R_repo_root_by_parents_count_outside_package_src=6
after:  R_repo_root_by_parents_count_outside_package_src=0
        R_repo_test_package_root_import=0   (unchanged)
```

All six files compile; black clean. No test bodies changed — only how they locate `scripts/` and the repo root.

Base `eeff6262e`. Independent of #7422.