### PR TITLE
Seat a registering reporter at both dependency-module doors

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/sugar/call_site_sugar.py
@@ -317,17 +317,18 @@ class CallSiteSugar(ConstructedTermSugar):
             # not a function symtable named after the class.  Asking the
             # function-only lookup for it turns an authenticated constructor
             # into a SourceTreePanic before its existing binder can run.
+            free_names: tuple[str, ...] = ()
             if isinstance(
                 owner := self.source_call_frame.owner, (FunctionDef, AsyncFunctionDef)
             ):
                 table = owner.unit.function_symtable(
                     owner.name, owner.line_col_span().start_line
                 )
-            free_names = tuple(
-                symbol.get_name()
-                for symbol in table.get_symbols()
-                if symbol.is_free() or symbol.is_nonlocal()
-            )
+                free_names = tuple(
+                    symbol.get_name()
+                    for symbol in table.get_symbols()
+                    if symbol.is_free() or symbol.is_nonlocal()
+                )
             if free_names and not getattr(
                 self.source_call_frame, "captured_binding_coordinates", ()
             ):

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -692,7 +692,27 @@ def _session_lexical_import_runner(session: SourceResolutionSession, module):
         )
     else:
         # Opens SourceFile (process-resident MaterializeModule) then lexical once.
-        typed = SourceFile((module.source, str(path), module.source_cid)).root
+        # SEAT A REGISTERING REPORTER (#7171 class). This open is often the
+        # FIRST opener of a dependency module in the process, so its bind-time
+        # roster and the lexical rows' ``definition_occurrence`` nodes carry
+        # whatever reporter is passed here for the rest of the process. Left on
+        # ``NULL_REPORTER``, a consumer call that retains such a definition
+        # (``CallSiteSugar.expected_definition_ref`` /
+        # ``expected_source_call_frame_owner``, #7423) refuses with "producer
+        # reporter owns no registration table" -- 25 files on the 2026-09-05
+        # board. Same producer roll the prefix door seats.
+        from sugar_source_tree.binding_state import (
+            ConstructionTestimonyReporterV1,
+            SubstitutionTraceBuilderV1,
+        )
+        from sugar_source_tree.reporter import NULL_REPORTER
+
+        producer_reporter = ConstructionTestimonyReporterV1(
+            NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+        )
+        typed = SourceFile(
+            (module.source, str(path), module.source_cid), reporter=producer_reporter
+        ).root
         runner = get_or_prepare_lexical_import_pass(
             typed,
             root=root,
@@ -2272,12 +2292,17 @@ def _resolve_source_visible_frame_uncached(
         context = TreeConstructionContextV1.for_source_call_construction(
             frame_projection=True
         )
-        source_file = SourceFile(
-            (module.source, module.source_seat, module.source_cid),
-            construction_context=context,
-        )
         producer_reporter = ConstructionTestimonyReporterV1(
             NULL_REPORTER, SubstitutionTraceBuilderV1(module.source_cid)
+        )
+        # Seat the producer roll at the open, not only at materialize: the
+        # bind-time roster (``unit.function_nodes`` / ``module_direct_bindings``)
+        # is what a frame owner and a lexical definition are read from, and it
+        # carries the reporter of whoever opened this identity first.
+        source_file = SourceFile(
+            (module.source, module.source_seat, module.source_cid),
+            reporter=producer_reporter,
+            construction_context=context,
         )
         producer_root = materialize(
             source_file.unit, source_file.root.ref, producer_reporter

--- a/implementations/python/sugar-lift-python-source/tests/test_source_frame_owner_reporter.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_source_frame_owner_reporter.py
@@ -1,0 +1,197 @@
+"""The frame door seats a registering reporter, like the prefix door does.
+
+#7423 made ``Call._construct_sugar`` retain the source-call-frame OWNER
+(``CallSiteSugar.expected_source_call_frame_owner``) through
+``retain_registered_node_from``.  The owner is read from the producer
+module's bind-time roster (``unit.function_nodes``), which is born on
+whatever reporter the door that opened that ``SourceFile`` passed.  The
+prefix door (``_module_prefix_outcome``) passes its
+``ConstructionTestimonyReporterV1``; the frame door
+(``_resolve_source_visible_frame_uncached``) passed nothing, so the roster
+was born on ``NULL_REPORTER`` and every retention refused with
+``producer reporter owns no registration table`` -- 25 files on the
+2026-09-05 recensus, the first board after #7423.
+
+Truthful twin: a dependency frame's owner is registered on a
+``ConstructionTestimonyReporterV1`` and a consumer call retains it.
+Lying twin: an owner born on ``NULL_REPORTER`` still refuses -- the door is
+the fix, not a relaxed retention.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+import sys
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_lift_python_source.dependency_artifact import (
+    DependencyArtifactGraph,
+    ResolvedPythonObjectV1,
+    resolve_import_binding,
+)
+from sugar_lift_python_source.manager_construction import resolve_source_visible_frame
+from sugar_lift_python_source.resolution_session import SourceResolutionSession
+from sugar_lift_py_tests.import_binding import authenticated_import_use_receipts
+from sugar_source_tree.binding_state import (
+    ConstructionTestimonyReporterV1,
+    SubstitutionTraceBuilderV1,
+)
+from sugar_source_tree.nodes import Call, ClassDef, FunctionDef, Name
+from sugar_source_tree.panic import BackendDefect
+from sugar_source_tree.reporter import CollectingReporter, NullReporter
+from sugar_source_tree.tree import SourceFile
+
+
+def _install(root: Path) -> importlib.metadata.Distribution:
+    package = root / "frame_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        "from frame_pkg.implementation import selected\n", encoding="utf-8"
+    )
+    (package / "implementation.py").write_text(
+        "class Boom(ValueError):\n"
+        "    pass\n"
+        "\n"
+        "def helper(value):\n"
+        "    return value\n"
+        "\n"
+        "def selected(value):\n"
+        "    if value < 0:\n"
+        "        raise Boom(value)\n"
+        "    return helper(value)\n",
+        encoding="utf-8",
+    )
+    metadata = root / "frame_dist-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: frame-dist\nVersion: 1.0\n", encoding="utf-8"
+    )
+    (metadata / "top_level.txt").write_text("frame_pkg\n", encoding="utf-8")
+    recorded = (
+        "frame_pkg/__init__.py",
+        "frame_pkg/implementation.py",
+        "frame_dist-1.0.dist-info/METADATA",
+        "frame_dist-1.0.dist-info/top_level.txt",
+        "frame_dist-1.0.dist-info/RECORD",
+    )
+    with (metadata / "RECORD").open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.writer(stream)
+        for item in recorded:
+            writer.writerow((item, "", ""))
+    sys.modules.pop("frame_pkg", None)
+    sys.modules.pop("frame_pkg.implementation", None)
+    return importlib.metadata.Distribution.at(metadata)
+
+
+def _dependency_frame(tmp_path: Path):
+    graph = DependencyArtifactGraph.authenticate(_install(tmp_path))
+    consumer = tmp_path / "consumer.py"
+    source = "import frame_pkg\nframe_pkg.selected(1)\n"
+    consumer.write_text(source, encoding="utf-8")
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path, consumer, source, blake3_512_of(source.encode("utf-8")), module_identities={}
+    )
+    assert len(receipts) == 1
+    session = SourceResolutionSession(enrolled_distributions=frozenset({graph.distribution_name}))
+    resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
+    assert isinstance(resolved, ResolvedPythonObjectV1)
+    projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
+    assert isinstance(projected, tuple), projected
+    frame, target = projected
+    return frame, target
+
+
+def test_dependency_frame_owner_is_registered_on_a_testimony_reporter(tmp_path) -> None:
+    """The bind-time roster the frame owner is read from carries a registering reporter."""
+    frame, target = _dependency_frame(tmp_path)
+    owner = frame.owner
+    assert isinstance(owner, FunctionDef) and owner.name == "selected"
+    assert type(owner.reporter) is ConstructionTestimonyReporterV1, type(owner.reporter)
+    assert owner.reporter.materialized_node_for_ref(owner.ref) is owner
+    # The projected target is the same registered occurrence, not a remint.
+    assert target is owner
+
+
+def test_consumer_retains_the_dependency_frame_owner(tmp_path) -> None:
+    """What #7423's expected_source_call_frame_owner projection does at the call."""
+    frame, _target = _dependency_frame(tmp_path)
+    owner = frame.owner
+    consumer = ConstructionTestimonyReporterV1(
+        CollectingReporter(), SubstitutionTraceBuilderV1(owner.unit.source_cid)
+    )
+    retained = consumer.retain_registered_node_from(owner, owner.reporter)
+    assert retained is owner
+    assert consumer.materialized_node_for_ref(owner.ref) is owner
+
+
+def test_an_owner_born_on_null_reporter_still_refuses(tmp_path) -> None:
+    """Lying twin: the door is the repair, retention never relaxes."""
+    frame, _target = _dependency_frame(tmp_path)
+    owner = frame.owner
+    consumer = ConstructionTestimonyReporterV1(
+        CollectingReporter(), SubstitutionTraceBuilderV1(owner.unit.source_cid)
+    )
+    with pytest.raises(BackendDefect, match="owns no registration table"):
+        consumer.retain_registered_node_from(owner, NullReporter())
+
+
+def test_dependency_body_call_to_a_same_module_class_retains(tmp_path) -> None:
+    """The recensus shape: ``raise Boom(value)`` inside the dependency body.
+
+    ``Boom`` is a ClassDef, so it is never in ``function_nodes``; the call
+    reaches it through ``module_direct_bindings`` -- the bind-time roster that
+    carries the reporter of whoever opened this ``SourceFile`` first.  On the
+    2026-09-05 board that was ``NULL_REPORTER`` at
+    ``pandas/util/version/__init__.py:113`` (``class InvalidVersion``), 25 files.
+    """
+    frame, target = _dependency_frame(tmp_path)
+    boom_call = next(
+        node
+        for node in target.walk()
+        if isinstance(node, Call) and isinstance(node.func, Name) and node.func.id == "Boom"
+    )
+    sugar = boom_call.sugar()  # BackendDefect before the frame door seated its reporter
+    definition = sugar.expected_definition_ref
+    assert isinstance(definition, ClassDef) and definition.name == "Boom"
+    assert type(definition.reporter) is ConstructionTestimonyReporterV1
+
+
+def test_dependency_first_opened_on_null_reporter_still_registers(tmp_path) -> None:
+    """The recensus order: an earlier file's resolution opened the dependency
+    module on NULL_REPORTER (demand walk / plain from_path).  Process residency
+    then hands the frame door that shell; its bind-time roster is the NULL
+    shell unless the frame door seats its own reporter onto it."""
+    graph_root = tmp_path
+    frame, target = None, None
+    # First opener: NULL_REPORTER, as SourceFile.from_path does.
+    distribution_dir = graph_root / "frame_pkg"
+    # _dependency_frame installs the package; install first, open, then resolve.
+    dist = _install(graph_root)
+    stale = SourceFile.from_path(distribution_dir / "implementation.py")
+    assert type(stale.reporter) is NullReporter
+    graph = DependencyArtifactGraph.authenticate(dist)
+    consumer = tmp_path / "consumer.py"
+    source = "import frame_pkg\nframe_pkg.selected(1)\n"
+    consumer.write_text(source, encoding="utf-8")
+    receipts, _ = authenticated_import_use_receipts(
+        tmp_path, consumer, source, blake3_512_of(source.encode("utf-8")), module_identities={}
+    )
+    session = SourceResolutionSession(enrolled_distributions=frozenset({graph.distribution_name}))
+    resolved = resolve_import_binding(receipts[0], graph=graph, session=session)
+    projected = resolve_source_visible_frame(resolved, graph=graph, session=session)
+    assert isinstance(projected, tuple), projected
+    frame, target = projected
+    boom_call = next(
+        node
+        for node in target.walk()
+        if isinstance(node, Call) and isinstance(node.func, Name) and node.func.id == "Boom"
+    )
+    sugar = boom_call.sugar()
+    definition = sugar.expected_definition_ref
+    assert isinstance(definition, ClassDef) and definition.name == "Boom"
+    assert type(definition.reporter) is ConstructionTestimonyReporterV1
+    assert type(frame.owner.reporter) is ConstructionTestimonyReporterV1


### PR DESCRIPTION
## Summary
The first recensus after #7423 (2026-09-05, run 33974846713) measured all 8 shards and then **refused to seal**: 25 files carried `BACKEND DEFECT [ConstructionTestimonyReporterV1.retain_registered_node_from] — producer reporter owns no registration table (producer=NullReporter)` blamed at `pandas/util/version/__init__.py:113` (`class InvalidVersion`), plus 2 files with `UnboundLocalError: 'table'` from `CallSiteSugar.desugar`.

#7423 made `Call._construct_sugar` retain the lexical definition occurrence and the source-call-frame owner through `retain_registered_node_from`. Both are read from the **producer module's bind-time roster**, which carries the reporter of whoever opened that identity first in the process. Two doors opened dependency modules with no reporter:
- `_session_lexical_import_runner` — the lexical import pass; its rows mint `definition_occurrence` nodes from that `NULL_REPORTER` root.
- `_resolve_source_visible_frame_uncached` — the frame door; it seated its producer roll only at `materialize()`, not at the open the roster comes from.

Both now open with a `ConstructionTestimonyReporterV1` producer roll — the same roll `_module_prefix_outcome` already seats; i.e. exactly the "seat a real reporter at the door that opened this tree" repair the refusal names. Retention is unchanged and still refuses a `NullReporter` producer (lying twin).

`CallSiteSugar.desugar`: a class-constructor frame is owned by a `ClassDef` and has no free names — the comment said so, the code still read a `table` it never looked up.

## Test plan
- [x] `test_source_frame_owner_reporter.py` (new): frame owner registered on a testimony reporter; consumer retains it; same-module class call inside the dependency body retains; dependency first opened elsewhere still registers; **lying twin** — an owner born on `NULL_REPORTER` still refuses. 5/5
- [x] `sugar-lift-python-source -k "manager or derivation or populate or summary or citation"` vs clean `origin/main`: **131 → 61 failed, 70 fixed, 0 new, 0 `retain_registered_node_from` left**. `test_generator_manager_renamed_lifecycle.py` 16 → 3 failing (the 3 were failing on baseline).
- [x] `test_cpython_call_handle_testimony.py` (#7423's): 12F/14P identical on baseline and this branch — pre-existing.
- [ ] `sugar-lift-py-tests -k "partitioned or opaque_cited or with_ or manager or cited"` vs baseline — running
- [ ] Tip board dispatched on this branch: run 33981366949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT