### PR TITLE
Enroll cpython-stdlib:contextlib on the daily recensus schedule

### DIFF
--- a/.github/workflows/control-effect-recensus.yml
+++ b/.github/workflows/control-effect-recensus.yml
@@ -70,10 +70,15 @@ permissions:
 env:
   PYTHONUNBUFFERED: "1"
   # Plan Cut 1: extra authenticated source populations to enroll (declared,
-  # never inferred). Empty on the schedule; a workflow_dispatch may set it to
-  # measure a tip board with e.g. contextlib/pytest enrolled. The corpus
-  # distribution is always enrolled regardless.
-  SUGAR_ENROLLED_POPULATIONS: ${{ github.event.inputs.enrolled_populations || '' }}
+  # never inferred). The schedule now enrolls the MEASURED-clean stdlib module
+  # cpython-stdlib:contextlib -- the corpus's own @contextmanager managers
+  # (option_context et al.) construct only through contextlib's generator
+  # machinery, so a corpus-only board hid 1,161 real constructions (+1 panic;
+  # measured on tip board run 34170728474 after #7443). Promoting a
+  # module-at-a-time measured population to the daily roster is exactly Cut 1.
+  # A workflow_dispatch may still override to add pytest/numpy or set corpus
+  # -only. The corpus distribution is always enrolled regardless.
+  SUGAR_ENROLLED_POPULATIONS: ${{ github.event.inputs.enrolled_populations || 'cpython-stdlib:contextlib' }}
   # Banked LPT k — keep fixed; change the split KEY (prior), not k (#7055).
   RECENSUS_SHARD_COUNT: "8"
   # Host bind-mount lease (serializes with human brun exclusive quiet gate).


### PR DESCRIPTION
## Why

The authoritative **daily** board enrolls no extra population, so it reports `constructed 0 / citedOpaque 5813 / unconstructed 2244` (run 34220913187) — despite #7443/#7444/#7445. The corpus's own `@contextmanager` managers (`option_context`, `set_locale`, `_get_buffer`, `pandas_converters`, …) construct **only** through `contextlib`'s generator machinery, and that stdlib module was enrolled only on ad-hoc `workflow_dispatch` tip boards. So **1,161 real, sealed constructions were invisible** on the deliverable.

## What

Promote the measured-clean `cpython-stdlib:contextlib` module to the schedule's default roster — exactly plan **Cut 1** (widen a population one module at a time, measured first).

```
- SUGAR_ENROLLED_POPULATIONS: ${{ github.event.inputs.enrolled_populations || '' }}
+ SUGAR_ENROLLED_POPULATIONS: ${{ github.event.inputs.enrolled_populations || 'cpython-stdlib:contextlib' }}
```

## Evidence

Tip board **run 34170728474** (post #7443) measured this exact enrollment: **+1,161 constructed / +1 file panic** vs the corpus-only board, conservation intact (1161 + 5763 + 1133 = 8057). Token verified canonical by `sugar-lift-python-source/tests/test_population_roster.py:57`.

`workflow_dispatch` may still override the roster (add `pytest`/`numpy`, or a bounded corpus subtree). The corpus distribution is always enrolled regardless; no other population changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWEZCAswjRcr2FEwya8XzT