### PR TITLE
An annotated declaration is not a binder of a partitioned manager callee

### DIFF
--- a/implementations/python/sugar-lift-py-tests/tests/test_partitioned_manager_citation.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_partitioned_manager_citation.py
@@ -157,3 +157,27 @@ def _site(line: int):
     )
 
     return SourceFragmentCoordinateV1("blake3-512:" + "ab" * 64, line, 0, line, 10)
+
+
+def test_annotated_declaration_is_not_a_binder(tmp_path: Path) -> None:
+    """``compress_method: Callable`` declares and binds nothing (pandas/_testing/_io.py:94).
+
+    The first sealed board after #7429 refused the reproducer through this
+    exact line. ``m: T = a.A`` with a value is an arm like any other."""
+    source = PARTITION.replace(
+        "def f(p, kind):\n",
+        "from typing import Callable\n\ndef f(p, kind):\n    compress_method: Callable\n",
+    ).replace(
+        "        compress_method = bz2.BZ2File\n",
+        "        compress_method: Callable = bz2.BZ2File\n",
+    )
+    root = _corpus(tmp_path, **{"annotated.py": source})
+    source_file = _open(root, "annotated.py")
+    with_node, ref = _with_resolution(source_file)
+
+    assert isinstance(ref, PartitionedOpaqueCitedContextManagerRefV1), ref
+    assert [m.target_name for m in ref.members] == [
+        "python:gzip.GzipFile",
+        "python:bz2.BZ2File",
+    ]
+    assert isinstance(with_node.sugar(), WithOpaqueCitedManagerSugar)

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1850,7 +1850,18 @@ def _name_binders(function, name: str):
                 assignments.append(node)
             elif any(name in names_in(target) for target in node.targets):
                 other.append(node)
-        elif isinstance(node, (AugAssign, AnnAssign, NamedExpr)):
+        elif isinstance(node, AnnAssign):
+            # ``m: Callable`` declares; it binds nothing (pandas/_testing/_io.py:94
+            # refused the reproducer through exactly this line on the first
+            # sealed board). ``m: T = a.A`` is an arm like any Assign to ``m``.
+            if node.value is None or not (
+                isinstance(node.target, Name) and node.target.id == name
+            ):
+                if name in names_in(node.target) and node.value is not None:
+                    other.append(node)
+                continue
+            assignments.append(node)
+        elif isinstance(node, (AugAssign, NamedExpr)):
             if name in names_in(node.target):
                 other.append(node)
         elif isinstance(node, (For, AsyncFor)):


### PR DESCRIPTION
## Summary
The first sealed board after #7429 (run 33982802518, `main` = 4089c6b1d4) refused the reproducer itself with `partition-member-unauthenticated … also bound by AnnAssign@94`: `pandas/_testing/_io.py` declares `compress_method: Callable` before the if/elif arms assign it, and `_name_binders` counted that bare annotation as a binder. A bare annotated declaration binds nothing; an annotated assignment **with** a value is an arm like any `Assign` to the name.

Board context: `runtime-selected` on the sealed board is 74 rows — 26 `with monkeypatch.context()`, 26 `with open(...)`, ~12 fixture/local method calls, ~5 bare Names, and exactly **1** assigned-partition callee (this one). The builtin-`open` and fixture-method shapes are separate laws.

## Test plan
- [x] `test_partitioned_manager_citation.py` + new `test_annotated_declaration_is_not_a_binder`: 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT