### PR TITLE
Construct dotted import-bound except types (except re.error)

### DIFF
--- a/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
+++ b/implementations/python/sugar-lift-py-tests/src/sugar_lift_py_tests/import_binding.py
@@ -932,6 +932,13 @@ class _Pass:
             handler_entry = _join(*exceptional_prefixes)
             paths = [self.statements(node.body, state, scope)]
             for handler in node.handlers:
+                # The except-TYPE expression is a value use on the exceptional
+                # path (``except re.error`` reads the import-bound ``re``); it
+                # must be enrolled so a dotted handler type can later
+                # authenticate its import identity, exactly as a With
+                # context_expr is enrolled below.
+                if handler.type_ is not None:
+                    self.expression(handler.type_, handler_entry, scope)
                 handler_state = dict(handler_entry)
                 if handler.name:
                     handler_state[handler.name] = frozenset({_NON_IMPORT})

--- a/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
+++ b/implementations/python/sugar-source-tree/src/sugar_source_tree/nodes.py
@@ -9717,19 +9717,23 @@ class Try(Statement):
             if not type_nodes:
                 return super()._construct_sugar()  # empty tuple: no honest matcher
             for type_node in type_nodes:
-                if not isinstance(type_node, Name):
-                    # ``except re.error`` / dotted types are not bare Names.
-                    # SoftUnresolvedTrySugar was a second mechanism that
-                    # rendered unfinished except-type Sugar as Incomplete.
-                    # Raise: write the missing Sugar door, do not soft-survive.
-                    raise SugarNotWritten(
-                        owner="Try._construct_sugar",
-                        blame=self.fragment,
-                        observed="non-Name except type without authenticated identity",
-                        requested="a constructed exception-type coordinate (or Name)",
-                        fix="resolve the handler type lexically or write Sugar for dotted except types",
+                # A bare Name authenticates through the lexical builtin/source
+                # vocabulary; a dotted import-bound type (``except re.error``)
+                # authenticates through the same closed import identity used for
+                # ``raise re.error(...)`` operands.  Only a head that is neither
+                # -- a computed, shadowed, or instance-attribute except type --
+                # stays loud.
+                class_value = None
+                if isinstance(type_node, Name):
+                    identity = self.unit.exception_type_identity(type_node)
+                    mro = (
+                        self.unit.exception_type_mro(type_node)
+                        if identity is not None
+                        else None
                     )
-                identity = self.unit.exception_type_identity(type_node)
+                else:
+                    identity = self.unit.imported_exception_type_identity(type_node)
+                    mro = None
                 if identity is None:
                     raise SugarNotWritten(
                         owner="Try._construct_sugar",
@@ -9742,13 +9746,27 @@ class Try(Statement):
                     AuthenticatedExceptionTypeSugar,
                 )
 
+                if not isinstance(type_node, Name):
+                    # Seal the import-bound dotted head as an exception class
+                    # value, exactly as the Raise-operand door does, so the
+                    # handler carries a concrete class rather than a bare
+                    # module-attribute floor.
+                    from sugar_lift_py_tests.floor.exception_class_value import (
+                        ExceptionClassValue,
+                    )
+
+                    qualified = getattr(identity.args[1], "value", None)
+                    if isinstance(qualified, str) and qualified:
+                        class_value = ExceptionClassValue(qualified)
+
                 handler_specs.append(
                     (
                         AuthenticatedExceptionTypeSugar(
                             type_node.sugar(),
                             identity,
-                            self.unit.exception_type_mro(type_node),
+                            mro,
                             type_node.fragment,
+                            class_value=class_value,
                         ),
                         body_sugars,
                         slot_id,

--- a/implementations/python/sugar-source-tree/tests/test_try_imported_except_type.py
+++ b/implementations/python/sugar-source-tree/tests/test_try_imported_except_type.py
@@ -1,0 +1,85 @@
+"""Zero-name (dotted) except types authenticate through the same closed import
+identity that ``raise re.error(...)`` operands ride.
+
+``except re.error`` is the exact wall pytest's ``AbstractRaises.__init__``
+force-floors (``try: re.compile(match) / except re.error as e``) when a with
+site constructs ``pytest.raises(..., match=...)``.  Two edits make it hold:
+the except-TYPE expression is now enrolled as an import value-use (so its head
+is import-bound), and ``Try._construct_sugar`` authenticates a non-Name handler
+type through ``imported_exception_type_identity``.  A dotted head that is NOT
+import-bound (an instance/param attribute) still stays loud.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from sugar_lift_py_tests.ir import ctor, str_const
+from sugar_source_tree.panic import SugarNotWritten
+from with_resolution_fixture import source_file_with_preconstruction
+
+
+def _function(src: str):
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False, dir="/tmp") as f:
+        f.write(src)
+        path = f.name
+    return next(source_file_with_preconstruction(Path(path)).functions())
+
+
+def _except_type_node(function, attr: str):
+    return next(
+        node
+        for node in function.walk()
+        if node.kind == "Attribute" and getattr(node, "attr", None) == attr
+    )
+
+
+_TRUTHFUL = (
+    "import re\n"
+    "\n"
+    "def f(pattern):\n"
+    "    try:\n"
+    "        compiled = re.compile(pattern)\n"
+    "    except re.error as exc:\n"
+    "        compiled = exc\n"
+    "    return compiled\n"
+)
+
+
+def test_except_type_head_is_now_import_enrolled() -> None:
+    # The re.error head inside the except clause is enrolled as an import
+    # value-use, so its dotted identity authenticates (previously None).
+    fn = _function(_TRUTHFUL)
+    node = _except_type_node(fn, "error")
+    identity = fn.unit.imported_exception_type_identity(node)
+    assert identity == ctor(
+        "python:exception_type_identity",
+        [str_const("import"), str_const("re.error")],
+    )
+
+
+def test_dotted_import_bound_except_type_constructs() -> None:
+    # Construction (Try._construct_sugar) no longer raises for re.error.
+    _function(_TRUTHFUL).sugar()
+
+
+_LIAR = (
+    "def f(registry):\n"
+    "    try:\n"
+    "        registry.load()\n"
+    "    except registry.Error as exc:\n"
+    "        registry = exc\n"
+    "    return registry\n"
+)
+
+
+def test_non_import_bound_dotted_except_type_stays_loud() -> None:
+    fn = _function(_LIAR)
+    # The param head is not import-bound: no authenticated identity ...
+    assert fn.unit.imported_exception_type_identity(
+        _except_type_node(fn, "Error")
+    ) is None
+    # ... and construction stays loud rather than fabricating one.
+    with pytest.raises(SugarNotWritten):
+        fn.sugar()


### PR DESCRIPTION
## What

`Try._construct_sugar` authenticated only **bare-Name** except types; any dotted handler type (`except re.error`, `except np.AxisError`) raised `SugarNotWritten`.

That is the exact wall constructing `pytest.raises` hits: `RaisesExc.__init__` → `super().__init__` (now constructed, #7444) → `AbstractRaises.__init__`, whose body is `try: re.compile(match) / except re.error as e`. On the pytest-enrolled tip board (run 34186700446), **592 of 723 panics** were this single message:

> `force-floor for manager 'python:pytest.raises' [Try._construct_sugar: non-Name except type without authenticated identity]`

## How (both edits reuse existing machinery)

- **`import_binding`**: the except-**type** expression is now enrolled as an import value-use on the exceptional path (mirroring how a `With` `context_expr` is enrolled), so a dotted head like `re` becomes import-bound. Without this the head at the handler occurrence had no import receipt, so any identity was `None`.
- **`Try._construct_sugar`**: a non-Name handler type authenticates through `imported_exception_type_identity` and projects an `AuthenticatedExceptionTypeSugar` with an `ExceptionClassValue` — the same closed coordinate the `raise re.error(...)` operand door already uses. A head that is not import-bound (an instance/param attribute like `registry.Error`) still stays loud.

## Twins

- `except re.error` (re import-bound): enrolls its head, identity is `python:exception_type_identity(import, re.error)`, constructs.
- `except registry.Error` (param head): no import identity, stays loud (`SugarNotWritten`).

Regression-checked against clean HEAD across the try / imported-exception / import-binding neighborhoods: **identical pass/fail** (residual failures there are the pre-existing ungated-suite scoreboard, not this change).

Next link in the pytest.raises chain after super() (#7444). Follow-ups: `re.compile` C-floor and `ExceptionInfo.for_later()` in `RaisesExc.__enter__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT