### PR TITLE
Cut 1: enroll authenticated source populations; share the async member door

### DIFF
--- a/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
+++ b/implementations/python/sugar-lift-py-tests/scripts/compose_control_effect_board.py
@@ -1428,6 +1428,12 @@ def build_plan(
     return plan
 
 
+def _declared_extra_populations() -> frozenset:
+    from sugar_lift_python_source.resolution_session import declared_extra_populations
+
+    return declared_extra_populations()
+
+
 def mint_partial(
     *,
     plan: Mapping[str, Any],
@@ -1606,6 +1612,9 @@ def mint_partial(
             "kind": "shard-bin",
             "assignedFiles": assigned,
             "assignedFileCount": len(assigned),
+            # Plan Cut 1: the extra authenticated source populations this
+            # measurement enrolled (declared, never inferred).
+            "enrolledExtraPopulations": sorted(_declared_extra_populations()),
         },
         "shardFileSetCid": shard_file_set_cid(assigned),
         "terminalFiles": terminal_files,

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/lift_rpc.py
@@ -314,7 +314,10 @@ def open_source_file_for_construction(
     *before* SourceFile still raises (empty denominator). Process-control
     exceptions (``BaseException`` outside ``Exception``) still halt.
     """
-    from sugar_lift_python_source.resolution_session import walk_session_for
+    from sugar_lift_python_source.resolution_session import (
+        enrolled_population_roster,
+        walk_session_for,
+    )
     from sugar_lift_python_source.source_oracle import workspace_path_source
     from sugar_source_tree.reporter import NULL_REPORTER
     from sugar_source_tree.tree import SourceFile
@@ -385,7 +388,7 @@ def open_source_file_for_construction(
                 )
             session = walk_session_for(
                 root,
-                enrolled_distributions=frozenset({distribution}),
+                enrolled_distributions=enrolled_population_roster(distribution),
             )
         # Catch Exception, not BaseException: KeyboardInterrupt / SystemExit /
         # GeneratorExit still halt the process. Do not enumerate SNW/TypeError
@@ -2528,7 +2531,10 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                 from sugar_lift_python_source.manager_summary_derivation import (
                     populate_source_derived_resource_refs,
                 )
-                from sugar_lift_python_source.resolution_session import walk_session_for
+                from sugar_lift_python_source.resolution_session import (
+        enrolled_population_roster,
+        walk_session_for,
+    )
 
                 # Walk-scoped multi-resolve owner: same session as other opens
                 # under this workspace root (census / re-open amortization).
@@ -2549,7 +2555,7 @@ def _handle_enumerate(msg_id: Any, params: Dict[str, Any]) -> None:
                         path=full_path,
                         session=walk_session_for(
                             root,
-                            enrolled_distributions=frozenset({distribution}),
+                            enrolled_distributions=enrolled_population_roster(distribution),
                         ),
                         source_workspace_root=locus_root,
                         distribution=distribution,

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_construction.py
@@ -899,7 +899,9 @@ def _module_prefix_outcome(module, locus, *, graph=None, session=None):
     # Defensive membrane: stdlib must never reach MaterializeModule here.
     # Callers should short-circuit in prefix_has_completed_fallthrough; if they
     # do not, refuse loudly rather than rebuild an unenrolled module.
-    if graph is not None and _graph_is_off_population(graph, session=session):
+    if graph is not None and _graph_is_off_population(
+        graph, session=session, module_name=getattr(module, "module_name", None)
+    ):
         raise RuntimeError(
             "population membrane: _module_prefix_outcome must not MaterializeModule "
             f"off-population seat {module.source_seat!r}; cite via "
@@ -1198,7 +1200,9 @@ def prefix_has_completed_fallthrough(
     from sugar_lift_py_tests.outcome import Completed, true_guard
 
     session = session_or_new(session)
-    if graph is not None and _graph_is_off_population(graph, session=session):
+    if graph is not None and _graph_is_off_population(
+        graph, session=session, module_name=getattr(module, "module_name", None)
+    ):
         # Cite path: admit static export without off-population construction.
         return PrefixFallthroughOutcomeV1("completed")
 
@@ -1409,8 +1413,18 @@ def _graph_is_off_population(
     graph: "DependencyArtifactGraph",
     *,
     session: SourceResolutionSession | None = None,
+    module_name: str | None = None,
 ) -> bool:
     """True when ``graph`` is outside the enrolled measurement population.
+
+    ROSTER-ONLY LAW (plan Cut 1). The population is what the measurement
+    DECLARES (``enrolled_population_roster``): the corpus distribution plus
+    any extra authenticated source population -- ``pytest``, ``numpy``, and
+    the stdlib under its own graph name ``cpython-stdlib`` -- optionally one
+    module at a time (``cpython-stdlib:contextlib``). Nothing is refused by
+    kind any more; stdlib used to be refused unconditionally, which is why
+    every ``pytest.raises`` / ``nullcontext`` / ``open`` on the 2026-09-05
+    board was cited or gapped and ``cmResolutions.constructed`` was 0.
 
     - stdlib is always off-pin (CPython is not the corpus pin).
     - any distribution whose name is absent from the session's authoritative
@@ -1421,10 +1435,12 @@ def _graph_is_off_population(
         raise TypeError(
             "population classification requires an enrolled distribution roster"
         )
-    if getattr(graph, "artifact_kind", None) == "stdlib":
-        return True
+    from .resolution_session import population_admits
+
     name = getattr(graph, "distribution_name", None)
-    return name is not None and name not in session.enrolled_distributions
+    if name is None:
+        return False
+    return not population_admits(session.enrolled_distributions, name, module_name)
 
 
 def _off_population_materialize_gap(
@@ -1443,7 +1459,9 @@ def _off_population_materialize_gap(
     Return a typed gap so every caller takes the same cite path failure already
     uses.
     """
-    if not _graph_is_off_population(graph, session=session):
+    if not _graph_is_off_population(
+        graph, session=session, module_name=resolved.module_name
+    ):
         return None
     if graph.artifact_kind == "stdlib":
         detail = (

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/manager_summary_derivation.py
@@ -1288,7 +1288,14 @@ def populate_source_derived_resource_refs(
             distribution=distribution,
         )
     if distribution is not None:
-        session.enrolled_distributions = frozenset({distribution})
+        from .resolution_session import enrolled_population_roster
+
+        # Never NARROW a session's declared population mid-walk: the walk
+        # session was minted with the full roster; this open contributes its
+        # corpus distribution to it.
+        session.enrolled_distributions = enrolled_population_roster(
+            distribution
+        ) | (session.enrolled_distributions or frozenset())
     elif session.enrolled_distributions is None:
         raise MissingEnrolledDistributionRoster(
             "missing-enrolled-distribution-roster: distribution authority was not "

--- a/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
+++ b/implementations/python/sugar-lift-python-source/src/sugar_lift_python_source/resolution_session.py
@@ -94,6 +94,7 @@ from __future__ import annotations
 
 import collections
 import os
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -109,6 +110,51 @@ _ROSTER_UNSET = object()
 # retained frame_holds for every projected SourceFile forever recreated the
 # "shared context degrades across opens" disease at corpus scale.
 _DEFAULT_FRAME_MEMO_LIMIT = 512
+
+
+ENROLLED_POPULATIONS_ENV = "SUGAR_ENROLLED_POPULATIONS"
+
+_POPULATION_ENTRY = re.compile(r"^[A-Za-z0-9_.\-]+(:[A-Za-z_][A-Za-z0-9_]*)?$")
+
+
+def declared_extra_populations() -> frozenset[str]:
+    """The extra authenticated source populations this measurement enrolls.
+
+    Declared, never inferred: ``SUGAR_ENROLLED_POPULATIONS`` is a comma list
+    of entries. An entry is a distribution name as its dependency graph
+    spells it (``pytest``, ``numpy``, ``cpython-stdlib``) or a module-scoped
+    form ``<distribution>:<top-level module>`` (``cpython-stdlib:contextlib``)
+    that enrolls one module of a distribution so a population can be widened
+    one module at a time and measured (plan Cut 1). Malformed entries refuse.
+    """
+    raw = os.environ.get(ENROLLED_POPULATIONS_ENV, "")
+    entries = frozenset(item.strip() for item in raw.split(",") if item.strip())
+    for entry in entries:
+        if not _POPULATION_ENTRY.match(entry):
+            raise TypeError(
+                f"{ENROLLED_POPULATIONS_ENV} entry {entry!r} is not a distribution "
+                "name or '<distribution>:<module>'"
+            )
+    return entries
+
+
+def enrolled_population_roster(distribution: str) -> frozenset[str]:
+    """The corpus distribution plus every declared extra population."""
+    if not isinstance(distribution, str) or not distribution:
+        raise TypeError("enrolled_population_roster requires the corpus distribution")
+    return frozenset({distribution}) | declared_extra_populations()
+
+
+def population_admits(roster: frozenset[str], name: str, module_name: str | None) -> bool:
+    """True when ``name`` (a graph's distribution name) is enrolled for this
+    module: by distribution, or by a module-scoped entry naming its top-level
+    module. ``None`` module means only a distribution-level entry admits."""
+    if name in roster:
+        return True
+    if module_name:
+        top = module_name.split(".", 1)[0]
+        return f"{name}:{top}" in roster
+    return False
 
 
 def _require_enrolled_distribution_roster(value: object) -> frozenset[str]:

--- a/implementations/python/sugar-lift-python-source/tests/test_population_roster.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_population_roster.py
@@ -1,0 +1,137 @@
+"""Plan Cut 1: the population membrane is roster-only, declared, module-scoped.
+
+Board 33982802518: cmResolutions constructed 0 / cited-opaque 5,812 /
+unconstructed 2,245, because stdlib was refused by KIND and every
+non-corpus distribution by absence from a one-name roster. The population
+is now what the measurement DECLARES (``SUGAR_ENROLLED_POPULATIONS``):
+the corpus distribution plus extra authenticated source populations,
+optionally one module at a time (``cpython-stdlib:contextlib``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_python_source.resolution_session import (
+    ENROLLED_POPULATIONS_ENV,
+    clear_walk_sessions,
+    declared_extra_populations,
+    enrolled_population_roster,
+    population_admits,
+)
+from sugar_lift_py_tests.context_manager_resolution import (
+    ContextManagerResolutionGapV1,
+    OpaqueCitedContextManagerRefV1,
+)
+from sugar_lift_py_tests.corpus_pin import pin_corpus
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_source_tree.nodes import With
+from sugar_source_tree.reporter import CollectingReporter
+
+
+def test_roster_is_the_corpus_plus_declared_extras(monkeypatch) -> None:
+    monkeypatch.delenv(ENROLLED_POPULATIONS_ENV, raising=False)
+    assert enrolled_population_roster("pandas") == frozenset({"pandas"})
+    monkeypatch.setenv(ENROLLED_POPULATIONS_ENV, "pytest, cpython-stdlib:contextlib ,numpy")
+    assert declared_extra_populations() == frozenset(
+        {"pytest", "cpython-stdlib:contextlib", "numpy"}
+    )
+    assert "pandas" in enrolled_population_roster("pandas")
+
+
+def test_malformed_entries_refuse(monkeypatch) -> None:
+    monkeypatch.setenv(ENROLLED_POPULATIONS_ENV, "cpython-stdlib:contextlib.nullcontext")
+    with pytest.raises(TypeError, match="not a distribution name"):
+        declared_extra_populations()
+    monkeypatch.setenv(ENROLLED_POPULATIONS_ENV, "pytest raises")
+    with pytest.raises(TypeError):
+        declared_extra_populations()
+
+
+def test_module_scoped_entry_admits_only_its_module() -> None:
+    roster = frozenset({"pandas", "cpython-stdlib:contextlib"})
+    assert population_admits(roster, "pandas", "pandas.core.frame")
+    assert population_admits(roster, "cpython-stdlib", "contextlib")
+    assert not population_admits(roster, "cpython-stdlib", "warnings")
+    assert not population_admits(roster, "cpython-stdlib", None)
+    assert population_admits(frozenset({"cpython-stdlib"}), "cpython-stdlib", "warnings")
+    assert not population_admits(roster, "pytest", "_pytest.raises")
+
+
+NULLCONTEXT = (
+    "from contextlib import nullcontext\n"
+    "\n"
+    "def f():\n"
+    "    with nullcontext():\n"
+    "        return 1\n"
+)
+WARNINGS = (
+    "import warnings\n"
+    "\n"
+    "def f():\n"
+    "    with warnings.catch_warnings():\n"
+    "        return 1\n"
+)
+
+
+def _corpus(tmp_path: Path, **files: str) -> Path:
+    root = tmp_path / "c"
+    root.mkdir()
+    for name, source in files.items():
+        (root / name).write_text(source, encoding="utf-8")
+    (tmp_path / "c.identity.json").write_text(
+        json.dumps({"distribution": "tiny-corpus", "version": "0.0.1"}), encoding="utf-8"
+    )
+    pin_corpus(root, distribution="tiny-corpus", version="0.0.1")
+    return root
+
+
+def _with_resolution(root: Path, name: str):
+    clear_walk_sessions()
+    source_file = open_source_file_for_construction(
+        root / name,
+        root=root,
+        reporter=CollectingReporter(),
+        distribution="tiny-corpus",
+        source_workspace_root=root,
+    )
+    with_node = next(n for n in source_file.nodes() if isinstance(n, With))
+    refs = source_file.root.unit.construction_context.source_derived_contract_refs
+    line = with_node.line_col_span().start_line
+    (site,) = [k for k in refs if k.start_line == line]
+    return refs[site]
+
+
+def test_stdlib_manager_is_cited_under_the_corpus_only_roster(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv(ENROLLED_POPULATIONS_ENV, raising=False)
+    root = _corpus(tmp_path, **{"nc.py": NULLCONTEXT})
+    ref = _with_resolution(root, "nc.py")
+    assert isinstance(ref, OpaqueCitedContextManagerRefV1)
+    assert ref.roster.resolution_kind == "call-target-off-population"
+
+
+def test_enrolling_contextlib_stops_citing_nullcontext(tmp_path, monkeypatch) -> None:
+    """Truthful twin: with contextlib enrolled the membrane no longer cites;
+    whatever derivation says next is a NAMED fact about nullcontext's body,
+    never an off-population citation."""
+    monkeypatch.setenv(ENROLLED_POPULATIONS_ENV, "cpython-stdlib:contextlib")
+    root = _corpus(tmp_path, **{"nc.py": NULLCONTEXT})
+    ref = _with_resolution(root, "nc.py")
+    assert not isinstance(ref, OpaqueCitedContextManagerRefV1), ref
+    if isinstance(ref, ContextManagerResolutionGapV1):
+        assert ref.kind != "call-target-off-population", ref
+        print("nullcontext derivation gap:", ref.kind, ref.detail)
+    else:
+        print("nullcontext derived:", type(ref).__name__)
+
+
+def test_enrolling_contextlib_does_not_enroll_warnings(tmp_path, monkeypatch) -> None:
+    """Lying twin: a module-scoped entry admits one module, not the stdlib."""
+    monkeypatch.setenv(ENROLLED_POPULATIONS_ENV, "cpython-stdlib:contextlib")
+    root = _corpus(tmp_path, **{"w.py": WARNINGS})
+    ref = _with_resolution(root, "w.py")
+    assert isinstance(ref, OpaqueCitedContextManagerRefV1)
+    assert ref.roster.resolution_kind == "call-target-off-population"

--- a/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_static_prefix_fallthrough.py
@@ -101,16 +101,22 @@ def test_static_open_control_prefix_declines_static_door() -> None:
     assert _static_prefix_always_fallthrough(module, locus) is False
 
 
-def test_stdlib_graph_still_short_circuits(monkeypatch) -> None:
+def test_unenrolled_stdlib_graph_still_short_circuits(monkeypatch) -> None:
+    """A stdlib graph NOT in the roster still cites without MaterializeModule.
+
+    Since plan Cut 1 the membrane is roster-only (nothing refused by kind),
+    so the graph carries its real distribution name ``cpython-stdlib``; with
+    an empty roster it is off-population and short-circuits exactly as before.
+    """
     source = "def export():\n    return 1\n"
     module = _module(source)
     locus = _locus_of(source, "export")
-    graph = SimpleNamespace(artifact_kind="stdlib")
+    graph = SimpleNamespace(artifact_kind="stdlib", distribution_name="cpython-stdlib")
     calls = {"n": 0}
 
     def boom(*a, **k):
         calls["n"] += 1
-        raise AssertionError("stdlib must not reach outcome")
+        raise AssertionError("unenrolled stdlib must not reach outcome")
 
     monkeypatch.setattr(
         "sugar_lift_python_source.manager_construction._module_prefix_outcome",
@@ -132,6 +138,22 @@ def test_stdlib_graph_still_short_circuits(monkeypatch) -> None:
     assert calls["n"] == 0
 
 
+def test_the_membrane_is_roster_only_not_kind() -> None:
+    """Cut 1: stdlib is off-population only when NOT enrolled; a module-scoped
+    entry pulls exactly its module in. Nothing is decided by artifact kind."""
+    from sugar_lift_python_source.manager_construction import _graph_is_off_population
+
+    graph = SimpleNamespace(artifact_kind="stdlib", distribution_name="cpython-stdlib")
+    empty = SourceResolutionSession(enrolled_distributions=frozenset())
+    enrolled = SourceResolutionSession(
+        enrolled_distributions=frozenset({"cpython-stdlib:contextlib"})
+    )
+    assert _graph_is_off_population(graph, session=empty, module_name="contextlib")
+    assert not _graph_is_off_population(
+        graph, session=enrolled, module_name="contextlib"
+    )
+    # The module entry admits only its module, never the whole distribution.
+    assert _graph_is_off_population(graph, session=enrolled, module_name="warnings")
 def test_prefix_construction_refusal_is_typed_and_memoized(monkeypatch) -> None:
     """Construction refusal is testimony, never cached ordinary False."""
     from sugar_source_tree.panic import SugarNotWritten

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -4989,6 +4989,22 @@ class AsyncFunctionDef(Statement):
         """One body door: statement constructs through its children."""
         return FunctionDef._sugar_body_statement(self, stmt)
 
+    def source_visible_call_frame(self):
+        """Same frame door as FunctionDef (same formals/body shape); the
+        guard and the recursion seat live there."""
+        return FunctionDef.source_visible_call_frame(self)
+
+    # Frame-door helper shared with FunctionDef (a staticmethod there).
+    _owns_yield = staticmethod(FunctionDef._owns_yield)
+
+    def _make_coordinate_ref(self, *args, **kwargs):
+        """Frame-door helper shared with FunctionDef (see source_visible_call_frame)."""
+        return FunctionDef._make_coordinate_ref(self, *args, **kwargs)
+
+    def _source_visible_generator_steps_from(self, *args, **kwargs):
+        """Frame-door helper shared with FunctionDef (see source_visible_call_frame)."""
+        return FunctionDef._source_visible_generator_steps_from(self, *args, **kwargs)
+
     def _construct_sugar(self):
         """L1a: FunctionUniverse body construction — same door as FunctionDef."""
         return FunctionDef._construct_sugar(self)
@@ -5175,25 +5191,15 @@ class ClassDef(Statement):
         """
         from sugar_lift_py_tests.floor import ConstructedClassMethodV1
 
-        if isinstance(method, FunctionDef):
-            # White FunctionDef door — ClassDef does not reimplement method bodies.
+        if isinstance(method, (FunctionDef, AsyncFunctionDef)):
+            # White FunctionDef door -- ClassDef does not reimplement method
+            # bodies. AsyncFunctionDef shares it (same formals/body shape); its
+            # universe is a coroutine factory, which the SYNC manager protocol
+            # never enters. Refusing the whole class over an async member is
+            # why contextlib.nullcontext (async def __aenter__) stopped at
+            # force-floor the moment contextlib was enrolled (plan Cut 1).
             body = method.sugar()
             frame = method.source_visible_call_frame()
-        elif isinstance(method, AsyncFunctionDef):
-            from sugar_source_tree.panic import SugarNotWritten
-
-            # Membership is recognized (not "unsupported class member"). Body
-            # construction is the FunctionDef door (async arm not written yet).
-            raise SugarNotWritten(
-                blame=method.fragment,
-                owner="ClassDef._construct_class_method_member",
-                observed="AsyncFunctionDef method body construction",
-                requested="AsyncFunctionDef construction through the FunctionDef door",
-                fix=(
-                    "write AsyncFunctionDef body construction on the FunctionDef "
-                    "door; ClassDef L1b owns fields/nested/conditionals only"
-                ),
-            )
         else:
             from sugar_source_tree.panic import SugarNotWritten
 

--- a/implementations/python/sugar-source-tree/tests/test_async_class_member_door.py
+++ b/implementations/python/sugar-source-tree/tests/test_async_class_member_door.py
@@ -1,0 +1,61 @@
+"""An async method is a class member through the same FunctionDef door.
+
+``contextlib.nullcontext`` carries ``async def __aenter__/__aexit__`` beside
+the sync protocol. The class-member door refused every class with an async
+member ("async arm not written yet"), so the first module enrolled under
+plan Cut 1 stopped at ``force-floor`` before touching ``__enter__``.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+from sugar_lift_py_tests.lift_rpc import open_source_file_for_construction
+from sugar_lift_py_tests.sugar.function_universe_sugar import FunctionUniverseSugar
+from sugar_source_tree.nodes import AsyncFunctionDef, ClassDef
+from sugar_source_tree.reporter import CollectingReporter
+
+SOURCE = (
+    "class Both:\n"
+    "    def __init__(self, result=None):\n"
+    "        self.result = result\n"
+    "    def __enter__(self):\n"
+    "        return self.result\n"
+    "    def __exit__(self, *excinfo):\n"
+    "        pass\n"
+    "    async def __aenter__(self):\n"
+    "        return self.result\n"
+    "    async def __aexit__(self, *excinfo):\n"
+    "        pass\n"
+)
+
+
+def _class(tmp_path):
+    path = tmp_path / "both.py"
+    path.write_text(SOURCE)
+    source_file = open_source_file_for_construction(
+        path,
+        root=tmp_path,
+        reporter=CollectingReporter(),
+        construction_context=TreeConstructionContextV1.for_source_call_construction(),
+        populate_derived=False,
+    )
+    return next(n for n in source_file.nodes() if isinstance(n, ClassDef))
+
+
+def test_async_members_construct_through_the_function_door(tmp_path) -> None:
+    cls = _class(tmp_path)
+    async_member = next(m for m in cls.body if isinstance(m, AsyncFunctionDef))
+    member = cls._construct_class_method_member(async_member)
+    assert member.name == "__aenter__"
+    assert isinstance(member.body, FunctionUniverseSugar)
+    assert member.source_call_frame is not None and member.source_call_frame.owner is async_member
+
+
+def test_class_with_async_members_constructs(tmp_path) -> None:
+    """The sync protocol's owner no longer refuses over a member it never enters."""
+    cls = _class(tmp_path)
+    sugar = cls.sugar()
+    names = {m.name for m in getattr(sugar, "methods", ()) or ()} if hasattr(sugar, "methods") else None
+    assert sugar is not None
+    if names is not None:
+        assert {"__enter__", "__exit__", "__aenter__", "__aexit__"} <= names

--- a/implementations/python/sugar-source-tree/tests/test_classdef_body_members_l1b.py
+++ b/implementations/python/sugar-source-tree/tests/test_classdef_body_members_l1b.py
@@ -103,16 +103,21 @@ def test_l1b_fields_alongside_sync_method() -> None:
     assert sugar.methods[0].source_call_frame is not None
 
 
-def test_l1b_async_method_is_method_member_not_unsupported() -> None:
-    """AsyncFunctionDef is a method member — FunctionDef door, not unsupported."""
-    from sugar_source_tree.panic import SugarNotWritten
+def test_l1b_async_method_is_method_member_through_the_function_door() -> None:
+    """AsyncFunctionDef is a method member constructed through the FunctionDef
+    door -- not "unsupported class member", and (since plan Cut 1) not a
+    refusal either: ``contextlib.nullcontext`` carries ``async def __aenter__``
+    beside the sync protocol, and refusing the whole class over a member the
+    sync protocol never enters kept every enrolled stdlib manager at
+    ``force-floor``."""
+    from sugar_lift_py_tests.sugar.function_universe_sugar import FunctionUniverseSugar
+    from sugar_source_tree.nodes import AsyncFunctionDef
 
-    with pytest.raises(SugarNotWritten) as ei:
-        _class(
-            "class C:\n" "    a = 1\n" "    async def m(self):\n" "        return 1\n"
-        ).sugar()
-    err = ei.value
-    assert err.owner == "ClassDef._construct_class_method_member"
-    assert "AsyncFunctionDef" in err.observed
-    assert "unsupported class member" not in err.observed
-    assert "FunctionDef door" in err.fix
+    cls = _class("class C:\n" "    a = 1\n" "    async def m(self):\n" "        return 1\n")
+    member = next(m for m in cls.body if isinstance(m, AsyncFunctionDef))
+    constructed = cls._construct_class_method_member(member)
+    assert constructed.name == "m"
+    assert isinstance(constructed.body, FunctionUniverseSugar)
+    assert cls.sugar() is not None
+
+


### PR DESCRIPTION
Plan: `docs/plans/2026-09-05-with-sugar-construction-plan.md` (board 33993534115, `main` = 6abd1ab464: With constructed **0** / cited-opaque 5,812 / unconstructed 2,245).

## The wall
The population membrane refused everything not in a one-name roster — stdlib by **kind** unconditionally, every other distribution by absence. So `pytest` / `contextlib` / `warnings` / `io` / `numpy` were cited at the door, and every in-population manager whose body touched them died `source-body-gap`. That is why `cmResolutions.constructed` was 0.

## Cut 1: the population is a DECLARED roster (never inferred)
- `SUGAR_ENROLLED_POPULATIONS`: a comma list of authenticated source populations — a distribution name as its dependency graph spells it (`pytest`, `numpy`, `cpython-stdlib`) or a module-scoped `<distribution>:<module>` entry (`cpython-stdlib:contextlib`) so a population widens **one module at a time** and is measured. Malformed entries refuse.
- `enrolled_population_roster(distribution)` = corpus + declared extras; wired at both `walk_session_for` sites, **unioned** (never narrowed) at the populate door.
- `_graph_is_off_population` is roster-only and module-aware — nothing refused by kind. C-floor modules (`_io`, `_sre`, `posix`) are simply never named, so they take Cut 2's language-owned semantics rather than a rebuild.
- The shard partial records `enrolledExtraPopulations` so a board states the population it measured.

## The next door this surfaced (fixed here)
Enrolling one stdlib module proved `contextlib.nullcontext` carries `async def __aenter__/__aexit__` beside the sync protocol, and `ClassDef._construct_class_method_member` refused the whole class over an async member. An async method is a member constructed through the same FunctionDef door (its universe is a coroutine factory the sync protocol never enters); `AsyncFunctionDef` now delegates the frame door and its helpers to `FunctionDef` explicitly.

## Known next (plan Cut 6 — proven this session, NOT in this PR)
The import/frame-door builds the receiver `ObjectValue` without running `__init__`'s field stores, so `self.result` is undecided at `__enter__` (`enter-may-halt ObjectValue.attribute`). The same-module `force_floor` path seeds fields; the frame door must too before `nullcontext` derives fully. So Cut 1 removes the wall and the async door; flipping `constructed` off 0 needs Cut 2 (C floor) + Cut 6.

## Test plan (all vs correct parent `6abd1ab464`)
- [x] New twins: `test_population_roster` (corpus-only cites `nullcontext`; enrolling `contextlib` stops the citation; a module entry admits its module only), `test_async_class_member_door`, updated `test_static_prefix_fallthrough` (unenrolled stdlib still short-circuits; enrolled module is in-population), rewritten l1b async-member test
- [x] `sugar-lift-python-source -k "manager|derivation|populate|summary|citation|prefix|contextlib|dependency|population|static"`: 74 → 74 failed, **0 new**, +10 passing
- [x] `sugar-source-tree/tests` full: 301 → 301 failed, **0 new**, +2 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT