### PR TITLE
Fix: SubscriptOperation.site (crash -> honest boundary under enrolled bodies)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/subscript_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/subscript_operation.py
@@ -30,6 +30,19 @@ class SubscriptOperation:
     blame: object
     use_occurrence: object | None = None
 
+    @property
+    def site(self) -> object:
+        """The source locus of this subscript demand.
+
+        Sibling operations expose ``site``; this one recorded the same fragment
+        under ``blame`` (subscript_sugar passes ``blame=self.site``). A consumer
+        that reduces a subscript over an undecided receiver (an ImportMemberValue
+        under an enrolled stdlib body, e.g. warnings) reads ``operation.site`` --
+        without this it raised AttributeError and voided the file (31 files on the
+        warnings tip board).
+        """
+        return self.blame
+
     def submit(self, receiver: Any, ctx: object) -> Outcome:
         """Ask the receiver to answer this subscript demand."""
         return receiver.subscript_with(self, ctx)

--- a/implementations/python/sugar-lift-py-tests/tests/test_subscript_operation_site.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_subscript_operation_site.py
@@ -1,0 +1,20 @@
+"""SubscriptOperation exposes ``site`` (regression: warnings tip board).
+
+Reducing a subscript over an undecided receiver -- an ImportMemberValue under
+an enrolled stdlib body -- reads ``operation.site``. SubscriptOperation
+recorded that fragment under ``blame``; the missing ``site`` raised
+AttributeError and voided 31 files on the warnings-enrolled board. ``site`` is
+the same locus as ``blame`` and turns the crash into an honest undecided
+subscript boundary.
+"""
+
+from __future__ import annotations
+
+from sugar_lift_py_tests.floor.term_value import TermValue
+from sugar_lift_py_tests.operations.subscript_operation import SubscriptOperation
+
+
+def test_site_is_the_blame_locus() -> None:
+    op = SubscriptOperation(index=TermValue(0), owner="t", blame="f.py:3:1")
+    assert op.site == "f.py:3:1"
+    assert op.site is op.blame


### PR DESCRIPTION
The `warnings`-enrolled tip board came back **UNMEASURED**: 31 files voided with `'SubscriptOperation' object has no attribute 'site'`.

`SubscriptOperation` records its locus under `blame` (`subscript_sugar` passes `blame=self.site`), but consumers that reduce a subscript over an undecided receiver — an `ImportMemberValue` under an enrolled stdlib body (`warnings.filters[...]` and kin) — read `operation.site`. The missing attribute raised `AttributeError` and **voided the whole file** instead of naming an undecided subscript.

## Fix
Add `site` as the `blame` locus. The subscript now routes through the shared `undecided_*` door — a countable, typed boundary, never a crash — so `warnings` (and any stdlib body that subscripts an import member) can be measured instead of voiding the board.

## Test plan
- [x] `test_subscript_operation_site`: `op.site is op.blame`.
- [x] Verified directly: an authenticated `ImportMemberValue` subscript now returns an undecided-subscript gap instead of raising `AttributeError`.
- [x] `-k "subscript or import_member or operation"` subset green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT