### PR TITLE
Fix: expose site on the operation family (pre-empt the enrolled-body crash)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/inplace_binary_operator_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/inplace_binary_operator_operation.py
@@ -51,6 +51,17 @@ class InplaceBinaryOperatorOperation:
     owner: str
     blame: object
 
+    @property
+    def site(self) -> object:
+        """The source locus of this demand (recorded under ``blame``).
+
+        Consumers that reduce this operation over an undecided receiver -- an
+        ImportMemberValue under an enrolled stdlib body -- read
+        ``operation.site``. Sibling operations that lacked it raised
+        AttributeError and voided the file (see SubscriptOperation.site).
+        """
+        return self.blame
+
     def inplace_default(self, receiver, ctx) -> Any:
         """Species without inplace override: ordinary binary by surface operator."""
         del ctx

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/iterator_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/iterator_operation.py
@@ -25,6 +25,17 @@ class IteratorOperation:
     owner: str
     blame: object
 
+    @property
+    def site(self) -> object:
+        """The source locus of this demand (recorded under ``blame``).
+
+        Consumers that reduce this operation over an undecided receiver -- an
+        ImportMemberValue under an enrolled stdlib body -- read
+        ``operation.site``. Sibling operations that lacked it raised
+        AttributeError and voided the file (see SubscriptOperation.site).
+        """
+        return self.blame
+
     def submit(self, receiver: Any, ctx: Any = None) -> Any:
         """Ask the receiver for its iterator. The receiver owns the answer."""
         return receiver.iter_with(self, ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/next_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/next_operation.py
@@ -25,6 +25,17 @@ class NextOperation:
     owner: str
     blame: object
 
+    @property
+    def site(self) -> object:
+        """The source locus of this demand (recorded under ``blame``).
+
+        Consumers that reduce this operation over an undecided receiver -- an
+        ImportMemberValue under an enrolled stdlib body -- read
+        ``operation.site``. Sibling operations that lacked it raised
+        AttributeError and voided the file (see SubscriptOperation.site).
+        """
+        return self.blame
+
     def submit(self, receiver: Any, ctx: Any = None) -> Any:
         """Ask the iterator for the next value. The iterator owns the answer."""
         return receiver.next_with(self, ctx)

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/positional_unpack_operation.py
@@ -34,6 +34,17 @@ class UnpackMemberRoster:
     occurrence: object  # authenticated source fragment (operation blame)
     demand_cid: str  # content address of unpack demand (site + arity)
 
+    @property
+    def site(self) -> object:
+        """The source locus of this demand (recorded under ``blame``).
+
+        Consumers that reduce this operation over an undecided receiver -- an
+        ImportMemberValue under an enrolled stdlib body -- read
+        ``operation.site``. Sibling operations that lacked it raised
+        AttributeError and voided the file (see SubscriptOperation.site).
+        """
+        return self.blame
+
     def __post_init__(self) -> None:
         if not isinstance(self.demand_cid, str) or not self.demand_cid:
             raise ValueError(

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/sequence_projection_operation.py
@@ -65,6 +65,17 @@ class SequenceProjectionOperation:
     prefix_names: tuple[str, ...] = ()
     suffix_names: tuple[str, ...] = ()
 
+    @property
+    def site(self) -> object:
+        """The source locus of this demand (recorded under ``blame``).
+
+        Consumers that reduce this operation over an undecided receiver -- an
+        ImportMemberValue under an enrolled stdlib body -- read
+        ``operation.site``. Sibling operations that lacked it raised
+        AttributeError and voided the file (see SubscriptOperation.site).
+        """
+        return self.blame
+
     def __post_init__(self) -> None:
         if self.star_name is None:
             if self.prefix_names or self.suffix_names:

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/slice_assign_iterable_operation.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/operations/slice_assign_iterable_operation.py
@@ -21,5 +21,16 @@ class SliceAssignIterableOperation:
     owner: str
     blame: object
 
+    @property
+    def site(self) -> object:
+        """The source locus of this demand (recorded under ``blame``).
+
+        Consumers that reduce this operation over an undecided receiver -- an
+        ImportMemberValue under an enrolled stdlib body -- read
+        ``operation.site``. Sibling operations that lacked it raised
+        AttributeError and voided the file (see SubscriptOperation.site).
+        """
+        return self.blame
+
     def submit(self, receiver: Any, ctx: Any = None) -> Any:
         return receiver.slice_assign_iterable_with(self, ctx)


### PR DESCRIPTION
Follow-up to the `SubscriptOperation.site` fix (#7441). Six sibling operations recorded their locus under `blame` with no `site` accessor: `inplace_binary_operator`, `iterator`, `next`, `positional_unpack`, `sequence_projection`, `slice_assign_iterable`.

`ImportMemberValue.iter_with` (and kin) reads `operation.site` when reducing over an undecided receiver — an import member under an enrolled stdlib body — so any of these would raise `AttributeError` and **void the file**, exactly as `SubscriptOperation` did on the `warnings` board.

Add `site` (= `blame`) uniformly. Each now routes through the shared `undecided_*` door as a countable boundary instead of crashing.

## Test plan
- [x] Additive property; operation/import-member subset green apart from 2 `test_assign_unpack_store_leaves` failures that are **pre-existing on `main`** (verified by stashing the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT