### PR TITLE
Name the complex category in ConstructedValueV2

### DIFF
--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/binding_state.py
@@ -1546,6 +1546,17 @@ def _cv2_leaf(value: object) -> Any:
         # term_value.to_term / ir.real_lit): a fixed-point decimal string, never
         # a Python float text form.
         return {"float": format(Decimal(str(value)), "f")}
+    if isinstance(value, complex):
+        from decimal import Decimal
+
+        # Two fixed-point components under one tag: the pair IS the value, so
+        # a complex never collides with a float, a tuple of floats, or a str.
+        return {
+            "complex": {
+                "real": format(Decimal(str(value.real)), "f"),
+                "imag": format(Decimal(str(value.imag)), "f"),
+            }
+        }
     if isinstance(value, bytes):
         return {"bytes": value.hex()}
     if isinstance(value, SourceFragment):

--- a/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
+++ b/implementations/python/sugar-source-tree/tests/test_runtime_binding_entry_v1.py
@@ -193,12 +193,30 @@ def test_constructed_value_v2_seals_float_and_bytes():
         encoded = _cv2_leaf(value)
         assert cid_of_json({"v": encoded}) == cid_of_json({"v": encoded})
 
+
+def test_constructed_value_v2_seals_complex():
+    # ComplexLiteralSugar's node construction shape carries a bare ``complex``;
+    # it enters the wire as two fixed-point components under one tag.
+    from sugar_source_tree.binding_state import _cv2_leaf
+
+    assert _cv2_leaf(1.5 + 2j) == {"complex": {"real": "1.5", "imag": "2.0"}}
+    assert _cv2_leaf(3j) == {"complex": {"real": "0.0", "imag": "3.0"}}
+    assert _cv2_leaf(-1e-05j) == {"complex": {"real": "-0.0", "imag": "-0.00001"}}
+    # Never confusable with the float or the tuple that spell the same digits.
+    assert _cv2_leaf(2 + 0j) != _cv2_leaf(2.0)
+    assert _cv2_leaf(2 + 0j) != {"float": "2.0"}
+    encoded = _cv2_leaf(1.5 + 2j)
+    assert cid_of_json({"v": encoded}) == cid_of_json({"v": encoded})
+
     # Bad twin: a value with no canonical spelling stays LOUD, never silently
     # collapses to a fabricated testimony, and never falls back to reflection.
-    from sugar_source_tree.binding_state import constructed_value_cid_v2
+    from sugar_source_tree.binding_state import (
+        _NOT_A_LEAF,
+        ConstructedValueCategoryGap,
+        constructed_value_cid_v2,
+    )
 
-    from sugar_source_tree.binding_state import _NOT_A_LEAF
-
-    assert _cv2_leaf(1 + 2j) is _NOT_A_LEAF
+    unnamed = object()
+    assert _cv2_leaf(unnamed) is _NOT_A_LEAF
     with pytest.raises(ConstructedValueCategoryGap, match="unclassified"):
-        constructed_value_cid_v2(1 + 2j)
+        constructed_value_cid_v2(unnamed)


### PR DESCRIPTION
## Summary
- `ComplexLiteralSugar`'s node construction shape carries a bare `complex`; `_cv2_leaf` refused it as unclassified (3 `CollectingReporter.present_construction` rows on the Aug 17 recensus board).
- A `complex` now enters the wire as `{"complex": {"real": <fixed-point>, "imag": <fixed-point>}}`, spelled exactly the way `float` already is, so it never collides with a float, a tuple of floats, or a str.
- The bad twin that pinned "complex is unclassified" now pins an unnamed `object()`; the protected law (no reflection, stay loud) is unchanged.

## Test plan
- [x] `sugar-source-tree/tests/test_runtime_binding_entry_v1.py` (new `test_constructed_value_v2_seals_complex`) + `test_constant_kinds.py`: 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT