### PR TITLE
CI: let a tip board enroll extra source populations (plan Cut 1)

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -56,12 +56,24 @@ on:
       corpus_subtree:
         description: "Optional subtree inside the corpus for a bounded run"
         required: false
+      enrolled_populations:
+        description: >-
+          Extra authenticated source populations to enroll (plan Cut 1),
+          comma list of <distribution> or <distribution>:<module>, e.g.
+          'cpython-stdlib:contextlib,pytest'. Empty = corpus only.
+        required: false
+        default: ""
 
 permissions:
   contents: read
 
 env:
   PYTHONUNBUFFERED: "1"
+  # Plan Cut 1: extra authenticated source populations to enroll (declared,
+  # never inferred). Empty on the schedule; a workflow_dispatch may set it to
+  # measure a tip board with e.g. contextlib/pytest enrolled. The corpus
+  # distribution is always enrolled regardless.
+  SUGAR_ENROLLED_POPULATIONS: ${{ github.event.inputs.enrolled_populations || '' }}
   # Banked LPT k — keep fixed; change the split KEY (prior), not k (#7055).
   RECENSUS_SHARD_COUNT: "8"
   # Host bind-mount lease (serializes with human brun exclusive quiet gate).


### PR DESCRIPTION
The control-effect recensus had no way to enroll populations, so every board measured the corpus-only roster and `cmResolutions.constructed` stayed **0 by construction** even after Cut 1/2/6 made stdlib managers derivable.

Adds a `workflow_dispatch` input `enrolled_populations` (comma list of `<distribution>` or `<distribution>:<module>`, plan Cut 1 grammar) threaded into the workflow env as `SUGAR_ENROLLED_POPULATIONS`. **Empty on the schedule** — the authoritative daily board is unchanged — a manual dispatch can measure a tip board with e.g. `cpython-stdlib:contextlib` enrolled to watch cited-opaque rows move to constructed, without touching the scoreboard's default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT