### PR TITLE
Construct zero-arg super() into a source-defined base method

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/builtin_super_value.py
@@ -58,7 +58,7 @@ class BuiltinSuperValue(FloorValue):
         keywords=(),
         required_frame=None,
     ):
-        del owner, ctx
+        del owner
         if required_frame is not None:
             from sugar_lift_py_tests.gap.panic import construction_panic_gap
 
@@ -123,6 +123,24 @@ class BuiltinSuperValue(FloorValue):
                 lambda updated: Complete(
                     ReceiverOwnedMutationResult(self.receiver, updated, NoneValue())
                 )
+            )
+        from sugar_lift_py_tests.floor.class_definition_value import (
+            ClassDefinitionValue,
+        )
+
+        if isinstance(base, ClassDefinitionValue):
+            # Zero-arg super into a source-defined next class: run the selected
+            # base method on the original instance receiver.  The base body
+            # reduces with __class__ seeded to its defining class, so a further
+            # super() inside it selects the class after the base.
+            return base.dispatch_super_method(
+                self.receiver,
+                name,
+                arguments,
+                owner="BuiltinSuperValue.call_method_value",
+                blame=blame,
+                ctx=ctx,
+                keywords=keywords,
             )
         construction_panic_gap(
             owner="BuiltinSuperValue.call_method_value",

--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/floor/class_definition_value.py
@@ -187,6 +187,102 @@ class ClassDefinitionValue(GuardStableValue):
         )
         return call.producer_outcome(method_ctx)
 
+    def dispatch_super_method(
+        self,
+        receiver,
+        name,
+        arguments,
+        *,
+        owner,
+        blame,
+        ctx=None,
+        keywords=(),
+    ):
+        """Run method ``name`` resolved from THIS class's MRO, bound to an
+        explicit ``receiver``.
+
+        Zero-argument ``super()`` uses this to invoke a selected source-defined
+        base method: the original instance stays the bound ``self`` while the
+        base body reduces with ``__class__`` seeded to the method's defining
+        class, so a chained ``super`` inside that body selects the next class.
+        This mirrors ``ObjectValue.call_method_value`` exactly; only the method
+        table (this class's ``_object_methods`` MRO) and the explicit receiver
+        differ.
+        """
+        from sugar_lift_py_tests.floor.call_site_value import CallSiteValue
+        from sugar_lift_py_tests.ir import ctor
+        from sugar_lift_py_tests.outcome import Complete
+
+        for method in reversed(self._object_methods()):
+            if method.name != name:
+                continue
+            if not method.parameters:
+                raise SugarNotWritten(
+                    owner=owner,
+                    blame=blame,
+                    observed=f"{self.class_name}.{name}",
+                    requested="a bound self parameter on the selected base method",
+                    fix=f"add method binding sugar for `{self.class_name}.{name}`",
+                )
+            target_name = f"{self.class_name}.{name}"
+            arg_values = (receiver, *arguments)
+            bound_source_actuals = None
+            selected_frame = method.source_call_frame
+            if selected_frame is not None:
+                from sugar_lift_py_tests.source_call_frame import (
+                    SourceCallBindingGap,
+                )
+
+                try:
+                    bound_source_actuals = selected_frame.bind_actuals(
+                        arg_values, keywords, ctx
+                    )
+                    arg_values = bound_source_actuals.actuals
+                except SourceCallBindingGap as exc:
+                    raise SugarNotWritten(
+                        owner=owner,
+                        blame=blame,
+                        observed=str(exc),
+                        requested="actuals matching the selected base method signature",
+                        fix="preserve exact defaults/variadics or keep the call loud",
+                    )
+            elif keywords or len(arguments) != len(method.parameters) - 1:
+                raise SugarNotWritten(
+                    owner=owner,
+                    blame=blame,
+                    observed=f"{self.class_name}.{name}",
+                    requested="arguments matching the selected base method",
+                    fix="bind through the authenticated base frame or keep loud",
+                )
+            arg_terms = [
+                value.to_term(owner=f"{owner} super argument")
+                for value in arg_values
+            ]
+            call_value = CallSiteValue(
+                target_name=target_name,
+                arg_values=arg_values,
+                parameters=method.parameters,
+                term=ctor(
+                    f"call:{target_name}",
+                    arg_terms,
+                    symbol_kind="contract-target",
+                ),
+                body=method.body,
+                site=blame,
+                source_call_frame_cid=method.source_call_frame_cid,
+                formal_coordinate_cids=method.formal_coordinate_cids,
+                bound_source_actuals=bound_source_actuals,
+                lexical_defining_class=method.defining_class,
+            )
+            return Complete(call_value)
+        raise SugarNotWritten(
+            owner=owner,
+            blame=blame,
+            observed=f"{self.class_name}.{name}",
+            requested="a source-defined base method for zero-argument super",
+            fix=f"construct a diggable body for `{self.class_name}.{name}` or keep loud",
+        )
+
     def to_term(self, *, owner: str):
         del owner
         from sugar_lift_py_tests.ir import ctor, str_const

--- a/implementations/python/sugar-lift-py-tests/tests/test_super_dispatches_source_base.py
+++ b/implementations/python/sugar-lift-py-tests/tests/test_super_dispatches_source_base.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from sugar_lift_py_tests.context import ReduceContext
+from sugar_lift_py_tests.floor import CallSiteValue
+from sugar_lift_py_tests.floor.builtin_super_value import BuiltinSuperValue
+from sugar_lift_py_tests.floor.string_value import StringValue
+from sugar_lift_py_tests.outcome import Complete
+from sugar_lift_python_source.canonical import blake3_512_of
+from sugar_source_tree.nodes import ClassDef
+from sugar_source_tree.panic import SugarNotWritten
+from sugar_source_tree.tree import SourceFile
+from sugar_lift_py_tests.context_manager_resolution import TreeConstructionContextV1
+
+
+def _constructed(source: str):
+    tree = SourceFile(
+        (source, "super_dispatch.py", blake3_512_of(source.encode())),
+        construction_context=TreeConstructionContextV1.for_test_without_workspace(),
+    )
+    context = ReduceContext.root(owner="test")
+    values = []
+    for node in tree.root.body:
+        if not isinstance(node, ClassDef):
+            continue
+        value = node.sugar().desugar(context).value
+        context.temporal = context.temporal.bind_value(value.class_name, value)
+        values.append(value)
+    return context, values
+
+
+# --- truthful twin: zero-arg super() into a same-module source base -----------
+_TRUTHFUL = (
+    "class Base:\n"
+    "    def __init__(self, x):\n"
+    "        self.x = x\n"
+    "\n"
+    "class Derived(Base):\n"
+    "    def __init__(self, x):\n"
+    "        super().__init__(x)\n"
+)
+
+
+def test_super_dispatches_into_source_defined_base_init() -> None:
+    context, (base, derived) = _constructed(_TRUTHFUL)
+    receiver = derived.construct_receiver_state_from_block(None, "receiver")
+    zuper = BuiltinSuperValue(current_class=derived, receiver=receiver)
+
+    projected = zuper.call_method_value(
+        "__init__",
+        (StringValue("v"),),
+        owner="test",
+        blame="super-init",
+        ctx=context,
+    )
+
+    assert isinstance(projected, Complete)
+    call = projected.value
+    assert isinstance(call, CallSiteValue)
+    # The base body runs bound to the original instance receiver, and
+    # __class__ inside it is the base (so a chained super would select the
+    # class after Base, not restart from Derived).
+    assert call.lexical_defining_class is base
+    assert call.arg_values[0] is receiver
+    reduced = call.reduce_source_outcome(context)
+    assert isinstance(reduced, Complete)
+
+
+# --- lying twin: super() naming a method no base defines must stay loud --------
+_LIAR = (
+    "class Base:\n"
+    "    def __init__(self, x):\n"
+    "        self.x = x\n"
+    "\n"
+    "class Derived(Base):\n"
+    "    def __init__(self, x):\n"
+    "        super().greet(x)\n"
+)
+
+
+def test_super_refuses_absent_base_method() -> None:
+    context, (base, derived) = _constructed(_LIAR)
+    receiver = derived.construct_receiver_state_from_block(None, "receiver")
+    zuper = BuiltinSuperValue(current_class=derived, receiver=receiver)
+
+    with pytest.raises(SugarNotWritten):
+        zuper.call_method_value(
+            "greet",
+            (StringValue("v"),),
+            owner="test",
+            blame="super-greet",
+            ctx=context,
+        )


### PR DESCRIPTION
## What

Zero-arg `super()` already resolved `__class__` and the receiver, but `BuiltinSuperValue.call_method_value` only modelled **builtin** next-classes (`dict`, `type.__new__`). A **source-defined** selected base (a `ClassDefinitionValue`) fell through to a `ConstructionPanic`.

That panic is the wall every subclass `__init__` calling `super().__init__(...)` hits — including pytest's `RaisesExc(AbstractRaises)` → `AbstractRaises.__init__`, the load-bearing hop for constructing `pytest.raises` context managers (currently 5,815 sites, 0 constructed).

## How

- **`ClassDefinitionValue.dispatch_super_method`**: run a method resolved from this class's own MRO (`_object_methods` C3 tail) bound to an **explicit** receiver, producing a `CallSiteValue` whose `lexical_defining_class` is the method's defining class — so `__class__` inside the base body seeds correctly and a chained `super()` selects the class *after* the base. Mirrors `ObjectValue.call_method_value` exactly; only the method table and explicit receiver differ.
- **`BuiltinSuperValue.call_method_value`**: dispatch into it when the selected base is a `ClassDefinitionValue`; stop discarding `ctx` (needed to bind actuals through the base frame).

## Twins

- Truthful: a same-module `super().__init__` constructs, binds the original receiver, and carries `__class__ = base`.
- Lying: a `super()` naming a method no base defines stays loud (`SugarNotWritten`).

Isolated to the source-defined-base super path; the new arm fires only for `isinstance(base, ClassDefinitionValue)`. Part of the pytest.raises construction chain (super → same-module base seating → C3 MRO → ExceptionInfo); this is the super link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT