### PR TITLE
Register the commit_measurement module before exec_module

### DIFF
--- a/.github/workflows/heavy-measurement-attendance.yml
+++ b/.github/workflows/heavy-measurement-attendance.yml
@@ -145,11 +145,16 @@ jobs:
           import json
           import importlib.util
           import os
+          import sys
           print("attendance phase=compose status=loading_commit_measurement", flush=True)
           spec = importlib.util.spec_from_file_location(
               "cm", Path("tools/commit_measurement.py")
           )
           mod = importlib.util.module_from_spec(spec)
+          # @dataclass(slots=True) resolves its own class through
+          # sys.modules[cls.__module__]; an unregistered module makes that None
+          # and the decorator dies before any measurement is composed.
+          sys.modules[spec.name] = mod
           spec.loader.exec_module(mod)
           sha = os.environ["SHA"]
           vector = mod.compose_tip_from_receipts_dir(sha, Path("receipts"))


### PR DESCRIPTION
`Heavy measurement attendance (roll call)` has been red on main since at least **2026-08-17** (`eeff6262e`) — before #7422, #7423 and #7424, so none of those caused it.

It never reaches the gate. `CommitMeasurement` compose dies while *loading*:

```
attendance phase=compose status=loading_commit_measurement
Traceback (most recent call last):
  File "tools/commit_measurement.py", line 163, in <module>
    @dataclass(frozen=True, slots=True)
  File ".../dataclasses.py", line 749, in _is_type
    ns = sys.modules.get(cls.__module__).__dict__
AttributeError: 'NoneType' object has no attribute '__dict__'
```

The compose step builds the module with `module_from_spec` and calls `exec_module` without registering it. `@dataclass(slots=True)` resolves its own class through `sys.modules[cls.__module__]`, so an unregistered module makes that lookup `None` and the decorator dies before a single receipt is read.

## Both sides, locally, against the real file

```
without sys.modules registration (current CI): AttributeError: 'NoneType' object has no attribute '__dict__'
with    sys.modules registration (proposed)  : LOADED ok
```

## Why it matters more than one red check

This is measurement infrastructure, and the failure wore the wrong costume. **The roll call has not been able to bank anything since at least 2026-08-17**, and the red reads as an attendance result — as though attendance were measured and found wanting — when in fact the composer never ran. A measurement gate that fails before measuring reports the same colour as one that measured and refused, and those are entirely different facts.

One line, plus a comment naming the trap so the next person does not re-derive it.