### PR TITLE
Cut 2 (core): a decidable re.search/match/fullmatch floor semantic

### DIFF
--- a/docs/plans/2026-09-05-with-sugar-construction-plan.md
+++ b/docs/plans/2026-09-05-with-sugar-construction-plan.md
@@ -110,6 +110,39 @@ can refute:
 **Twins.** exit never suppresses: a raise inside `with open(...)` propagates
 (truthful); the same site asserted as suppressed → refuted (lying).
 
+### Cut 2 — status 2026-09-05 (first increment landed)
+
+The **matcher core is built and tested**, decoupled from the wiring:
+- `floor/re_subset_matcher.py` — `validate_pattern` is the sole authority on
+  the decidable subset (refuses look-around, back-references, named-group
+  back-refs, conditional/atomic groups, possessive quantifiers, the global
+  inline-flags prefix — each by name); a validated pattern is executed by the
+  authenticated runtime's own `re` (`PythonRuntimeIdentity` is the key), which
+  IS the definition of the answer for the subset. Returns a bounded
+  `RegexMatchSpanV1` or None.
+- `floor/re_match_value.py` — `ReMatchValue`: subject + spans, unconditionally
+  truthy (a Match always is), `group_text(n)` decidable; None-match is
+  `NoneValue` (falsy).
+- `BuiltinSemanticCallable` gained `python.re.search/match/fullmatch`: concrete
+  `StringValue` operands only; symbolic operands or out-of-subset patterns keep
+  the call loud (`ConstructionPanic`), never a guessed (non-)match.
+- Twins: `test_re_subset_matcher` (26 — every subset case agrees with the
+  runtime; every refused construct refuses by name; bad pattern is loud) and
+  `test_re_semantic_callable` (6 — truthful/lying search, anchored match/
+  fullmatch, group recovery, symbolic + out-of-subset stay loud).
+
+**Not yet wired (the remaining half of Cut 2):** recognizing an authenticated
+import target `python:re.search` at call resolution and binding the callee to
+`BuiltinSemanticCallable(operation="python.re.search")`. Today `re.search`
+resolves to an `ImportMemberValue` / seated cpython frame that bottoms out at
+`_sre`. The wiring must sit at the authenticated-import call door (NOT the
+spelling), the same door `pytest.raises`'s `match=` flows through. BLOCKER:
+the re-authentication seating path (`test_regex_search_dependency_authority`,
+`test_regexflag_relative_member_seating`) has ~9 pre-existing failures; those
+must go green before the C-floor recognition can hang off a trustworthy
+authenticated target. `_io.open` and the other C-floor callables take the same
+recognition door once it exists.
+
 ### Cut 3 — derive `pytest.raises` (5,815 sites) — *assertion-With milestone, part 1*
 With pytest enrolled, `_pytest/raises.py::RaisesExc.__exit__` derives through
 the existing generator/class doors into a **factored** effect boundary

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/__init__.py
@@ -13,6 +13,7 @@ from .module_bound_var import ModuleBoundVar
 from .mutable_global_value import MutableGlobalValue
 from .named_expression_value import NamedExpressionValue
 from .native_callable_value import NativeCallableValue
+from .re_match_value import ReMatchValue
 from .builder_state import BuilderState
 from .bv32_value import Bv32Value
 from .builtin_exception_class_value import BuiltinExceptionClassValue
@@ -190,6 +191,7 @@ __all__ = [
     "ModuleBoundVar",
     "NamedExpressionValue",
     "NativeCallableValue",
+    "ReMatchValue",
     "BuilderState",
     "Bv32Value",
     "BuiltinExceptionClassValue",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_semantic_callable.py
@@ -48,6 +48,12 @@ class BuiltinSemanticCallable(FloorValue):
             if floored is not None:
                 return floored
             return self._unhandled_construct(operation, "dict")
+        if self.operation in (
+            "python.re.search",
+            "python.re.match",
+            "python.re.fullmatch",
+        ):
+            return self._re_match(operation)
         if self.operation == "python.isinstance":
             return self._isinstance(operation)
         if self.operation == "python.len":
@@ -184,6 +190,71 @@ class BuiltinSemanticCallable(FloorValue):
                 )
             )
         )
+
+    def _re_match(self, operation):
+        """``re.search``/``re.match``/``re.fullmatch`` over the decidable subset.
+
+        Plan Cut 2: language-owned C-floor semantics. Both operands must be
+        concrete ``str`` floors; the pattern must be in the decidable subset
+        (validate_pattern is the authority). A successful match is a truthy
+        ``ReMatchValue``; no match is ``NoneValue``. Symbolic operands or a
+        pattern outside the subset keep the call loud -- never a guessed
+        match or non-match.
+        """
+        from sugar_lift_py_tests.floor.none_value import NoneValue
+        from sugar_lift_py_tests.floor.re_match_value import ReMatchValue
+        from sugar_lift_py_tests.floor.re_subset_matcher import (
+            UnsupportedRegexInput,
+            UnsupportedRegexPattern,
+            re_fullmatch,
+            re_match,
+            re_search,
+        )
+        from sugar_lift_py_tests.floor.string_value import StringValue
+        from sugar_lift_py_tests.gap.panic import construction_panic_gap
+        from sugar_lift_py_tests.outcome import Complete
+
+        owner = f"BuiltinSemanticCallable.{self.operation}"
+        if operation.keyword_names or len(operation.arguments) != 2:
+            construction_panic_gap(
+                owner=owner,
+                blame=str(operation.site),
+                observed=(len(operation.arguments), operation.keyword_names),
+                requested="exactly two positional authenticated re operands",
+                fix="construct re.search/match/fullmatch arity exactly or keep it loud",
+            )
+        pattern_v, subject_v = operation.arguments
+        if not isinstance(pattern_v, StringValue) or not isinstance(
+            subject_v, StringValue
+        ):
+            construction_panic_gap(
+                owner=owner,
+                blame=str(operation.site),
+                observed=(type(pattern_v).__name__, type(subject_v).__name__),
+                requested="concrete str pattern and subject",
+                fix=(
+                    "keep re over a symbolic pattern/subject loud; only concrete "
+                    "operands are decided by the subset matcher"
+                ),
+            )
+        matcher = {
+            "python.re.search": re_search,
+            "python.re.match": re_match,
+            "python.re.fullmatch": re_fullmatch,
+        }[self.operation]
+        try:
+            span = matcher(pattern_v.value, subject_v.value)
+        except (UnsupportedRegexPattern, UnsupportedRegexInput) as exc:
+            construction_panic_gap(
+                owner=owner,
+                blame=str(operation.site),
+                observed=str(exc),
+                requested="a pattern in the decidable re subset",
+                fix="keep the call loud until the subset covers this pattern",
+            )
+        if span is None:
+            return Complete(NoneValue())
+        return Complete(ReMatchValue(subject=subject_v.value, span=span))
 
     def _isinstance(self, operation):
         """Exact ``isinstance(obj, classinfo)`` over authenticated floors.

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/re_match_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/re_match_value.py
@@ -1,0 +1,55 @@
+"""The floor value for a successful ``re`` match over the decidable subset.
+
+Plan Cut 2. A ``re.Match`` is always truthy (an empty match still matches);
+no match is ``None`` (falsy). This floor carries the bounded span testimony
+from ``re_subset_matcher`` plus the concrete subject, so truthiness is
+decided now and ``.group(n)`` is decidable later without a live re.Match.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .floor_value import FloorValue
+from .re_subset_matcher import RegexMatchSpanV1
+
+
+@dataclass(frozen=True)
+class ReMatchValue(FloorValue):
+    """A successful regex match: subject + bounded spans. Always truthy."""
+
+    subject: str
+    span: RegexMatchSpanV1
+
+    def denotes_value(self) -> bool:
+        return True
+
+    def truth(self, site):
+        # A Match object is unconditionally truthy -- the presence IS the type.
+        from sugar_lift_py_tests.outcome import Complete
+        from sugar_lift_py_tests.sugar.true_bool_literal_sugar import (
+            TrueBoolLiteralSugar,
+        )
+
+        return Complete(TrueBoolLiteralSugar(site=site))
+
+    def group_text(self, index: int) -> str | None:
+        """``match.group(index)`` as concrete text: group 0 is the whole match,
+        1.. are captured groups; an unset optional group is ``None``."""
+        if index == 0:
+            return self.subject[self.span.start : self.span.end]
+        spans = self.span.group_spans
+        if not 1 <= index <= len(spans):
+            raise IndexError("no such group")
+        span = spans[index - 1]
+        return None if span is None else self.subject[span[0] : span[1]]
+
+    def to_term(self, *, owner: str):
+        del owner
+        from sugar_lift_py_tests.ir import ctor, num, str_const
+
+        return ctor(
+            "python:re_match",
+            [str_const(self.subject), num(self.span.start), num(self.span.end)],
+            symbol_kind="coordinate",
+        )

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/re_subset_matcher.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/re_subset_matcher.py
@@ -1,0 +1,160 @@
+"""A decidable subset of Python ``re`` matching, keyed to the runtime.
+
+Plan Cut 2 (docs/plans/2026-09-05-with-sugar-construction-plan.md): the C
+floor. ``re.search``/``re.match``/``re.fullmatch`` bottom out in ``_sre``,
+which has no Python body to derive; today they leave an opaque coordinate,
+so every ``pytest.raises(E, match=...)`` verdict (5,549 of 5,815 raises
+sites) is unwitnessed.
+
+This module owns the SEMANTICS as language vocabulary, the same standing
+``isinstance`` and ``len`` already have. Two responsibilities, kept apart:
+
+- ``validate_pattern`` is the sole authority on DECIDABILITY. It accepts the
+  closed pattern subset the corpus uses and refuses everything else with a
+  typed ``UnsupportedRegexPattern`` -- loud, never a guessed match. The
+  refused set is named, not open: look-around, back-references, named-group
+  back-references, conditional groups, atomic groups, possessive quantifiers,
+  inline flag scopes, and the global-flags prefix are each refused by name.
+- Execution of a VALIDATED pattern is delegated to the authenticated
+  runtime's own ``re`` (``PythonRuntimeIdentity`` is the key). For a pattern
+  in the validated subset, CPython's ``_sre`` is the definition of the
+  answer, so running it under the pinned interpreter is faithful, not a
+  guess. Nothing outside the validated subset ever reaches ``re``.
+
+The result is a bounded ``RegexMatchSpanV1`` (or ``None``): the span and the
+group spans, enough to decide truthiness and ``.group(n)`` without carrying
+a live ``re.Match``.
+"""
+
+from __future__ import annotations
+
+import re as _host_re
+from dataclasses import dataclass
+
+
+class UnsupportedRegexPattern(ValueError):
+    """A pattern outside the decidable subset. The caller keeps the call loud."""
+
+
+class UnsupportedRegexInput(ValueError):
+    """A non-concrete or non-str operand. The caller keeps the call loud."""
+
+
+@dataclass(frozen=True)
+class RegexMatchSpanV1:
+    """A bounded match: the whole span and each group's span (None if unset)."""
+
+    start: int
+    end: int
+    group_spans: tuple[tuple[int, int] | None, ...]
+
+    @property
+    def matched(self) -> str | None:
+        return None  # spans only; the caller holds the subject string
+
+
+# The closed set of pattern features this subset does NOT decide. Each is
+# recognized structurally in the RAW pattern so the refusal names the feature,
+# never "some regex thing". Ordinary escaped forms of these characters
+# (``\(``) are not features and pass.
+_REFUSED_CONSTRUCTS = (
+    ("(?=", "look-ahead"),
+    ("(?!", "negative look-ahead"),
+    ("(?<=", "look-behind"),
+    ("(?<!", "negative look-behind"),
+    ("(?P=", "named-group back-reference"),
+    ("(?(", "conditional group"),
+    ("(?>", "atomic group"),
+)
+
+
+def _scan_refused(pattern: str) -> None:
+    # Walk outside character classes and past escapes so a literal "(?=" inside
+    # ``[...]`` or after ``\`` is not mistaken for the construct.
+    i, n, in_class = 0, len(pattern), False
+    while i < n:
+        c = pattern[i]
+        if c == "\\":
+            i += 2
+            continue
+        if in_class:
+            if c == "]":
+                in_class = False
+            i += 1
+            continue
+        if c == "[":
+            in_class = True
+            i += 1
+            continue
+        for prefix, name in _REFUSED_CONSTRUCTS:
+            if pattern.startswith(prefix, i):
+                raise UnsupportedRegexPattern(
+                    f"pattern uses {name} ({prefix!r}), outside the decidable subset"
+                )
+        # Possessive quantifiers (``*+`` ``++`` ``?+`` ``{m,n}+``) and the
+        # global-flags prefix ``(?<flags>)`` are refused by name too.
+        if c in "*+?}" and pattern.startswith("+", i + 1):
+            raise UnsupportedRegexPattern(
+                "pattern uses a possessive quantifier, outside the decidable subset"
+            )
+        i += 1
+    if _host_re.match(r"\(\?[aiLmsux]+\)", pattern):
+        raise UnsupportedRegexPattern(
+            "pattern uses a global inline-flags prefix, outside the decidable subset"
+        )
+    # Back-references (\1..\99) are refused: the subset decides structure, not
+    # captured-text equality.
+    if _host_re.search(r"\\[1-9][0-9]?", pattern):
+        raise UnsupportedRegexPattern(
+            "pattern uses a numeric back-reference, outside the decidable subset"
+        )
+
+
+def validate_pattern(pattern: str) -> None:
+    """Refuse anything outside the decidable subset, by name. Also refuses a
+    pattern the runtime's own compiler rejects -- a syntactically bad pattern
+    is a loud error at match time, not a silent non-match."""
+    if not isinstance(pattern, str):
+        raise UnsupportedRegexInput("regex pattern must be a concrete str")
+    _scan_refused(pattern)
+    try:
+        _host_re.compile(pattern)
+    except _host_re.error as exc:
+        raise UnsupportedRegexPattern(f"pattern does not compile: {exc}") from exc
+
+
+def _match_to_span(match: "_host_re.Match[str] | None") -> RegexMatchSpanV1 | None:
+    if match is None:
+        return None
+    group_spans: list[tuple[int, int] | None] = []
+    for index in range(1, (match.re.groups) + 1):
+        span = match.span(index)
+        group_spans.append(None if span == (-1, -1) else span)
+    start, end = match.span(0)
+    return RegexMatchSpanV1(start, end, tuple(group_spans))
+
+
+def re_search(pattern: str, string: str) -> RegexMatchSpanV1 | None:
+    """``re.search`` over the validated subset on concrete operands."""
+    _require_concrete(string)
+    validate_pattern(pattern)
+    return _match_to_span(_host_re.search(pattern, string))
+
+
+def re_match(pattern: str, string: str) -> RegexMatchSpanV1 | None:
+    """``re.match`` (anchored at start) over the validated subset."""
+    _require_concrete(string)
+    validate_pattern(pattern)
+    return _match_to_span(_host_re.match(pattern, string))
+
+
+def re_fullmatch(pattern: str, string: str) -> RegexMatchSpanV1 | None:
+    """``re.fullmatch`` (anchored both ends) over the validated subset."""
+    _require_concrete(string)
+    validate_pattern(pattern)
+    return _match_to_span(_host_re.fullmatch(pattern, string))
+
+
+def _require_concrete(string: object) -> None:
+    if not isinstance(string, str):
+        raise UnsupportedRegexInput("regex subject must be a concrete str")

--- a/implementations/python/sugar-lift-py-tests/tests/test_re_semantic_callable.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_re_semantic_callable.py
@@ -1,0 +1,77 @@
+"""Plan Cut 2: re.search/match/fullmatch as language-owned floor operations.
+
+The matcher core is proven separately; here the BuiltinSemanticCallable arm
+applies it to concrete StringValue operands, yields a truthy ReMatchValue or
+None, and keeps symbolic operands / out-of-subset patterns loud.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.callable_application import CallableApplication
+from sugar_lift_py_tests.floor import BuiltinSemanticCallable
+from sugar_lift_py_tests.floor.none_value import NoneValue
+from sugar_lift_py_tests.floor.re_match_value import ReMatchValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.floor.symbolic_value import SymbolicValue
+from sugar_lift_py_tests.ir import make_var
+from sugar_lift_py_tests.outcome import Complete
+
+
+class _Op:
+    def __init__(self, args, site="re.py:1"):
+        self.arguments = tuple(args)
+        self.keyword_names = ()
+        self.site = site
+
+
+def _apply(op_name, pattern, subject):
+    callee = BuiltinSemanticCallable(operation=op_name)
+    return callee.callable_application_with(
+        _Op([StringValue(pattern) if isinstance(pattern, str) else pattern,
+             StringValue(subject) if isinstance(subject, str) else subject]),
+        None,
+    )
+
+
+def test_search_truthful_and_lying() -> None:
+    msg = "A value is being set on a copy of a DataFrame"
+    hit = _apply("python.re.search", "A value is being set", msg)
+    assert isinstance(hit, Complete) and isinstance(hit.value, ReMatchValue)
+    from sugar_lift_py_tests.sugar.true_bool_literal_sugar import TrueBoolLiteralSugar
+    truth = hit.value.truth(site="s")
+    assert isinstance(truth, Complete) and isinstance(truth.value, TrueBoolLiteralSugar)
+    miss = _apply("python.re.search", "NOT the message", msg)
+    assert isinstance(miss, Complete) and isinstance(miss.value, NoneValue)
+
+
+def test_match_is_anchored_at_start() -> None:
+    assert isinstance(_apply("python.re.match", "abc", "abcdef").value, ReMatchValue)
+    assert isinstance(_apply("python.re.match", "bcd", "abcdef").value, NoneValue)
+
+
+def test_fullmatch_requires_both_ends() -> None:
+    assert isinstance(_apply("python.re.fullmatch", "a.c", "abc").value, ReMatchValue)
+    assert isinstance(_apply("python.re.fullmatch", "ab", "abc").value, NoneValue)
+
+
+def test_groups_are_recoverable() -> None:
+    m = _apply("python.re.search", r"(\d+)-(\d+)", "id 12-345").value
+    assert m.group_text(0) == "12-345"
+    assert m.group_text(1) == "12" and m.group_text(2) == "345"
+
+
+def test_symbolic_operand_stays_loud() -> None:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    sym = SymbolicValue(make_var("s"))
+    with pytest.raises(ConstructionPanic, match="concrete str"):
+        _apply("python.re.search", "abc", sym)
+
+
+def test_out_of_subset_pattern_stays_loud() -> None:
+    from sugar_lift_py_tests.gap.panic import ConstructionPanic
+
+    with pytest.raises(ConstructionPanic, match="decidable re subset"):
+        _apply("python.re.search", "(?=lookahead)", "text")

--- a/implementations/python/sugar-lift-py-tests/tests/test_re_subset_matcher.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_re_subset_matcher.py
@@ -1,0 +1,110 @@
+"""Plan Cut 2: the decidable re subset — matcher core twins.
+
+Truthful: patterns in the subset match exactly what the runtime's re does.
+Lying/refusal: every construct outside the subset refuses BY NAME, never a
+guessed non-match; symbolic/non-str operands refuse; a bad pattern is loud.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from sugar_lift_py_tests.floor.re_subset_matcher import (
+    RegexMatchSpanV1,
+    UnsupportedRegexInput,
+    UnsupportedRegexPattern,
+    re_fullmatch,
+    re_match,
+    re_search,
+    validate_pattern,
+)
+
+# The corpus subset: literals, . ^ $, quantifiers, classes, groups, \d\w\s\b, |.
+SUBSET_CASES = [
+    ("abc", "xabcy"),
+    ("a.c", "a-c"),
+    ("^start", "start here"),
+    ("end$", "at the end"),
+    (" a+b*c?", " aaab"),
+    (r"\d{2,4}", "id=1234 done"),
+    (r"[A-Za-z_]\w*", "name0 = 1"),
+    ("(foo|bar)baz", "well barbaz"),
+    (r"(?:ab)+", "ababab"),
+    (r"\bword\b", "a word here"),
+    ("A value is being set", "A value is being set on a copy"),
+    ("", "anything"),
+    ("nomatch", "xxxxx"),
+]
+
+
+@pytest.mark.parametrize("pattern,subject", SUBSET_CASES)
+def test_subset_matches_agree_with_the_runtime(pattern, subject) -> None:
+    for ours, host in (
+        (re_search(pattern, subject), re.search(pattern, subject)),
+        (re_match(pattern, subject), re.match(pattern, subject)),
+        (re_fullmatch(pattern, subject), re.fullmatch(pattern, subject)),
+    ):
+        if host is None:
+            assert ours is None
+        else:
+            assert isinstance(ours, RegexMatchSpanV1)
+            assert (ours.start, ours.end) == host.span(0)
+            assert ours.group_spans == tuple(
+                (None if host.span(i) == (-1, -1) else host.span(i))
+                for i in range(1, host.re.groups + 1)
+            )
+
+
+def test_group_spans_are_carried() -> None:
+    m = re_search(r"(\d+)-(\d+)", "id 12-345 x")
+    assert m is not None and m.group_spans == ((3, 5), (6, 9))
+    subject = "id 12-345 x"
+    assert subject[slice(*m.group_spans[0])] == "12"
+    assert subject[slice(*m.group_spans[1])] == "345"
+
+
+REFUSED = [
+    ("(?=foo)", "look-ahead"),
+    ("(?!foo)", "negative look-ahead"),
+    ("(?<=foo)", "look-behind"),
+    ("(?<!foo)", "negative look-behind"),
+    (r"(?P<n>a)(?P=n)", "named-group back-reference"),
+    (r"(a)\1", "numeric back-reference"),
+    ("(?i)abc", "global inline-flags prefix"),
+    ("a*+", "possessive quantifier"),
+]
+
+
+@pytest.mark.parametrize("pattern,name", REFUSED)
+def test_out_of_subset_refuses_by_name(pattern, name) -> None:
+    with pytest.raises(UnsupportedRegexPattern, match=re.escape(name)):
+        validate_pattern(pattern)
+    with pytest.raises(UnsupportedRegexPattern):
+        re_search(pattern, "whatever")
+
+
+def test_escaped_lookalikes_are_not_features() -> None:
+    # ``\(?=`` etc. are literal characters, not constructs, and pass.
+    for pattern in (r"\(\?=x", r"a\\b", r"[(?=]", "(?:ok)"):
+        validate_pattern(pattern)
+
+
+def test_a_bad_pattern_is_loud_not_a_silent_non_match() -> None:
+    with pytest.raises(UnsupportedRegexPattern, match="does not compile"):
+        validate_pattern("(unclosed")
+
+
+def test_non_concrete_operands_refuse() -> None:
+    with pytest.raises(UnsupportedRegexInput):
+        re_search("abc", object())  # type: ignore[arg-type]
+    with pytest.raises(UnsupportedRegexInput):
+        re_search(object(), "abc")  # type: ignore[arg-type]
+
+
+def test_pytest_raises_match_shape_is_decided() -> None:
+    """The prize: pytest.raises(E, match=P) truthiness on a concrete message."""
+    message = "A value is being set on a copy of a DataFrame"
+    assert re_search("A value is being set", message) is not None  # truthful
+    assert re_search("A value is NOT being set", message) is None  # lying twin


### PR DESCRIPTION
Plan: `docs/plans/2026-09-05-with-sugar-construction-plan.md` (board 33995906761 — With constructed **0** / cited-opaque 5,812 / unconstructed 2,245).

`re.search` bottoms out in `_sre` (C, no Python body), so it leaves an opaque coordinate and every `pytest.raises(E, match=P)` verdict — **5,549 of 5,815** raises sites — is unwitnessed. Cut 2 owns the semantics as language vocabulary, the way `isinstance` and `len` already are.

## This PR: the matcher core (wiring deferred)
- **`floor/re_subset_matcher.py`** — `validate_pattern` is the sole authority on the decidable subset (refuses look-around, back-references, named-group back-refs, conditional/atomic groups, possessive quantifiers, the global inline-flags prefix — **each by name**); a validated pattern is executed by the authenticated runtime's own `re` (`PythonRuntimeIdentity` is the key), which *is* the definition of the answer for the subset. Returns a bounded `RegexMatchSpanV1` or None; nothing outside the validated subset ever reaches `re`.
- **`floor/re_match_value.py`** — `ReMatchValue`: subject + spans, unconditionally truthy (a Match always is), `group_text(n)` decidable; no match is `NoneValue`.
- **`BuiltinSemanticCallable`** gains `python.re.search/match/fullmatch`: concrete `StringValue` operands only; symbolic operands or out-of-subset patterns keep the call **loud** (`ConstructionPanic`), never a guessed (non-)match.

## Test plan
- [x] `test_re_subset_matcher` (26): every subset case agrees with the runtime `re`; every refused construct refuses by name; a bad pattern is loud; non-str operands refuse.
- [x] `test_re_semantic_callable` (6): truthful/lying search, anchored match/fullmatch, group recovery, symbolic + out-of-subset stay loud.
- [x] Additive — floor/builtin/isinstance/len/super/string subset unchanged, **0 new failures**.

## Not wired yet (the remaining half of Cut 2)
Recognizing an authenticated import target `python:re.search` at the call door and binding the callee to `BuiltinSemanticCallable(operation="python.re.search")` — the same door `pytest.raises`'s `match=` flows through, keyed to the authenticated target, never the spelling. **Blocker:** the re-authentication seating path (`test_regex_search_dependency_authority`, `test_regexflag_relative_member_seating`) has ~9 pre-existing failures that must go green first. `_io.open` takes the same recognition door once it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT