### PR TITLE
Cite a partitioned manager callee assigned an import value per arm

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/context_manager_resolution.py
@@ -509,6 +509,127 @@ def mint_opaque_cited_context_manager_ref(
 
 
 @dataclass(frozen=True)
+class PartitionedOpaqueCitedContextManagerRefV1:
+    """A ``with`` head whose manager is ONE OF several cited callees.
+
+    The consumer wrote ``m = a.A`` / ``elif``: ``m = b.B`` / ``with m(...)``.
+    Every arm is an authenticated import value whose callee the population
+    membrane declined to look inside, so every arm is an
+    :class:`OpaqueCitedContextManagerRefV1` seated at its own assignment
+    occurrence.  The partition is cited exactly when every member is: opacity
+    is carried through the selection, never averaged over it.
+
+    Like the single-member ref this carries NO semantics -- a manager chosen at
+    runtime among callees nobody materialized has, at best, the union of their
+    unknowns.  ``target_name`` is testimony text only (the members, ordered by
+    their assignment coordinates); the identity is ``citation_cid`` over the
+    member citations.  Members are keyed by their own use sites, so the same
+    callee assigned in two arms is two members, not one.
+    """
+
+    use_site: SourceFragmentCoordinateV1
+    members: tuple[OpaqueCitedContextManagerRefV1, ...]
+    citation_cid: str
+    _authority: _OpaqueCitedManagerAuthority = field(
+        init=False,
+        repr=False,
+        compare=False,
+        default_factory=_OpaqueCitedManagerAuthority,
+    )
+    uncited: str = "enter-exit-semantics-uncited"
+
+    def __post_init__(self) -> None:
+        if self._authority is not _OPAQUE_CITED_MANAGER_AUTHORITY:
+            raise ContractRefProtocolError(
+                "partitioned opaque-cited context-manager ref lacks producer authority"
+            )
+        if not self.members:
+            raise ContractRefProtocolError(
+                "partitioned opaque-cited context-manager ref names no member"
+            )
+        for member in self.members:
+            if type(member) is not OpaqueCitedContextManagerRefV1:
+                raise ContractRefProtocolError(
+                    "partitioned opaque-cited context-manager ref admits only "
+                    "authenticated opaque-cited members"
+                )
+        sites = [member.use_site for member in self.members]
+        if len(set(sites)) != len(sites):
+            raise ContractRefProtocolError(
+                "partitioned opaque-cited context-manager ref seats one member twice"
+            )
+        if sites != sorted(sites, key=_coordinate_order):
+            raise ContractRefProtocolError(
+                "partitioned opaque-cited context-manager ref is not member-ordered"
+            )
+        if self.uncited != "enter-exit-semantics-uncited":
+            raise ContractRefProtocolError(
+                "partitioned opaque-cited context-manager ref may state only "
+                "that its enter/exit semantics are uncited"
+            )
+
+    @property
+    def target_name(self) -> str:
+        """Testimony text for reasons and rows; never a bucket key."""
+        return " | ".join(member.target_name for member in self.members)
+
+    @property
+    def semantics(self):
+        raise ContractRefProtocolError(
+            "partitioned opaque-cited context-manager ref has no enter/exit "
+            f"semantics: the manager at {self.use_site} is one of "
+            f"{self.target_name!r}, each cited, none materialized. Carry the "
+            "undischarged obligation; never substitute assumed semantics"
+        )
+
+
+def _coordinate_order(site: SourceFragmentCoordinateV1) -> tuple:
+    return (site.start_line, site.start_col, site.end_line, site.end_col)
+
+
+def mint_partitioned_opaque_cited_context_manager_ref(
+    *,
+    use_site: SourceFragmentCoordinateV1,
+    members: tuple[OpaqueCitedContextManagerRefV1, ...],
+) -> PartitionedOpaqueCitedContextManagerRefV1:
+    """The sole door that mints a partitioned opaque-cited manager ref.
+
+    Every member must itself have come through
+    :func:`mint_opaque_cited_context_manager_ref`; this door orders them by
+    their assignment coordinates and seals the citation over their CIDs.
+    """
+    from sugar_lift_python_source.canonical import cid_of_json
+
+    for member in members:
+        if type(member) is not OpaqueCitedContextManagerRefV1:
+            raise ContractRefProtocolError(
+                "partitioned opaque-cited context-manager ref requires "
+                "authenticated opaque-cited members"
+            )
+    ordered = tuple(sorted(members, key=lambda m: _coordinate_order(m.use_site)))
+    citation_cid = cid_of_json(
+        {
+            "schemaVersion": 1,
+            "kind": "partitioned-opaque-cited-context-manager-ref",
+            "useSite": use_site.wire(),
+            "members": [member.citation_cid for member in ordered],
+            "uncited": "enter-exit-semantics-uncited",
+        }
+    )
+    ref = object.__new__(PartitionedOpaqueCitedContextManagerRefV1)
+    for name, value in (
+        ("use_site", use_site),
+        ("members", ordered),
+        ("citation_cid", citation_cid),
+        ("uncited", "enter-exit-semantics-uncited"),
+    ):
+        object.__setattr__(ref, name, value)
+    object.__setattr__(ref, "_authority", _OPAQUE_CITED_MANAGER_AUTHORITY)
+    ref.__post_init__()
+    return ref
+
+
+@dataclass(frozen=True)
 class ContextManagerResolutionGapV1:
     """One unresolved context-manager demand: a structural kind beside its data.
 

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_opaque_cited_manager_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/with_opaque_cited_manager_sugar.py
@@ -59,9 +59,13 @@ class WithOpaqueCitedManagerSugar(Sugar):
     def __post_init__(self) -> None:
         from sugar_lift_py_tests.context_manager_resolution import (
             OpaqueCitedContextManagerRefV1,
+            PartitionedOpaqueCitedContextManagerRefV1,
         )
 
-        if type(self.contract_ref) is not OpaqueCitedContextManagerRefV1:
+        if type(self.contract_ref) not in (
+            OpaqueCitedContextManagerRefV1,
+            PartitionedOpaqueCitedContextManagerRefV1,
+        ):
             raise ValueError(
                 "WithOpaqueCitedManagerSugar requires an authenticated "
                 "OpaqueCitedContextManagerRefV1; a cited manager is never "

--- a/implementations/python/sugar-lift-py-tests/tests/test_partitioned_manager_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partitioned_manager_citation.py
@@ -1,0 +1,159 @@
+"""``with m(...)`` where ``m`` is assigned an import value per selection arm.
+
+Reproducer: ``pandas/_testing/_io.py`` binds ``compress_method`` to
+``gzip.GzipFile`` / ``bz2.BZ2File`` / ... in an if/elif chain and uses it once
+as the manager callee. The call has no import receipt (its callee is a local
+Name), so the demand table left it ``runtime-selected`` and ``With`` panicked.
+
+Law under test: when nothing but the assignment arms binds the callee name in
+the function, the reaching value IS the arms; each arm derives through the
+ordinary import door, and a partition whose members are all cited by the
+population membrane is one cited partition. Any other shape stays a loud typed
+gap that names the arm -- never ``runtime-selected``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    ContractRefProtocolError,
+    OpaqueCitedContextManagerRefV1,
+    PartitionedOpaqueCitedContextManagerRefV1,
+    mint_partitioned_opaque_cited_context_manager_ref,
+)
+from sugar_lift_py_tests.corpus_pin import pin_corpus
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.sugar.with_opaque_cited_manager_sugar import (
+    WithOpaqueCitedManagerSugar,
+)
+from sugar_source_tree.binding_state import constructed_value_cid_v2
+from sugar_source_tree.nodes import With
+from sugar_source_tree.reporter import CollectingReporter
+
+PARTITION = (
+    "import bz2\n"
+    "import gzip\n"
+    "\n"
+    "def f(p, kind):\n"
+    "    if kind == 'gzip':\n"
+    "        compress_method = gzip.GzipFile\n"
+    "    elif kind == 'bz2':\n"
+    "        compress_method = bz2.BZ2File\n"
+    "    else:\n"
+    "        raise ValueError(kind)\n"
+    "    with compress_method(p, mode='wb') as fh:\n"
+    "        return fh\n"
+)
+
+
+def _corpus(tmp_path: Path, **files: str) -> Path:
+    root = tmp_path / "c"
+    root.mkdir()
+    for name, source in files.items():
+        (root / name).write_text(source, encoding="utf-8")
+    (tmp_path / "c.identity.json").write_text(
+        json.dumps({"distribution": "tiny-corpus", "version": "0.0.1"}),
+        encoding="utf-8",
+    )
+    pin_corpus(root, distribution="tiny-corpus", version="0.0.1")
+    return root
+
+
+def _open(root: Path, name: str):
+    return open_source_file_for_construction(
+        root / name,
+        root=root,
+        reporter=CollectingReporter(),
+        distribution="tiny-corpus",
+        source_workspace_root=root,
+    )
+
+
+def _with_resolution(source_file):
+    with_node = next(n for n in source_file.nodes() if isinstance(n, With))
+    context = source_file.root.unit.construction_context
+    refs = context.source_derived_contract_refs
+    (site,) = [k for k in refs if k.start_line == with_node.line_col_span().start_line]
+    return with_node, refs[site]
+
+
+def test_partition_of_cited_members_constructs(tmp_path: Path) -> None:
+    """Truthful twin: both arms cited off-population → one cited partition."""
+    root = _corpus(tmp_path, **{"part.py": PARTITION})
+    source_file = _open(root, "part.py")
+    with_node, ref = _with_resolution(source_file)
+
+    assert isinstance(ref, PartitionedOpaqueCitedContextManagerRefV1)
+    assert [m.target_name for m in ref.members] == ["python:gzip.GzipFile", "python:bz2.BZ2File"]
+    assert [m.use_site.start_line for m in ref.members] == [6, 8]
+    for member in ref.members:
+        assert isinstance(member, OpaqueCitedContextManagerRefV1)
+        assert member.roster.resolution_kind == "call-target-off-population"
+    with pytest.raises(ContractRefProtocolError, match="no enter/exit semantics"):
+        _ = ref.semantics
+
+    sugar = with_node.sugar()
+    assert isinstance(sugar, WithOpaqueCitedManagerSugar)
+    assert sugar.contract_ref is ref
+    # The constructed value must canonicalize: the ref is frozen data plus the
+    # producer authority category (#7422), never a bare object.
+    assert constructed_value_cid_v2(sugar).startswith("blake3-512:")
+
+
+def test_arm_that_is_not_an_import_value_stays_loud(tmp_path: Path) -> None:
+    """Lying twin: one arm bound to a local helper is not a cited member."""
+    source = PARTITION.replace(
+        "        compress_method = bz2.BZ2File\n",
+        "        compress_method = helper\n",
+    ).replace("def f(p, kind):", "def helper(p, mode):\n    return p\n\ndef f(p, kind):")
+    root = _corpus(tmp_path, **{"lying.py": source})
+    source_file = _open(root, "lying.py")
+    with_node, ref = _with_resolution(source_file)
+
+    assert isinstance(ref, ContextManagerResolutionGapV1)
+    assert ref.kind == "partition-member-unauthenticated"
+    assert "not authenticated import values" in (ref.detail or "")
+    with pytest.raises(Exception, match="partition-member-unauthenticated"):
+        with_node.sugar()
+
+
+def test_name_rebound_elsewhere_is_not_a_partition(tmp_path: Path) -> None:
+    """A loop target rebinding the callee means the arms are not its whole value."""
+    source = PARTITION.replace(
+        "    with compress_method(p, mode='wb') as fh:\n",
+        "    for compress_method in (gzip.GzipFile,):\n        pass\n"
+        "    with compress_method(p, mode='wb') as fh:\n",
+    )
+    root = _corpus(tmp_path, **{"rebound.py": source})
+    source_file = _open(root, "rebound.py")
+    _with_node, ref = _with_resolution(source_file)
+
+    assert isinstance(ref, ContextManagerResolutionGapV1)
+    assert ref.kind == "partition-member-unauthenticated"
+    assert "also bound by For@" in (ref.detail or "")
+
+
+def test_mint_refuses_lies() -> None:
+    site = _site(1)
+    with pytest.raises(ContractRefProtocolError, match="names no member"):
+        mint_partitioned_opaque_cited_context_manager_ref(use_site=site, members=())
+    with pytest.raises(ContractRefProtocolError, match="authenticated opaque-cited"):
+        mint_partitioned_opaque_cited_context_manager_ref(
+            use_site=site, members=(object(),)  # type: ignore[arg-type]
+        )
+    # The public constructor cannot mint authority.
+    with pytest.raises(ContractRefProtocolError, match="lacks producer authority"):
+        PartitionedOpaqueCitedContextManagerRefV1(site, (), "blake3-512:" + "00" * 64)
+
+
+def _site(line: int):
+    from sugar_lift_py_tests.context_manager_resolution import (
+        SourceFragmentCoordinateV1,
+    )
+
+    return SourceFragmentCoordinateV1("blake3-512:" + "ab" * 64, line, 0, line, 10)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1360,6 +1360,7 @@ def populate_source_derived_resource_refs(
         owner="manager_summary_derivation imported manager value receipt pairing",
     )
     paired_receipts = []
+    paired_keys = set()
     for call_key, selected in uses.items():
         _, call, _ = selected
         source_cid = call.unit.source_cid
@@ -1381,6 +1382,7 @@ def populate_source_derived_resource_refs(
             receipt = value_receipts_by_site.get(callee_key)
         if receipt is not None:
             paired_receipts.append((receipt, selected))
+            paired_keys.add(call_key)
 
     graphs = {} if artifact_graph_cache is None else artifact_graph_cache
     # Seed from session so tops already resolved in frame/prefix projection
@@ -1758,11 +1760,302 @@ def populate_source_derived_resource_refs(
             )
         )
 
+    # A callee Name assigned in every arm of a selection (``m = a.A`` /
+    # ``elif``: ``m = b.B`` / ``with m(...)``) has no receipt at the call, but
+    # each ARM has a value receipt at its own occurrence. Derive the partition
+    # member by member through the same import door; a partition of cited
+    # members is a cited partition.
+    _populate_assigned_partition_manager_uses(
+        source_file,
+        context,
+        uses,
+        paired_keys=paired_keys,
+        value_receipts_by_site=value_receipts_by_site,
+        graphs=graphs,
+        session=session,
+        distribution_index=distribution_index,
+    )
+
     # Same-module ClassDef managers have no import receipt. Derive them through
     # module_direct_bindings → Call.force_floor → protocol → summary — the same
     # publication door as import-backed ClassDef CMs. Uncovered uses stay empty
     # for With.require (L3d) to panic.
     _populate_same_module_class_manager_uses(source_file, context, uses)
+
+
+def _enclosing_function(source_file, node):
+    """The innermost FunctionDef whose body contains ``node``, or None."""
+    innermost = None
+    innermost_span = None
+    for function in source_file.functions():
+        if not any(candidate is node for candidate in function.walk()):
+            continue
+        span = function.line_col_span()
+        key = (span.start_line, span.start_col, -span.end_line, -span.end_col)
+        if innermost_span is None or key > innermost_span:
+            innermost, innermost_span = function, key
+    return innermost
+
+
+def _name_binders(function, name: str):
+    """Every statement in ``function`` that binds ``name``, by shape.
+
+    Returns ``(assignments, other_binders)``: the single-target ``Assign``
+    arms whose RHS may carry an import value receipt, and every other binder
+    (augmented / annotated assignment, loop or with target, walrus, nested
+    def/class, global/nonlocal, a formal of the same name). Any entry in the
+    second list means the name's reaching value is not the assignment arms
+    alone, so the partition is not authenticated by them.
+    """
+    from sugar_source_tree.nodes import (
+        AnnAssign,
+        Assign,
+        AsyncFor,
+        AsyncWith,
+        AugAssign,
+        ClassDef,
+        For,
+        FunctionDef,
+        Global,
+        Name,
+        NamedExpr,
+        Nonlocal,
+        With,
+    )
+
+    def names_in(target) -> set:
+        if isinstance(target, Name):
+            return {target.id}
+        found = set()
+        for child in getattr(target, "elts", ()) or ():
+            found |= names_in(child)
+        value = getattr(target, "value", None)
+        if getattr(target, "kind", None) == "Starred" and value is not None:
+            found |= names_in(value)
+        return found
+
+    assignments = []
+    other = []
+    if any(param.name == name for param in function.params):
+        other.append(function)
+    for node in function.walk():
+        if node is function:
+            continue
+        if isinstance(node, Assign):
+            if (
+                len(node.targets) == 1
+                and isinstance(node.targets[0], Name)
+                and node.targets[0].id == name
+            ):
+                assignments.append(node)
+            elif any(name in names_in(target) for target in node.targets):
+                other.append(node)
+        elif isinstance(node, (AugAssign, AnnAssign, NamedExpr)):
+            if name in names_in(node.target):
+                other.append(node)
+        elif isinstance(node, (For, AsyncFor)):
+            if name in names_in(node.target):
+                other.append(node)
+        elif isinstance(node, (With, AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None and name in names_in(
+                    item.optional_vars
+                ):
+                    other.append(node)
+        elif isinstance(node, (FunctionDef, ClassDef)):
+            if node.name == name:
+                other.append(node)
+        elif isinstance(node, (Global, Nonlocal)):
+            if name in tuple(node.names):
+                other.append(node)
+    return assignments, other
+
+
+def _populate_assigned_partition_manager_uses(
+    source_file,
+    context,
+    uses,
+    *,
+    paired_keys,
+    value_receipts_by_site,
+    graphs,
+    session,
+    distribution_index,
+) -> None:
+    """Derive ``with m(...)`` where ``m`` is assigned an import value per arm.
+
+    Reproducer (pandas/_testing/_io.py): ``compress_method`` is bound to
+    ``gzip.GzipFile`` / ``bz2.BZ2File`` / ... in an if/elif chain, then used
+    once as the manager callee. The call has no receipt (its callee is a local
+    Name), so the demand table left it ``runtime-selected``. Every arm,
+    however, is an authenticated import value with its own receipt.
+
+    Law: the reaching value of the callee is exactly the set of assignment
+    arms when nothing else binds the name in the function. Each arm resolves
+    through the ordinary import door. The membrane's off-population refusal
+    cites the member (the same seat a direct ``with gzip.GzipFile(...)`` gets);
+    a partition whose members are all cited is minted as one
+    ``PartitionedOpaqueCitedContextManagerRefV1``. Anything else stays a loud
+    typed gap naming the arm that refused -- never ``runtime-selected``.
+    """
+    from sugar_lift_py_tests.context_manager_resolution import (
+        OpaqueSourceCallObligationV1,
+        SourceFragmentCoordinateV1,
+        mint_opaque_cited_context_manager_ref,
+        mint_partitioned_opaque_cited_context_manager_ref,
+        opaque_source_call_roster_of,
+    )
+    from sugar_source_tree.nodes import Name
+
+    from .dependency_artifact import (
+        DependencyArtifactAuthenticationError,
+        ResolvedPythonObjectV1,
+        authenticate_dependency_top_level,
+        resolve_import_binding,
+    )
+    from .manager_construction import (
+        ManagerConstructionGapV1,
+        resolve_source_visible_frame,
+    )
+
+    def arm_coordinate(node):
+        span = node.value.line_col_span()
+        return SourceFragmentCoordinateV1(
+            node.unit.source_cid,
+            span.start_line,
+            span.start_col,
+            span.end_line,
+            span.end_col,
+        )
+
+    def arm_receipt(node):
+        span = node.value.line_col_span()
+        return value_receipts_by_site.get(
+            (
+                node.unit.source_cid,
+                span.start_line,
+                span.start_col,
+                span.end_line,
+                span.end_col,
+            )
+        )
+
+    def graph_for(receipt):
+        top_level = receipt.target_symbol.removeprefix("python:").split(".", 1)[0]
+        graph = graphs.get(top_level)
+        if graph is None and session.enabled:
+            graph = session.dependency_graphs.get(top_level)
+        if graph is None:
+            graph = authenticate_dependency_top_level(
+                top_level, distribution_index=distribution_index
+            )
+            if session.enabled:
+                session.dependency_graphs[top_level] = graph
+        graphs[top_level] = graph
+        return graph
+
+    for call_key, (coordinate, call, _exit_face_id) in uses.items():
+        if call_key in paired_keys:
+            continue
+        if coordinate in context.source_derived_contract_refs:
+            continue
+        if not isinstance(call.func, Name):
+            continue
+        function = _enclosing_function(source_file, call)
+        if function is None:
+            continue
+        name = call.func.id
+        assignments, other_binders = _name_binders(function, name)
+        arms = [(node, arm_receipt(node)) for node in assignments]
+        receipted = [(node, receipt) for node, receipt in arms if receipt is not None]
+        if not receipted:
+            # Not this law's shape: no arm is an import value.
+            continue
+        first_receipt = receipted[0][1]
+        if other_binders:
+            where = ", ".join(
+                f"{type(binder).__name__}@{binder.line_col_span().start_line}"
+                for binder in other_binders
+            )
+            _install_derivation_gap(
+                context,
+                coordinate,
+                first_receipt,
+                "partition-member-unauthenticated",
+                f"{name!r} is also bound by {where}; the assignment arms are not "
+                "its whole reaching value",
+            )
+            continue
+        unreceipted = [node for node, receipt in arms if receipt is None]
+        if unreceipted:
+            where = ", ".join(str(node.line_col_span().start_line) for node in unreceipted)
+            _install_derivation_gap(
+                context,
+                coordinate,
+                first_receipt,
+                "partition-member-unauthenticated",
+                f"{name!r} arm(s) at line {where} are not authenticated import values",
+            )
+            continue
+        members = []
+        failed = None
+        for node, receipt in receipted:
+            member_site = arm_coordinate(node)
+            try:
+                graph = graph_for(receipt)
+            except DependencyArtifactAuthenticationError as exc:
+                failed = (
+                    "partition-member-no-derived-contract",
+                    f"{receipt.target_symbol}: dependency artifact authentication "
+                    f"failed: {exc}",
+                )
+                break
+            resolved = resolve_import_binding(receipt, graph=graph, session=session)
+            if not isinstance(resolved, ResolvedPythonObjectV1):
+                kind = getattr(resolved, "kind", None) or "no-derived-contract"
+                failed = (f"partition-member-{kind}", receipt.target_symbol)
+                break
+            frame_result = resolve_source_visible_frame(
+                resolved,
+                graph=graph,
+                dependency_graphs=graphs,
+                session=session,
+            )
+            if not isinstance(frame_result, ManagerConstructionGapV1):
+                # An in-population member has a real body. Folding N derived
+                # protocols under one selection is its own law; keep this arm
+                # loud under a name that says so.
+                failed = (
+                    "partition-member-derived-unfolded",
+                    f"{receipt.target_symbol} resolves to an enrolled definition",
+                )
+                break
+            if frame_result.kind != "call-target-off-population":
+                failed = (
+                    f"partition-member-{frame_result.kind}",
+                    f"{receipt.target_symbol}: {frame_result.detail}",
+                )
+                break
+            demand_cid = receipt.demand.get("cid", receipt.use["cid"])
+            roster = opaque_source_call_roster_of(
+                OpaqueSourceCallObligationV1(
+                    member_site,
+                    str(receipt.target_symbol),
+                    demand_cid,
+                    "call-target-off-population",
+                )
+            )
+            context.opaque_source_call_obligations.setdefault(member_site, roster)
+            members.append(mint_opaque_cited_context_manager_ref(roster=roster))
+        if failed is not None:
+            kind, detail = failed
+            _install_derivation_gap(context, coordinate, first_receipt, kind, detail)
+            continue
+        context.source_derived_contract_refs[coordinate] = (
+            mint_partitioned_opaque_cited_context_manager_ref(
+                use_site=coordinate, members=tuple(members)
+            )
+        )
 
 
 def _populate_same_module_class_manager_uses(source_file, context, uses) -> None:

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -8136,9 +8136,16 @@ class With(Statement):
             OpaqueCitedContextManagerRefV1,
         )
 
+        from sugar_lift_py_tests.context_manager_resolution import (
+            PartitionedOpaqueCitedContextManagerRefV1,
+        )
+
         if isinstance(resolution, ContextManagerResolutionGapV1):
             self._raise_resolution_gap(resolution)
-        if isinstance(resolution, OpaqueCitedContextManagerRefV1):
+        if isinstance(
+            resolution,
+            (OpaqueCitedContextManagerRefV1, PartitionedOpaqueCitedContextManagerRefV1),
+        ):
             # A POSITIVE seated citation, not a rescued refusal. This arm never
             # catches a panic and never infers opacity from a missing contract:
             # the producer authenticated the callee and authenticated that its
@@ -8403,9 +8410,16 @@ class With(Statement):
 
             from sugar_lift_py_tests.context_manager_resolution import (
                 OpaqueCitedContextManagerRefV1,
+                PartitionedOpaqueCitedContextManagerRefV1,
             )
 
-            if isinstance(resolved_ref, OpaqueCitedContextManagerRefV1):
+            if isinstance(
+                resolved_ref,
+                (
+                    OpaqueCitedContextManagerRefV1,
+                    PartitionedOpaqueCitedContextManagerRefV1,
+                ),
+            ):
                 from sugar_lift_py_tests.sugar.with_opaque_cited_manager_sugar import (
                     WithOpaqueCitedManagerSugar,
                 )


### PR DESCRIPTION
## Summary
Reproducer: `pandas/_testing/_io.py:128` — `compress_method` is bound to `gzip.GzipFile` / `bz2.BZ2File` / … in an if/elif chain and used once as `with compress_method(path, mode=mode)`. The call has no import receipt (its callee is a local Name), so the demand table stamped it `runtime-selected` and `With` panicked — the largest owner left on the Aug 17 board (78 of 193 With rows).

A direct `with gzip.GzipFile(p)` already constructs today: the population membrane refuses stdlib as off-population and *cites* it (`OpaqueCitedContextManagerRefV1` → `WithOpaqueCitedManagerSugar`). So the partition law is: derive each arm through the same door; a partition of cited members is a cited partition, opacity carried through the selection, never averaged over it.

- **Producer** `manager_summary_derivation._populate_assigned_partition_manager_uses` (after receipt pairing, before the same-module ClassDef door). The reaching value of the callee is exactly the single-target `Assign` arms **iff nothing else binds the name in the function** (loop/with targets, aug/ann-assign, walrus, nested def/class, global/nonlocal, a formal → refuse). Each arm's RHS value receipt → `resolve_import_binding` → `resolve_source_visible_frame`; off-population → cited member seated at the arm's own coordinate.
- **Ref** `PartitionedOpaqueCitedContextManagerRefV1` + sole mint door; carries the #7422 producer-authority category so it canonicalizes; `.semantics` refuses like the single ref.
- **Consumers** `With._require_narrow_cm_ref` / `_construct_sugar` and `WithOpaqueCitedManagerSugar` admit it beside the single ref.
- **Loud, named refusals** (never `runtime-selected`): `partition-member-unauthenticated`, `partition-member-derived-unfolded` (an in-population member has a real body — folding N derived protocols under one selection is its own law), `partition-member-<kind>`.

## Test plan
- [x] `test_partitioned_manager_citation.py`: truthful twin (reproducer shape → cited partition `python:gzip.GzipFile | python:bz2.BZ2File`, constructs, `constructed_value_cid_v2` canonicalizes), lying twin (arm bound to a local helper → typed gap), rebinding twin (`for compress_method in …` → typed gap), mint refusals. 4/4
- [x] `test_opaque_cited_manager_ref.py` 16/16
- [x] `sugar-lift-py-tests -k "partitioned or opaque_cited or with_ or manager or cited"` vs a clean `origin/main` worktree: **0 new failures** (mine 95F/285P, baseline 96F/280P; the 95 are pre-existing — `_CompletedProtocol.enter_resource_outcome_for`, `YieldStepV1.value`, `UnboundLocalError 'table'`). One baseline failure passes on this branch: `test_numpy_errstate_with_still_refuses` (asserts numpy.errstate refusals are unchanged — a direct-Call path this PR does not touch; no failure text was captured on baseline).
- [x] `sugar-lift-python-source -k "manager or derivation or populate or summary or citation"`: 131F/81P identical on both.

Follow-ups this surfaced: `with open(p)` is also `runtime-selected` (builtin, no import receipt) — same citation machinery, separate cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT