### PR TITLE
Fold Param defaults into ParamSugar through the frame's default door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/param_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/param_sugar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field as dataclass_field
+from typing import Optional
 
 from sugar_lift_py_tests.floor import SymbolicValue
 from sugar_lift_py_tests.ir import make_var
@@ -22,6 +23,11 @@ class ParamSugar(Sugar):
 
     name: str
     site: object = dataclass_field(compare=False)
+    # The default expression's sugar, constructed through the same door the
+    # source-visible call frame uses (``param.default.sugar()``). None for a
+    # formal without a default. Carried, not reduced here: the formal still
+    # stands as its universe variable; the caller-side frame applies defaults.
+    default: Optional[Sugar] = None
 
     @classmethod
     def witnesses(cls):

--- a/implementations/python/sugar-lift-py-tests/tests/test_call_surface_kw_star_defaults.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_call_surface_kw_star_defaults.py
@@ -1,0 +1,144 @@
+"""Call surface: keyword actuals, starred actuals, default formals — construct.
+
+Scope (black door): CallSite / MethodCall / SpreadCall + signature defaults.
+Not value floors, not undecided attribution.
+
+Triage: constructs already existed —
+  - CallSiteSugar.keywords / MethodCallSugar.keywords (CTS pin L2a)
+  - SpreadCallSugar for *args / **kwargs
+  - ParamSugar for bare formals
+Wrong entrance was Param with a default (or annotation) falling through to
+``write more Sugar`` instead of folding the default expression into ParamSugar.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_py_tests.sugar.call_site_sugar import CallSiteSugar
+from sugar_lift_py_tests.sugar.int_literal_sugar import IntLiteralSugar
+from sugar_lift_py_tests.sugar.method_call_sugar import MethodCallSugar
+from sugar_lift_py_tests.sugar.param_sugar import ParamSugar
+from sugar_lift_py_tests.sugar.spread_sugar import SpreadCallSugar
+from sugar_lift_py_tests.sugar.sugar_base import ConstructedTermSugar
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import Call, FunctionDef, Param
+from sugar_source_tree.tree import SourceFile
+
+
+def _cid(source: str) -> str:
+    return blake3_512_of(source.encode("utf-8"))
+
+
+def _sf(source: str, name: str = "t.py") -> SourceFile:
+    return SourceFile((source, name, _cid(source)))
+
+
+def test_named_keyword_actual_constructs_on_call_site() -> None:
+    """f(a=1) — keywords ride CallSiteSugar, values are ConstructedTermSugar."""
+    call = next(
+        n
+        for n in _sf("def f(a):\n    return a\nf(a=1)\n", "kw.py").nodes()
+        if isinstance(n, Call)
+    )
+    sugar = call.sugar()
+    assert isinstance(sugar, CallSiteSugar)
+    assert len(sugar.keywords) == 1
+    name, value = sugar.keywords[0]
+    assert name == "a"
+    assert isinstance(value, ConstructedTermSugar)
+    assert isinstance(value, IntLiteralSugar)
+    assert isinstance(sugar.desugar(None), Complete)
+
+
+def test_method_keyword_actual_constructs() -> None:
+    """obj.m(x=2) — MethodCallSugar.keywords construct."""
+    from sugar_source_tree.nodes import Attribute
+
+    calls = [
+        n
+        for n in _sf(
+            "class C:\n    def m(self, x=1):\n        return x\nC().m(x=2)\n",
+            "method_kw.py",
+        ).nodes()
+        if isinstance(n, Call)
+    ]
+    method_call = next(
+        c for c in calls if c.keywords and isinstance(c.func, Attribute)
+    )
+    sugar = method_call.sugar()
+    assert isinstance(sugar, MethodCallSugar)
+    assert sugar.keywords[0][0] == "x"
+    assert isinstance(sugar.keywords[0][1], ConstructedTermSugar)
+    assert isinstance(sugar.desugar(None), Complete)
+
+
+def test_starred_positional_actual_constructs_spread_call() -> None:
+    """f(*xs) — starred positional is SpreadCallSugar, not a bare gap."""
+    from sugar_source_tree.nodes import Starred
+
+    call = next(
+        n
+        for n in _sf(
+            "def f(a, b):\n    return a\nxs = (1, 2)\nf(*xs)\n", "star_call.py"
+        ).nodes()
+        if isinstance(n, Call) and any(isinstance(a, Starred) for a in n.args)
+    )
+    sugar = call.sugar()
+    assert isinstance(sugar, SpreadCallSugar)
+    assert isinstance(sugar.desugar(None), Complete)
+
+
+def test_double_star_keyword_actual_constructs_spread_call() -> None:
+    """f(**d) — double-star keyword is SpreadCallSugar."""
+    call = next(
+        n
+        for n in _sf(
+            "def f(a=1):\n    return a\nd = {'a': 2}\nf(**d)\n", "dstar.py"
+        ).nodes()
+        if isinstance(n, Call) and any(kw.arg is None for kw in n.keywords)
+    )
+    sugar = call.sugar()
+    assert isinstance(sugar, SpreadCallSugar)
+    assert isinstance(sugar.desugar(None), Complete)
+
+
+def test_param_with_default_constructs_param_sugar_not_gap() -> None:
+    """def f(a=1): — Param.sugar is ParamSugar with CTS default, not SugarNotWritten."""
+    param = next(
+        n
+        for n in _sf("def f(a=1):\n    return a\n", "default.py").nodes()
+        if isinstance(n, Param) and n.default is not None
+    )
+    sugar = param.sugar()
+    assert isinstance(sugar, ParamSugar)
+    assert sugar.name == "a"
+    assert sugar.default is not None
+    assert isinstance(sugar.default, ConstructedTermSugar)
+    assert isinstance(sugar.default, IntLiteralSugar)
+    assert isinstance(sugar.desugar(None), Complete)
+
+
+def test_param_with_annotation_only_still_constructs() -> None:
+    """def f(a: int): — annotation must not refuse the formal."""
+    param = next(
+        n
+        for n in _sf("def f(a: int):\n    return a\n", "ann.py").nodes()
+        if isinstance(n, Param)
+    )
+    sugar = param.sugar()
+    assert isinstance(sugar, ParamSugar)
+    assert sugar.default is None
+
+
+def test_frame_default_sugars_match_param_default_construction() -> None:
+    """Source-visible frame and Param.sugar share the same default door."""
+    tree = _sf("def f(a=1, b=2):\n    return a\n", "frame_defaults.py")
+    function = next(n for n in tree.nodes() if isinstance(n, FunctionDef))
+    frame = function.source_visible_call_frame()
+    params = [n for n in tree.nodes() if isinstance(n, Param)]
+    assert len(params) == 2
+    for param, frame_default in zip(params, frame.default_sugars, strict=True):
+        sugar = param.sugar()
+        assert isinstance(sugar, ParamSugar)
+        assert type(sugar.default) is type(frame_default)
+        assert isinstance(sugar.default, ConstructedTermSugar)

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -3576,14 +3576,17 @@ class Param(Node):
         return self._substitute_children(scope)
 
     def _construct_sugar(self):
-        """A formal stands as its symbolic universe variable. Plain parameters
-        only; a default or annotation is not yet folded in, so a parameter that
-        carries one stays a loud gap rather than silently dropping it."""
-        if self.default is not None or self.annotation is not None:
-            return super()._construct_sugar()
+        """A formal stands as its symbolic universe variable. A default is
+        folded in through the same door the source-visible call frame uses
+        (``default.sugar()``), so the two can never disagree; an annotation is
+        a type witness, not a value, and never refuses the formal."""
         from sugar_lift_py_tests.sugar.param_sugar import ParamSugar
 
-        return ParamSugar(name=self.name, site=self.fragment)
+        return ParamSugar(
+            name=self.name,
+            site=self.fragment,
+            default=self.default.sugar() if self.default is not None else None,
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- `Param._construct_sugar` refused any formal carrying a default or annotation, so `def f(a=1)` / `def f(a: int)` were loud `SUGAR NOT WRITTEN [Param.sugar]` gaps even though `source_visible_call_frame()` already constructed the same default via `param.default.sugar()`.
- `ParamSugar` now carries `default: Optional[Sugar]` (carried, not reduced — the formal still stands as its universe variable; the frame applies the default). `Param._construct_sugar` folds it through the identical door the frame uses, so the two can never disagree. An annotation is a type witness and never refuses.
- New `test_call_surface_kw_star_defaults.py`: keyword actuals, starred actuals, default/annotated formals all construct; frame `default_sugars` and `Param.sugar().default` share one door. Helper mints blake3-512 source CIDs (the tree refuses sha256).

## Test plan
- [x] `test_call_surface_kw_star_defaults.py` 7/7
- [x] `sugar-lift-py-tests -k "param or frame or default or signature or formal"` green on rebased branch (pre-existing collection error in `test_enum_floor_runtime_surface.py` — missing `sugar_lift_py_tests.scripts` — excluded; unrelated, already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT