### PR TITLE
Cut 6 fix: the frame-door receiver IS the initializer's constructed object

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -250,6 +250,24 @@ class ClassDefinitionValue(GuardStableValue):
         )
         if block is None:
             return receiver
+        # The initializer may reduce directly to the CONSTRUCTED receiver -- an
+        # ObjectValue that already carries __init__'s field stores -- rather
+        # than to pending ReceiverFieldStoreValue statements. The same-module
+        # path leaves stores pending; the import/frame door completes them into
+        # the receiver (its ObjectValue.identity is exactly this receiver
+        # coordinate). A block that is exactly this receiver IS the receiver;
+        # rebuilding an empty one here dropped every __init__ field on the
+        # frame door (enter-may-halt ObjectValue.attribute, plan Cut 6).
+        if (
+            len(block.statements) == 1
+            and isinstance(block.statements[0], (ObjectValue, MappingObjectValue))
+            and getattr(
+                block.statements[0].defining_class, "class_definition_cid", None
+            )
+            == self.class_definition_cid
+            and block.statements[0].identity == receiver.identity
+        ):
+            return block.statements[0]
         guarded_stores = tuple(
             statement
             for statement in block.statements

--- a/implementations/python/sugar-lift-python-source/tests/test_frame_door_init_field_seeding.py
+++ b/implementations/python/sugar-lift-python-source/tests/test_frame_door_init_field_seeding.py
@@ -14,8 +14,8 @@ i.e. `self.r = r`'s post_state reduces to a fresh empty ObjectValue instead of
 a ReceiverFieldStoreValue, because the constructed-receiver coordinate minted
 by ClassDef._source_visible_body is not matched on the frame-door path.
 
-This test pins the DESIRED behavior; xfail(strict) so it flips to a failure
-the moment the receiver seeds its field, forcing the pin to be removed.
+This is the fix's regression pin: the frame-door receiver seeds __init__'s
+field stores, so ``self.r`` is decided at __enter__.
 """
 
 from __future__ import annotations
@@ -75,7 +75,6 @@ def _install(root: Path) -> importlib.metadata.Distribution:
     return importlib.metadata.Distribution.at(meta)
 
 
-@pytest.mark.xfail(strict=True, reason="Cut 6: frame-door receiver drops __init__ field stores")
 def test_import_backed_manager_receiver_runs_init_field_stores(tmp_path) -> None:
     dist = _install(tmp_path)
     graph = DependencyArtifactGraph.authenticate(dist)


### PR DESCRIPTION
Plan: `docs/plans/2026-09-05-with-sugar-construction-plan.md` (§Cut 6 diagnosis, pinned by the prior xfail).

## Root cause
The import/frame door reduces `__init__` directly to the **constructed** receiver `ObjectValue` (fields already seeded); the same-module path leaves pending `ReceiverFieldStoreValue` statements. `construct_receiver_state_from_block` only built fields from the pending-store form — so it **discarded** the frame-door's already-constructed receiver and returned a fresh **empty** one. `self.r` / `self.result` was then undecided at `__enter__` (`enter-may-halt ObjectValue.attribute`), blocking every stdlib/import-backed resource manager (`contextlib.nullcontext`, `ExcelFile`/`HDFStore`/`StataReader`/`get_handle`, ~320 pandas sites).

## Fix
A block that is exactly this receiver, already constructed (a single `ObjectValue`/`MappingObjectValue` of this class whose `identity` equals the receiver coordinate), **is** the receiver — return it. The pending-store path (same-module) is untouched.

## Effect
- `contextlib.nullcontext` and an import-backed class manager now derive to `SourceDerivedContextManagerRefV1` instead of `enter-may-halt` — the first stdlib managers to actually **construct**.
- The Cut 6 `xfail` reproducer flips to a passing assertion.

## Test plan
- [x] Broad `manager|class|receiver|object_field|constructor|derivation|sole_path|populate|summary` subset vs origin `main` (2e2b066e81): **131 → 114 failed, 0 new, 17 fixed**.
- [x] `test_frame_door_init_field_seeding` passes (was strict xfail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT